### PR TITLE
Fixes issue #140 whitespace renders inside canvas

### DIFF
--- a/src/components/costume-canvas/costume-canvas.jsx
+++ b/src/components/costume-canvas/costume-canvas.jsx
@@ -48,7 +48,12 @@ class CostumeCanvas extends React.Component {
 
         // Rotation origin point will be center of the canvas.
         const contextTranslateX = this.canvas.width / 2;
-        const contextTranslateY = this.canvas.height / 2;
+        let contextTranslateY = this.canvas.height / 2;
+
+        // If vertical align is top, draw the image from the top of the canvas
+        if(this.props.verticalAlign === 'top') {
+            contextTranslateY = this.canvas.height / 2 - (this.canvas.height - scale * img.height) / 2;
+        }
 
         // First, clear the canvas.
         context.clearRect(0, 0,
@@ -115,11 +120,13 @@ class CostumeCanvas extends React.Component {
 CostumeCanvas.defaultProps = {
     width: 100,
     height: 100,
-    direction: 90
+    direction: 90,
+    verticalAlign: 'center'
 };
 
 CostumeCanvas.propTypes = {
     className: React.PropTypes.string,
+    verticalAlign: React.PropTypes.string,
     direction: React.PropTypes.number,
     height: React.PropTypes.number,
     url: React.PropTypes.string.isRequired,

--- a/src/components/costume-canvas/costume-canvas.jsx
+++ b/src/components/costume-canvas/costume-canvas.jsx
@@ -51,8 +51,8 @@ class CostumeCanvas extends React.Component {
         let contextTranslateY = this.canvas.height / 2;
 
         // If vertical align is top, draw the image from the top of the canvas
-        if(this.props.verticalAlign === 'top') {
-            contextTranslateY = this.canvas.height / 2 - (this.canvas.height - scale * img.height) / 2;
+        if (this.props.verticalAlign === 'top') {
+            contextTranslateY = (this.canvas.height / 2) - ((this.canvas.height - (scale * img.height)) / 2);
         }
 
         // First, clear the canvas.
@@ -126,10 +126,10 @@ CostumeCanvas.defaultProps = {
 
 CostumeCanvas.propTypes = {
     className: React.PropTypes.string,
-    verticalAlign: React.PropTypes.string,
     direction: React.PropTypes.number,
     height: React.PropTypes.number,
     url: React.PropTypes.string.isRequired,
+    verticalAlign: React.PropTypes.string,
     width: React.PropTypes.number
 };
 

--- a/src/components/stage-selector/stage-selector.jsx
+++ b/src/components/stage-selector/stage-selector.jsx
@@ -32,6 +32,7 @@ const StageSelector = props => {
                     {url ? (
                         <CostumeCanvas
                             className={styles.costumeCanvas}
+                            verticalAlign="top"
                             height={44}
                             url={url}
                             width={56}

--- a/src/components/stage-selector/stage-selector.jsx
+++ b/src/components/stage-selector/stage-selector.jsx
@@ -32,9 +32,9 @@ const StageSelector = props => {
                     {url ? (
                         <CostumeCanvas
                             className={styles.costumeCanvas}
-                            verticalAlign="top"
                             height={44}
                             url={url}
+                            verticalAlign="top"
                             width={56}
                         />
                     ) : null}


### PR DESCRIPTION
by adding a "vertical align" property inside the costume-canvas component

### Resolves

issue #140 
There's 2 ways to solve this issue: 
1. allow the canvas to align the image to the top, eliminating the space;
2. recompute the size of the canvas before/after rendering.

Approach 1 is taken for this pr. Because it is more elegant since the parent element
do not need to mingle with the dimensions of the image, which should be in the domain
of the canvas.

### Proposed Changes

1. In costume canvas, add a prop called "verticalAlign";
2. set "verticalAlign" to top when stage selector is using the canvas.
