### PR TITLE
Set editing target when double clicking on sprite in stage

### DIFF
--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -13,7 +13,7 @@ class Stage extends React.Component {
             'attachMouseEvents',
             'cancelMouseDownTimeout',
             'detachMouseEvents',
-            'onDoubleClick',
+            'handleDoubleClick',
             'onMouseUp',
             'onMouseMove',
             'onMouseDown',
@@ -72,7 +72,8 @@ class Stage extends React.Component {
             y - (this.rect.height / 2)
         ];
     }
-    onDoubleClick (e) {
+    handleDoubleClick (e) {
+        // Set editing target from cursor position, if clicking on a sprite.
         const mousePosition = [e.clientX - this.rect.left, e.clientY - this.rect.top];
         const drawableId = this.renderer.pick(mousePosition[0], mousePosition[1]);
         if (drawableId === null) return;
@@ -177,7 +178,7 @@ class Stage extends React.Component {
         return (
             <StageComponent
                 canvasRef={this.setCanvas}
-                onDoubleClick={this.onDoubleClick}
+                onDoubleClick={this.handleDoubleClick}
                 {...props}
             />
         );

--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -13,6 +13,7 @@ class Stage extends React.Component {
             'attachMouseEvents',
             'cancelMouseDownTimeout',
             'detachMouseEvents',
+            'onDoubleClick',
             'onMouseUp',
             'onMouseMove',
             'onMouseDown',
@@ -70,6 +71,14 @@ class Stage extends React.Component {
             x - (this.rect.width / 2),
             y - (this.rect.height / 2)
         ];
+    }
+    onDoubleClick (e) {
+        const mousePosition = [e.clientX - this.rect.left, e.clientY - this.rect.top];
+        const drawableId = this.renderer.pick(mousePosition[0], mousePosition[1]);
+        if (drawableId === null) return;
+        const targetId = this.props.vm.getTargetIdForDrawableId(drawableId);
+        if (targetId === null) return;
+        this.props.vm.setEditingTarget(targetId);
     }
     onMouseMove (e) {
         const mousePosition = [e.clientX - this.rect.left, e.clientY - this.rect.top];
@@ -168,6 +177,7 @@ class Stage extends React.Component {
         return (
             <StageComponent
                 canvasRef={this.setCanvas}
+                onDoubleClick={this.onDoubleClick}
                 {...props}
             />
         );


### PR DESCRIPTION
### Resolves

#260

### Proposed Changes

Double-clicking a sprite in the stage now focuses the editing target to that sprite.

### Reason for Changes

Added feature present in 2.0.

### Test Coverage

N/A, tested locally
