### PR TITLE
Filter toolbox to blocks available to the VM

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -25,6 +25,8 @@ class Blocks extends React.Component {
     componentDidMount () {
         const workspaceConfig = defaultsDeep({}, Blocks.defaultOptions, this.props.options);
         this.workspace = this.ScratchBlocks.inject(this.blocks, workspaceConfig);
+        const filteredToolbox = this.props.vm.filterToolbox(this.workspace.options.languageTree);
+        this.workspace.updateToolbox(filteredToolbox);
         this.attachVM();
     }
     componentWillUnmount () {


### PR DESCRIPTION
Resolves #16

Utilize the `filterToolbox` method now available from https://github.com/LLK/scratch-vm/pull/461