### PR TITLE
Get `Asset` and `AssetType` from storage instance

### DIFF
--- a/src/containers/sound-library.jsx
+++ b/src/containers/sound-library.jsx
@@ -2,7 +2,6 @@ const bindAll = require('lodash.bindall');
 const React = require('react');
 const VM = require('scratch-vm');
 const AudioEngine = require('scratch-audio');
-const AssetType = require('scratch-storage').AssetType;
 const LibaryComponent = require('../components/library/library.jsx');
 
 const soundIcon = require('../components/asset-panel/icon--sound.svg');
@@ -26,7 +25,7 @@ class SoundLibrary extends React.Component {
         const idParts = md5ext.split('.');
         const md5 = idParts[0];
         const vm = this.props.vm;
-        vm.runtime.storage.load(AssetType.Sound, md5).then(soundAsset => {
+        vm.runtime.storage.load(vm.runtime.storage.AssetType.Sound, md5).then(soundAsset => {
             const sound = {
                 md5: md5ext,
                 name: soundItem.name,

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -1,5 +1,4 @@
 const ScratchStorage = require('scratch-storage');
-const AssetType = ScratchStorage.AssetType;
 
 const PROJECT_SERVER = 'https://cdn.projects.scratch.mit.edu';
 const ASSET_SERVER = 'https://cdn.assets.scratch.mit.edu';
@@ -12,7 +11,7 @@ class Storage extends ScratchStorage {
     constructor () {
         super();
         this.addWebSource(
-            [AssetType.Project],
+            [this.AssetType.Project],
             projectAsset => {
                 const [projectId, revision] = projectAsset.assetId.split('.');
                 return revision ?
@@ -21,7 +20,7 @@ class Storage extends ScratchStorage {
             }
         );
         this.addWebSource(
-            [AssetType.ImageVector, AssetType.ImageBitmap, AssetType.Sound],
+            [this.AssetType.ImageVector, this.AssetType.ImageBitmap, this.AssetType.Sound],
             asset => `${ASSET_SERVER}/internalapi/asset/${asset.assetId}.${asset.assetType.runtimeFormat}/get/`
         );
     }


### PR DESCRIPTION
### Resolves

Resolves #320 

### Proposed Changes

Access `Asset` and `AssetType` through an instance of ScratchStorage. Remove a now-unnecessary instance of `require('scratch-storage')`.

### Reason for Changes

Accessing `Asset` and `AssetType` as properties of `ScratchStorage` instead of an instance is deprecated as of LLK/scratch-storage#9. Accessing them through an instance ensures consistency between the storage runtime code and the values and objects being used with it, and allows for the possibility of a dynamic asset type list in the future.
