### PR TITLE
StageArea: fixed space near edge, on projects with less than 1 row of sprites

### DIFF
--- a/src/components/sprite-selector/sprite-selector.css
+++ b/src/components/sprite-selector/sprite-selector.css
@@ -1,6 +1,7 @@
 @import "../../css/units.css";
 
 .sprite-selector {
+    flex-grow: 1;
     position: relative; 
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
     margin-right: calc($space / 2);


### PR DESCRIPTION
#### Issue

The right edge of the Stage Selector isn't vertically aligned with the right edge of the Stage above it.

![screen shot 2017-03-01 at 4 37 28 pm](https://cloud.githubusercontent.com/assets/716168/23482645/cff6ea2e-fe9d-11e6-8843-e0a5b6e8f3c6.png)

#### Cause

In  #134, we made StageSelector a fixed width for now, to 72px, to match design spec. 
Forgot to update`flex-grow` on the StageSelector to explicitly have it take up the available width.

I was testing projects during dev with ~15 sprites, thinking it wouldn't render differently with less sprites. Note to self: check projects with various numbers of sprites when submitting a PR involving layout updates.

