### PR TITLE
Add reducer, components and containers for monitors

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "prop-types": "15.5.8",
     "react": "15.5.4",
     "react-dom": "15.5.4",
+    "react-draggable": "^2.2.6",
     "react-modal": "1.7.7",
     "react-redux": "5.0.4",
     "react-style-proptype": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "prop-types": "15.5.8",
     "react": "15.5.4",
     "react-dom": "15.5.4",
-    "react-draggable": "^2.2.6",
+    "react-draggable": "2.2.6",
     "react-modal": "1.7.7",
     "react-redux": "5.0.4",
     "react-style-proptype": "3.0.0",

--- a/src/components/monitor-list/monitor-list.css
+++ b/src/components/monitor-list/monitor-list.css
@@ -1,7 +1,4 @@
 .monitor-list {
-    position: absolute;
-    top: 0;
-    left: 0;
     width: 100%;
     height: 100%;
     pointer-events: none;

--- a/src/components/monitor-list/monitor-list.css
+++ b/src/components/monitor-list/monitor-list.css
@@ -1,0 +1,8 @@
+.monitor-list {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+}

--- a/src/components/monitor-list/monitor-list.jsx
+++ b/src/components/monitor-list/monitor-list.jsx
@@ -1,0 +1,33 @@
+const React = require('react');
+const Box = require('../box/box.jsx');
+const Monitor = require('../../containers/monitor.jsx');
+const PropTypes = require('prop-types');
+
+const styles = require('./monitor-list.css');
+
+const MonitorList = props => (
+    <Box
+        className={styles.monitorList}
+    >
+        {props.monitors.map(monitorData => (
+            <Monitor
+                {...monitorData}
+                key={monitorData.id}
+                onDragEnd={props.onMonitorChange}
+            />
+        ))}
+    </Box>
+);
+
+MonitorList.propTypes = {
+    monitors: PropTypes.arrayOf(PropTypes.shape({
+        color: PropTypes.string,
+        label: PropTypes.string.isRequired,
+        value: PropTypes.string.isRequired,
+        x: PropTypes.number,
+        y: PropTypes.number
+    })),
+    onMonitorChange: PropTypes.func.isRequired
+};
+
+module.exports = MonitorList;

--- a/src/components/monitor/monitor.css
+++ b/src/components/monitor/monitor.css
@@ -1,0 +1,40 @@
+@import "../../css/units.css";
+@import "../../css/colors.css";
+
+.monitor {
+    position: absolute;
+    padding: 3px;
+    background: $ui-pane-gray;
+    z-index: 100;
+    border: 1px solid $ui-pane-border;
+    border-radius: calc($space / 2);
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 0.75rem;
+    display: flex;
+    transition: box-shadow 0.2s;
+    pointer-events: all;
+}
+
+.monitor:hover {
+    cursor: pointer;
+}
+
+.dragging {
+    z-index: 101;
+    box-shadow: 3px 3px 5px #888888;
+}
+
+.label {
+    font-weight: bold;
+    text-align: center;
+    margin: 0 5px;
+}
+
+.value {
+    min-width: 40px;
+    text-align: center;
+    color: white;
+    margin: 0 5px;
+    border-radius: calc($space / 2);
+    padding: 0 2px;
+}

--- a/src/components/monitor/monitor.jsx
+++ b/src/components/monitor/monitor.jsx
@@ -1,0 +1,56 @@
+const React = require('react');
+const PropTypes = require('prop-types');
+const Draggable = require('react-draggable');
+const Box = require('../box/box.jsx');
+const styles = require('./monitor.css');
+
+const categories = {
+    data: '#FF8C1A',
+    sensing: '#5CB1D6',
+    sounds: '#CF63CF',
+    looks: '#9966FF',
+    motion: '#4C97FF'
+};
+
+const MonitorComponent = props => (
+    <Draggable
+        bounds="parent"
+        defaultClassNameDragging={styles.dragging}
+        defaultPosition={{
+            x: props.x,
+            y: props.y
+        }}
+        onStop={props.onDragEnd}
+    >
+        <Box className={styles.monitor}>
+            <Box className={styles.label}>
+                {props.label}
+            </Box>
+            <Box
+                className={styles.value}
+                style={{background: categories[props.category]}}
+            >
+                {props.value}
+            </Box>
+        </Box>
+    </Draggable>
+);
+
+MonitorComponent.categories = categories;
+
+MonitorComponent.propTypes = {
+    category: PropTypes.oneOf(Object.keys(categories)),
+    label: PropTypes.string.isRequired,
+    onDragEnd: PropTypes.func.isRequired,
+    value: PropTypes.string.isRequired,
+    x: PropTypes.number,
+    y: PropTypes.number
+};
+
+MonitorComponent.defaultProps = {
+    category: 'data',
+    x: 0,
+    y: 0
+};
+
+module.exports = MonitorComponent;

--- a/src/components/stage/stage.css
+++ b/src/components/stage/stage.css
@@ -21,4 +21,6 @@
     position: absolute;
     top: 0;
     left: 0;
+    width: 100%;
+    height: 100%;
 }

