### PR TITLE
Set up base eslint config in .eslintrc.js

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,3 @@
 module.exports = {
-    env: {
-        node: true
-    }
+    extends: ['scratch', 'scratch/node']
 };

--- a/package.json
+++ b/package.json
@@ -18,9 +18,6 @@
     "start": "webpack-dev-server --port $npm_package_config_port --content-base=./build",
     "test": "npm run lint && npm run build"
   },
-  "eslintConfig": {
-    "extends": ["scratch"]
-  },
   "author": "Massachusetts Institute of Technology",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/LLK/scratch-gui#readme",
@@ -40,7 +37,7 @@
     "babel-preset-es2015": "6.14.0",
     "babel-preset-react": "6.11.1",
     "copy-webpack-plugin": "3.0.1",
-    "eslint": "3.5.0",
+    "eslint": "3.8.1",
     "eslint-config-scratch": "^2.0.0",
     "eslint-plugin-react": "6.4.1",
     "gh-pages": "0.11.0",

--- a/src/.eslintrc.js
+++ b/src/.eslintrc.js
@@ -3,5 +3,8 @@ module.exports = {
         node: false,
         browser: true
     },
-    extends: ['scratch/es6', 'scratch/react']
+    extends: ['scratch/es6', 'scratch/react'],
+    globals: {
+        process: true
+    }
 };

--- a/src/components/green-flag.jsx
+++ b/src/components/green-flag.jsx
@@ -26,7 +26,7 @@ class GreenFlagComponent extends React.Component {
 
 GreenFlagComponent.propTypes = {
     onClick: React.PropTypes.func,
-    title: React.PropTypes.string,
+    title: React.PropTypes.string
 };
 
 GreenFlagComponent.defaultProps = {

--- a/src/components/library.jsx
+++ b/src/components/library.jsx
@@ -61,7 +61,7 @@ LibraryComponent.propTypes = {
         React.PropTypes.shape({
             md5: React.PropTypes.string,
             name: React.PropTypes.string,
-            rawURL: React.PropTypes.string,
+            rawURL: React.PropTypes.string
         })
         /* eslint-enable react/no-unused-prop-types, lines-around-comment */
     ),

--- a/src/components/sprite-selector.jsx
+++ b/src/components/sprite-selector.jsx
@@ -16,7 +16,7 @@ class SpriteSelectorComponent extends React.Component {
                 style={{
                     position: 'absolute',
                     top: 380,
-                    right: 10,
+                    right: 10
                 }}
                 {...props}
             >

--- a/src/components/stage.jsx
+++ b/src/components/stage.jsx
@@ -17,7 +17,7 @@ class StageComponent extends React.Component {
                     top: 10,
                     right: 10,
                     width: width,
-                    height: height,
+                    height: height
                 }}
                 {...props}
             />

--- a/src/components/stop-all.jsx
+++ b/src/components/stop-all.jsx
@@ -26,7 +26,7 @@ class StopAllComponent extends React.Component {
 
 StopAllComponent.propTypes = {
     onClick: React.PropTypes.func,
-    title: React.PropTypes.string,
+    title: React.PropTypes.string
 };
 
 StopAllComponent.defaultProps = {

--- a/src/containers/gui.jsx
+++ b/src/containers/gui.jsx
@@ -122,7 +122,7 @@ GUI.propTypes = {
     spriteSelectorProps: shapeFromPropTypes(SpriteSelector.propTypes, {omit: ['vm']}),
     stageProps: shapeFromPropTypes(Stage.propTypes, {omit: ['vm']}),
     stopAllProps: shapeFromPropTypes(StopAll.propTypes, {omit: ['vm']}),
-    vm: React.PropTypes.instanceOf(VM),
+    vm: React.PropTypes.instanceOf(VM)
 };
 
 GUI.defaultProps = {


### PR DESCRIPTION
After doing this, new rules began applying for some reason:

`eol-last` only began taking the 'always' parameter as of 3.6.0, so I needed to update eslint.
`no-unused-var` started warning about process.env after updating the config structure
`comma-dangle` decided to start working, maybe because of the upgrade to eslint?  Autofixed with --fix

/cc @cwillisf 
