### PR TITLE
Allow pointer events to fall through the overlay

### DIFF
--- a/src/components/stage/stage.css
+++ b/src/components/stage/stage.css
@@ -23,4 +23,5 @@
     left: 0;
     width: 100%;
     height: 100%;
+    pointer-events: none;
 }


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_
Fixes https://github.com/LLK/scratch-gui/issues/341
### Proposed Changes

_Describe what this Pull Request does_
Add `pointer-events: none` to the container.

### Reason for Changes

_Explain why these changes should be made_
Allow pointer events to fall through the overlay
