### PR TITLE
Wire sprite info panel to VM

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "react-redux": "5.0.2",
     "react-style-proptype": "2.0.1",
     "redux": "3.6.0",
+    "redux-throttle": "0.1.1",
     "scratch-audio": "latest",
     "scratch-blocks": "latest",
     "scratch-render": "latest",

--- a/src/components/sprite-info/sprite-info.css
+++ b/src/components/sprite-info/sprite-info.css
@@ -36,29 +36,27 @@
 }
 
 /* TODO: refactor from descendant selector, to a regular class */
-.group img { 
+.group img {
     display: inline-block;
-    width: 1rem; 
+    width: 1rem;
     height: 1rem;
     margin: 0 0.1rem;
 }
 
+.icon {
+    opacity: 0.4;
+}
+
+.icon.is-active {
+    opacity: 1;
+}
+
 .draggable-icon {
-    width: 0.55rem !important;
-    opacity: 1 !important;
+    width: 0.55rem;
 }
 
 .not-draggable-icon {
-    width: 0.75rem !important;
-    opacity: 0.4 !important;
-}
-
-.show-icon {
-    opacity: 1 !important;
-}
-
-.hide-icon {
-    opacity: 0.4 !important;
+    width: 0.75rem;
 }
 
 .input-label {
@@ -87,19 +85,19 @@
     font-size: 0.625rem;
     font-weight: bold;
     border-width: 1px;
-    border-style: solid; 
-    border-color: #e9eef2; 
-    border-radius: 2rem; 
+    border-style: solid;
+    border-color: #e9eef2;
+    border-radius: 2rem;
     cursor: text;
-    transition: 0.25s ease-out; /* TODO: standardize with var */ 
+    transition: 0.25s ease-out; /* TODO: standardize with var */
     box-shadow: none;
 
-    /* 
+    /*
         For truncating overflowing text gracefully
         Min-width is for a bug: https://css-tricks.com/flexbox-truncated-text
         TODO: move this out into a mixin or a helper component
     */
-    overflow: hidden;  
+    overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
     min-width: 0;
@@ -122,5 +120,5 @@
     border: 1px solid #e9eef2;
     border-radius: 0.25rem;
     cursor: pointer;
-    transition: 0.25s ease-out; /* TODO: standardize with var */ 
+    transition: 0.25s ease-out; /* TODO: standardize with var */
 }

--- a/src/components/sprite-info/sprite-info.css
+++ b/src/components/sprite-info/sprite-info.css
@@ -122,3 +122,7 @@
     cursor: pointer;
     transition: 0.25s ease-out; /* TODO: standardize with var */
 }
+
+.radio-box.is-disabled {
+    cursor: default;
+}

--- a/src/components/sprite-info/sprite-info.jsx
+++ b/src/components/sprite-info/sprite-info.jsx
@@ -74,7 +74,7 @@ const SpriteInfo = props => (
                             }
                         )}
                         src={showIcon}
-                        onClick={props.onChangeVisibility}
+                        onClick={props.onClickVisible}
                     />
                     <img
                         className={classNames(
@@ -85,6 +85,7 @@ const SpriteInfo = props => (
                             }
                         )}
                         src={hideIcon}
+                        onClick={props.onClickNotVisible}
                     />
                 </div>
             </div>
@@ -103,7 +104,7 @@ const SpriteInfo = props => (
                             }
                         )}
                         src={draggableIcon}
-                        onClick={props.onChangeDraggability}
+                        onClick={props.onClickDraggable}
                     />
                     <img
                         className={classNames(
@@ -114,7 +115,7 @@ const SpriteInfo = props => (
                             }
                         )}
                         src={notDraggableIcon}
-                        onClick={props.onChangeDraggability}
+                        onClick={props.onClickNotDraggable}
                     />
                 </div>
             </div>
