### PR TITLE
Add prompt for variable creation

### DIFF
--- a/src/components/prompt/prompt.css
+++ b/src/components/prompt/prompt.css
@@ -25,6 +25,16 @@
     overflow: hidden;
 }
 
+.header {
+    font-size: 1.25rem;
+    height: 3.25rem;
+    background-color: $blue;
+    font-weight: 500;
+    color: #fff;
+    text-align: center;
+    line-height: 3.25rem;
+}
+
 .body {
     background: $ui-pane-gray;
     padding: 1.5rem 2.25rem;

--- a/src/components/prompt/prompt.css
+++ b/src/components/prompt/prompt.css
@@ -1,0 +1,71 @@
+@import "../../css/colors.css";
+@import "../../css/units.css";
+
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 1000;
+    background-color: rgba(94, 102, 125, .95);
+}
+
+.modal-content {
+    width: 360px;
+    margin: 100px auto;
+    outline: none;
+    border: 3px solid rgb(126, 133, 151);
+    padding: 0;
+    border-radius: $space;
+    user-select: none;
+
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    color: #5d647a;
+    overflow: hidden;
+}
+
+.body {
+    background: $ui-pane-gray;
+    padding: 1.5rem 2.25rem;
+}
+
+.label {
+    font-weight: 500;
+    margin: 0 0 0.75rem;
+}
+
+.input {
+    margin-bottom: 1.5rem;
+    width: 100%;
+    border: 1px solid rgba(0,0,0,.1);
+    border-radius: 5px;
+    padding: 0 1rem;
+    height: 3rem;
+    color: #6b6b6b;
+    font-size: .875rem;
+}
+
+.button-row {
+    font-weight: bolder;
+    text-align: right;
+}
+
+.button-row button {
+    padding: 0.75rem 1rem;
+    border-radius: 0.25rem;
+    background: white;
+    border: 1px solid $ui-pane-border;
+    font-weight: 600;
+    font-size: 0.85rem;
+}
+
+.button-row button.ok-button {
+    background: $blue;
+    border: $blue;
+    color: white;
+}
+
+.button-row button + button {
+    margin-left: 0.5rem;
+}

--- a/src/components/prompt/prompt.jsx
+++ b/src/components/prompt/prompt.jsx
@@ -1,70 +1,59 @@
 const React = require('react');
 const ReactModal = require('react-modal');
-const bindAll = require('lodash.bindall');
 const Box = require('../box/box.jsx');
 
 const styles = require('./prompt.css');
 
