### PR TITLE
Load all Scratch 3.0 modules with Babel

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,10 +13,12 @@
 *.iml text eol=lf
 *.js text eol=lf
 *.js.map text eol=lf
+*.jsx text eol=lf
 *.json text eol=lf
 *.md text eol=lf
 *.vert text eol=lf
 *.xml text eol=lf
+*.yml text eol=lf
 
 # Prefer LF for these files
 .editorconfig text eol=lf

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
 - '4.2'
-- 'stable'
+- 'node'
 cache:
   directories:
   - node_modules

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "GraphicaL User Interface for creating and running Scratch 3.0 projects",
   "main": "./src/index.js",
   "scripts": {
-    "build": "npm run clean && webpack --progress --colors --bail",
+    "build": "webpack --progress --colors --bail",
     "clean": "rm -rf ./build && mkdir -p build",
     "deploy": "touch build/.nojekyll && gh-pages -t -d build -m \"Build for $(git log --pretty=format:%H -n1)\"",
     "lint": "eslint . --ext .js,.jsx",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,7 @@ module.exports = {
         host: '0.0.0.0',
         port: process.env.PORT || 8601
     },
+    devtool: 'cheap-module-source-map',
     entry: {
         lib: ['react', 'react-dom'],
         gui: './src/index.jsx'
@@ -24,15 +25,18 @@ module.exports = {
         path: path.resolve(__dirname, 'build'),
         filename: '[name].js'
     },
+    resolve: {
+        symlinks: false
+    },
     externals: {
         React: 'react',
         ReactDOM: 'react-dom'
     },
     module: {
         rules: [{
-            test: /\.jsx?$/,
+            // allow ES2015 in any *.js or *.jsx file under .../scratch-*/src/...
+            test: /[\\/]+scratch-[^\\/]+[\\/]+src[\\/]+.+\.jsx?$/,
             loader: 'babel-loader',
-            include: path.resolve(__dirname, 'src'),
             options: {
                 plugins: ['transform-object-rest-spread'],
                 presets: [['es2015', {modules: false}], 'react']


### PR DESCRIPTION
### Proposed Changes

This change adjusts the webpack configuration for compatibility with unpacked audio, render, storage, and VM modules. There are also a few other small tweaks to build settings. See line comments for details.

### Reason for Changes

This sets us up to build `scratch-gui` in a single step, allowing webpack to better optimize our files and reducing the duplication of code within our output bundles.

### Test Coverage

Test coverage has not changed.
