### PR TITLE
Made selected tab more prominent

### DIFF
--- a/src/components/gui/gui.css
+++ b/src/components/gui/gui.css
@@ -64,8 +64,10 @@
 }
 
 .tab.is-selected {
+    z-index: 1;
     color: #40B9F5;
     background-color: #FFFFFF;
+    border-bottom: white 1px solid;
 }
 
 .tabs {


### PR DESCRIPTION
Updates border bottom color of selected tab to the same color as the background of what's under it, to better show what's selected/unselected

Depends on #396 to keep the width set

![tabs-fixed-border-v2 mov](https://cloud.githubusercontent.com/assets/716168/26604312/f72278f6-4557-11e7-9736-21b31ecdc9e2.gif)



