### PR TITLE
Actually lint React files

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "babel-preset-react": "6.11.1",
     "copy-webpack-plugin": "3.0.1",
     "eslint": "3.5.0",
-    "eslint-config-scratch": "^1.0.0",
+    "eslint-config-scratch": "^2.0.0",
     "eslint-plugin-react": "6.4.1",
     "gh-pages": "0.11.0",
     "html-webpack-plugin": "2.22.0",


### PR DESCRIPTION
Previously the lint command ignored `.jsx` files.

Also upgrade to 2.0 to allow rest/spread syntax.
