### PR TITLE
Fix audio images in sounds tab

### DIFF
--- a/src/containers/sound-tab.jsx
+++ b/src/containers/sound-tab.jsx
@@ -50,7 +50,7 @@ class SoundTab extends React.Component {
 
         const sounds = vm.editingTarget ? vm.editingTarget.sprite.sounds.map(sound => (
             {
-                image: soundIcon,
+                url: soundIcon,
                 name: sound.name
             }
         )) : [];


### PR DESCRIPTION
Fixes https://github.com/LLK/scratch-gui/issues/299, showing the sound icon again in the sounds list. 

