### PR TITLE
Only listen to targets updates

### DIFF
--- a/src/containers/costume-tab.jsx
+++ b/src/containers/costume-tab.jsx
@@ -38,7 +38,7 @@ class CostumeTab extends React.Component {
         editingTarget.sprite.costumes = editingTarget.sprite.costumes
             .slice(0, costumeIndex)
             .concat(editingTarget.sprite.costumes.slice(costumeIndex + 1));
-        this.props.vm.runtime.spriteInfoReport(editingTarget);
+        this.props.vm.runtime.requestTargetsUpdate(editingTarget);
         // @todo not sure if this is getting redrawn correctly
         this.props.vm.runtime.requestRedraw();
 

--- a/src/lib/vm-listener-hoc.jsx
+++ b/src/lib/vm-listener-hoc.jsx
@@ -27,7 +27,6 @@ const vmListenerHOC = function (WrappedComponent) {
             // If the wrapped component uses the vm in componentDidMount, then
             // we need to start listening before mounting the wrapped component.
             this.props.vm.on('targetsUpdate', this.props.onTargetsUpdate);
-            this.props.vm.on('SPRITE_INFO_REPORT', this.props.onSpriteInfoReport);
         }
         componentDidMount () {
             if (this.props.attachKeyboardEvents) {
@@ -100,9 +99,6 @@ const vmListenerHOC = function (WrappedComponent) {
         onTargetsUpdate: data => {
             dispatch(targets.updateEditingTarget(data.editingTarget));
             dispatch(targets.updateTargets(data.targetList));
-        },
-        onSpriteInfoReport: spriteInfo => {
-            dispatch(targets.updateTarget(spriteInfo));
         }
     });
     return connect(

--- a/src/reducers/targets.js
+++ b/src/reducers/targets.js
@@ -15,8 +15,8 @@ const reducer = function (state, action) {
                 .filter(target => !target.isStage)
                 .reduce(
                     (targets, target, listId) => Object.assign(
-                        {[target.id]: {order: listId, ...target}},
-                        targets
+                        targets,
+                        {[target.id]: {order: listId, ...target}}
                     ),
                     {}
                 ),

--- a/src/reducers/targets.js
+++ b/src/reducers/targets.js
@@ -1,8 +1,5 @@
-const defaultsDeep = require('lodash.defaultsdeep');
-
 const UPDATE_EDITING_TARGET = 'scratch-gui/targets/UPDATE_EDITING_TARGET';
 const UPDATE_TARGET_LIST = 'scratch-gui/targets/UPDATE_TARGET_LIST';
-const UPDATE_TARGET = 'scratch/targets/UPDATE_TARGET';
 
 const initialState = {
     sprites: {},
@@ -12,54 +9,25 @@ const initialState = {
 const reducer = function (state, action) {
     if (typeof state === 'undefined') state = initialState;
     switch (action.type) {
-    case UPDATE_TARGET:
-        if (action.target.id === state.stage.id) {
-            return Object.assign({}, state, {
-                stage: Object.assign({}, state.stage, action.target)
-            });
-        }
-        return Object.assign({}, state, {
-            sprites: defaultsDeep(
-                {[action.target.id]: action.target},
-                state.sprites
-            )
-        });
     case UPDATE_TARGET_LIST:
         return Object.assign({}, state, {
             sprites: action.targets
                 .filter(target => !target.isStage)
                 .reduce(
-                    (targets, target, listId) => defaultsDeep(
+                    (targets, target, listId) => Object.assign(
                         {[target.id]: {order: listId, ...target}},
-                        {[target.id]: state.sprites[target.id]},
                         targets
                     ),
                     {}
                 ),
             stage: action.targets
-                .filter(target => target.isStage)
-                .reduce(
-                    (stage, target) => {
-                        if (target.id !== stage.id) return target;
-                        return defaultsDeep(target, stage);
-                    },
-                    state.stage
-                )
+                .filter(target => target.isStage)[0] || {}
         });
     case UPDATE_EDITING_TARGET:
         return Object.assign({}, state, {editingTarget: action.target});
     default:
         return state;
     }
-};
-reducer.updateTarget = function (target) {
-    return {
-        type: UPDATE_TARGET,
-        target: target,
-        meta: {
-            throttle: 30
-        }
-    };
 };
 reducer.updateTargets = function (targetList) {
     return {


### PR DESCRIPTION
This reduces the complexity of the reducer, as well as how frequently it's run. The VM will emit a targets update after a step if any target info has changed.

### Resolves

_What Github issue does this resolve (please include link)?_
Resolves https://github.com/LLK/scratch-vm/issues/550. Brings the "medium complexity" project to comparable performance of the VM playground.

### Proposed Changes

_Describe what this Pull Request does_
Stop listening to `SPRITE_INFO_REPORT`, since as of https://github.com/LLK/scratch-vm/pull/563 the VM isn't emitting them anymore.

### Reason for Changes

_Explain why these changes should be made_
A lot of time is spent in the reducer merging sprite info into the GUI's target list. Instead just use the current state of the list from `targetsUpdate`, which now is emitted each step which modifies target data.

Before (lots of time in reducer):
![image](https://cloud.githubusercontent.com/assets/1512021/26006558/e3a02612-370a-11e7-99b3-3346d268c152.png)

After (only a little time in reducer):
![image](https://cloud.githubusercontent.com/assets/1512021/26006594/01d41ac6-370b-11e7-94d5-c45c4472cdd7.png)

/cc @thisandagain @fsih 