### PR TITLE
An import button was added to library

### DIFF
--- a/src/components/library/library.jsx
+++ b/src/components/library/library.jsx
@@ -10,7 +10,7 @@ const styles = require('./library.css');
 class LibraryComponent extends React.Component {
     constructor (props) {
         super(props);
-        bindAll(this, ['handleSelect']);
+        bindAll(this, ['handleSelect', 'handleImport']);
         this.state = {selectedItem: null};
     }
     handleSelect (id) {
@@ -21,7 +21,19 @@ class LibraryComponent extends React.Component {
         }
         this.setState({selectedItem: id});
     }
+    handleImport () {
+        this.props.onRequestClose();
+        this.props.import();
+    }
     render () {
+        let importButton;
+        if (this.props.showImport){
+            importButton = (
+                <div style={{padding: '50px 10px 50px 10px'}}>
+                    <button onClick={this.handleImport}>Import Backdrop</button>
+                </div>
+            );
+        }
         return (
             <ModalComponent
                 visible={this.props.visible}
@@ -34,6 +46,7 @@ class LibraryComponent extends React.Component {
                     justifyContent="space-around"
                     wrap="wrap"
                 >
+                    {importButton}
                     {this.props.data.map((dataItem, itemId) => {
                         const scratchURL = dataItem.md5 ?
                             `https://cdn.assets.scratch.mit.edu/internalapi/asset/${dataItem.md5}/get/` :
@@ -65,8 +78,10 @@ LibraryComponent.propTypes = {
         })
         /* eslint-enable react/no-unused-prop-types, lines-around-comment */
     ),
+    import: React.PropTypes.func,
     onItemSelected: React.PropTypes.func,
     onRequestClose: React.PropTypes.func,
+    showImport: React.PropTypes.bool,
     title: React.PropTypes.string,
     visible: React.PropTypes.bool
 };

--- a/src/containers/backdrop-library.jsx
+++ b/src/containers/backdrop-library.jsx
@@ -10,8 +10,11 @@ class BackdropLibrary extends React.Component {
     constructor (props) {
         super(props);
         bindAll(this, [
-            'handleItemSelect'
+            'handleItemSelect',
+            'selectBackdropToImport',
+            'importBackdrop'
         ]);
+        this.props.vm.filepicker = null;
     }
     handleItemSelect (item) {
         const vmBackdrop = {
@@ -25,10 +28,65 @@ class BackdropLibrary extends React.Component {
         }
         this.props.vm.addBackdrop(vmBackdrop);
     }
+    
+    selectBackdropToImport () {
+        const vm = this.props.vm;
+        const backdrop = this;
+        const inp = document.createElement('input');
+        const imageSelectedCallback = function () {
+            document.body.removeChild(inp);
+            vm.filePicker = null;
+            for (let i = 0; i < inp.files.length; i++){
+                backdrop.importBackdrop(inp.files[i], vm);
+            }
+        };
+        if (vm.filePicker) {
+            document.body.removeChild(vm.filePicker);
+            vm.filePicker = null;
+        }
+        inp.type = 'file';
+        inp.style.color = 'transparent';
+        inp.style.backgroundColor = 'transparent';
+        inp.style.border = 'none';
+        inp.style.outline = 'none';
+        inp.style.position = 'absolute';
+        inp.style.top = '0px';
+        inp.style.left = '0px';
+        inp.style.width = '0px';
+        inp.style.height = '0px';
+        inp.style.display = 'none';
+        inp.addEventListener('change', imageSelectedCallback, false);
+        
+        document.body.appendChild(inp);
+        vm.filePicker = inp;
+        inp.click();
+    }
+
+    importBackdrop (aFile, vm) {
+        const frd = new FileReader();
+        const pic = new Image();
+        pic.onload = function () {
+            const vmBackdrop = {
+                skin: pic.src,
+                name: aFile.name,
+                rotationCenterX: pic.width / 2,
+                rotationCenterY: pic.height / 2,
+                bitmapResolution: 1
+            };
+            vm.addBackdrop(vmBackdrop);
+        };
+        frd.onloadend = function (e) {
+            pic.src = e.target.result;
+        };
+        frd.readAsDataURL(aFile);
+    }
+    
     render () {
         return (
             <LibaryComponent
                 data={backdropLibraryContent}
+                import={this.selectBackdropToImport}
+                showImport={this.props.visible}
                 title="Backdrop Library"
                 visible={this.props.visible}
                 onItemSelected={this.handleItemSelect}


### PR DESCRIPTION
### Resolves

Resolves #37 

### Proposed Changes

Add an import button to the library, rendered on _showimport_, calls back to function _handleImport_.
_handleImport_ closes backdrop and then returns callback _import_.
Add _importBackdrop_ to backdrop-library, takes a file and loads it as a new backdrop
Add _selectBackdropToImport_ to backdrop library, creates a file picker dialog which on close calls _importBackdrop_

### Test Coverage

None added.