### PR TITLE
Stricter PropType validation

### DIFF
--- a/src/components/asset-panel/selector.jsx
+++ b/src/components/asset-panel/selector.jsx
@@ -43,14 +43,14 @@ const Selector = props => {
 
 Selector.propTypes = {
     items: React.PropTypes.arrayOf(React.PropTypes.shape({
-        image: React.PropTypes.string,
-        name: React.PropTypes.string
+        image: React.PropTypes.string.isRequired,
+        name: React.PropTypes.string.isRequired
     })),
-    newText: React.PropTypes.string,
-    onDeleteClick: React.PropTypes.func,
-    onItemClick: React.PropTypes.func,
+    newText: React.PropTypes.string.isRequired,
+    onDeleteClick: React.PropTypes.func.isRequired,
+    onItemClick: React.PropTypes.func.isRequired,
     onNewClick: React.PropTypes.func,
-    selectedItemIndex: React.PropTypes.number
+    selectedItemIndex: React.PropTypes.number.isRequired
 };
 
 module.exports = Selector;

--- a/src/components/close-button/close-button.jsx
+++ b/src/components/close-button/close-button.jsx
@@ -28,7 +28,7 @@ CloseButton.SIZE_SMALL = 'small';
 
 CloseButton.propTypes = {
     className: React.PropTypes.string,
-    onClick: React.PropTypes.func,
+    onClick: React.PropTypes.func.isRequired,
     size: React.PropTypes.oneOf([CloseButton.SIZE_LARGE, CloseButton.SIZE_SMALL])
 };
 

--- a/src/components/costume-canvas/costume-canvas.jsx
+++ b/src/components/costume-canvas/costume-canvas.jsx
@@ -122,7 +122,7 @@ CostumeCanvas.propTypes = {
     className: React.PropTypes.string,
     direction: React.PropTypes.number,
     height: React.PropTypes.number,
-    url: React.PropTypes.string,
+    url: React.PropTypes.string.isRequired,
     width: React.PropTypes.number
 };
 

--- a/src/components/green-flag/green-flag.jsx
+++ b/src/components/green-flag/green-flag.jsx
@@ -26,7 +26,7 @@ const GreenFlagComponent = function (props) {
 };
 GreenFlagComponent.propTypes = {
     active: React.PropTypes.bool,
-    onClick: React.PropTypes.func,
+    onClick: React.PropTypes.func.isRequired,
     title: React.PropTypes.string
 };
 GreenFlagComponent.defaultProps = {

--- a/src/components/library-item/library-item.jsx
+++ b/src/components/library-item/library-item.jsx
@@ -36,11 +36,11 @@ class LibraryItem extends React.Component {
 }
 
 LibraryItem.propTypes = {
-    iconURL: React.PropTypes.string,
-    id: React.PropTypes.number,
-    name: React.PropTypes.string,
-    onSelect: React.PropTypes.func,
-    selected: React.PropTypes.bool
+    iconURL: React.PropTypes.string.isRequired,
+    id: React.PropTypes.number.isRequired,
+    name: React.PropTypes.string.isRequired,
+    onSelect: React.PropTypes.func.isRequired,
+    selected: React.PropTypes.bool.isRequired
 };
 
 module.exports = LibraryItem;

--- a/src/components/library/library.jsx
+++ b/src/components/library/library.jsx
@@ -59,8 +59,9 @@ LibraryComponent.propTypes = {
     data: React.PropTypes.arrayOf(
         /* eslint-disable react/no-unused-prop-types, lines-around-comment */
         React.PropTypes.shape({
+            // @todo remove md5/rawURL prop from library, refactor to use storage
             md5: React.PropTypes.string,
-            name: React.PropTypes.string,
+            name: React.PropTypes.string.isRequired,
             rawURL: React.PropTypes.string
         })
         /* eslint-enable react/no-unused-prop-types, lines-around-comment */
@@ -69,7 +70,7 @@ LibraryComponent.propTypes = {
     onItemSelected: React.PropTypes.func,
     onRequestClose: React.PropTypes.func,
     title: React.PropTypes.string.isRequired,
-    visible: React.PropTypes.bool
+    visible: React.PropTypes.bool.isRequired
 };
 
 module.exports = LibraryComponent;

--- a/src/components/modal/modal.jsx
+++ b/src/components/modal/modal.jsx
@@ -35,8 +35,8 @@ class ModalComponent extends React.Component {
 ModalComponent.propTypes = {
     children: React.PropTypes.node,
     contentLabel: React.PropTypes.string.isRequired,
-    onRequestClose: React.PropTypes.func,
-    visible: React.PropTypes.bool
+    onRequestClose: React.PropTypes.func.isRequired,
+    visible: React.PropTypes.bool.isRequired
 };
 
 module.exports = ModalComponent;

--- a/src/components/sprite-selector-item/sprite-selector-item.jsx
+++ b/src/components/sprite-selector-item/sprite-selector-item.jsx
@@ -38,11 +38,11 @@ const SpriteSelectorItem = props => (
 
 SpriteSelectorItem.propTypes = {
     className: React.PropTypes.string,
-    costumeURL: React.PropTypes.string,
-    name: React.PropTypes.string,
+    costumeURL: React.PropTypes.string.isRequired,
+    name: React.PropTypes.string.isRequired,
     onClick: React.PropTypes.func,
     onDeleteButtonClick: React.PropTypes.func,
-    selected: React.PropTypes.bool
+    selected: React.PropTypes.bool.isRequired
 };
 
 module.exports = SpriteSelectorItem;

--- a/src/components/sprite-selector/sprite-selector.jsx
+++ b/src/components/sprite-selector/sprite-selector.jsx
@@ -83,14 +83,14 @@ SpriteSelectorComponent.propTypes = {
     sprites: React.PropTypes.shape({
         id: React.PropTypes.shape({
             costume: React.PropTypes.shape({
-                skin: React.PropTypes.string,
-                name: React.PropTypes.string,
-                bitmapResolution: React.PropTypes.number,
-                rotationCenterX: React.PropTypes.number,
-                rotationCenterY: React.PropTypes.number
+                skin: React.PropTypes.string.isRequired,
+                name: React.PropTypes.string.isRequired,
+                bitmapResolution: React.PropTypes.number.isRequired,
+                rotationCenterX: React.PropTypes.number.isRequired,
+                rotationCenterY: React.PropTypes.number.isRequired
             }),
-            name: React.PropTypes.string,
-            order: React.PropTypes.number
+            name: React.PropTypes.string.isRequired,
+            order: React.PropTypes.number.isRequired
         })
     })
 };

--- a/src/components/stage-selector/stage-selector.jsx
+++ b/src/components/stage-selector/stage-selector.jsx
@@ -40,16 +40,16 @@ const StageSelector = props => {
                     <div className={styles.label}>Backdrops</div>
                     <div className={styles.count}>{backdropCount}</div>
                 </div>
-                
+
             </div>
         </Box>
     );
 };
 
 StageSelector.propTypes = {
-    backdropCount: React.PropTypes.number,
+    backdropCount: React.PropTypes.number.isRequired,
     onClick: React.PropTypes.func,
-    selected: React.PropTypes.bool,
+    selected: React.PropTypes.bool.isRequired,
     url: React.PropTypes.string
 };
 module.exports = StageSelector;

--- a/src/components/stop-all/stop-all.jsx
+++ b/src/components/stop-all/stop-all.jsx
@@ -27,7 +27,7 @@ const StopAllComponent = function (props) {
 
 StopAllComponent.propTypes = {
     active: React.PropTypes.bool,
-    onClick: React.PropTypes.func,
+    onClick: React.PropTypes.func.isRequired,
     title: React.PropTypes.string
 };
 

--- a/src/containers/costume-tab.jsx
+++ b/src/containers/costume-tab.jsx
@@ -74,7 +74,7 @@ class CostumeTab extends React.Component {
 }
 
 CostumeTab.propTypes = {
-    ...AssetPanel.propTypes,
+    onNewCostumeClick: React.PropTypes.func.isRequired,
     vm: React.PropTypes.instanceOf(VM)
 };
 

--- a/src/containers/sound-tab.jsx
+++ b/src/containers/sound-tab.jsx
@@ -70,8 +70,8 @@ class SoundTab extends React.Component {
 }
 
 SoundTab.propTypes = {
-    ...AssetPanel.propTypes,
-    vm: React.PropTypes.instanceOf(VM)
+    onNewSoundClick: React.PropTypes.func.isRequired,
+    vm: React.PropTypes.instanceOf(VM).isRequired
 };
 
 const mapStateToProps = state => ({


### PR DESCRIPTION
This PR adds more `.isRequired` validations to the prop types of components. These should be used whenever the prop is actually required. It will help us with debugging and catching bugs when reviewing, as well as for testing. 

There are a few new proptype validation errors you'll see from this: 
- `.image is undefined` (costume tab doesn’t render images)
- `costumeURL is undefined` (sprite selector doesn’t render images)

Those are actual bugs introduced by `scratch-storage`, so they can be fixed separately. 

---

_Note:_ I have in general left out `isRequired` from function props on components that are wrapped directly by containers. The pattern we use for proptypes on containers would have required a fairly large refactoring. Since those wouldn't have caught any bugs, I'm going to leave them out of this PR for consideration later down the road.