### PR TITLE
Check for empty sound array

### DIFF
--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -22,7 +22,11 @@ module.exports = function (vm) {
     };
 
     const soundsMenu = function () {
-        return vm.editingTarget.sprite.sounds.map(sound => [sound.name, sound.name]);
+        const sounds = vm.editingTarget.sprite.sounds;
+        if (sounds.length === 0) {
+            return [['', '']];
+        }
+        return sounds.map(sound => [sound.name, sound.name]);
     };
 
     const costumesMenu = function () {


### PR DESCRIPTION
### Resolves

Addresses https://github.com/LLK/scratch-gui/issues/101

### Proposed Changes

If the sound array is empty, populate the sounds menu with a single entry containing an empty string. 

### Reason for Changes

Currently, if you load a sprite with no sounds, there's an error and the sound blocks disappear.