@@ -138,11 +139,13 @@ const SpriteInfo = props => (
 SpriteInfo.propTypes = {
     draggable: React.PropTypes.bool,
     name: React.PropTypes.string,
-    onChangeDraggability: React.PropTypes.func,
     onChangeName: React.PropTypes.func,
-    onChangeVisibility: React.PropTypes.func,
     onChangeX: React.PropTypes.func,
     onChangeY: React.PropTypes.func,
+    onClickDraggable: React.PropTypes.func,
+    onClickNotDraggable: React.PropTypes.func,
+    onClickNotVisible: React.PropTypes.func,
+    onClickVisible: React.PropTypes.func,
     visible: React.PropTypes.bool,
     x: React.PropTypes.number,
     y: React.PropTypes.number

--- a/src/components/sprite-info/sprite-info.jsx
+++ b/src/components/sprite-info/sprite-info.jsx
@@ -37,6 +37,8 @@ const SpriteInfo = props => (
                     className={classNames(styles.inputForm, styles.inputFormX)}
                     placeholder="x"
                     type="text"
+                    value={typeof props.x === 'undefined' ? '' : props.x}
+                    onChange={props.onChangeX}
                 />
             </div>
 
@@ -50,6 +52,8 @@ const SpriteInfo = props => (
                     className={classNames(styles.inputForm, styles.inputFormY)}
                     placeholder="y"
                     type="text"
+                    value={typeof props.y === 'undefined' ? '' : props.y}
+                    onChange={props.onChangeY}
                 />
             </div>
         </div>
@@ -106,7 +110,11 @@ const SpriteInfo = props => (
 
 SpriteInfo.propTypes = {
     name: React.PropTypes.string,
-    onChangeName: React.PropTypes.func
+    onChangeName: React.PropTypes.func,
+    onChangeX: React.PropTypes.func,
+    onChangeY: React.PropTypes.func,
+    x: React.PropTypes.number,
+    y: React.PropTypes.number
 };
 
 SpriteInfo.defaultProps = {

--- a/src/components/sprite-info/sprite-info.jsx
+++ b/src/components/sprite-info/sprite-info.jsx
@@ -13,149 +13,161 @@ const notDraggableIcon = require('./icon--not-draggable.svg');
 
 const ROTATION_STYLES = ['left-right', 'don\'t rotate', 'all around'];
 
-const SpriteInfo = props => {
-    const nameDisabled = typeof props.name === 'undefined';
-    const xDisabled = typeof props.x === 'undefined';
-    const yDisabled = typeof props.y === 'undefined';
-    const visibleDisabled = typeof props.visible === 'undefined';
-    const draggableDisabled = typeof props.draggable === 'undefined';
-    const rotationStyleDisabled = typeof props.rotationStyle === 'undefined';
-    return (
-        <Box
-            className={styles.spriteInfo}
-        >
-            <div className={styles.row}>
-                <div className={styles.group}>
-                    <span className={styles.inputLabel}>Sprite</span>
-                    <input
-                        className={classNames(styles.inputForm, styles.inputFormSpriteName)}
-                        disabled={nameDisabled}
-                        placeholder="Name"
-                        type="text"
-                        value={nameDisabled ? '' : props.name}
-                        onChange={props.onChangeName}
-                    />
-                </div>
-
-                <div className={styles.group}>
-                    <img
-                        className={classNames(styles.xIcon, styles.icon)}
-                        src={xIcon}
-                    />
-                    <span className={styles.inputLabel}>x</span>
-                    <input
-                        className={classNames(styles.inputForm, styles.inputFormX)}
-                        disabled={xDisabled}
-                        placeholder="x"
-                        type="text"
-                        value={xDisabled ? '' : props.x}
-                        onChange={props.onChangeX}
-                    />
-                </div>
-
-                <div className={styles.group}>
-                    <img
-                        className={classNames(styles.yIcon, styles.icon)}
-                        src={yIcon}
-                    />
-                    <span className={styles.inputLabel}>y</span>
-                    <input
-                        className={classNames(styles.inputForm, styles.inputFormY)}
-                        disabled={yDisabled}
-                        placeholder="y"
-                        type="text"
-                        value={yDisabled ? '' : props.y}
-                        onChange={props.onChangeY}
-                    />
-                </div>
-            </div>
-
-
-            <div className={styles.row}>
-                <div className={styles.group}>
-                    <span className={styles.inputLabelSmall}>
-                        Show
-                    </span>
-                    <div className={classNames(styles.radioBox, {[styles.isDisabled]: visibleDisabled})}>
-                        <img
-                            className={classNames(
-                                styles.icon,
-                                styles.showIcon,
-                                {
-                                    [styles.isActive]: props.visible && !visibleDisabled
-                                }
-                            )}
-                            src={showIcon}
-                            onClick={props.onClickVisible}
+class SpriteInfo extends React.Component {
+    shouldComponentUpdate (nextProps) {
+        return (
+            this.props.draggable !== nextProps.draggable ||
+            this.props.name !== nextProps.name ||
+            this.props.rotationStyle !== nextProps.rotationStyle ||
+            this.props.visible !== nextProps.visible ||
+            this.props.x !== nextProps.x ||
+            this.props.y !== nextProps.y
+        );
+    }
+    render () {
+        const nameDisabled = typeof this.props.name === 'undefined';
+        const xDisabled = typeof this.props.x === 'undefined';
+        const yDisabled = typeof this.props.y === 'undefined';
+        const visibleDisabled = typeof this.props.visible === 'undefined';
+        const draggableDisabled = typeof this.props.draggable === 'undefined';
+        const rotationStyleDisabled = typeof this.props.rotationStyle === 'undefined';
+        return (
+            <Box
+                className={styles.spriteInfo}
+            >
+                <div className={styles.row}>
+                    <div className={styles.group}>
+                        <span className={styles.inputLabel}>Sprite</span>
+                        <input
+                            className={classNames(styles.inputForm, styles.inputFormSpriteName)}
+                            disabled={nameDisabled}
+                            placeholder="Name"
+                            type="text"
+                            value={nameDisabled ? '' : this.props.name}
+                            onChange={this.props.onChangeName}
                         />
+                    </div>
+
+                    <div className={styles.group}>
                         <img
-                            className={classNames(
-                                styles.icon,
-                                styles.hideIcon,
-                                {
-                                    [styles.isActive]: !props.visible && !visibleDisabled
-                                }
-                            )}
-                            src={hideIcon}
-                            onClick={props.onClickNotVisible}
+                            className={classNames(styles.xIcon, styles.icon)}
+                            src={xIcon}
+                        />
+                        <span className={styles.inputLabel}>x</span>
+                        <input
+                            className={classNames(styles.inputForm, styles.inputFormX)}
+                            disabled={xDisabled}
+                            placeholder="x"
+                            type="text"
+                            value={xDisabled ? '' : this.props.x}
+                            onChange={this.props.onChangeX}
+                        />
+                    </div>
+
+                    <div className={styles.group}>
+                        <img
+                            className={classNames(styles.yIcon, styles.icon)}
+                            src={yIcon}
+                        />
+                        <span className={styles.inputLabel}>y</span>
+                        <input
+                            className={classNames(styles.inputForm, styles.inputFormY)}
+                            disabled={yDisabled}
+                            placeholder="y"
+                            type="text"
+                            value={yDisabled ? '' : this.props.y}
+                            onChange={this.props.onChangeY}
                         />
                     </div>
                 </div>
 
-                <div className={styles.group}>
-                    <span className={styles.inputLabelSmall}>
-                        Draggable
-                    </span>
-                    <div className={classNames(styles.radioBox, {[styles.isDisabled]: visibleDisabled})}>
-                        <img
-                            className={classNames(
-                                styles.icon,
-                                styles.draggableIcon,
-                                {
-                                    [styles.isActive]: props.draggable && !draggableDisabled
-                                }
-                            )}
-                            src={draggableIcon}
-                            onClick={props.onClickDraggable}
-                        />
-                        <img
-                            className={classNames(
-                                styles.icon,
-                                styles.notDraggableIcon,
-                                {
-                                    [styles.isActive]: !props.draggable && !draggableDisabled
-                                }
-                            )}
-                            src={notDraggableIcon}
-                            onClick={props.onClickNotDraggable}
-                        />
+
+                <div className={styles.row}>
+                    <div className={styles.group}>
+                        <span className={styles.inputLabelSmall}>
+                            Show
+                        </span>
+                        <div className={classNames(styles.radioBox, {[styles.isDisabled]: visibleDisabled})}>
+                            <img
+                                className={classNames(
+                                    styles.icon,
+                                    styles.showIcon,
+                                    {
+                                        [styles.isActive]: this.props.visible && !visibleDisabled
+                                    }
+                                )}
+                                src={showIcon}
+                                onClick={this.props.onClickVisible}
+                            />
+                            <img
+                                className={classNames(
+                                    styles.icon,
+                                    styles.hideIcon,
+                                    {
+                                        [styles.isActive]: !this.props.visible && !visibleDisabled
+                                    }
+                                )}
+                                src={hideIcon}
+                                onClick={this.props.onClickNotVisible}
+                            />
+                        </div>
+                    </div>
+
+                    <div className={styles.group}>
+                        <span className={styles.inputLabelSmall}>
+                            Draggable
+                        </span>
+                        <div className={classNames(styles.radioBox, {[styles.isDisabled]: visibleDisabled})}>
+                            <img
+                                className={classNames(
+                                    styles.icon,
+                                    styles.draggableIcon,
+                                    {
+                                        [styles.isActive]: this.props.draggable && !draggableDisabled
+                                    }
+                                )}
+                                src={draggableIcon}
+                                onClick={this.props.onClickDraggable}
+                            />
+                            <img
+                                className={classNames(
+                                    styles.icon,
+                                    styles.notDraggableIcon,
+                                    {
+                                        [styles.isActive]: !this.props.draggable && !draggableDisabled
+                                    }
+                                )}
+                                src={notDraggableIcon}
+                                onClick={this.props.onClickNotDraggable}
+                            />
+                        </div>
+                    </div>
+
+                    <div className={styles.group}>
+                        <span className={styles.inputLabelSmall}>
+                            Rotation
+                        </span>
+                        <select
+                            className={classNames(styles.selectForm, styles.inputFormRotationSelect)}
+                            disabled={rotationStyleDisabled}
+                            value={this.props.rotationStyle}
+                            onChange={this.props.onChangeRotationStyle}
+                        >
+                            {ROTATION_STYLES.map(style => (
+                                <option
+                                    key={style}
+                                    value={style}
+                                >
+                                    {style}
+                                </option>
+                            ))}
+                        </select>
                     </div>
                 </div>
-
-                <div className={styles.group}>
-                    <span className={styles.inputLabelSmall}>
-                        Rotation
-                    </span>
-                    <select
-                        className={classNames(styles.selectForm, styles.inputFormRotationSelect)}
-                        disabled={rotationStyleDisabled}
-                        value={props.rotationStyle}
-                        onChange={props.onChangeRotationStyle}
-                    >
-                        {ROTATION_STYLES.map(style => (
-                            <option
-                                key={style}
-                                value={style}
-                            >
-                                {style}
-                            </option>
-                        ))}
-                    </select>
-                </div>
-            </div>
-        </Box>
-    );
-};
+            </Box>
+        );
+    }
+}
 
 SpriteInfo.propTypes = {
     draggable: React.PropTypes.bool,

--- a/src/components/sprite-info/sprite-info.jsx
+++ b/src/components/sprite-info/sprite-info.jsx
@@ -11,6 +11,8 @@ const hideIcon = require('./icon--hide.svg');
 const draggableIcon = require('./icon--draggable.svg');
 const notDraggableIcon = require('./icon--not-draggable.svg');
 
+const ROTATION_STYLES = ['left-right', 'don\'t rotate', 'all around'];
+
 const SpriteInfo = props => (
     <Box
         className={styles.spriteInfo}
@@ -126,10 +128,17 @@ const SpriteInfo = props => (
                 </span>
                 <select
                     className={classNames(styles.selectForm, styles.inputFormRotationSelect)}
+                    value={props.rotationStyle}
+                    onChange={props.onChangeRotationStyle}
                 >
-                    <option value="left-right">left-right</option>
-                    <option value="clockwise">don&#39;t rotate</option>
-                    <option value="anchored">all around</option>
+                    {ROTATION_STYLES.map(style => (
+                        <option
+                            key={style}
+                            value={style}
+                        >
+                            {style}
+                        </option>
+                    ))}
                 </select>
             </div>
         </div>
@@ -140,12 +149,14 @@ SpriteInfo.propTypes = {
     draggable: React.PropTypes.bool,
     name: React.PropTypes.string,
     onChangeName: React.PropTypes.func,
+    onChangeRotationStyle: React.PropTypes.func,
     onChangeX: React.PropTypes.func,
     onChangeY: React.PropTypes.func,
     onClickDraggable: React.PropTypes.func,
     onClickNotDraggable: React.PropTypes.func,
     onClickNotVisible: React.PropTypes.func,
     onClickVisible: React.PropTypes.func,
+    rotationStyle: React.PropTypes.oneOf(ROTATION_STYLES),
     visible: React.PropTypes.bool,
     x: React.PropTypes.number,
     y: React.PropTypes.number

--- a/src/components/sprite-info/sprite-info.jsx
+++ b/src/components/sprite-info/sprite-info.jsx
@@ -66,11 +66,24 @@ const SpriteInfo = props => (
                 </span>
                 <div className={styles.radioBox}>
                     <img
-                        className={classNames(styles.showIcon, styles.icon)}
+                        className={classNames(
+                            styles.icon,
+                            styles.showIcon,
+                            {
+                                [styles.isActive]: props.visible
+                            }
+                        )}
                         src={showIcon}
+                        onClick={props.onChangeVisibility}
                     />
                     <img
-                        className={classNames(styles.hideIcon, styles.icon)}
+                        className={classNames(
+                            styles.icon,
+                            styles.hideIcon,
+                            {
+                                [styles.isActive]: !props.visible
+                            }
+                        )}
                         src={hideIcon}
                     />
                 </div>
@@ -82,12 +95,26 @@ const SpriteInfo = props => (
                 </span>
                 <div className={styles.radioBox}>
                     <img
-                        className={classNames(styles.draggableIcon, styles.icon)}
+                        className={classNames(
+                            styles.icon,
+                            styles.draggableIcon,
+                            {
+                                [styles.isActive]: props.draggable
+                            }
+                        )}
                         src={draggableIcon}
+                        onClick={props.onChangeDraggability}
                     />
                     <img
-                        className={classNames(styles.notDraggableIcon, styles.icon)}
+                        className={classNames(
+                            styles.icon,
+                            styles.notDraggableIcon,
+                            {
+                                [styles.isActive]: !props.draggable
+                            }
+                        )}
                         src={notDraggableIcon}
+                        onClick={props.onChangeDraggability}
                     />
                 </div>
             </div>
@@ -109,10 +136,14 @@ const SpriteInfo = props => (
 );
 
 SpriteInfo.propTypes = {
+    draggable: React.PropTypes.bool,
     name: React.PropTypes.string,
+    onChangeDraggability: React.PropTypes.func,
     onChangeName: React.PropTypes.func,
+    onChangeVisibility: React.PropTypes.func,
     onChangeX: React.PropTypes.func,
     onChangeY: React.PropTypes.func,
+    visible: React.PropTypes.bool,
     x: React.PropTypes.number,
     y: React.PropTypes.number
 };

--- a/src/components/sprite-info/sprite-info.jsx
+++ b/src/components/sprite-info/sprite-info.jsx
@@ -17,13 +17,13 @@ const SpriteInfo = props => (
     >
         <div className={styles.row}>
             <div className={styles.group}>
-                <span className={styles.inputLabel}>
-                    {props.name}
-                </span>
+                <span className={styles.inputLabel}>Sprite</span>
                 <input
                     className={classNames(styles.inputForm, styles.inputFormSpriteName)}
                     placeholder="Name"
                     type="text"
+                    value={props.name}
+                    onChange={props.onChangeName}
                 />
             </div>
 
@@ -39,7 +39,7 @@ const SpriteInfo = props => (
                     type="text"
                 />
             </div>
-            
+
             <div className={styles.group}>
                 <img
                     className={classNames(styles.yIcon, styles.icon)}
@@ -87,7 +87,7 @@ const SpriteInfo = props => (
                     />
                 </div>
             </div>
-            
+
             <div className={styles.group}>
                 <span className={styles.inputLabelSmall}>
                     Rotation
@@ -105,7 +105,12 @@ const SpriteInfo = props => (
 );
 
 SpriteInfo.propTypes = {
-    name: React.PropTypes.string
+    name: React.PropTypes.string,
+    onChangeName: React.PropTypes.func
+};
+
+SpriteInfo.defaultProps = {
+    name: ''
 };
 
 module.exports = SpriteInfo;

--- a/src/components/sprite-info/sprite-info.jsx
+++ b/src/components/sprite-info/sprite-info.jsx
@@ -16,6 +16,7 @@ const ROTATION_STYLES = ['left-right', 'don\'t rotate', 'all around'];
 class SpriteInfo extends React.Component {
     shouldComponentUpdate (nextProps) {
         return (
+            this.props.disabled !== nextProps.disabled ||
             this.props.draggable !== nextProps.draggable ||
             this.props.name !== nextProps.name ||
             this.props.rotationStyle !== nextProps.rotationStyle ||
@@ -25,12 +26,6 @@ class SpriteInfo extends React.Component {
         );
     }
     render () {
-        const nameDisabled = typeof this.props.name === 'undefined';
-        const xDisabled = typeof this.props.x === 'undefined';
-        const yDisabled = typeof this.props.y === 'undefined';
-        const visibleDisabled = typeof this.props.visible === 'undefined';
-        const draggableDisabled = typeof this.props.draggable === 'undefined';
-        const rotationStyleDisabled = typeof this.props.rotationStyle === 'undefined';
         return (
             <Box
                 className={styles.spriteInfo}
@@ -40,10 +35,10 @@ class SpriteInfo extends React.Component {
                         <span className={styles.inputLabel}>Sprite</span>
                         <input
                             className={classNames(styles.inputForm, styles.inputFormSpriteName)}
-                            disabled={nameDisabled}
+                            disabled={this.props.disabled}
                             placeholder="Name"
                             type="text"
-                            value={nameDisabled ? '' : this.props.name}
+                            value={this.props.disabled ? '' : this.props.name}
                             onChange={this.props.onChangeName}
                         />
                     </div>
@@ -56,10 +51,10 @@ class SpriteInfo extends React.Component {
                         <span className={styles.inputLabel}>x</span>
                         <input
                             className={classNames(styles.inputForm, styles.inputFormX)}
-                            disabled={xDisabled}
+                            disabled={this.props.disabled}
                             placeholder="x"
                             type="text"
-                            value={xDisabled ? '' : this.props.x}
+                            value={this.props.disabled ? '' : this.props.x}
                             onChange={this.props.onChangeX}
                         />
                     </div>
@@ -72,10 +67,10 @@ class SpriteInfo extends React.Component {
                         <span className={styles.inputLabel}>y</span>
                         <input
                             className={classNames(styles.inputForm, styles.inputFormY)}
-                            disabled={yDisabled}
+                            disabled={this.props.disabled}
                             placeholder="y"
                             type="text"
-                            value={yDisabled ? '' : this.props.y}
+                            value={this.props.disabled ? '' : this.props.y}
                             onChange={this.props.onChangeY}
                         />
                     </div>
@@ -87,13 +82,13 @@ class SpriteInfo extends React.Component {
                         <span className={styles.inputLabelSmall}>
                             Show
                         </span>
-                        <div className={classNames(styles.radioBox, {[styles.isDisabled]: visibleDisabled})}>
+                        <div className={classNames(styles.radioBox, {[styles.isDisabled]: this.props.disabled})}>
                             <img
                                 className={classNames(
                                     styles.icon,
                                     styles.showIcon,
                                     {
-                                        [styles.isActive]: this.props.visible && !visibleDisabled
+                                        [styles.isActive]: this.props.visible && !this.props.disabled
                                     }
                                 )}
                                 src={showIcon}
@@ -104,7 +99,7 @@ class SpriteInfo extends React.Component {
                                     styles.icon,
                                     styles.hideIcon,
                                     {
-                                        [styles.isActive]: !this.props.visible && !visibleDisabled
+                                        [styles.isActive]: !this.props.visible && !this.props.disabled
                                     }
                                 )}
                                 src={hideIcon}
@@ -117,13 +112,13 @@ class SpriteInfo extends React.Component {
                         <span className={styles.inputLabelSmall}>
                             Draggable
                         </span>
-                        <div className={classNames(styles.radioBox, {[styles.isDisabled]: visibleDisabled})}>
+                        <div className={classNames(styles.radioBox, {[styles.isDisabled]: this.props.disabled})}>
                             <img
                                 className={classNames(
                                     styles.icon,
                                     styles.draggableIcon,
                                     {
-                                        [styles.isActive]: this.props.draggable && !draggableDisabled
+                                        [styles.isActive]: this.props.draggable && !this.props.disabled
                                     }
                                 )}
                                 src={draggableIcon}
@@ -134,7 +129,7 @@ class SpriteInfo extends React.Component {
                                     styles.icon,
                                     styles.notDraggableIcon,
                                     {
-                                        [styles.isActive]: !this.props.draggable && !draggableDisabled
+                                        [styles.isActive]: !this.props.draggable && !this.props.disabled
                                     }
                                 )}
                                 src={notDraggableIcon}
@@ -149,7 +144,7 @@ class SpriteInfo extends React.Component {
                         </span>
                         <select
                             className={classNames(styles.selectForm, styles.inputFormRotationSelect)}
-                            disabled={rotationStyleDisabled}
+                            disabled={this.props.disabled}
                             value={this.props.rotationStyle}
                             onChange={this.props.onChangeRotationStyle}
                         >
@@ -170,6 +165,7 @@ class SpriteInfo extends React.Component {
 }
 
 SpriteInfo.propTypes = {
+    disabled: React.PropTypes.bool,
     draggable: React.PropTypes.bool,
     name: React.PropTypes.string,
     onChangeName: React.PropTypes.func,

--- a/src/components/sprite-info/sprite-info.jsx
+++ b/src/components/sprite-info/sprite-info.jsx
@@ -13,137 +13,149 @@ const notDraggableIcon = require('./icon--not-draggable.svg');
 
 const ROTATION_STYLES = ['left-right', 'don\'t rotate', 'all around'];
 
-const SpriteInfo = props => (
-    <Box
-        className={styles.spriteInfo}
-    >
-        <div className={styles.row}>
-            <div className={styles.group}>
-                <span className={styles.inputLabel}>Sprite</span>
-                <input
-                    className={classNames(styles.inputForm, styles.inputFormSpriteName)}
-                    placeholder="Name"
-                    type="text"
-                    value={props.name}
-                    onChange={props.onChangeName}
-                />
-            </div>
-
-            <div className={styles.group}>
-                <img
-                    className={classNames(styles.xIcon, styles.icon)}
-                    src={xIcon}
-                />
-                <span className={styles.inputLabel}>x</span>
-                <input
-                    className={classNames(styles.inputForm, styles.inputFormX)}
-                    placeholder="x"
-                    type="text"
-                    value={typeof props.x === 'undefined' ? '' : props.x}
-                    onChange={props.onChangeX}
-                />
-            </div>
-
-            <div className={styles.group}>
-                <img
-                    className={classNames(styles.yIcon, styles.icon)}
-                    src={yIcon}
-                />
-                <span className={styles.inputLabel}>y</span>
-                <input
-                    className={classNames(styles.inputForm, styles.inputFormY)}
-                    placeholder="y"
-                    type="text"
-                    value={typeof props.y === 'undefined' ? '' : props.y}
-                    onChange={props.onChangeY}
-                />
-            </div>
-        </div>
-
-
-        <div className={styles.row}>
-            <div className={styles.group}>
-                <span className={styles.inputLabelSmall}>
-                    Show
-                </span>
-                <div className={styles.radioBox}>
-                    <img
-                        className={classNames(
-                            styles.icon,
-                            styles.showIcon,
-                            {
-                                [styles.isActive]: props.visible
-                            }
-                        )}
-                        src={showIcon}
-                        onClick={props.onClickVisible}
+const SpriteInfo = props => {
+    const nameDisabled = typeof props.name === 'undefined';
+    const xDisabled = typeof props.x === 'undefined';
+    const yDisabled = typeof props.y === 'undefined';
+    const visibleDisabled = typeof props.visible === 'undefined';
+    const draggableDisabled = typeof props.draggable === 'undefined';
+    const rotationStyleDisabled = typeof props.rotationStyle === 'undefined';
+    return (
+        <Box
+            className={styles.spriteInfo}
+        >
+            <div className={styles.row}>
+                <div className={styles.group}>
+                    <span className={styles.inputLabel}>Sprite</span>
+                    <input
+                        className={classNames(styles.inputForm, styles.inputFormSpriteName)}
+                        disabled={nameDisabled}
+                        placeholder="Name"
+                        type="text"
+                        value={nameDisabled ? '' : props.name}
+                        onChange={props.onChangeName}
                     />
+                </div>
+
+                <div className={styles.group}>
                     <img
-                        className={classNames(
-                            styles.icon,
-                            styles.hideIcon,
-                            {
-                                [styles.isActive]: !props.visible
-                            }
-                        )}
-                        src={hideIcon}
-                        onClick={props.onClickNotVisible}
+                        className={classNames(styles.xIcon, styles.icon)}
+                        src={xIcon}
+                    />
+                    <span className={styles.inputLabel}>x</span>
+                    <input
+                        className={classNames(styles.inputForm, styles.inputFormX)}
+                        disabled={xDisabled}
+                        placeholder="x"
+                        type="text"
+                        value={xDisabled ? '' : props.x}
+                        onChange={props.onChangeX}
+                    />
+                </div>
+
+                <div className={styles.group}>
+                    <img
+                        className={classNames(styles.yIcon, styles.icon)}
+                        src={yIcon}
+                    />
+                    <span className={styles.inputLabel}>y</span>
+                    <input
+                        className={classNames(styles.inputForm, styles.inputFormY)}
+                        disabled={yDisabled}
+                        placeholder="y"
+                        type="text"
+                        value={yDisabled ? '' : props.y}
+                        onChange={props.onChangeY}
                     />
                 </div>
             </div>
 
-            <div className={styles.group}>
-                <span className={styles.inputLabelSmall}>
-                    Draggable
-                </span>
-                <div className={styles.radioBox}>
-                    <img
-                        className={classNames(
-                            styles.icon,
-                            styles.draggableIcon,
-                            {
-                                [styles.isActive]: props.draggable
-                            }
-                        )}
-                        src={draggableIcon}
-                        onClick={props.onClickDraggable}
-                    />
-                    <img
-                        className={classNames(
-                            styles.icon,
-                            styles.notDraggableIcon,
-                            {
-                                [styles.isActive]: !props.draggable
-                            }
-                        )}
-                        src={notDraggableIcon}
-                        onClick={props.onClickNotDraggable}
-                    />
+
+            <div className={styles.row}>
+                <div className={styles.group}>
+                    <span className={styles.inputLabelSmall}>
+                        Show
+                    </span>
+                    <div className={classNames(styles.radioBox, {[styles.isDisabled]: visibleDisabled})}>
+                        <img
+                            className={classNames(
+                                styles.icon,
+                                styles.showIcon,
+                                {
+                                    [styles.isActive]: props.visible && !visibleDisabled
+                                }
+                            )}
+                            src={showIcon}
+                            onClick={props.onClickVisible}
+                        />
+                        <img
+                            className={classNames(
+                                styles.icon,
+                                styles.hideIcon,
+                                {
+                                    [styles.isActive]: !props.visible && !visibleDisabled
+                                }
+                            )}
+                            src={hideIcon}
+                            onClick={props.onClickNotVisible}
+                        />
+                    </div>
+                </div>
+
+                <div className={styles.group}>
+                    <span className={styles.inputLabelSmall}>
+                        Draggable
+                    </span>
+                    <div className={classNames(styles.radioBox, {[styles.isDisabled]: visibleDisabled})}>
+                        <img
+                            className={classNames(
+                                styles.icon,
+                                styles.draggableIcon,
+                                {
+                                    [styles.isActive]: props.draggable && !draggableDisabled
+                                }
+                            )}
+                            src={draggableIcon}
+                            onClick={props.onClickDraggable}
+                        />
+                        <img
+                            className={classNames(
+                                styles.icon,
+                                styles.notDraggableIcon,
+                                {
+                                    [styles.isActive]: !props.draggable && !draggableDisabled
+                                }
+                            )}
+                            src={notDraggableIcon}
+                            onClick={props.onClickNotDraggable}
+                        />
+                    </div>
+                </div>
+
+                <div className={styles.group}>
+                    <span className={styles.inputLabelSmall}>
+                        Rotation
+                    </span>
+                    <select
+                        className={classNames(styles.selectForm, styles.inputFormRotationSelect)}
+                        disabled={rotationStyleDisabled}
+                        value={props.rotationStyle}
+                        onChange={props.onChangeRotationStyle}
+                    >
+                        {ROTATION_STYLES.map(style => (
+                            <option
+                                key={style}
+                                value={style}
+                            >
+                                {style}
+                            </option>
+                        ))}
+                    </select>
                 </div>
             </div>
-
-            <div className={styles.group}>
-                <span className={styles.inputLabelSmall}>
-                    Rotation
-                </span>
-                <select
-                    className={classNames(styles.selectForm, styles.inputFormRotationSelect)}
-                    value={props.rotationStyle}
-                    onChange={props.onChangeRotationStyle}
-                >
-                    {ROTATION_STYLES.map(style => (
-                        <option
-                            key={style}
-                            value={style}
-                        >
-                            {style}
-                        </option>
-                    ))}
-                </select>
-            </div>
-        </div>
-    </Box>
-);
+        </Box>
+    );
+};
 
 SpriteInfo.propTypes = {
     draggable: React.PropTypes.bool,
@@ -160,10 +172,6 @@ SpriteInfo.propTypes = {
     visible: React.PropTypes.bool,
     x: React.PropTypes.number,
     y: React.PropTypes.number
-};
-
-SpriteInfo.defaultProps = {
-    name: ''
 };
 
 module.exports = SpriteInfo;

--- a/src/components/sprite-selector/sprite-selector.jsx
+++ b/src/components/sprite-selector/sprite-selector.jsx
@@ -9,6 +9,7 @@ const SpriteSelectorComponent = function (props) {
     const {
         onChangeSpriteDraggability,
         onChangeSpriteName,
+        onChangeSpriteRotationStyle,
         onChangeSpriteVisibility,
         onChangeSpriteX,
         onChangeSpriteY,
@@ -26,11 +27,13 @@ const SpriteSelectorComponent = function (props) {
             <SpriteInfo
                 draggable={selectedSprite.draggable}
                 name={selectedSprite.name}
+                rotationStyle={selectedSprite.rotationStyle}
                 visible={selectedSprite.visible}
                 x={selectedSprite.x}
                 y={selectedSprite.y}
                 onChangeDraggability={onChangeSpriteDraggability}
                 onChangeName={onChangeSpriteName}
+                onChangeRotationStyle={onChangeSpriteRotationStyle}
                 onChangeVisibility={onChangeSpriteVisibility}
                 onChangeX={onChangeSpriteX}
                 onChangeY={onChangeSpriteY}
@@ -62,6 +65,7 @@ const SpriteSelectorComponent = function (props) {
 SpriteSelectorComponent.propTypes = {
     onChangeSpriteDraggability: React.PropTypes.func,
     onChangeSpriteName: React.PropTypes.func,
+    onChangeSpriteRotationStyle: React.PropTypes.func,
     onChangeSpriteVisibility: React.PropTypes.func,
     onChangeSpriteX: React.PropTypes.func,
     onChangeSpriteY: React.PropTypes.func,

--- a/src/components/sprite-selector/sprite-selector.jsx
+++ b/src/components/sprite-selector/sprite-selector.jsx
@@ -1,7 +1,7 @@
 const React = require('react');
 
 const Box = require('../box/box.jsx');
-const SpriteInfo = require('../sprite-info/sprite-info.jsx');
+const SpriteInfo = require('../../containers/sprite-info.jsx');
 const SpriteSelectorItem = require('../../containers/sprite-selector-item.jsx');
 const styles = require('./sprite-selector.css');
 

--- a/src/components/sprite-selector/sprite-selector.jsx
+++ b/src/components/sprite-selector/sprite-selector.jsx
@@ -8,6 +8,8 @@ const styles = require('./sprite-selector.css');
 const SpriteSelectorComponent = function (props) {
     const {
         onChangeSpriteName,
+        onChangeSpriteX,
+        onChangeSpriteY,
         onSelectSprite,
         selectedId,
         sprites,
@@ -21,7 +23,11 @@ const SpriteSelectorComponent = function (props) {
         >
             <SpriteInfo
                 name={selectedSprite.name}
+                x={selectedSprite.x}
+                y={selectedSprite.y}
                 onChangeName={onChangeSpriteName}
+                onChangeX={onChangeSpriteX}
+                onChangeY={onChangeSpriteY}
             />
 
             <Box className={styles.scrollWrapper}>
@@ -49,6 +55,8 @@ const SpriteSelectorComponent = function (props) {
 
 SpriteSelectorComponent.propTypes = {
     onChangeSpriteName: React.PropTypes.func,
+    onChangeSpriteX: React.PropTypes.func,
+    onChangeSpriteY: React.PropTypes.func,
     onSelectSprite: React.PropTypes.func,
     selectedId: React.PropTypes.string,
     sprites: React.PropTypes.shape({

--- a/src/components/sprite-selector/sprite-selector.jsx
+++ b/src/components/sprite-selector/sprite-selector.jsx
@@ -1,13 +1,15 @@
 const React = require('react');
 
 const Box = require('../box/box.jsx');
-const SpriteSelectorItem = require('../../containers/sprite-selector-item.jsx');
 const SpriteInfo = require('../sprite-info/sprite-info.jsx');
+const SpriteSelectorItem = require('../../containers/sprite-selector-item.jsx');
 const styles = require('./sprite-selector.css');
 
 const SpriteSelectorComponent = function (props) {
     const {
+        onChangeSpriteDraggability,
         onChangeSpriteName,
+        onChangeSpriteVisibility,
         onChangeSpriteX,
         onChangeSpriteY,
         onSelectSprite,
@@ -22,10 +24,14 @@ const SpriteSelectorComponent = function (props) {
             {...componentProps}
         >
             <SpriteInfo
+                draggable={selectedSprite.draggable}
                 name={selectedSprite.name}
+                visible={selectedSprite.visible}
                 x={selectedSprite.x}
                 y={selectedSprite.y}
+                onChangeDraggability={onChangeSpriteDraggability}
                 onChangeName={onChangeSpriteName}
+                onChangeVisibility={onChangeSpriteVisibility}
                 onChangeX={onChangeSpriteX}
                 onChangeY={onChangeSpriteY}
             />
@@ -54,7 +60,9 @@ const SpriteSelectorComponent = function (props) {
 };
 
 SpriteSelectorComponent.propTypes = {
+    onChangeSpriteDraggability: React.PropTypes.func,
     onChangeSpriteName: React.PropTypes.func,
+    onChangeSpriteVisibility: React.PropTypes.func,
     onChangeSpriteX: React.PropTypes.func,
     onChangeSpriteY: React.PropTypes.func,
     onSelectSprite: React.PropTypes.func,

--- a/src/components/sprite-selector/sprite-selector.jsx
+++ b/src/components/sprite-selector/sprite-selector.jsx
@@ -7,17 +7,22 @@ const styles = require('./sprite-selector.css');
 
 const SpriteSelectorComponent = function (props) {
     const {
+        onChangeSpriteName,
         onSelectSprite,
         selectedId,
         sprites,
         ...componentProps
     } = props;
+    const selectedSprite = sprites[selectedId] || {};
     return (
         <Box
             className={styles.spriteSelector}
             {...componentProps}
         >
-            <SpriteInfo name="Sprite" />
+            <SpriteInfo
+                name={selectedSprite.name}
+                onChangeName={onChangeSpriteName}
+            />
 
             <Box className={styles.scrollWrapper}>
                 <Box className={styles.itemsWrapper}>
@@ -43,6 +48,7 @@ const SpriteSelectorComponent = function (props) {
 };
 
 SpriteSelectorComponent.propTypes = {
+    onChangeSpriteName: React.PropTypes.func,
     onSelectSprite: React.PropTypes.func,
     selectedId: React.PropTypes.string,
     sprites: React.PropTypes.shape({

--- a/src/components/sprite-selector/sprite-selector.jsx
+++ b/src/components/sprite-selector/sprite-selector.jsx
@@ -18,13 +18,19 @@ const SpriteSelectorComponent = function (props) {
         sprites,
         ...componentProps
     } = props;
-    const selectedSprite = sprites[selectedId] || {};
+    let selectedSprite = sprites[selectedId];
+    let spriteInfoDisabled = false;
+    if (typeof selectedSprite === 'undefined') {
+        selectedSprite = {};
+        spriteInfoDisabled = true;
+    }
     return (
         <Box
             className={styles.spriteSelector}
             {...componentProps}
         >
             <SpriteInfo
+                disabled={spriteInfoDisabled}
                 draggable={selectedSprite.draggable}
                 name={selectedSprite.name}
                 rotationStyle={selectedSprite.rotationStyle}

--- a/src/components/target-pane/target-pane.jsx
+++ b/src/components/target-pane/target-pane.jsx
@@ -37,7 +37,9 @@ class TargetPane extends React.Component {
             backdropLibraryVisible,
             costumeLibraryVisible,
             spriteLibraryVisible,
+            onChangeSpriteDraggability,
             onChangeSpriteName,
+            onChangeSpriteVisibility,
             onChangeSpriteX,
             onChangeSpriteY,
             onNewSpriteClick,
@@ -60,7 +62,9 @@ class TargetPane extends React.Component {
                 <SpriteSelectorComponent
                     selectedId={editingTarget}
                     sprites={sprites}
+                    onChangeSpriteDraggability={onChangeSpriteDraggability}
                     onChangeSpriteName={onChangeSpriteName}
+                    onChangeSpriteVisibility={onChangeSpriteVisibility}
                     onChangeSpriteX={onChangeSpriteX}
                     onChangeSpriteY={onChangeSpriteY}
                     onSelectSprite={onSelectSprite}
@@ -124,16 +128,22 @@ const spriteShape = React.PropTypes.shape({
         rotationCenterX: React.PropTypes.number,
         rotationCenterY: React.PropTypes.number
     }),
+    draggable: React.PropTypes.bool,
     id: React.PropTypes.string,
     name: React.PropTypes.string,
-    order: React.PropTypes.number
+    order: React.PropTypes.number,
+    visibility: React.PropTypes.bool,
+    x: React.PropTypes.number,
+    y: React.PropTypes.number
 });
 
 TargetPane.propTypes = {
     backdropLibraryVisible: React.PropTypes.bool,
     costumeLibraryVisible: React.PropTypes.bool,
     editingTarget: React.PropTypes.string,
+    onChangeSpriteDraggability: React.PropTypes.func,
     onChangeSpriteName: React.PropTypes.func,
+    onChangeSpriteVisibility: React.PropTypes.func,
     onChangeSpriteX: React.PropTypes.func,
     onChangeSpriteY: React.PropTypes.func,
     onNewBackdropClick: React.PropTypes.func,

--- a/src/components/target-pane/target-pane.jsx
+++ b/src/components/target-pane/target-pane.jsx
@@ -38,6 +38,8 @@ class TargetPane extends React.Component {
             costumeLibraryVisible,
             spriteLibraryVisible,
             onChangeSpriteName,
+            onChangeSpriteX,
+            onChangeSpriteY,
             onNewSpriteClick,
             onNewBackdropClick,
             onRequestCloseBackdropLibrary,
@@ -59,6 +61,8 @@ class TargetPane extends React.Component {
                     selectedId={editingTarget}
                     sprites={sprites}
                     onChangeSpriteName={onChangeSpriteName}
+                    onChangeSpriteX={onChangeSpriteX}
+                    onChangeSpriteY={onChangeSpriteY}
                     onSelectSprite={onSelectSprite}
                 />
                 <Box className={styles.stageSelectorWrapper}>
@@ -130,6 +134,8 @@ TargetPane.propTypes = {
     costumeLibraryVisible: React.PropTypes.bool,
     editingTarget: React.PropTypes.string,
     onChangeSpriteName: React.PropTypes.func,
+    onChangeSpriteX: React.PropTypes.func,
+    onChangeSpriteY: React.PropTypes.func,
     onNewBackdropClick: React.PropTypes.func,
     onNewSpriteClick: React.PropTypes.func,
     onRequestCloseBackdropLibrary: React.PropTypes.func,

--- a/src/components/target-pane/target-pane.jsx
+++ b/src/components/target-pane/target-pane.jsx
@@ -39,6 +39,7 @@ class TargetPane extends React.Component {
             spriteLibraryVisible,
             onChangeSpriteDraggability,
             onChangeSpriteName,
+            onChangeSpriteRotationStyle,
             onChangeSpriteVisibility,
             onChangeSpriteX,
             onChangeSpriteY,
@@ -64,6 +65,7 @@ class TargetPane extends React.Component {
                     sprites={sprites}
                     onChangeSpriteDraggability={onChangeSpriteDraggability}
                     onChangeSpriteName={onChangeSpriteName}
+                    onChangeSpriteRotationStyle={onChangeSpriteRotationStyle}
                     onChangeSpriteVisibility={onChangeSpriteVisibility}
                     onChangeSpriteX={onChangeSpriteX}
                     onChangeSpriteY={onChangeSpriteY}
@@ -132,6 +134,7 @@ const spriteShape = React.PropTypes.shape({
     id: React.PropTypes.string,
     name: React.PropTypes.string,
     order: React.PropTypes.number,
+    rotationStyle: React.PropTypes.string,
     visibility: React.PropTypes.bool,
     x: React.PropTypes.number,
     y: React.PropTypes.number
@@ -143,6 +146,7 @@ TargetPane.propTypes = {
     editingTarget: React.PropTypes.string,
     onChangeSpriteDraggability: React.PropTypes.func,
     onChangeSpriteName: React.PropTypes.func,
+    onChangeSpriteRotationStyle: React.PropTypes.func,
     onChangeSpriteVisibility: React.PropTypes.func,
     onChangeSpriteX: React.PropTypes.func,
     onChangeSpriteY: React.PropTypes.func,

--- a/src/components/target-pane/target-pane.jsx
+++ b/src/components/target-pane/target-pane.jsx
@@ -37,6 +37,7 @@ class TargetPane extends React.Component {
             backdropLibraryVisible,
             costumeLibraryVisible,
             spriteLibraryVisible,
+            onChangeSpriteName,
             onNewSpriteClick,
             onNewBackdropClick,
             onRequestCloseBackdropLibrary,
@@ -53,10 +54,11 @@ class TargetPane extends React.Component {
                 className={styles.targetPane}
                 {...componentProps}
             >
-               
+
                 <SpriteSelectorComponent
                     selectedId={editingTarget}
                     sprites={sprites}
+                    onChangeSpriteName={onChangeSpriteName}
                     onSelectSprite={onSelectSprite}
                 />
                 <Box className={styles.stageSelectorWrapper}>
@@ -127,6 +129,7 @@ TargetPane.propTypes = {
     backdropLibraryVisible: React.PropTypes.bool,
     costumeLibraryVisible: React.PropTypes.bool,
     editingTarget: React.PropTypes.string,
+    onChangeSpriteName: React.PropTypes.func,
     onNewBackdropClick: React.PropTypes.func,
     onNewSpriteClick: React.PropTypes.func,
     onRequestCloseBackdropLibrary: React.PropTypes.func,

--- a/src/containers/sprite-info.jsx
+++ b/src/containers/sprite-info.jsx
@@ -1,0 +1,74 @@
+const bindAll = require('lodash.bindall');
+const React = require('react');
+
+const SpriteInfoComponent = require('../components/sprite-info/sprite-info.jsx');
+
+class SpriteInfo extends React.Component {
+    constructor (props) {
+        super(props);
+        bindAll(this, [
+            'handleChangeName',
+            'handleChangeX',
+            'handleChangeY',
+            'handleClickVisible',
+            'handleClickNotVisible',
+            'handleClickDraggable',
+            'handleClickNotDraggable'
+        ]);
+    }
+    handleChangeName (e) {
+        this.props.onChangeName(e.target.value);
+    }
+    handleChangeX (e) {
+        let x = e.target.value;
+        if (x === '-') x = -1;
+        if (isNaN(x)) return;
+        this.props.onChangeX(x);
+    }
+    handleChangeY (e) {
+        let y = e.target.value;
+        if (y === '-') y = -1;
+        if (isNaN(y)) return;
+        this.props.onChangeY(y);
+    }
+    handleClickVisible (e) {
+        e.preventDefault();
+        this.props.onChangeVisibility(true);
+    }
+    handleClickNotVisible (e) {
+        e.preventDefault();
+        this.props.onChangeVisibility(false);
+    }
+    handleClickDraggable (e) {
+        e.preventDefault();
+        this.props.onChangeDraggability(true);
+    }
+    handleClickNotDraggable (e) {
+        e.preventDefault();
+        this.props.onChangeDraggability(false);
+    }
+    render () {
+        return (
+            <SpriteInfoComponent
+                onChangeName={this.handleChangeName}
+                onChangeX={this.handleChangeX}
+                onChangeY={this.handleChangeY}
+                onClickDraggable={this.handleClickDraggable}
+                onClickNotDraggable={this.handleClickNotDraggable}
+                onClickVisible={this.handleClickVisible}
+                onClickNotVisible={this.handleClickNotVisible}
+                {...this.props}
+            />
+        );
+    }
+}
+
+SpriteInfo.propTypes = {
+    onChangeDraggability: React.PropTypes.func,
+    onChangeName: React.PropTypes.func,
+    onChangeVisibility: React.PropTypes.func,
+    onChangeX: React.PropTypes.func,
+    onChangeY: React.PropTypes.func,
+};
+
+module.exports = SpriteInfo;

--- a/src/containers/sprite-info.jsx
+++ b/src/containers/sprite-info.jsx
@@ -8,6 +8,7 @@ class SpriteInfo extends React.Component {
         super(props);
         bindAll(this, [
             'handleChangeName',
+            'handleChangeRotationStyle',
             'handleChangeX',
             'handleChangeY',
             'handleClickVisible',
@@ -18,6 +19,9 @@ class SpriteInfo extends React.Component {
     }
     handleChangeName (e) {
         this.props.onChangeName(e.target.value);
+    }
+    handleChangeRotationStyle (e) {
+        this.props.onChangeRotationStyle(e.target.value);
     }
     handleChangeX (e) {
         let x = e.target.value;
@@ -50,14 +54,15 @@ class SpriteInfo extends React.Component {
     render () {
         return (
             <SpriteInfoComponent
+                {...this.props}
                 onChangeName={this.handleChangeName}
+                onChangeRotationStyle={this.handleChangeRotationStyle}
                 onChangeX={this.handleChangeX}
                 onChangeY={this.handleChangeY}
                 onClickDraggable={this.handleClickDraggable}
                 onClickNotDraggable={this.handleClickNotDraggable}
                 onClickVisible={this.handleClickVisible}
                 onClickNotVisible={this.handleClickNotVisible}
-                {...this.props}
             />
         );
     }
@@ -66,6 +71,7 @@ class SpriteInfo extends React.Component {
 SpriteInfo.propTypes = {
     onChangeDraggability: React.PropTypes.func,
     onChangeName: React.PropTypes.func,
+    onChangeRotationStyle: React.PropTypes.func,
     onChangeVisibility: React.PropTypes.func,
     onChangeX: React.PropTypes.func,
     onChangeY: React.PropTypes.func,

--- a/src/containers/sprite-info.jsx
+++ b/src/containers/sprite-info.jsx
@@ -61,8 +61,8 @@ class SpriteInfo extends React.Component {
                 onChangeY={this.handleChangeY}
                 onClickDraggable={this.handleClickDraggable}
                 onClickNotDraggable={this.handleClickNotDraggable}
-                onClickVisible={this.handleClickVisible}
                 onClickNotVisible={this.handleClickNotVisible}
+                onClickVisible={this.handleClickVisible}
             />
         );
     }
@@ -74,7 +74,7 @@ SpriteInfo.propTypes = {
     onChangeRotationStyle: React.PropTypes.func,
     onChangeVisibility: React.PropTypes.func,
     onChangeX: React.PropTypes.func,
-    onChangeY: React.PropTypes.func,
+    onChangeY: React.PropTypes.func
 };
 
 module.exports = SpriteInfo;

--- a/src/containers/target-pane.jsx
+++ b/src/containers/target-pane.jsx
@@ -25,25 +25,19 @@ class TargetPane extends React.Component {
             'handleSelectSprite'
         ]);
     }
-    handleChangeSpriteDraggability () {
-        this.props.vm.postSpriteInfo({draggable: true});
+    handleChangeSpriteDraggability (draggable) {
+        this.props.vm.postSpriteInfo({draggable});
     }
-    handleChangeSpriteName (e) {
-        this.props.vm.renameSprite(this.props.editingTarget, e.target.value);
+    handleChangeSpriteName (name) {
+        this.props.vm.renameSprite(this.props.editingTarget, name);
     }
-    handleChangeSpriteVisibility () {
-        this.props.vm.postSpriteInfo({visible: false});
+    handleChangeSpriteVisibility (visible) {
+        this.props.vm.postSpriteInfo({visible});
     }
-    handleChangeSpriteX (e) {
-        let x = e.target.value;
-        if (x === '-') x = -1;
-        if (isNaN(x)) return;
+    handleChangeSpriteX (x) {
         this.props.vm.postSpriteInfo({x});
     }
-    handleChangeSpriteY (e) {
-        let y = e.target.value;
-        if (y === '-') y = -1;
-        if (isNaN(y)) return;
+    handleChangeSpriteY (y) {
         this.props.vm.postSpriteInfo({y});
     }
     handleSelectSprite (id) {

--- a/src/containers/target-pane.jsx
+++ b/src/containers/target-pane.jsx
@@ -19,6 +19,7 @@ class TargetPane extends React.Component {
         bindAll(this, [
             'handleChangeSpriteDraggability',
             'handleChangeSpriteName',
+            'handleChangeSpriteRotationStyle',
             'handleChangeSpriteVisibility',
             'handleChangeSpriteX',
             'handleChangeSpriteY',
@@ -30,6 +31,9 @@ class TargetPane extends React.Component {
     }
     handleChangeSpriteName (name) {
         this.props.vm.renameSprite(this.props.editingTarget, name);
+    }
+    handleChangeSpriteRotationStyle (rotationStyle) {
+        this.props.vm.postSpriteInfo({rotationStyle});
     }
     handleChangeSpriteVisibility (visible) {
         this.props.vm.postSpriteInfo({visible});
@@ -49,6 +53,7 @@ class TargetPane extends React.Component {
                 {...this.props}
                 onChangeSpriteDraggability={this.handleChangeSpriteDraggability}
                 onChangeSpriteName={this.handleChangeSpriteName}
+                onChangeSpriteRotationStyle={this.handleChangeSpriteRotationStyle}
                 onChangeSpriteVisibility={this.handleChangeSpriteVisibility}
                 onChangeSpriteX={this.handleChangeSpriteX}
                 onChangeSpriteY={this.handleChangeSpriteY}

--- a/src/containers/target-pane.jsx
+++ b/src/containers/target-pane.jsx
@@ -17,14 +17,22 @@ class TargetPane extends React.Component {
     constructor (props) {
         super(props);
         bindAll(this, [
+            'handleChangeSpriteDraggability',
             'handleChangeSpriteName',
+            'handleChangeSpriteVisibility',
             'handleChangeSpriteX',
             'handleChangeSpriteY',
             'handleSelectSprite'
         ]);
     }
+    handleChangeSpriteDraggability () {
+        this.props.vm.postSpriteInfo({draggable: true});
+    }
     handleChangeSpriteName (e) {
         this.props.vm.renameSprite(this.props.editingTarget, e.target.value);
+    }
+    handleChangeSpriteVisibility () {
+        this.props.vm.postSpriteInfo({visible: false});
     }
     handleChangeSpriteX (e) {
         let x = e.target.value;
@@ -45,7 +53,9 @@ class TargetPane extends React.Component {
         return (
             <TargetPaneComponent
                 {...this.props}
+                onChangeSpriteDraggability={this.handleChangeSpriteDraggability}
                 onChangeSpriteName={this.handleChangeSpriteName}
+                onChangeSpriteVisibility={this.handleChangeSpriteVisibility}
                 onChangeSpriteX={this.handleChangeSpriteX}
                 onChangeSpriteY={this.handleChangeSpriteY}
                 onSelectSprite={this.handleSelectSprite}

--- a/src/containers/target-pane.jsx
+++ b/src/containers/target-pane.jsx
@@ -1,5 +1,4 @@
 const bindAll = require('lodash.bindall');
-const pick = require('lodash.pick');
 const React = require('react');
 
 const {connect} = require('react-redux');
@@ -19,11 +18,25 @@ class TargetPane extends React.Component {
         super(props);
         bindAll(this, [
             'handleChangeSpriteName',
+            'handleChangeSpriteX',
+            'handleChangeSpriteY',
             'handleSelectSprite'
         ]);
     }
     handleChangeSpriteName (e) {
         this.props.vm.renameSprite(this.props.editingTarget, e.target.value);
+    }
+    handleChangeSpriteX (e) {
+        let x = e.target.value;
+        if (x === '-') x = -1;
+        if (isNaN(x)) return;
+        this.props.vm.postSpriteInfo({x});
+    }
+    handleChangeSpriteY (e) {
+        let y = e.target.value;
+        if (y === '-') y = -1;
+        if (isNaN(y)) return;
+        this.props.vm.postSpriteInfo({y});
     }
     handleSelectSprite (id) {
         this.props.vm.setEditingTarget(id);
@@ -33,6 +46,8 @@ class TargetPane extends React.Component {
             <TargetPaneComponent
                 {...this.props}
                 onChangeSpriteName={this.handleChangeSpriteName}
+                onChangeSpriteX={this.handleChangeSpriteX}
+                onChangeSpriteY={this.handleChangeSpriteY}
                 onSelectSprite={this.handleSelectSprite}
             />
         );
@@ -51,7 +66,10 @@ TargetPane.propTypes = {
 const mapStateToProps = state => ({
     editingTarget: state.targets.editingTarget,
     sprites: Object.keys(state.targets.sprites).reduce((sprites, k) => {
-        sprites[k] = pick(state.targets.sprites[k], ['costume', 'name', 'order']);
+        let {x, y, ...sprite} = state.targets.sprites[k];
+        if (typeof x !== 'undefined') x = Math.round(x);
+        if (typeof y !== 'undefined') y = Math.round(y);
+        sprites[k] = {...sprite, x, y};
         return sprites;
     }, {}),
     stage: state.targets.stage,

--- a/src/containers/target-pane.jsx
+++ b/src/containers/target-pane.jsx
@@ -18,8 +18,12 @@ class TargetPane extends React.Component {
     constructor (props) {
         super(props);
         bindAll(this, [
+            'handleChangeSpriteName',
             'handleSelectSprite'
         ]);
+    }
+    handleChangeSpriteName (e) {
+        this.props.vm.renameSprite(this.props.editingTarget, e.target.value);
     }
     handleSelectSprite (id) {
         this.props.vm.setEditingTarget(id);
@@ -28,6 +32,7 @@ class TargetPane extends React.Component {
         return (
             <TargetPaneComponent
                 {...this.props}
+                onChangeSpriteName={this.handleChangeSpriteName}
                 onSelectSprite={this.handleSelectSprite}
             />
         );

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,7 +1,8 @@
 const React = require('react');
 const ReactDOM = require('react-dom');
 const {Provider} = require('react-redux');
-const {createStore} = require('redux');
+const {createStore, applyMiddleware} = require('redux');
+const throttle = require('redux-throttle').default;
 
 const GUI = require('./containers/gui.jsx');
 const log = require('./lib/log');
@@ -63,7 +64,9 @@ App.propTypes = {
 const appTarget = document.createElement('div');
 appTarget.className = styles.app;
 document.body.appendChild(appTarget);
-const store = createStore(
+const store = applyMiddleware(
+    throttle(300, {leading: true, trailing: true})
+)(createStore)(
     reducer,
     window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
 );

--- a/src/reducers/targets.js
+++ b/src/reducers/targets.js
@@ -55,19 +55,28 @@ const reducer = function (state, action) {
 reducer.updateTarget = function (target) {
     return {
         type: UPDATE_TARGET,
-        target: target
+        target: target,
+        meta: {
+            throttle: 30
+        }
     };
 };
 reducer.updateTargets = function (targetList) {
     return {
         type: UPDATE_TARGET_LIST,
-        targets: targetList
+        targets: targetList,
+        meta: {
+            throttle: 30
+        }
     };
 };
 reducer.updateEditingTarget = function (editingTarget) {
     return {
         type: UPDATE_EDITING_TARGET,
-        target: editingTarget
+        target: editingTarget,
+        meta: {
+            throttle: 30
+        }
     };
 };
 module.exports = reducer;

--- a/src/reducers/targets.js
+++ b/src/reducers/targets.js
@@ -30,7 +30,7 @@ const reducer = function (state, action) {
                 .filter(target => !target.isStage)
                 .reduce(
                     (targets, target, listId) => defaultsDeep(
-                        {[target.id]: {order: listId}},
+                        {[target.id]: {order: listId, ...target}},
                         {[target.id]: state.sprites[target.id]},
                         targets
                     ),


### PR DESCRIPTION
Sets up sprite info component to reflect data about the selected sprite in the panel.

In the interest of time:
* Every field is updated as you type, including x/y position. Typing `-` is interpreted as `-1`. Eventually this should only happen on blur or enter key pressed.  Good luck trying to update position while a sprite is moving 🙃 
* When you select the stage, the sprite info pane becomes disabled, with placeholder values set in the inputs
* Everything is handled with props passing. This is a good place for redux, but I needed it to be done for the play test tomorrow.
* I did minimal performance testing. I would not be surprised if some projects perform more slowly after this update.  I believe the redux refactor could help with this, since it would reduce the number of parent components that would need to re-render as sprite info changes.

/cc @lifeinchords @cwillisf @carljbowman 