### PR TITLE
Use scratch-storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "scratch-audio": "latest",
     "scratch-blocks": "latest",
     "scratch-render": "latest",
+    "scratch-storage": "latest",
     "scratch-vm": "latest",
     "style-loader": "0.13.2",
     "svg-to-image": "1.1.3",

--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -11,8 +11,6 @@ const MenuBar = require('../menu-bar/menu-bar.jsx');
 const Box = require('../box/box.jsx');
 const styles = require('./gui.css');
 
-const Storage = require('../../lib/storage');
-
 const GUIComponent = props => {
     const {
         basePath,
@@ -72,12 +70,9 @@ const GUIComponent = props => {
 GUIComponent.propTypes = {
     basePath: React.PropTypes.string,
     children: React.PropTypes.node,
-    vm: React.PropTypes.instanceOf(VM)
+    vm: React.PropTypes.instanceOf(VM).isRequired
 };
 GUIComponent.defaultProps = {
-    basePath: '/',
-    vm: new VM(),
-    storage: new Storage()
+    basePath: '/'
 };
-GUIComponent.defaultProps.vm.attachStorage(GUIComponent.defaultProps.storage);
 module.exports = GUIComponent;

--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -11,6 +11,8 @@ const MenuBar = require('../menu-bar/menu-bar.jsx');
 const Box = require('../box/box.jsx');
 const styles = require('./gui.css');
 
+const Storage = require('../../lib/storage');
+
 const GUIComponent = props => {
     const {
         basePath,
@@ -48,7 +50,7 @@ const GUIComponent = props => {
                             <GreenFlag vm={vm} />
                             <StopAll vm={vm} />
                         </Box>
-                        
+
                         <Box className={styles.stageWrapper} >
                             <Stage
                                 shrink={0}
@@ -74,6 +76,8 @@ GUIComponent.propTypes = {
 };
 GUIComponent.defaultProps = {
     basePath: '/',
-    vm: new VM()
+    vm: new VM(),
+    storage: new Storage()
 };
+GUIComponent.defaultProps.vm.attachStorage(GUIComponent.defaultProps.storage);
 module.exports = GUIComponent;

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -159,7 +159,7 @@ Blocks.propTypes = {
             dragShadowOpacity: React.PropTypes.number
         })
     }),
-    vm: React.PropTypes.instanceOf(VM)
+    vm: React.PropTypes.instanceOf(VM).isRequired
 };
 
 Blocks.defaultOptions = {
@@ -188,8 +188,7 @@ Blocks.defaultOptions = {
 };
 
 Blocks.defaultProps = {
-    options: Blocks.defaultOptions,
-    vm: new VM()
+    options: Blocks.defaultOptions
 };
 
 module.exports = Blocks;

--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -1,10 +1,11 @@
 const bindAll = require('lodash.bindall');
+const AudioEngine = require('scratch-audio');
 const React = require('react');
 const Renderer = require('scratch-render');
-const AudioEngine = require('scratch-audio');
 const VM = require('scratch-vm');
 
 const StageComponent = require('../components/stage/stage.jsx');
+const Storage = require('../lib/storage');
 
 class Stage extends React.Component {
     constructor (props) {
@@ -32,10 +33,12 @@ class Stage extends React.Component {
         this.attachRectEvents();
         this.attachMouseEvents(this.canvas);
         this.updateRect();
-        this.renderer = new Renderer(this.canvas);
-        this.props.vm.attachRenderer(this.renderer);
         this.audioEngine = new AudioEngine();
         this.props.vm.attachAudioEngine(this.audioEngine);
+        this.renderer = new Renderer(this.canvas);
+        this.props.vm.attachRenderer(this.renderer);
+        this.storage = new Storage();
+        this.props.vm.attachStorage(this.storage);
     }
     shouldComponentUpdate () {
         return false;

--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -175,11 +175,7 @@ class Stage extends React.Component {
 }
 
 Stage.propTypes = {
-    vm: React.PropTypes.instanceOf(VM)
-};
-
-Stage.defaultProps = {
-    vm: new VM()
+    vm: React.PropTypes.instanceOf(VM).isRequired
 };
 
 module.exports = Stage;

--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -1,11 +1,10 @@
 const bindAll = require('lodash.bindall');
-const AudioEngine = require('scratch-audio');
 const React = require('react');
 const Renderer = require('scratch-render');
+const AudioEngine = require('scratch-audio');
 const VM = require('scratch-vm');
 
 const StageComponent = require('../components/stage/stage.jsx');
-const Storage = require('../lib/storage');
 
 class Stage extends React.Component {
     constructor (props) {
@@ -33,12 +32,10 @@ class Stage extends React.Component {
         this.attachRectEvents();
         this.attachMouseEvents(this.canvas);
         this.updateRect();
-        this.audioEngine = new AudioEngine();
-        this.props.vm.attachAudioEngine(this.audioEngine);
         this.renderer = new Renderer(this.canvas);
         this.props.vm.attachRenderer(this.renderer);
-        this.storage = new Storage();
-        this.props.vm.attachStorage(this.storage);
+        this.audioEngine = new AudioEngine();
+        this.props.vm.attachAudioEngine(this.audioEngine);
     }
     shouldComponentUpdate () {
         return false;

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -1,0 +1,30 @@
+const ScratchStorage = require('scratch-storage');
+const AssetType = ScratchStorage.AssetType;
+
+const PROJECT_SERVER = 'https://cdn.projects.scratch.mit.edu';
+const ASSET_SERVER = 'https://cdn.assets.scratch.mit.edu';
+
+/**
+ * Wrapper for ScratchStorage which adds default web sources.
+ * @todo make this more configurable
+ */
+class Storage extends ScratchStorage {
+    constructor () {
+        super();
+        this.addWebSource(
+            [AssetType.Project],
+            projectAsset => {
+                const [projectId, revision] = projectAsset.assetId.split('.');
+                return revision ?
+                    `${PROJECT_SERVER}/internalapi/project/${projectId}/get/${revision}` :
+                    `${PROJECT_SERVER}/internalapi/project/${projectId}/get/`;
+            }
+        );
+        this.addWebSource(
+            [AssetType.ImageVector, AssetType.ImageBitmap, AssetType.Sound],
+            asset => `${ASSET_SERVER}/internalapi/asset/${asset.assetId}.${asset.assetType.runtimeFormat}/get/`
+        );
+    }
+}
+
+module.exports = Storage;

--- a/src/lib/vm-listener-hoc.jsx
+++ b/src/lib/vm-listener-hoc.jsx
@@ -2,6 +2,8 @@ const bindAll = require('lodash.bindall');
 const React = require('react');
 const VM = require('scratch-vm');
 
+const Storage = require('./storage');
+
 const {connect} = require('react-redux');
 
 const targets = require('../reducers/targets');
@@ -89,9 +91,11 @@ const vmListenerHOC = function (WrappedComponent) {
         onTargetsUpdate: React.PropTypes.func,
         vm: React.PropTypes.instanceOf(VM).isRequired
     };
+    const defaultVM = new VM('vm-listener-hoc');
+    defaultVM.attachStorage(new Storage());
     VMListener.defaultProps = {
         attachKeyboardEvents: true,
-        vm: new VM()
+        vm: defaultVM
     };
     const mapStateToProps = () => ({});
     const mapDispatchToProps = dispatch => ({


### PR DESCRIPTION
### Resolves

This is the GUI side of LLK/scratch-vm#427

### Proposed Changes

This change causes the GUI (specifically, the stage container) to:
1. create an instance of `ScratchStorage`, storing a reference locally,
2. add two standard web sources to the storage module, and
3. give the storage module instance to the VM.

There are several places in the GUI that could use the storage module for file access; those are not yet updated to use this module but they could be.

### Reason for Changes

This is the minimum necessary to make it safe to merge LLK/scratch-vm#498
