### PR TITLE
Build in production mode for gh-pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ env:
   - BASE_PATH=/scratch-gui/
   - NODE_ENV=production
 install:
-- npm install
-- npm update
+- npm --production=false install
+- npm --production=false update
 after_script:
 - |
   # RELEASE_BRANCHES and NPM_TOKEN defined in Travis settings panel

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ cache:
 env:
   global:
   - BASE_PATH=/scratch-gui/
+  - NODE_ENV=production
 install:
 - npm install
 - npm update

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -64,6 +64,7 @@ module.exports = {
     },
     plugins: [
         new webpack.DefinePlugin({
+            'process.env.NODE_ENV': '"' + process.env.NODE_ENV + '"',
             'process.env.BASE_PATH': '"' + (process.env.BASE_PATH || '/') + '"',
             'process.env.DEBUG': Boolean(process.env.DEBUG)
         }),


### PR DESCRIPTION
This improves React performance by skipping prop type checks and warnings.

PR #62 was hanging in Travis due to a problem with an upstream dependency.