### PR TITLE
Use PureComponent and remove incorrect shouldComponentUpdate call

### DIFF
--- a/src/components/library-item/library-item.jsx
+++ b/src/components/library-item/library-item.jsx
@@ -5,7 +5,7 @@ const React = require('react');
 const Box = require('../box/box.jsx');
 const styles = require('./library-item.css');
 
-class LibraryItem extends React.Component {
+class LibraryItem extends React.PureComponent {
     constructor (props) {
         super(props);
         bindAll(this, [
@@ -13,9 +13,6 @@ class LibraryItem extends React.Component {
             'handleMouseEnter',
             'handleMouseLeave'
         ]);
-    }
-    shouldComponentUpdate (nextProps) {
-        return this.props.iconURL !== nextProps.iconURL;
     }
     handleClick (e) {
         this.props.onSelect(this.props.id);


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_
Fixes https://github.com/LLK/scratch-gui/issues/393
### Proposed Changes

_Describe what this Pull Request does_
Instead of only checking for iconURL changes, check all props for `shouldUpdate` by using `PureComponent` (reference: https://facebook.github.io/react/docs/react-api.html#react.purecomponent)
### Reason for Changes

_Explain why these changes should be made_
With filtering, the other props can change! See https://github.com/LLK/scratch-gui/issues/393 for an explanation of the resulting bug.