### PR TITLE
Revert "Merge pull request #313 from paulkaplan/use-vm-data-for-sound…

### DIFF
--- a/src/containers/costume-tab.jsx
+++ b/src/containers/costume-tab.jsx
@@ -38,7 +38,7 @@ class CostumeTab extends React.Component {
         editingTarget.sprite.costumes = editingTarget.sprite.costumes
             .slice(0, costumeIndex)
             .concat(editingTarget.sprite.costumes.slice(costumeIndex + 1));
-        this.props.vm.runtime.spriteInfoReport(editingTarget);
+        this.props.vm.emitTargetsUpdate();
         // @todo not sure if this is getting redrawn correctly
         this.props.vm.runtime.requestRedraw();
 
@@ -49,25 +49,19 @@ class CostumeTab extends React.Component {
 
     render () {
         const {
-            editingTarget,
-            sprites,
-            stage,
+            vm,
             onNewCostumeClick,
             onNewBackdropClick
         } = this.props;
 
-        const target = editingTarget && sprites[editingTarget] ? sprites[editingTarget] : stage;
+        const costumes = vm.editingTarget ? vm.editingTarget.sprite.costumes : [];
 
-        if (!target) {
-            return null;
-        }
-
-        const addText = target.isStage ? 'Add Backdrop' : 'Add Costume';
-        const addFunc = target.isStage ? onNewBackdropClick : onNewCostumeClick;
+        const addText = vm.editingTarget && vm.editingTarget.isStage ? 'Add Backdrop' : 'Add Costume';
+        const addFunc = vm.editingTarget && vm.editingTarget.isStage ? onNewBackdropClick : onNewCostumeClick;
 
         return (
             <AssetPanel
-                items={target.costumes || []}
+                items={costumes}
                 newText={addText}
                 selectedItemIndex={this.state.selectedCostumeIndex}
                 onDeleteClick={this.handleDeleteCostume}
@@ -79,29 +73,14 @@ class CostumeTab extends React.Component {
 }
 
 CostumeTab.propTypes = {
-    editingTarget: PropTypes.string,
     onNewBackdropClick: PropTypes.func.isRequired,
     onNewCostumeClick: PropTypes.func.isRequired,
-    sprites: PropTypes.shape({
-        id: PropTypes.shape({
-            costumes: PropTypes.arrayOf(PropTypes.shape({
-                url: PropTypes.string,
-                name: PropTypes.string.isRequired
-            }))
-        })
-    }),
-    stage: PropTypes.shape({
-        sounds: PropTypes.arrayOf(PropTypes.shape({
-            name: PropTypes.string.isRequired
-        }))
-    }),
     vm: PropTypes.instanceOf(VM)
 };
 
 const mapStateToProps = state => ({
     editingTarget: state.targets.editingTarget,
     sprites: state.targets.sprites,
-    stage: state.targets.stage,
     costumeLibraryVisible: state.modals.costumeLibrary,
     backdropLibraryVisible: state.modals.backdropLibrary
 });

--- a/src/containers/sound-tab.jsx
+++ b/src/containers/sound-tab.jsx
@@ -45,31 +45,21 @@ class SoundTab extends React.Component {
 
     render () {
         const {
-            editingTarget,
-            sprites,
-            stage,
+            vm,
             onNewSoundClick
         } = this.props;
 
-        const target = editingTarget && sprites[editingTarget] ? sprites[editingTarget] : stage;
-
-        if (!target) {
-            return null;
-        }
-
-        const sounds = target.sounds ? target.sounds.map(sound => (
+        const sounds = vm.editingTarget ? vm.editingTarget.sprite.sounds.map(sound => (
             {
                 url: soundIcon,
                 name: sound.name
             }
         )) : [];
 
+
         return (
             <AssetPanel
-                items={sounds.map(sound => ({
-                    url: soundIcon,
-                    ...sound
-                }))}
+                items={sounds}
                 newText={'Add Sound'}
                 selectedItemIndex={this.state.selectedSoundIndex}
                 onDeleteClick={this.handleDeleteSound}
@@ -81,27 +71,13 @@ class SoundTab extends React.Component {
 }
 
 SoundTab.propTypes = {
-    editingTarget: PropTypes.string,
     onNewSoundClick: PropTypes.func.isRequired,
-    sprites: PropTypes.shape({
-        id: PropTypes.shape({
-            sounds: PropTypes.arrayOf(PropTypes.shape({
-                name: PropTypes.string.isRequired
-            }))
-        })
-    }),
-    stage: PropTypes.shape({
-        sounds: PropTypes.arrayOf(PropTypes.shape({
-            name: PropTypes.string.isRequired
-        }))
-    }),
     vm: PropTypes.instanceOf(VM).isRequired
 };
 
 const mapStateToProps = state => ({
     editingTarget: state.targets.editingTarget,
     sprites: state.targets.sprites,
-    stage: state.targets.stage,
     soundLibraryVisible: state.modals.soundLibrary
 });
 


### PR DESCRIPTION
This reverts commit d20238ae73e97c0aa6c12bd469a274b0aedd7130, reversing
changes made to a151f4bfb24ac7aee8591d97295743a2fba66ce2.

Reverting PR https://github.com/LLK/scratch-gui/pull/313

The code changed in the VM that made this possible is causing performance problems that make it basically unusable. As a quick example, try adding a sprite and then dragging a sprite around the stage. For this reason, I think we should revert this and https://github.com/llk/scratch-vm/pull/526 and rethink how we want to do it. 