### PR TITLE
Use library mouseenter and mouseleave to cycle sprite costumes

### DIFF
--- a/src/components/library-item/library-item.css
+++ b/src/components/library-item/library-item.css
@@ -26,8 +26,16 @@
     border-color: #1dacf4;
 }
 
-.library-item-image-container {
+.library-item-image-container-wrapper {
     height: 100px;
+    width: 100%;
+    position: relative;
+}
+
+.library-item-image-container {
+    position: absolute;
+    height: 100px;
+    width: 100%;
 }
 
 .library-item-image {

--- a/src/components/library-item/library-item.jsx
+++ b/src/components/library-item/library-item.jsx
@@ -35,11 +35,14 @@ class LibraryItem extends React.Component {
                 onMouseEnter={this.handleMouseEnter}
                 onMouseLeave={this.handleMouseLeave}
             >
-                <Box className={styles.libraryItemImageContainer}>
-                    <img
-                        className={styles.libraryItemImage}
-                        src={this.props.iconURL}
-                    />
+                {/* Layers of wrapping is to prevent layout thrashing on animation */}
+                <Box className={styles.libraryItemImageContainerWrapper}>
+                    <Box className={styles.libraryItemImageContainer}>
+                        <img
+                            className={styles.libraryItemImage}
+                            src={this.props.iconURL}
+                        />
+                    </Box>
                 </Box>
                 <span className={styles.libraryItemName}>{this.props.name}</span>
             </Box>

--- a/src/components/library-item/library-item.jsx
+++ b/src/components/library-item/library-item.jsx
@@ -14,6 +14,9 @@ class LibraryItem extends React.Component {
             'handleMouseLeave'
         ]);
     }
+    shouldComponentUpdate (nextProps) {
+        return this.props.iconURL !== nextProps.iconURL;
+    }
     handleClick (e) {
         this.props.onSelect(this.props.id);
         e.preventDefault();

--- a/src/containers/costume-library.jsx
+++ b/src/containers/costume-library.jsx
@@ -7,7 +7,7 @@ const costumeLibraryContent = require('../lib/libraries/costumes.json');
 const LibraryComponent = require('../components/library/library.jsx');
 
 
-class CostumeLibrary extends React.Component {
+class CostumeLibrary extends React.PureComponent {
     constructor (props) {
         super(props);
         bindAll(this, [

--- a/src/containers/sound-library.jsx
+++ b/src/containers/sound-library.jsx
@@ -9,7 +9,7 @@ const soundIcon = require('../components/asset-panel/icon--sound.svg');
 
 const soundLibraryContent = require('../lib/libraries/sounds.json');
 
-class SoundLibrary extends React.Component {
+class SoundLibrary extends React.PureComponent {
     constructor (props) {
         super(props);
         bindAll(this, [

--- a/src/containers/sprite-library.jsx
+++ b/src/containers/sprite-library.jsx
@@ -11,18 +11,55 @@ class SpriteLibrary extends React.Component {
     constructor (props) {
         super(props);
         bindAll(this, [
-            'handleItemSelect'
+            'handleItemSelect',
+            'handleMouseEnter',
+            'handleMouseLeave',
+            'rotateCostume'
         ]);
+        this.state = {
+            activeSprite: null,
+            costumeIndex: 0,
+            sprites: spriteLibraryContent
+        };
+    }
+    componentWillReceiveProps (newProps) {
+        if (!newProps.visible) clearInterval(this.intervalId);
     }
     handleItemSelect (item) {
         this.props.vm.addSprite2(JSON.stringify(item.json));
     }
+    handleMouseEnter (item) {
+        this.setState({activeSprite: item});
+        if (this.intervalId) clearInterval(this.intervalId);
+        this.intervalId = setInterval(this.rotateCostume, 300);
+    }
+    handleMouseLeave () {
+        this.intervalId = clearInterval(this.intervalId);
+    }
+    rotateCostume () {
+        const costumes = this.state.activeSprite.json.costumes;
+        const nextCostumeIndex = (this.state.costumeIndex + 1) % costumes.length;
+        this.setState({
+            costumeIndex: nextCostumeIndex,
+            sprites: this.state.sprites.map(sprite => {
+                if (sprite.name === this.state.activeSprite.name) {
+                    return {
+                        ...sprite,
+                        md5: sprite.json.costumes[nextCostumeIndex].baseLayerMD5
+                    };
+                }
+                return sprite;
+            })
+        });
+    }
     render () {
         return (
             <LibraryComponent
-                data={spriteLibraryContent}
+                data={this.state.sprites}
                 title="Sprite Library"
                 visible={this.props.visible}
+                onItemMouseEnter={this.handleMouseEnter}
+                onItemMouseLeave={this.handleMouseLeave}
                 onItemSelected={this.handleItemSelect}
                 onRequestClose={this.props.onRequestClose}
             />

--- a/src/containers/sprite-library.jsx
+++ b/src/containers/sprite-library.jsx
@@ -7,7 +7,7 @@ const spriteLibraryContent = require('../lib/libraries/sprites.json');
 
 const LibraryComponent = require('../components/library/library.jsx');
 
-class SpriteLibrary extends React.Component {
+class SpriteLibrary extends React.PureComponent {
     constructor (props) {
         super(props);
         bindAll(this, [

--- a/src/containers/sprite-library.jsx
+++ b/src/containers/sprite-library.jsx
@@ -14,7 +14,9 @@ class SpriteLibrary extends React.Component {
             'handleItemSelect',
             'handleMouseEnter',
             'handleMouseLeave',
-            'rotateCostume'
+            'rotateCostume',
+            'startRotatingCostumes',
+            'stopRotatingCostumes'
         ]);
         this.state = {
             activeSprite: null,
@@ -29,11 +31,17 @@ class SpriteLibrary extends React.Component {
         this.props.vm.addSprite2(JSON.stringify(item.json));
     }
     handleMouseEnter (item) {
-        this.setState({activeSprite: item});
-        if (this.intervalId) clearInterval(this.intervalId);
-        this.intervalId = setInterval(this.rotateCostume, 300);
+        this.stopRotatingCostumes();
+        this.setState({activeSprite: item}, this.startRotatingCostumes);
     }
     handleMouseLeave () {
+        this.stopRotatingCostumes();
+    }
+    startRotatingCostumes () {
+        if (!this.state.activeSprite) return;
+        this.intervalId = setInterval(this.rotateCostume, 300);
+    }
+    stopRotatingCostumes () {
         this.intervalId = clearInterval(this.intervalId);
     }
     rotateCostume () {

--- a/src/containers/sprite-library.jsx
+++ b/src/containers/sprite-library.jsx
@@ -39,6 +39,7 @@ class SpriteLibrary extends React.PureComponent {
     }
     startRotatingCostumes () {
         if (!this.state.activeSprite) return;
+        this.rotateCostume();
         this.intervalId = setInterval(this.rotateCostume, 300);
     }
     stopRotatingCostumes () {


### PR DESCRIPTION
### Proposed Changes

_Describe what this Pull Request does_

Use the new mouseenter and mouseleave hooks to cycle through a sprites costume when it is hovered over. 

![costume-cycling](https://cloud.githubusercontent.com/assets/654102/26407046/ff1b7188-4067-11e7-9373-ccce491f24cc.gif)

Note that as shown in the gif, if a sprites costume does not have the correct svg positioning, it will not show or it may show off center. That is a separate issue that we will have to deal with. 