### PR TITLE
Add simple blocks background pattern

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -123,6 +123,11 @@ Blocks.defaultOptions = {
         wheel: true,
         startScale: 0.75
     },
+    grid: {
+        spacing: 40,
+        length: 2,
+        colour: '#ddd'
+    },
     colours: {
         workspace: '#F9F9F9',
         flyout: '#F9F9F9',


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_
First iteration of a background pattern, fixes https://github.com/LLK/scratch-blocks/issues/817

Note this pattern isn't actually what was given in that issue. This just uses what scratch-blocks already offers as a starting point to create something similar without approaching the issues mentioned in the comments of https://github.com/LLK/scratch-blocks/issues/817

![screen shot 2017-03-13 at 10 25 53 am](https://cloud.githubusercontent.com/assets/654102/23858728/cc905e9a-07d7-11e7-929e-9830f7082a03.png)

cc @thisandagain @carljbowman 
