### PR TITLE
Revert "Filter toolbox to blocks available to the VM"

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -25,8 +25,6 @@ class Blocks extends React.Component {
     componentDidMount () {
         const workspaceConfig = defaultsDeep({}, Blocks.defaultOptions, this.props.options);
         this.workspace = this.ScratchBlocks.inject(this.blocks, workspaceConfig);
-        const filteredToolbox = this.props.vm.filterToolbox(this.workspace.options.languageTree);
-        this.workspace.updateToolbox(filteredToolbox);
         this.attachVM();
     }
     componentWillUnmount () {


### PR DESCRIPTION
Reverts LLK/scratch-gui#135

With https://github.com/LLK/scratch-blocks/pull/830 this hackiness is no longer needed.