### PR TITLE
PygmyMarmosetPatch for sound menu updates on workspace update

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -73,6 +73,7 @@ class Blocks extends React.Component {
         const dom = this.ScratchBlocks.Xml.textToDom(data.xml);
         this.ScratchBlocks.Xml.domToWorkspace(dom, this.workspace);
         this.ScratchBlocks.Events.enable();
+        this.workspace.toolbox_.refreshSelection();
     }
     setBlocks (blocks) {
         this.blocks = blocks;

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -11,7 +11,6 @@ module.exports = function (vm) {
                         name: 'SOUND_MENU',
                         options: function () {
                             const menu = vm.editingTarget.sprite.sounds.map(sound => [sound.name, sound.name]);
-                            menu.unshift(['select...', '0']);
                             return menu;
                         }
                     }


### PR DESCRIPTION
### Resolves

Addresses LLK/scratch-audio#25

### Proposed Changes

The toolbox refreshes itself on workspace update.

### Reason for Changes

The contents of the sound menu now change to reflect the sounds in the target you switch to.

In the earlier, larger monkeypatch, we included a dummy menu item that appears first ('select...'), to cover up the fact that the menu was not updating when you switch targets. This is no longer necessary. 

### Fun Facts

"The pygmy marmoset is a small New World monkey native to rainforests of the western Amazon Basin in South America. It is notable for being the smallest monkey and one of the smallest primates in the world at just over 100 grams." [wikipedia](https://en.wikipedia.org/wiki/Pygmy_marmoset)