--- a/src/components/stage/stage.css
+++ b/src/components/stage/stage.css
@@ -1,14 +1,24 @@
 @import "../../css/units.css";
 
 .stage {
-    /* 
-        Fixes a few extra pixels of margin/padding, that adds on to the bottom 
+    /*
+        Fixes a few extra pixels of margin/padding, that adds on to the bottom
         of the element, which messes up the chrome padding consistency
     */
-    display: block; 
-    
-    border-radius: $space; 
+    display: block;
+
+    border-radius: $space;
 
     /* @todo: This is for overriding the value being set somewhere. Where is it being set? */
-    background-color: transparent; 
+    background-color: transparent;
+}
+
+.stage-wrapper {
+    position: relative;
+}
+
+.monitor-wrapper {
+    position: absolute;
+    top: 0;
+    left: 0;
 }

--- a/src/components/stage/stage.jsx
+++ b/src/components/stage/stage.jsx
@@ -2,6 +2,7 @@ const PropTypes = require('prop-types');
 const React = require('react');
 
 const Box = require('../box/box.jsx');
+const MonitorList = require('../../containers/monitor-list.jsx');
 const styles = require('./stage.css');
 
 const StageComponent = props => {
@@ -12,14 +13,17 @@ const StageComponent = props => {
         ...boxProps
     } = props;
     return (
-        <Box
-            className={styles.stage}
-            componentRef={canvasRef}
-            element="canvas"
-            height={height}
-            width={width}
-            {...boxProps}
-        />
+        <Box className={styles.stageWrapper}>
+            <Box
+                className={styles.stage}
+                componentRef={canvasRef}
+                element="canvas"
+                height={height}
+                width={width}
+                {...boxProps}
+            />
+            <MonitorList />
+        </Box>
     );
 };
 StageComponent.propTypes = {

--- a/src/components/stage/stage.jsx
+++ b/src/components/stage/stage.jsx
@@ -22,7 +22,9 @@ const StageComponent = props => {
                 width={width}
                 {...boxProps}
             />
-            <MonitorList />
+            <Box className={styles.monitorWrapper}>
+                <MonitorList />
+            </Box>
         </Box>
     );
 };

--- a/src/containers/monitor-list.jsx
+++ b/src/containers/monitor-list.jsx
@@ -26,7 +26,7 @@ class MonitorList extends React.Component {
 }
 
 const mapStateToProps = state => ({
-    monitors: state.monitors.monitors
+    monitors: state.monitors
 });
 const mapDispatchToProps = () => ({});
 

--- a/src/containers/monitor-list.jsx
+++ b/src/containers/monitor-list.jsx
@@ -1,0 +1,36 @@
+const bindAll = require('lodash.bindall');
+const React = require('react');
+
+const {connect} = require('react-redux');
+
+const MonitorListComponent = require('../components/monitor-list/monitor-list.jsx');
+
+class MonitorList extends React.Component {
+    constructor (props) {
+        super(props);
+        bindAll(this, [
+            'handleMonitorChange'
+        ]);
+    }
+    handleMonitorChange (id, x, y) { // eslint-disable-line no-unused-vars
+        // @todo send this event to the VM
+    }
+    render () {
+        return (
+            <MonitorListComponent
+                onMonitorChange={this.handleMonitorChange}
+                {...this.props}
+            />
+        );
+    }
+}
+
+const mapStateToProps = state => ({
+    monitors: state.monitors.monitors
+});
+const mapDispatchToProps = () => ({});
+
+module.exports = connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(MonitorList);

