### PR TITLE
Buffer sprite info text fields

### DIFF
--- a/src/components/sprite-info/sprite-info.jsx
+++ b/src/components/sprite-info/sprite-info.jsx
@@ -39,7 +39,9 @@ class SpriteInfo extends React.Component {
                             placeholder="Name"
                             type="text"
                             value={this.props.disabled ? '' : this.props.name}
+                            onBlur={this.props.onBlurName}
                             onChange={this.props.onChangeName}
+                            onKeyPress={this.props.onKeyPress}
                         />
                     </div>
 
@@ -55,7 +57,9 @@ class SpriteInfo extends React.Component {
                             placeholder="x"
                             type="text"
                             value={this.props.disabled ? '' : this.props.x}
+                            onBlur={this.props.onBlurX}
                             onChange={this.props.onChangeX}
+                            onKeyPress={this.props.onKeyPress}
                         />
                     </div>
 
@@ -71,7 +75,9 @@ class SpriteInfo extends React.Component {
                             placeholder="y"
                             type="text"
                             value={this.props.disabled ? '' : this.props.y}
+                            onBlur={this.props.onBlurY}
                             onChange={this.props.onChangeY}
+                            onKeyPress={this.props.onKeyPress}
                         />
                     </div>
                 </div>
@@ -168,6 +174,9 @@ SpriteInfo.propTypes = {
     disabled: React.PropTypes.bool,
     draggable: React.PropTypes.bool,
     name: React.PropTypes.string,
+    onBlurName: React.PropTypes.func,
+    onBlurX: React.PropTypes.func,
+    onBlurY: React.PropTypes.func,
     onChangeName: React.PropTypes.func,
     onChangeRotationStyle: React.PropTypes.func,
     onChangeX: React.PropTypes.func,
@@ -176,6 +185,7 @@ SpriteInfo.propTypes = {
     onClickNotDraggable: React.PropTypes.func,
     onClickNotVisible: React.PropTypes.func,
     onClickVisible: React.PropTypes.func,
+    onKeyPress: React.PropTypes.func,
     rotationStyle: React.PropTypes.oneOf(ROTATION_STYLES),
     visible: React.PropTypes.bool,
     x: React.PropTypes.number,

--- a/src/components/sprite-info/sprite-info.jsx
+++ b/src/components/sprite-info/sprite-info.jsx
@@ -188,8 +188,8 @@ SpriteInfo.propTypes = {
     onKeyPress: React.PropTypes.func,
     rotationStyle: React.PropTypes.oneOf(ROTATION_STYLES),
     visible: React.PropTypes.bool,
-    x: React.PropTypes.number,
-    y: React.PropTypes.number
+    x: React.PropTypes.string,
+    y: React.PropTypes.string
 };
 
 module.exports = SpriteInfo;

--- a/src/containers/sprite-info.jsx
+++ b/src/containers/sprite-info.jsx
@@ -25,7 +25,10 @@ class SpriteInfo extends React.Component {
         };
     }
     handleKeyPress (e) {
-        if (e.key === 'Enter') this.handleFlush();
+        if (e.key === 'Enter') {
+            this.handleFlush();
+            e.target.blur();
+        }
     }
     handleFlush () {
         if (this.state.name !== null) {

--- a/src/containers/sprite-info.jsx
+++ b/src/containers/sprite-info.jsx
@@ -14,26 +14,46 @@ class SpriteInfo extends React.Component {
             'handleClickVisible',
             'handleClickNotVisible',
             'handleClickDraggable',
-            'handleClickNotDraggable'
+            'handleClickNotDraggable',
+            'handleFlush',
+            'handleKeyPress'
         ]);
+        this.state = {
+            name: null,
+            x: null,
+            y: null
+        };
+    }
+    handleKeyPress (e) {
+        if (e.key === 'Enter') this.handleFlush();
+    }
+    handleFlush () {
+        if (this.state.name !== null) {
+            this.props.onChangeName(this.state.name);
+        }
+        if (this.state.x !== null && !isNaN(this.state.x)) {
+            this.props.onChangeX(this.state.x);
+        }
+        if (this.state.y !== null && !isNaN(this.state.y)) {
+            this.props.onChangeY(this.state.y);
+        }
+        this.setState({
+            name: null,
+            x: null,
+            y: null
+        });
     }
     handleChangeName (e) {
-        this.props.onChangeName(e.target.value);
+        this.setState({name: e.target.value});
     }
     handleChangeRotationStyle (e) {
         this.props.onChangeRotationStyle(e.target.value);
     }
     handleChangeX (e) {
-        let x = e.target.value;
-        if (x === '-') x = -1;
-        if (isNaN(x)) return;
-        this.props.onChangeX(x);
+        this.setState({x: e.target.value});
     }
     handleChangeY (e) {
-        let y = e.target.value;
-        if (y === '-') y = -1;
-        if (isNaN(y)) return;
-        this.props.onChangeY(y);
+        this.setState({y: e.target.value});
     }
     handleClickVisible (e) {
         e.preventDefault();
@@ -52,9 +72,18 @@ class SpriteInfo extends React.Component {
         this.props.onChangeDraggability(false);
     }
     render () {
+        const bufferedInputs = {
+            name: this.state.name === null ? this.props.name : this.state.name,
+            x: this.state.x === null ? this.props.x : this.state.x,
+            y: this.state.y === null ? this.props.y : this.state.y
+        };
         return (
             <SpriteInfoComponent
                 {...this.props}
+                {...bufferedInputs}
+                onBlurName={this.handleFlush}
+                onBlurX={this.handleFlush}
+                onBlurY={this.handleFlush}
                 onChangeName={this.handleChangeName}
                 onChangeRotationStyle={this.handleChangeRotationStyle}
                 onChangeX={this.handleChangeX}
@@ -63,12 +92,14 @@ class SpriteInfo extends React.Component {
                 onClickNotDraggable={this.handleClickNotDraggable}
                 onClickNotVisible={this.handleClickNotVisible}
                 onClickVisible={this.handleClickVisible}
+                onKeyPress={this.handleKeyPress}
             />
         );
     }
 }
 
 SpriteInfo.propTypes = {
+    ...SpriteInfoComponent.propTypes,
     onChangeDraggability: React.PropTypes.func,
     onChangeName: React.PropTypes.func,
     onChangeRotationStyle: React.PropTypes.func,

--- a/src/containers/sprite-info.jsx
+++ b/src/containers/sprite-info.jsx
@@ -108,7 +108,9 @@ SpriteInfo.propTypes = {
     onChangeRotationStyle: React.PropTypes.func,
     onChangeVisibility: React.PropTypes.func,
     onChangeX: React.PropTypes.func,
-    onChangeY: React.PropTypes.func
+    onChangeY: React.PropTypes.func,
+    x: React.PropTypes.number,
+    y: React.PropTypes.number
 };
 
 module.exports = SpriteInfo;


### PR DESCRIPTION
Changes to the name, x, or y fields should only be sent to the VM when the field is blurred or when enter is pressed.

Still allow updates while the fields are focused, but unchanged.

Fixes #154

/cc @carljbowman 