### PR TITLE
fix #108 add button is not centered in firefox

### DIFF
--- a/src/components/target-pane/target-pane.css
+++ b/src/components/target-pane/target-pane.css
@@ -44,6 +44,7 @@
 
 .add-button {
     height: 0.8rem;
+    margin: auto;
 }
 
 /* @todo: This is hacky. Better: move buttons in their corresponding panes, and set values relatively */


### PR DESCRIPTION
### Resolves

solved #108 add button not centered in Firefox

### Reason for Changes

There could be 2 ways in solving this:
1. adding "margin: auto" to center the img displayed in block;
2. turn the img to flexbox and center it with align-items.

I tried to do 2. But it somewhat does not work in Firefox (an issue in Firefox?). 
So I fallback to 1.

### Test Coverage

no link issue emerges