### PR TITLE
Fix block editor borders 

### DIFF
--- a/src/components/blocks/blocks.css
+++ b/src/components/blocks/blocks.css
@@ -1,13 +1,31 @@
+$border-style: 1px solid #dbdbdb;
+
 .blocks :global(.injectionDiv){
     position: absolute;
     top: 0;
     right: 0;
     bottom: 0;
     left: 0;
+    border: $border-style;
 
     /* 
         @todo: using _space doesn't compute to the right amount? 
         Related to `scratch-blocks` 
     */
     border-top-right-radius: 0.75rem;
+}
+
+.blocks :global(.blocklyMainBackground) {
+    stroke: none;
+}
+
+.blocks :global(.blocklyToolboxDiv) {
+    border-right: $border-style;
+    border-bottom: $border-style;
+    box-sizing: content-box;
+}
+
+.blocks :global(.blocklyFlyout) {
+    border-right: $border-style;
+    box-sizing: content-box;
 }


### PR DESCRIPTION
This is a simpler and more flexible way to fix the UI issues with the scratch-block borders. Instead of changing it in scratch-blocks and needing to support many orientations, for now just do it in the GUI. There is precedent for this, since we are doing the rounded edge in GUI also.

Before:
![screen shot 2017-03-21 at 7 59 50 am](https://cloud.githubusercontent.com/assets/654102/24146507/663f2820-0e0c-11e7-9cfb-e02b074ffd03.png)

After:
![screen shot 2017-03-21 at 7 55 36 am](https://cloud.githubusercontent.com/assets/654102/24146490/55a4413a-0e0c-11e7-8336-d6a7e30d1f61.png)

css @carljbowman @lifeinchords 