### PR TITLE
Monkeypatch dynamic sound menu into ScratchBlocks

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -1,7 +1,7 @@
 const bindAll = require('lodash.bindall');
 const defaultsDeep = require('lodash.defaultsdeep');
 const React = require('react');
-const ScratchBlocks = require('scratch-blocks');
+const VMScratchBlocks = require('../lib/blocks');
 const VM = require('scratch-vm');
 
 const BlocksComponent = require('../components/blocks/blocks.jsx');
@@ -9,6 +9,7 @@ const BlocksComponent = require('../components/blocks/blocks.jsx');
 class Blocks extends React.Component {
     constructor (props) {
         super(props);
+        this.ScratchBlocks = VMScratchBlocks(props.vm);
         bindAll(this, [
             'attachVM',
             'detachVM',
@@ -23,7 +24,7 @@ class Blocks extends React.Component {
     }
     componentDidMount () {
         const workspaceConfig = defaultsDeep({}, Blocks.defaultOptions, this.props.options);
-        this.workspace = ScratchBlocks.inject(this.blocks, workspaceConfig);
+        this.workspace = this.ScratchBlocks.inject(this.blocks, workspaceConfig);
         this.attachVM();
     }
     componentWillUnmount () {
@@ -67,11 +68,11 @@ class Blocks extends React.Component {
         this.workspace.reportValue(data.id, data.value);
     }
     onWorkspaceUpdate (data) {
-        ScratchBlocks.Events.disable();
+        this.ScratchBlocks.Events.disable();
         this.workspace.clear();
-        const dom = ScratchBlocks.Xml.textToDom(data.xml);
-        ScratchBlocks.Xml.domToWorkspace(dom, this.workspace);
-        ScratchBlocks.Events.enable();
+        const dom = this.ScratchBlocks.Xml.textToDom(data.xml);
+        this.ScratchBlocks.Xml.domToWorkspace(dom, this.workspace);
+        this.ScratchBlocks.Events.enable();
     }
     setBlocks (blocks) {
         this.blocks = blocks;

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -1,0 +1,28 @@
+const ScratchBlocks = require('scratch-blocks');
+
+module.exports = function (vm) {
+    ScratchBlocks.Blocks.sound_sounds_menu.init = function () {
+        this.jsonInit(
+            {
+                message0: '%1',
+                args0: [
+                    {
+                        type: 'field_dropdown',
+                        name: 'SOUND_MENU',
+                        options: function () {
+                            const menu = vm.editingTarget.sprite.sounds.map(sound => [sound.name, sound.name]);
+                            menu.unshift(['select...', '0']);
+                            return menu;
+                        }
+                    }
+                ],
+                inputsInline: true,
+                output: 'String',
+                colour: ScratchBlocks.Colours.sounds.secondary,
+                colourSecondary: ScratchBlocks.Colours.sounds.secondary,
+                colourTertiary: ScratchBlocks.Colours.sounds.tertiary,
+                outputShape: ScratchBlocks.OUTPUT_SHAPE_ROUND
+            });
+    };
+    return ScratchBlocks;
+};


### PR DESCRIPTION
/ht @rschamp

### Resolves

Addresses https://github.com/LLK/scratch-audio/issues/25

### Proposed Changes

Update the Blocks component to receive a patched version of ScratchBlocks. The patched version receives a reference to the VM from the Blocks component. 

### Reason for Changes

We use the reference to the VM to create a dynamic Blockly menu containing the names of the sounds of the editing target.