### PR TITLE
Add sprites to drop-down menus

### DIFF
--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -39,7 +39,7 @@ module.exports = function (vm) {
         var k = 0;
         for (i = 0; i < vm.runtime.targets.length; i++) {
             if (vm.runtime.targets[i].isOriginal == true) {
-                if (vm.runtime.targets[i].isStae == false) {
+                if (vm.runtime.targets[i].isStage == false) {
                     sprites[k] = [];
                     sprites[k][0] = vm.runtime.targets[k].sprite.name;
                     sprites[k][1] = vm.runtime.targets[k].sprite.name;
@@ -71,8 +71,8 @@ module.exports = function (vm) {
         this.jsonInit(json);
     };
     
-    ScratchBlocks.Blocks.motion_pointtowards_menu = function () {
-        const json = jsonForMenuBlock('TOWARDS', spriteMenu, motionColors, []);
+    ScratchBlocks.Blocks.motion_pointtowards_menu.init = function () {
+        const json = jsonForMenuBlock('TOWARDS', spriteMenu, motionColors, [['mouse-pointer', '_mouse_']]);
         this.jsonInit(json);
     };
 

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -34,19 +34,15 @@ module.exports = function (vm) {
     };
     
     const spriteMenu = function () {
-        var i = 0;
         var sprites = [];
-        var k = 0;
-        for (i = 0; i < vm.runtime.targets.length; i++) {
-            if (vm.runtime.targets[i].isOriginal === true) {
-                if (vm.runtime.targets[i].isStage === false) {
-                    if (vm.runtime.targets[i].sprite.name === vm.editingTarget.sprite.name) {
+        for (var targetId in vm.runtime.targets) {
+            if (!vm.runtime.targets.hasOwnProperty(targetId)) continue;
+            if (vm.runtime.targets[targetId].isOriginal) {
+                if (!vm.runtime.targets[targetId].isStage) {
+                    if (vm.runtime.targets[targetId].sprite.id === vm.editingTarget.sprite.id) {
                         continue;
                     }
-                    sprites[k] = [];
-                    sprites[k][0] = vm.runtime.targets[i].sprite.name;
-                    sprites[k][1] = vm.runtime.targets[i].sprite.name;
-                    k++;
+                    sprites.push([vm.runtime.targets[targetId].sprite.name, vm.runtime.targets[targetId].sprite.name]);
                 }
             }
         }

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -72,7 +72,17 @@ module.exports = function (vm) {
     };
     
     ScratchBlocks.Blocks.motion_pointtowards_menu.init = function () {
-        const json = jsonForMenuBlock('TOWARDS', spriteMenu, motionColors, [['mouse-pointer', '_mouse_']]);
+        const json = jsonForMenuBlock('TOWARDS', spriteMenu, motionColors, [
+            ['mouse-pointer', '_mouse_']
+        ]);
+        this.jsonInit(json);
+    };
+    
+    ScratchBlocks.Blocks.motion_goto_menu.init = function () {
+        const json = jsonForMenuBlock('TO', spriteMenu, motionColors, [
+            ['mouse-pointer', '_mouse_'],
+            ['random position', '_random_']
+        ]);
         this.jsonInit(json);
     };
 

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -2,14 +2,14 @@ const ScratchBlocks = require('scratch-blocks');
 
 module.exports = function (vm) {
 
-    const jsonForMenuBlock = function (name, menuOptionsFn, colors) {
+    const jsonForMenuBlock = function (name, menuOptionsFn, colors, static) {
         return {
             message0: '%1',
             args0: [
                 {
                     type: 'field_dropdown',
                     name: name,
-                    options: menuOptionsFn
+                    options: staic.concat(menuOptionsFn)
                 }
             ],
             inputsInline: true,
@@ -32,23 +32,47 @@ module.exports = function (vm) {
     const backdropsMenu = function () {
         return vm.runtime.targets[0].sprite.costumes.map(costume => [costume.name, costume.name]);
     };
+    
+    const spriteMenu = function () {
+        var i = 0;
+        var sprites = [];
+        var k = 0;
+        for (i = 0; i < vm.runtime.targets.length) {
+            if (vm.runtime.targets[i].isOriginal == true) {
+                if (vm.runtime.targets[i].isStae == false) {
+                    var sprites[k] = [];
+                    sprites[k][0] = vm.runtime.targets[k].sprite.name;
+                    sprites[k][1] = vm.runtime.targets[k].sprite.name;
+                    k++;
+                }
+            }
+        }
+        return sprites;
+    }
 
     const soundColors = ScratchBlocks.Colours.sounds;
 
     const looksColors = ScratchBlocks.Colours.looks;
+    
+    const motionColors = ScratchBlocks.Colours.motion;
 
     ScratchBlocks.Blocks.sound_sounds_menu.init = function () {
-        const json = jsonForMenuBlock('SOUND_MENU', soundsMenu, soundColors);
+        const json = jsonForMenuBlock('SOUND_MENU', soundsMenu, soundColors, []);
         this.jsonInit(json);
     };
 
     ScratchBlocks.Blocks.looks_costume.init = function () {
-        const json = jsonForMenuBlock('COSTUME', costumesMenu, looksColors);
+        const json = jsonForMenuBlock('COSTUME', costumesMenu, looksColors, []);
         this.jsonInit(json);
     };
 
     ScratchBlocks.Blocks.looks_backdrops.init = function () {
-        const json = jsonForMenuBlock('BACKDROP', backdropsMenu, looksColors);
+        const json = jsonForMenuBlock('BACKDROP', backdropsMenu, looksColors, []);
+        this.jsonInit(json);
+    };
+    
+    ScratchBlocks.Blocks.motion_pointtowards_menu = function () {
+        const json = jsonForMenuBlock('TOWARDS', spriteMenu, motionColors, []);
         this.jsonInit(json);
     };
 

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -9,7 +9,7 @@ module.exports = function (vm) {
                 {
                     type: 'field_dropdown',
                     name: name,
-                    options: start.concat(menuOptionsFn)
+                    options: start.concat(menuOptionsFn())
                 }
             ],
             inputsInline: true,

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -41,8 +41,8 @@ module.exports = function (vm) {
             if (vm.runtime.targets[i].isOriginal == true) {
                 if (vm.runtime.targets[i].isStage == false) {
                     sprites[k] = [];
-                    sprites[k][0] = vm.runtime.targets[k].sprite.name;
-                    sprites[k][1] = vm.runtime.targets[k].sprite.name;
+                    sprites[k][0] = vm.runtime.targets[i].sprite.name;
+                    sprites[k][1] = vm.runtime.targets[i].sprite.name;
                     k++;
                 }
             }

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -40,6 +40,9 @@ module.exports = function (vm) {
         for (i = 0; i < vm.runtime.targets.length; i++) {
             if (vm.runtime.targets[i].isOriginal == true) {
                 if (vm.runtime.targets[i].isStage == false) {
+                    if (vm.runtime.targets[i].sprite.name == vm.editingTarget.sprite.name) {
+                        continue;
+                    }
                     sprites[k] = [];
                     sprites[k][0] = vm.runtime.targets[i].sprite.name;
                     sprites[k][1] = vm.runtime.targets[i].sprite.name;

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -57,6 +57,8 @@ module.exports = function (vm) {
     const motionColors = ScratchBlocks.Colours.motion;
     
     const sensingColors = ScratchBlocks.Colours.sensing;
+    
+    const controlColors = ScratchBlocks.Colours.control;
 
     ScratchBlocks.Blocks.sound_sounds_menu.init = function () {
         const json = jsonForMenuBlock('SOUND_MENU', soundsMenu, soundColors, []);
@@ -113,6 +115,13 @@ module.exports = function (vm) {
         const json = jsonForMenuBlock('TOUCHINGOBJECTMENU', spriteMenu, sensingColors, [
             ['mouse-pointer', '_mouse_'],
             ['edge', '_edge_']
+        ]);
+        this.jsonInit(json);
+    };
+    
+    ScratchBlocks.Blocks.control_create_clone_of_menu.init = function () {
+        const json = jsonForMenuBlock('CLONE_OPTION', spriteMenu, controlColors, [
+            ['myself', '_myself_']
         ]);
         this.jsonInit(json);
     };

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -2,14 +2,14 @@ const ScratchBlocks = require('scratch-blocks');
 
 module.exports = function (vm) {
 
-    const jsonForMenuBlock = function (name, menuOptionsFn, colors, static) {
+    const jsonForMenuBlock = function (name, menuOptionsFn, colors, start) {
         return {
             message0: '%1',
             args0: [
                 {
                     type: 'field_dropdown',
                     name: name,
-                    options: staic.concat(menuOptionsFn)
+                    options: start.concat(menuOptionsFn)
                 }
             ],
             inputsInline: true,
@@ -37,10 +37,10 @@ module.exports = function (vm) {
         var i = 0;
         var sprites = [];
         var k = 0;
-        for (i = 0; i < vm.runtime.targets.length) {
+        for (i = 0; i < vm.runtime.targets.length; i++) {
             if (vm.runtime.targets[i].isOriginal == true) {
                 if (vm.runtime.targets[i].isStae == false) {
-                    var sprites[k] = [];
+                    sprites[k] = [];
                     sprites[k][0] = vm.runtime.targets[k].sprite.name;
                     sprites[k][1] = vm.runtime.targets[k].sprite.name;
                     k++;

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -55,6 +55,8 @@ module.exports = function (vm) {
     const looksColors = ScratchBlocks.Colours.looks;
     
     const motionColors = ScratchBlocks.Colours.motion;
+    
+    const sensingColors = ScratchBlocks.Colours.sensing;
 
     ScratchBlocks.Blocks.sound_sounds_menu.init = function () {
         const json = jsonForMenuBlock('SOUND_MENU', soundsMenu, soundColors, []);
@@ -82,6 +84,20 @@ module.exports = function (vm) {
         const json = jsonForMenuBlock('TO', spriteMenu, motionColors, [
             ['mouse-pointer', '_mouse_'],
             ['random position', '_random_']
+        ]);
+        this.jsonInit(json);
+    };
+    
+    ScratchBlocks.Blocks.sensing_of_object_menu.init = function () {
+        const json = jsonForMenuBlock('OBJECT', spriteMenu, sensingColors, [
+            ['Stage', '_stage_']
+        ]);
+        this.jsonInit(json);
+    };
+    
+    ScratchBlocks.Blocks.sensing_videoonmenutwo.init = function () {
+        const json = jsonForMenuBlock('VIDEOONMENU2', spriteMenu, sensingColors, [
+            ['stage', 'STAGE']
         ]);
         this.jsonInit(json);
     };

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -38,9 +38,9 @@ module.exports = function (vm) {
         var sprites = [];
         var k = 0;
         for (i = 0; i < vm.runtime.targets.length; i++) {
-            if (vm.runtime.targets[i].isOriginal == true) {
-                if (vm.runtime.targets[i].isStage == false) {
-                    if (vm.runtime.targets[i].sprite.name == vm.editingTarget.sprite.name) {
+            if (vm.runtime.targets[i].isOriginal === true) {
+                if (vm.runtime.targets[i].isStage === false) {
+                    if (vm.runtime.targets[i].sprite.name === vm.editingTarget.sprite.name) {
                         continue;
                     }
                     sprites[k] = [];
@@ -51,7 +51,7 @@ module.exports = function (vm) {
             }
         }
         return sprites;
-    }
+    };
 
     const soundColors = ScratchBlocks.Colours.sounds;
 

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -101,6 +101,21 @@ module.exports = function (vm) {
         ]);
         this.jsonInit(json);
     };
+    
+    ScratchBlocks.Blocks.sensing_distancetomenu.init = function () {
+        const json = jsonForMenuBlock('DISTANCETOMENU', spriteMenu, sensingColors, [
+            ['mouse-pointer', '_mouse_']
+        ]);
+        this.jsonInit(json);
+    };
+    
+    ScratchBlocks.Blocks.sensing_touchingobjectmenu.init = function () {
+        const json = jsonForMenuBlock('TOUCHINGOBJECTMENU', spriteMenu, sensingColors, [
+            ['mouse-pointer', '_mouse_'],
+            ['edge', '_edge_']
+        ]);
+        this.jsonInit(json);
+    };
 
     return ScratchBlocks;
 };


### PR DESCRIPTION
### Resolves

_Part of LLK/scratch-blocks#749_

### Proposed Changes

_Adds sprites to drop-down menus in the same way #80 did_

### Reason for Changes

_So you can actually select sprites in drop-down menus to interact with them._