### PR TITLE
Fix whitespace canvas

### DIFF
--- a/src/components/stage-selector/stage-selector.css
+++ b/src/components/stage-selector/stage-selector.css
@@ -76,13 +76,14 @@ $border-width: 2px;
     display: flex;
     flex-direction: column; /* makes rows */
     align-items: center;
+    overflow: hidden;
     background-color: white;
     border-radius: calc($space / 2);
     border-width: $border-width;
     border-style: solid;
     border-color: #e9eef2;
     cursor: pointer;
-    transition: border-color 0.1s ease-out; 
+    transition: border-color 0.1s ease-out;
 }
 
 .flex-wrapper:hover {
@@ -96,7 +97,5 @@ $border-width: 2px;
 .costume-canvas {
     display: block;
     width: 100%;
-    border-top-left-radius: calc($space / 2);
-    border-top-right-radius: calc($space / 2);
     user-select: none;
 }

--- a/src/components/stage-selector/stage-selector.jsx
+++ b/src/components/stage-selector/stage-selector.jsx
@@ -33,7 +33,7 @@ const StageSelector = props => {
                     {url ? (
                         <CostumeCanvas
                             className={styles.costumeCanvas}
-                            height={44}
+                            height={42}
                             url={url}
                             width={56}
                         />


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_
Fixes #140, follow up on discussion from #285. 

### Proposed Changes

_Describe what this Pull Request does_
Use 4x3 aspect ratio on stage thumbnail to prevent blank space at the top. Also fix border radius mismatch by using overflow: hidden; on the container with the border-radius. 

![screen shot 2017-04-24 at 10 59 07 am](https://cloud.githubusercontent.com/assets/654102/25343538/5ecebee8-28dd-11e7-8752-42c15f1fc854.png)


![screen shot 2017-04-24 at 11 00 52 am](https://cloud.githubusercontent.com/assets/654102/25343539/5ecf31de-28dd-11e7-93be-976ee9637a65.png)
