### PR TITLE
Remove errant conditional logic for backdrop / costume modal

### DIFF
--- a/src/components/target-pane/target-pane.jsx
+++ b/src/components/target-pane/target-pane.jsx
@@ -38,7 +38,6 @@ class TargetPane extends React.Component {
             costumeLibraryVisible,
             spriteLibraryVisible,
             onNewSpriteClick,
-            onNewCostumeClick,
             onNewBackdropClick,
             onRequestCloseBackdropLibrary,
             onRequestCloseCostumeLibrary,

--- a/src/components/target-pane/target-pane.jsx
+++ b/src/components/target-pane/target-pane.jsx
@@ -80,27 +80,16 @@ class TargetPane extends React.Component {
                             />
                         </button>
 
-                        {editingTarget === stage.id ? (
-                            <button
-                                className={classNames(styles.addButtonWrapper, styles.addButtonWrapperStage)}
-                                onClick={onNewBackdropClick}
-                            >
-                                <img
-                                    className={styles.addButton}
-                                    src={addIcon}
-                                />
-                            </button>
-                        ) : (
-                            <button
-                                className={classNames(styles.addButtonWrapper, styles.addButtonWrapperCostume)}
-                                onClick={onNewCostumeClick}
-                            >
-                                <img
-                                    className={styles.addButton}
-                                    src={addIcon}
-                                />
-                            </button>
-                        )}
+                        <button
+                            className={classNames(styles.addButtonWrapper, styles.addButtonWrapperStage)}
+                            onClick={onNewBackdropClick}
+                        >
+                            <img
+                                className={styles.addButton}
+                                src={addIcon}
+                            />
+                        </button>
+
                         <SpriteLibrary
                             visible={spriteLibraryVisible}
                             vm={vm}


### PR DESCRIPTION
### Resolves

Resolves GH-100

### Proposed Changes

Remove errant conditional logic for backdrop / costume modal

### Reason for Changes

Backdrop "+" button should always cause the backdrop library modal to be displayed and should not depend on the user's sprite / backdrop selection state.
