### PR TITLE
Use sprite info for costumes and sounds

### DIFF
--- a/src/containers/costume-tab.jsx
+++ b/src/containers/costume-tab.jsx
@@ -37,7 +37,7 @@ class CostumeTab extends React.Component {
         editingTarget.sprite.costumes = editingTarget.sprite.costumes
             .slice(0, costumeIndex)
             .concat(editingTarget.sprite.costumes.slice(costumeIndex + 1));
-        this.props.vm.emitTargetsUpdate();
+        this.props.vm.runtime.spriteInfoReport(editingTarget);
         // @todo not sure if this is getting redrawn correctly
         this.props.vm.runtime.requestRedraw();
 
@@ -50,16 +50,23 @@ class CostumeTab extends React.Component {
         const {
             editingTarget,
             sprites,
+            stage,
             onNewCostumeClick,
             onNewBackdropClick
         } = this.props;
 
-        const addText = editingTarget && sprites[editingTarget].isStage ? 'Add Backdrop' : 'Add Costume';
-        const addFunc = editingTarget && sprites[editingTarget].isStage ? onNewBackdropClick : onNewCostumeClick;
+        const target = editingTarget && sprites[editingTarget] ? sprites[editingTarget] : stage;
+
+        if (!target) {
+            return null;
+        }
+
+        const addText = target.isStage ? 'Add Backdrop' : 'Add Costume';
+        const addFunc = target.isStage ? onNewBackdropClick : onNewCostumeClick;
 
         return (
             <AssetPanel
-                items={editingTarget ? sprites[editingTarget].costumes : []}
+                items={target.costumes || []}
                 newText={addText}
                 selectedItemIndex={this.state.selectedCostumeIndex}
                 onDeleteClick={this.handleDeleteCostume}
@@ -82,12 +89,18 @@ CostumeTab.propTypes = {
             }))
         })
     }),
+    stage: React.PropTypes.shape({
+        sounds: React.PropTypes.arrayOf(React.PropTypes.shape({
+            name: React.PropTypes.string.isRequired
+        }))
+    }),
     vm: React.PropTypes.instanceOf(VM)
 };
 
 const mapStateToProps = state => ({
     editingTarget: state.targets.editingTarget,
     sprites: state.targets.sprites,
+    stage: state.targets.stage,
     costumeLibraryVisible: state.modals.costumeLibrary,
     backdropLibraryVisible: state.modals.backdropLibrary
 });

--- a/src/containers/costume-tab.jsx
+++ b/src/containers/costume-tab.jsx
@@ -48,19 +48,18 @@ class CostumeTab extends React.Component {
 
     render () {
         const {
-            vm,
+            editingTarget,
+            sprites,
             onNewCostumeClick,
             onNewBackdropClick
         } = this.props;
 
-        const costumes = vm.editingTarget ? vm.editingTarget.sprite.costumes : [];
-
-        const addText = vm.editingTarget && vm.editingTarget.isStage ? 'Add Backdrop' : 'Add Costume';
-        const addFunc = vm.editingTarget && vm.editingTarget.isStage ? onNewBackdropClick : onNewCostumeClick;
+        const addText = editingTarget && sprites[editingTarget].isStage ? 'Add Backdrop' : 'Add Costume';
+        const addFunc = editingTarget && sprites[editingTarget].isStage ? onNewBackdropClick : onNewCostumeClick;
 
         return (
             <AssetPanel
-                items={costumes}
+                items={editingTarget ? sprites[editingTarget].costumes : []}
                 newText={addText}
                 selectedItemIndex={this.state.selectedCostumeIndex}
                 onDeleteClick={this.handleDeleteCostume}
@@ -72,8 +71,17 @@ class CostumeTab extends React.Component {
 }
 
 CostumeTab.propTypes = {
+    editingTarget: React.PropTypes.string,
     onNewBackdropClick: React.PropTypes.func.isRequired,
     onNewCostumeClick: React.PropTypes.func.isRequired,
+    sprites: React.PropTypes.shape({
+        id: React.PropTypes.shape({
+            costumes: React.PropTypes.arrayOf(React.PropTypes.shape({
+                url: React.PropTypes.string,
+                name: React.PropTypes.string.isRequired
+            }))
+        })
+    }),
     vm: React.PropTypes.instanceOf(VM)
 };
 

--- a/src/containers/sound-tab.jsx
+++ b/src/containers/sound-tab.jsx
@@ -46,10 +46,17 @@ class SoundTab extends React.Component {
         const {
             editingTarget,
             sprites,
+            stage,
             onNewSoundClick
         } = this.props;
 
-        const sounds = editingTarget ? sprites[editingTarget].sounds.map(sound => (
+        const target = editingTarget && sprites[editingTarget] ? sprites[editingTarget] : stage;
+
+        if (!target) {
+            return null;
+        }
+
+        const sounds = target.sounds ? target.sounds.map(sound => (
             {
                 url: soundIcon,
                 name: sound.name
@@ -82,12 +89,18 @@ SoundTab.propTypes = {
             }))
         })
     }),
+    stage: React.PropTypes.shape({
+        sounds: React.PropTypes.arrayOf(React.PropTypes.shape({
+            name: React.PropTypes.string.isRequired
+        }))
+    }),
     vm: React.PropTypes.instanceOf(VM).isRequired
 };
 
 const mapStateToProps = state => ({
     editingTarget: state.targets.editingTarget,
     sprites: state.targets.sprites,
+    stage: state.targets.stage,
     soundLibraryVisible: state.modals.soundLibrary
 });
 

--- a/src/containers/sound-tab.jsx
+++ b/src/containers/sound-tab.jsx
@@ -44,21 +44,24 @@ class SoundTab extends React.Component {
 
     render () {
         const {
-            vm,
+            editingTarget,
+            sprites,
             onNewSoundClick
         } = this.props;
 
-        const sounds = vm.editingTarget ? vm.editingTarget.sprite.sounds.map(sound => (
+        const sounds = editingTarget ? sprites[editingTarget].sounds.map(sound => (
             {
                 url: soundIcon,
                 name: sound.name
             }
         )) : [];
 
-
         return (
             <AssetPanel
-                items={sounds}
+                items={sounds.map(sound => ({
+                    url: soundIcon,
+                    ...sound
+                }))}
                 newText={'Add Sound'}
                 selectedItemIndex={this.state.selectedSoundIndex}
                 onDeleteClick={this.handleDeleteSound}
@@ -70,7 +73,15 @@ class SoundTab extends React.Component {
 }
 
 SoundTab.propTypes = {
+    editingTarget: React.PropTypes.string,
     onNewSoundClick: React.PropTypes.func.isRequired,
+    sprites: React.PropTypes.shape({
+        id: React.PropTypes.shape({
+            sounds: React.PropTypes.arrayOf(React.PropTypes.shape({
+                name: React.PropTypes.string.isRequired
+            }))
+        })
+    }),
     vm: React.PropTypes.instanceOf(VM).isRequired
 };
 


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/280

### Proposed Changes

_Describe what this Pull Request does_

Make rendering costume and sound tab lists use data passed in through redux instead of reaching into the VM. 

### Reason for Changes

_Explain why these changes should be made_

Reaching into the VM breaks the module boundaries and can result in unexpected problems. 

**Note**: the sound and costume tabs still reach into the VM to delete costumes, because there is no public API from the VM for that yet. And the issue with deleting sprites seems to still exist.

### Test Coverage

_Please show how you have added tests to cover your changes_
n/a
