### PR TITLE
Don't block keys intended for the browser

### DIFF
--- a/src/lib/vm-manager.js
+++ b/src/lib/vm-manager.js
@@ -21,9 +21,11 @@ class VMManager {
     }
     onKeyDown (e) {
         // Don't capture keys intended for Blockly inputs.
-        if (e.target !== document && e.target !== document.body) {
-            return;
-        }
+        if (e.target !== document && e.target !== document.body) return;
+
+        // Don't capture browser keyboard shortcuts
+        if (e.metaKey || e.altKey || e.ctrlKey) return;
+
         this.vm.postIOData('keyboard', {
             keyCode: e.keyCode,
             isDown: true

--- a/src/lib/vm-manager.js
+++ b/src/lib/vm-manager.js
@@ -23,13 +23,14 @@ class VMManager {
         // Don't capture keys intended for Blockly inputs.
         if (e.target !== document && e.target !== document.body) return;
 
-        // Don't capture browser keyboard shortcuts
-        if (e.metaKey || e.altKey || e.ctrlKey) return;
-
         this.vm.postIOData('keyboard', {
             keyCode: e.keyCode,
             isDown: true
         });
+
+        // Don't stop browser keyboard shortcuts
+        if (e.metaKey || e.altKey || e.ctrlKey) return;
+
         e.preventDefault();
     }
     onKeyUp (e) {


### PR DESCRIPTION
This is mostly because it was annoying that Cmd-Opt-J didn't work, but seems like a good thing to have in general.