-class PromptComponent extends React.Component {
-    constructor (props) {
-        super(props);
-        bindAll(this, [
-            'handleOk',
-            'handleKeyPress'
-        ]);
-    }
-    handleKeyPress (event) {
-        if (event.key === 'Enter') this.handleOk();
-    }
-    handleOk () {
-        this.props.onOk(this.input.value);
-    }
-    render () {
-        return (
-            <ReactModal
-                isOpen
-                className={styles.modalContent}
-                overlayClassName={styles.modalOverlay}
-                onRequestClose={this.props.onCancel}
-            >
-                <Box className={styles.body}>
-                    <Box className={styles.label}>
-                        {this.props.label}
-                    </Box>
-                    <Box>
-                        <input
-                            autoFocus
-                            className={styles.input}
-                            placeholder={this.props.placeholder}
-                            ref={el => (this.input = el)}
-                            onKeyPress={this.handleKeyPress}
-                        />
-                    </Box>
-                    <Box className={styles.buttonRow}>
-                        <button
-                            className={styles.cancelButton}
-                            onClick={this.props.onCancel}
-                        >
-                            Cancel
-                        </button>
-                        <button
-                            className={styles.okButton}
-                            onClick={this.handleOk}
-                        >
-                            OK
-                        </button>
-                    </Box>
-                </Box>
-            </ReactModal>
-        );
-    }
-}
+const PromptComponent = props => (
+    <ReactModal
+        isOpen
+        className={styles.modalContent}
+        contentLabel={props.title}
+        overlayClassName={styles.modalOverlay}
+        onRequestClose={props.onCancel}
+    >
+        <Box className={styles.header}>
+            {props.title}
+        </Box>
+        <Box className={styles.body}>
+            <Box className={styles.label}>
+                {props.label}
+            </Box>
+            <Box>
+                <input
+                    autoFocus
+                    className={styles.input}
+                    placeholder={props.placeholder}
+                    onChange={props.onChange}
+                    onKeyPress={props.onKeyPress}
+                />
+            </Box>
+            <Box className={styles.buttonRow}>
+                <button
+                    className={styles.cancelButton}
+                    onClick={props.onCancel}
+                >
+                    Cancel
+                </button>
+                <button
+                    className={styles.okButton}
+                    onClick={props.onOk}
+                >
+                    OK
+                </button>
+            </Box>
+        </Box>
+    </ReactModal>
+);
 
 PromptComponent.propTypes = {
     label: React.PropTypes.string.isRequired,
     onCancel: React.PropTypes.func.isRequired,
+    onChange: React.PropTypes.func.isRequired,
+    onKeyPress: React.PropTypes.func.isRequired,
     onOk: React.PropTypes.func.isRequired,
-    placeholder: React.PropTypes.string
+    placeholder: React.PropTypes.string,
+    title: React.PropTypes.string.isRequired
 };
 
 PromptComponent.defaultProps = {

--- a/src/components/prompt/prompt.jsx
+++ b/src/components/prompt/prompt.jsx
@@ -1,3 +1,4 @@
+const PropTypes = require('prop-types');
 const React = require('react');
 const ReactModal = require('react-modal');
 const Box = require('../box/box.jsx');
@@ -47,17 +48,13 @@ const PromptComponent = props => (
 );
 
 PromptComponent.propTypes = {
-    label: React.PropTypes.string.isRequired,
-    onCancel: React.PropTypes.func.isRequired,
-    onChange: React.PropTypes.func.isRequired,
-    onKeyPress: React.PropTypes.func.isRequired,
-    onOk: React.PropTypes.func.isRequired,
-    placeholder: React.PropTypes.string,
-    title: React.PropTypes.string.isRequired
-};
-
-PromptComponent.defaultProps = {
-    placeholder: '...'
+    label: PropTypes.string.isRequired,
+    onCancel: PropTypes.func.isRequired,
+    onChange: PropTypes.func.isRequired,
+    onKeyPress: PropTypes.func.isRequired,
+    onOk: PropTypes.func.isRequired,
+    placeholder: PropTypes.string,
+    title: PropTypes.string.isRequired
 };
 
 module.exports = PromptComponent;

--- a/src/components/prompt/prompt.jsx
+++ b/src/components/prompt/prompt.jsx
@@ -1,0 +1,74 @@
+const React = require('react');
+const ReactModal = require('react-modal');
+const bindAll = require('lodash.bindall');
+const Box = require('../box/box.jsx');
+
+const styles = require('./prompt.css');
+
+class PromptComponent extends React.Component {
+    constructor (props) {
+        super(props);
+        bindAll(this, [
+            'handleOk',
+            'handleKeyPress'
+        ]);
+    }
+    handleKeyPress (event) {
+        if (event.key === 'Enter') this.handleOk();
+    }
+    handleOk () {
+        this.props.onOk(this.input.value);
+    }
+    render () {
+        return (
+            <ReactModal
+                isOpen
+                className={styles.modalContent}
+                overlayClassName={styles.modalOverlay}
+                onRequestClose={this.props.onCancel}
+            >
+                <Box className={styles.body}>
+                    <Box className={styles.label}>
+                        {this.props.label}
+                    </Box>
+                    <Box>
+                        <input
+                            autoFocus
+                            className={styles.input}
+                            placeholder={this.props.placeholder}
+                            ref={el => (this.input = el)}
+                            onKeyPress={this.handleKeyPress}
+                        />
+                    </Box>
+                    <Box className={styles.buttonRow}>
+                        <button
+                            className={styles.cancelButton}
+                            onClick={this.props.onCancel}
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            className={styles.okButton}
+                            onClick={this.handleOk}
+                        >
+                            OK
+                        </button>
+                    </Box>
+                </Box>
+            </ReactModal>
+        );
+    }
+}
+
+PromptComponent.propTypes = {
+    label: React.PropTypes.string.isRequired,
+    onCancel: React.PropTypes.func.isRequired,
+    onOk: React.PropTypes.func.isRequired,
+    placeholder: React.PropTypes.string
+};
+
+PromptComponent.defaultProps = {
+    placeholder: '...'
+};
+
+module.exports = PromptComponent;

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -4,7 +4,7 @@ const PropTypes = require('prop-types');
 const React = require('react');
 const VMScratchBlocks = require('../lib/blocks');
 const VM = require('scratch-vm');
-const Prompt = require('../components/prompt/prompt.jsx');
+const Prompt = require('./prompt.jsx');
 const BlocksComponent = require('../components/blocks/blocks.jsx');
 
 const addFunctionListener = (object, property, callback) => {
@@ -23,6 +23,7 @@ class Blocks extends React.Component {
         bindAll(this, [
             'attachVM',
             'detachVM',
+            'handlePromptStart',
             'handlePromptCallback',
             'handlePromptClose',
             'onScriptGlowOn',
@@ -34,6 +35,7 @@ class Blocks extends React.Component {
             'onWorkspaceMetricsChange',
             'setBlocks'
         ]);
+        this.ScratchBlocks.prompt = this.handlePromptStart;
         this.state = {
             workspaceMetrics: {},
             prompt: null
@@ -42,10 +44,6 @@ class Blocks extends React.Component {
     componentDidMount () {
         const workspaceConfig = defaultsDeep({}, Blocks.defaultOptions, this.props.options);
         this.workspace = this.ScratchBlocks.inject(this.blocks, workspaceConfig);
-
-        this.ScratchBlocks.prompt = (message, defaultValue, callback) => {
-            this.setState({prompt: {callback, message, defaultValue}});
-        };
 
         // @todo change this when blockly supports UI events
         addFunctionListener(this.workspace, 'translate', this.onWorkspaceMetricsChange);
@@ -134,6 +132,9 @@ class Blocks extends React.Component {
     setBlocks (blocks) {
         this.blocks = blocks;
     }
+    handlePromptStart (message, defaultValue, callback) {
+        this.setState({prompt: {callback, message, defaultValue}});
+    }
     handlePromptCallback (data) {
         this.state.prompt.callback(data);
         this.handlePromptClose();
@@ -157,6 +158,7 @@ class Blocks extends React.Component {
                     <Prompt
                         label={this.state.prompt.message}
                         placeholder={this.state.prompt.defaultValue}
+                        title="New Variable" // @todo the only prompt is for new variables
                         onCancel={this.handlePromptClose}
                         onOk={this.handlePromptCallback}
                     />

--- a/src/containers/prompt.jsx
+++ b/src/containers/prompt.jsx
@@ -1,0 +1,57 @@
+const React = require('react');
+const bindAll = require('lodash.bindall');
+const PromptComponent = require('../components/prompt/prompt.jsx');
+
+class Prompt extends React.Component {
+    constructor (props) {
+        super(props);
+        bindAll(this, [
+            'handleOk',
+            'handleCancel',
+            'handleChange',
+            'handleKeyPress'
+        ]);
+        this.state = {
+            inputValue: ''
+        };
+    }
+    handleKeyPress (event) {
+        if (event.key === 'Enter') this.handleOk();
+    }
+    handleOk () {
+        this.props.onOk(this.state.inputValue);
+    }
+    handleCancel () {
+        this.props.onCancel();
+    }
+    handleChange (e) {
+        this.setState({inputValue: e.target.value});
+    }
+    render () {
+        return (
+            <PromptComponent
+                label={this.props.label}
+                placeholder={this.props.placeholder}
+                title={this.props.title}
+                onCancel={this.handleCancel}
+                onChange={this.handleChange}
+                onKeyPress={this.handleKeyPress}
+                onOk={this.handleOk}
+            />
+        );
+    }
+}
+
+Prompt.propTypes = {
+    label: React.PropTypes.string.isRequired,
+    onCancel: React.PropTypes.func.isRequired,
+    onOk: React.PropTypes.func.isRequired,
+    placeholder: React.PropTypes.string,
+    title: React.PropTypes.string.isRequired
+};
+
+PromptComponent.defaultProps = {
+    placeholder: '...'
+};
+
+module.exports = Prompt;

--- a/src/containers/prompt.jsx
+++ b/src/containers/prompt.jsx
@@ -1,3 +1,4 @@
+const PropTypes = require('prop-types');
 const React = require('react');
 const bindAll = require('lodash.bindall');
 const PromptComponent = require('../components/prompt/prompt.jsx');
@@ -43,15 +44,11 @@ class Prompt extends React.Component {
 }
 
 Prompt.propTypes = {
-    label: React.PropTypes.string.isRequired,
-    onCancel: React.PropTypes.func.isRequired,
-    onOk: React.PropTypes.func.isRequired,
-    placeholder: React.PropTypes.string,
-    title: React.PropTypes.string.isRequired
-};
-
-PromptComponent.defaultProps = {
-    placeholder: '...'
+    label: PropTypes.string.isRequired,
+    onCancel: PropTypes.func.isRequired,
+    onOk: PropTypes.func.isRequired,
+    placeholder: PropTypes.string,
+    title: PropTypes.string.isRequired
 };
 
 module.exports = Prompt;


### PR DESCRIPTION
A simple first iteration of a new variable prompt. I wanted to get some feedback on the way this is implemented @rschamp. (The css definitely needs some work, and I avoided the header bar from the mockup because there isn't the data to fill it). 
_Update:_ Added the prompt header and refactored container/component divide.
<img width="845" alt="screen shot 2017-04-26 at 10 17 26 am" src="https://cloud.githubusercontent.com/assets/654102/25439124/94c0d13e-2a69-11e7-8850-1dd5eb2f3101.png">

Fixes https://github.com/LLK/scratch-blocks/issues/535