### PR TITLE
Costume tab title changes to "Backdrops" when stage is selected

### DIFF
--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -25,6 +25,7 @@ const GUIComponent = props => {
         children,
         vm,
         onTabSelect,
+        costumeTabText,
         tabIndex,
         ...componentProps
     } = props;
@@ -63,7 +64,7 @@ const GUIComponent = props => {
                         >
                             <TabList className={tabClassNames.tabList}>
                                 <Tab className={tabClassNames.tab}>Scripts</Tab>
-                                <Tab className={tabClassNames.tab}>Costumes</Tab>
+                                <Tab className={tabClassNames.tab}>{costumeTabText}</Tab>
                                 <Tab className={tabClassNames.tab}>Sounds</Tab>
                             </TabList>
                             <TabPanel className={tabClassNames.tabPanel}>
@@ -114,6 +115,7 @@ const GUIComponent = props => {
 GUIComponent.propTypes = {
     basePath: PropTypes.string,
     children: PropTypes.node,
+    costumeTabText: PropTypes.string,
     onTabSelect: PropTypes.func,
     tabIndex: PropTypes.number,
     vm: PropTypes.instanceOf(VM).isRequired

--- a/src/containers/costume-tab.jsx
+++ b/src/containers/costume-tab.jsx
@@ -55,7 +55,7 @@ class CostumeTab extends React.Component {
             onNewCostumeClick,
             onNewBackdropClick
         } = this.props;
-
+        
         const target = editingTarget && sprites[editingTarget] ? sprites[editingTarget] : stage;
 
         if (!target) {

--- a/src/containers/gui.jsx
+++ b/src/containers/gui.jsx
@@ -7,6 +7,8 @@ const vmListenerHOC = require('../lib/vm-listener-hoc.jsx');
 
 const GUIComponent = require('../components/gui/gui.jsx');
 
+const {connect} = require('react-redux');
+
 class GUI extends React.Component {
     constructor (props) {
         super(props);
@@ -35,10 +37,16 @@ class GUI extends React.Component {
         const {
             projectData, // eslint-disable-line no-unused-vars
             vm,
+            editingTarget,
+            sprites,
             ...componentProps
         } = this.props;
+        
+        const costumeTabText = editingTarget && sprites[editingTarget] ? 'Costumes' : 'Backdrops';
+        
         return (
             <GUIComponent
+                costumeTabText={costumeTabText}
                 tabIndex={this.state.tabIndex}
                 vm={vm}
                 onTabSelect={this.handleTabSelect}
@@ -50,10 +58,24 @@ class GUI extends React.Component {
 
 GUI.propTypes = {
     ...GUIComponent.propTypes,
+    editingTarget: PropTypes.string,
     projectData: PropTypes.string,
+    sprites: PropTypes.shape({
+        id: PropTypes.shape({
+            costumes: PropTypes.arrayOf(PropTypes.shape({
+                url: PropTypes.string,
+                name: PropTypes.string.isRequired
+            }))
+        })
+    }),
     vm: PropTypes.instanceOf(VM)
 };
 
 GUI.defaultProps = GUIComponent.defaultProps;
 
-module.exports = vmListenerHOC(GUI);
+const mapStateToProps = state => ({
+    editingTarget: state.targets.editingTarget,
+    sprites: state.targets.sprites
+});
+
+module.exports = vmListenerHOC(connect(mapStateToProps)(GUI));


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_
#267 

### Proposed Changes

_Describe what this Pull Request does_

The "Costumes" tab title now changes to "Backdrops" when the stage is selected.

### Reason for Changes

_Explain why these changes should be made_

Matching behavior from Scratch 2.0.