### PR TITLE
Stop clobbering loading projects with default data

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -19,7 +19,7 @@ class App extends React.Component {
         this.updateProject = this.updateProject.bind(this);
         this.state = {
             projectId: null,
-            projectData: JSON.stringify(ProjectLoader.DEFAULT_PROJECT_DATA)
+            projectData: this.fetchProjectId().length ? null : ProjectLoader.DEFAULT_PROJECT_DATA
         };
     }
     componentDidMount () {
@@ -49,6 +49,7 @@ class App extends React.Component {
         }
     }
     render () {
+        if (this.state.projectData === null) return null;
         return (
             <GUI
                 basePath={this.props.basePath}


### PR DESCRIPTION
If the app is loading with an initial project id, don't try to load the default project. Previously, this default data would load on top of the project being loaded.

Does not fix the issue of blocks not loading in the blocks pane, which appears to be separate.