--- a/src/containers/monitor.jsx
+++ b/src/containers/monitor.jsx
@@ -1,0 +1,32 @@
+const bindAll = require('lodash.bindall');
+const React = require('react');
+
+const MonitorComponent = require('../components/monitor/monitor.jsx');
+
+class Monitor extends React.Component {
+    constructor (props) {
+        super(props);
+        bindAll(this, [
+            'handleDragEnd'
+        ]);
+    }
+    handleDragEnd (_, {x, y}) {
+        this.props.onDragEnd(
+            this.props.id,
+            x,
+            y
+        );
+    }
+    render () {
+        return (
+            <MonitorComponent
+                {...this.props}
+                onDragEnd={this.handleDragEnd}
+            />
+        );
+    }
+}
+
+Monitor.propTypes = MonitorComponent.propTypes;
+
+module.exports = Monitor;

--- a/src/containers/monitor.jsx
+++ b/src/containers/monitor.jsx
@@ -10,7 +10,7 @@ class Monitor extends React.Component {
             'handleDragEnd'
         ]);
     }
-    handleDragEnd (_, {x, y}) {
+    handleDragEnd (e, {x, y}) {
         this.props.onDragEnd(
             this.props.id,
             x,

--- a/src/reducers/gui.js
+++ b/src/reducers/gui.js
@@ -2,5 +2,6 @@ const {combineReducers} = require('redux');
 
 module.exports = combineReducers({
     modals: require('./modals'),
-    targets: require('./targets')
+    targets: require('./targets'),
+    monitors: require('./monitors')
 });

--- a/src/reducers/monitors.js
+++ b/src/reducers/monitors.js
@@ -1,0 +1,27 @@
+const UPDATE_MONITORS = 'scratch-gui/monitors/UPDATE_MONITORS';
+
+const initialState = {
+    monitors: []
+};
+
+const reducer = function (state, action) {
+    if (typeof state === 'undefined') state = initialState;
+    switch (action.type) {
+    case UPDATE_MONITORS:
+        return Object.assign({}, state, {monitors: action.monitors});
+    default:
+        return state;
+    }
+};
+
+reducer.updateMonitors = function (monitors) {
+    return {
+        type: UPDATE_MONITORS,
+        monitors: monitors,
+        meta: {
+            throttle: 30
+        }
+    };
+};
+
+module.exports = reducer;

--- a/src/reducers/monitors.js
+++ b/src/reducers/monitors.js
@@ -6,7 +6,7 @@ const reducer = function (state, action) {
     if (typeof state === 'undefined') state = initialState;
     switch (action.type) {
     case UPDATE_MONITORS:
-        return action.monitors;
+        return [...action.monitors];
     default:
         return state;
     }

--- a/src/reducers/monitors.js
+++ b/src/reducers/monitors.js
@@ -1,14 +1,12 @@
 const UPDATE_MONITORS = 'scratch-gui/monitors/UPDATE_MONITORS';
 
-const initialState = {
-    monitors: []
-};
+const initialState = [];
 
 const reducer = function (state, action) {
     if (typeof state === 'undefined') state = initialState;
     switch (action.type) {
     case UPDATE_MONITORS:
-        return Object.assign({}, state, {monitors: action.monitors});
+        return action.monitors;
     default:
         return state;
     }


### PR DESCRIPTION
Initial front-end for monitors including a reducer for updating monitors, an stage-overlayed component that displays monitors and draggable monitor components that emit position events at the end of their drags. 

![monitor-updates](https://cloud.githubusercontent.com/assets/654102/25668234/206c97b0-2ff4-11e7-996e-0728e4bb8d6d.gif)

You can add monitors through the redux console by dispatching this event:
```
{
    type: 'scratch-gui/monitors/UPDATE_MONITORS',
    monitors: [{
        id: 'var1',
        category: 'data',
        label: 'Variable',
        value: '123',
        x: 20,
        y: 40
    }, {
        id: 'var2',
        category: 'motion',
        label: 'Variable2',
        value: '123123123',
        x: 200,
        y: 100
    }]
}
```