### PR TITLE
Configure port through webpack, not npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "version": "0.1.0",
   "description": "GraphicaL User Interface for creating and running Scratch 3.0 projects",
   "main": "./src/index.js",
-  "config": {
-    "port": 8601
-  },
   "scripts": {
     "build": "npm run clean && webpack --progress --colors --bail",
     "clean": "rm -rf ./build && mkdir -p build",
@@ -14,7 +11,7 @@
     "postmerge": "opt --in postmerge --exec 'npm install'",
     "postrewrite": "opt --in postrewrite --exec 'npm install'",
     "prepush": "opt --in prepush --exec 'npm run lint'",
-    "start": "webpack-dev-server --port $npm_package_config_port --content-base=./build",
+    "start": "webpack-dev-server",
     "test": "npm run lint && npm run build"
   },
   "author": "Massachusetts Institute of Technology",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,11 @@ var HtmlWebpackPlugin = require('html-webpack-plugin');
 var webpack = require('webpack');
 
 module.exports = {
+    devServer: {
+        contentBase: path.resolve(__dirname, 'build'),
+        host: '0.0.0.0',
+        port: process.env.PORT || 8601
+    },
     entry: {
         lib: ['react', 'react-dom'],
         gui: './src/index.jsx'


### PR DESCRIPTION
The previous method of configuring the port number was not cross-platform.  Resolves #20