### PR TITLE
Put letter blocks back at the end of the sprites list

### DIFF
--- a/src/lib/libraries/sprites.json
+++ b/src/lib/libraries/sprites.json
@@ -1,5 +1,15294 @@
 [
     {
+        "name": "Abby",
+        "md5": "afab2d2141e9811bd89e385e9628cb5f.svg",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "city",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            4,
+            1
+        ],
+        "json": {
+            "objName": "Abby",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "abby-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "afab2d2141e9811bd89e385e9628cb5f.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 31,
+                    "rotationCenterY": 100
+                },
+                {
+                    "costumeName": "abby-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "1e0116c7c2e5e80c679d0b33f1f5cfb7.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 31,
+                    "rotationCenterY": 100
+                },
+                {
+                    "costumeName": "abby-c",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "b6e23922f23b49ddc6f62f675e77417c.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 32,
+                    "rotationCenterY": 100
+                },
+                {
+                    "costumeName": "abby-d",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "2193cf08f74b8354f7c4fac37a06ea24.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 31,
+                    "rotationCenterY": 100
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Airplane",
+        "md5": "58bcb130f226bda9017f1a443360a78a.png",
+        "type": "sprite",
+        "tags": [
+            "transportation",
+            "flying",
+            "city",
+            "photo",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Airplane",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "airplane2",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "58bcb130f226bda9017f1a443360a78a.png",
+                    "rotationCenterX": 100,
+                    "rotationCenterY": 32
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Amon",
+        "md5": "8d508770c1991fe05959c9b3b5167036.gif",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "flying",
+            "photo",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Amon",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "amon",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "8d508770c1991fe05959c9b3b5167036.gif",
+                    "rotationCenterX": 87,
+                    "rotationCenterY": 81
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Anina Hip-Hop",
+        "md5": "6d01c961449223f9e61dda9281100806.png",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "dance",
+            "city",
+            "photo",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            13,
+            1
+        ],
+        "json": {
+            "objName": "Anina Hip-Hop",
+            "sounds": [
+                {
+                    "soundName": "dance celebrate",
+                    "soundID": -1,
+                    "md5": "0edb8fb88af19e6e17d0f8cf64c1d136.wav",
+                    "sampleCount": 176401,
+                    "rate": 22050,
+                    "format": "adpcm"
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "anina stance",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "6d01c961449223f9e61dda9281100806.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 76,
+                    "rotationCenterY": 252
+                },
+                {
+                    "costumeName": "anina top stand",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "34d6362cb4030d92be6fec73300f0aec.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 74,
+                    "rotationCenterY": 280
+                },
+                {
+                    "costumeName": "anina top R step",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "0477f7105d02b9a902382eca080476dc.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 248,
+                    "rotationCenterY": 272
+                },
+                {
+                    "costumeName": "anina top L step",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "62a89d8c6f7680e342132fcde59b2a5d.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 228,
+                    "rotationCenterY": 274
+                },
+                {
+                    "costumeName": "anina top freeze",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "dd67565519bdebea1b931deb19621384.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 110,
+                    "rotationCenterY": 268
+                },
+                {
+                    "costumeName": "anina R cross",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "22f3ca23b2f0ac67f8ebc36a8c3116a0.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 126,
+                    "rotationCenterY": 268
+                },
+                {
+                    "costumeName": "anina pop front",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "c163f1002f61421816386e52522b9133.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 68,
+                    "rotationCenterY": 270
+                },
+                {
+                    "costumeName": "anina pop down",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "e9e54ff1fa61c71507e25540d0326177.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 74,
+                    "rotationCenterY": 156
+                },
+                {
+                    "costumeName": "anina pop left",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "9fda30f66d51b2ad5f6fe11d57e199d6.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 238,
+                    "rotationCenterY": 266
+                },
+                {
+                    "costumeName": "anina pop right",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "cc2594e9278494e82f725be34369f178.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 66,
+                    "rotationCenterY": 268
+                },
+                {
+                    "costumeName": "anina pop L arm",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "843bff4a5ee3d61fd8cbd419cb2797a3.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 68,
+                    "rotationCenterY": 274
+                },
+                {
+                    "costumeName": "anina pop stand",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "de7cab2c8d567d49a5a1f378b5709bb4.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 76,
+                    "rotationCenterY": 276
+                },
+                {
+                    "costumeName": "anina pop R arm",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "e7e1a86233b7ad28d6ee9970b152be20.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 88,
+                    "rotationCenterY": 272
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Anna",
+        "md5": "23ab3e9be3be672fa2c43571e92b2b3e.png",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "city",
+            "photo",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Anna",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "anna-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "23ab3e9be3be672fa2c43571e92b2b3e.png",
+                    "rotationCenterX": 76,
+                    "rotationCenterY": 87
+                },
+                {
+                    "costumeName": "anna-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "25b8d4f7eae0add3bc24c20f5f17ada9.png",
+                    "rotationCenterX": 57,
+                    "rotationCenterY": 110
+                }
+            ],
+            "currentCostumeIndex": 1,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Anna Ode to Code",
+        "md5": "74b5e9c882deb81d88c175d548b8ff66.png",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "dance",
+            "photo",
+            "bitmap"
+        ],
+        "info": [
+            1,
+            14,
+            1
+        ],
+        "json": {
+            "objName": "Anna Ode to Code",
+            "scripts": [
+                [
+                    8,
+                    77.65,
+                    [
+                        [
+                            "whenKeyPressed",
+                            "space"
+                        ],
+                        [
+                            "nextCostume"
+                        ]
+                    ]
+                ]
+            ],
+            "sounds": [
+                {
+                    "soundName": "odesong-b",
+                    "soundID": -1,
+                    "md5": "2c41921491b1da2bfa1ebcaba34265ca.wav",
+                    "sampleCount": 212553,
+                    "rate": 22050,
+                    "format": "adpcm"
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "anna01",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "74b5e9c882deb81d88c175d548b8ff66.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 78,
+                    "rotationCenterY": 190
+                },
+                {
+                    "costumeName": "anna02",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "ece557e1c4500b30fd0e22b0d693cf4c.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 132,
+                    "rotationCenterY": 260
+                },
+                {
+                    "costumeName": "anna03",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "2e97d9d9d6bc1f174d3fc897638e8a46.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 138,
+                    "rotationCenterY": 242
+                },
+                {
+                    "costumeName": "anna04",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "69da72a9a29181425944e7963eb4f32a.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 138,
+                    "rotationCenterY": 70
+                },
+                {
+                    "costumeName": "anna05",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "1b396abf1336bceddb01166d975dad3b.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 134,
+                    "rotationCenterY": 246
+                },
+                {
+                    "costumeName": "anna06",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "d32ac2b2e9c8fa2f7b251275d8eec8c9.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 118,
+                    "rotationCenterY": 224
+                },
+                {
+                    "costumeName": "anna07",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "c0961caabfa8545b6080ea7825d6fc66.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 124,
+                    "rotationCenterY": 224
+                },
+                {
+                    "costumeName": "anna07b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "c21f0ef20be25af3b7c1ed42e974c75f.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 202,
+                    "rotationCenterY": 224
+                },
+                {
+                    "costumeName": "anna07c",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "54ed739e6ea31d128c319e8a3401af71.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 58,
+                    "rotationCenterY": 218
+                },
+                {
+                    "costumeName": "anna08",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "2d9bffdb6cda1ce0c77cfb3e001598f3.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 126,
+                    "rotationCenterY": 212
+                },
+                {
+                    "costumeName": "anna09",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "91f689627fa18d43ff6362ef872d90e2.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 130,
+                    "rotationCenterY": 220
+                },
+                {
+                    "costumeName": "anna10",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "eab5b5e2c4be253de024dd3deab68a66.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 148,
+                    "rotationCenterY": 260
+                },
+                {
+                    "costumeName": "anna11",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "859f95864d28fdb49d4170ce30fdd031.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 46,
+                    "rotationCenterY": 278
+                },
+                {
+                    "costumeName": "anna12",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "66133f695a23f669cc0fa6f06f275ab7.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 42,
+                    "rotationCenterY": 206
+                }
+            ],
+            "currentCostumeIndex": 13,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Apple",
+        "md5": "831ccd4741a7a56d85f6698a21f4ca69.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Apple",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "apple",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "831ccd4741a7a56d85f6698a21f4ca69.svg",
+                    "rotationCenterX": 31,
+                    "rotationCenterY": 31
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Arrow1",
+        "md5": "62f8794dd120e9b4ead4d098d50fc64b.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            4,
+            1
+        ],
+        "json": {
+            "objName": "Arrow1",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "arrow1-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "62f8794dd120e9b4ead4d098d50fc64b.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 28,
+                    "rotationCenterY": 23
+                },
+                {
+                    "costumeName": "arrow1-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "a157dc7e33d7c7a048af933de999e397.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 28,
+                    "rotationCenterY": 23
+                },
+                {
+                    "costumeName": "arrow1-c",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "d3b389e91f7beb22b2b1a80af09990ee.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 23,
+                    "rotationCenterY": 28
+                },
+                {
+                    "costumeName": "arrow1-d",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "412717ff731e9f19003a5840054057eb.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 23,
+                    "rotationCenterY": 28
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Avery",
+        "md5": "21393c9114c7d34b1df7ccd12c793672.svg",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "city",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Avery",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "avery-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "21393c9114c7d34b1df7ccd12c793672.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 39,
+                    "rotationCenterY": 94
+                },
+                {
+                    "costumeName": "avery-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "cc55f2f09599edc4ae0876e8b3d187d0.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 39,
+                    "rotationCenterY": 94
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Avery Walking",
+        "md5": "ed334e546806dfbf26d2591d7ddb12d0.svg",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "city",
+            "walking",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            4,
+            1
+        ],
+        "json": {
+            "objName": "Avery Walking",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "avery walking-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "ed334e546806dfbf26d2591d7ddb12d0.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 50,
+                    "rotationCenterY": 95
+                },
+                {
+                    "costumeName": "avery walking-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "c295731e8666ad2e1575fb4b4f82988d.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 50,
+                    "rotationCenterY": 102
+                },
+                {
+                    "costumeName": "avery walking-c",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "597a834225c9949e419dff7db1bc2453.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 48,
+                    "rotationCenterY": 95
+                },
+                {
+                    "costumeName": "avery walking-d",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "ce9622d11d24607eec7988196b38c3c6.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 50,
+                    "rotationCenterY": 101
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "leftRight",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "AZ Hip-Hop",
+        "md5": "e64363afc7f1e6951cb7967f50de2ba7.png",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "dance",
+            "city",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            13,
+            1
+        ],
+        "json": {
+            "objName": "AZ Hip-Hop",
+            "sounds": [
+                {
+                    "soundName": "dance celebrate",
+                    "soundID": -1,
+                    "md5": "0edb8fb88af19e6e17d0f8cf64c1d136.wav",
+                    "sampleCount": 176401,
+                    "rate": 22050,
+                    "format": "adpcm"
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "AZ stance",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "e64363afc7f1e6951cb7967f50de2ba7.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 70,
+                    "rotationCenterY": 278
+                },
+                {
+                    "costumeName": "AZ top stand",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "75b370524c92025cfa6f9071a6333e00.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 74,
+                    "rotationCenterY": 274
+                },
+                {
+                    "costumeName": "AZ top R step",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "3769dbe6e19b0e19ebf9416ba8660b88.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 200,
+                    "rotationCenterY": 270
+                },
+                {
+                    "costumeName": "AZ top L step",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "3d618085bce1a68829fa2cd5deab7871.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 144,
+                    "rotationCenterY": 266
+                },
+                {
+                    "costumeName": "AZ top freeze",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "ea33d5c631d8308b47685f1963becd4c.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 54,
+                    "rotationCenterY": 258
+                },
+                {
+                    "costumeName": "AZ top R cross",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "44216804569454067953fdd5c6b72928.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 206,
+                    "rotationCenterY": 252
+                },
+                {
+                    "costumeName": "AZ pop front",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "97c14e52551ae65679d61de6c94f0ec8.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 72,
+                    "rotationCenterY": 266
+                },
+                {
+                    "costumeName": "AZ pop down",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "2f8d07b568c8c67a0d211b5de09295d3.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 74,
+                    "rotationCenterY": 188
+                },
+                {
+                    "costumeName": "AZ pop left",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "4e7e43a86f1f09f1194e3579e7f385f5.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 184,
+                    "rotationCenterY": 266
+                },
+                {
+                    "costumeName": "AZ pop right",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "15a9d503613c649ca3a55829dbd98869.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 78,
+                    "rotationCenterY": 276
+                },
+                {
+                    "costumeName": "AZ pop L arm",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "0f6462025c20ac346a7f54164832d495.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 100,
+                    "rotationCenterY": 280
+                },
+                {
+                    "costumeName": "AZ pop stand",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "34b67b9e4db3aacbae735ade6a0539c2.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 92,
+                    "rotationCenterY": 280
+                },
+                {
+                    "costumeName": "AZ pop R arm",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "129472ac2779eb6bc2dd9bfbf0d33f56.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 74,
+                    "rotationCenterY": 278
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Ball",
+        "md5": "10117ddaefa98d819f2b1df93805622f.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "drawing",
+            "sports",
+            "vector"
+        ],
+        "info": [
+            0,
+            5,
+            1
+        ],
+        "json": {
+            "objName": "Ball",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "ball-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "10117ddaefa98d819f2b1df93805622f.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 22,
+                    "rotationCenterY": 22
+                },
+                {
+                    "costumeName": "ball-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "6e6330cad7750ea7e9dc88402661deb8.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 22,
+                    "rotationCenterY": 22
+                },
+                {
+                    "costumeName": "ball-c",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "bb45ed5db278f15c17c012c34a6b160f.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 22,
+                    "rotationCenterY": 22
+                },
+                {
+                    "costumeName": "ball-d",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "5d494659deae5c0de06b5885f5524276.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 22,
+                    "rotationCenterY": 22
+                },
+                {
+                    "costumeName": "ball-e",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "e80c98bc62fd32e8df81642af11ffb1a.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 22,
+                    "rotationCenterY": 22
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Ball-Soccer",
+        "md5": "4e4cc84380ccf6d4e59e53bc6d3a0a3f.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "drawing",
+            "sports",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Ball-Soccer",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "ball-soccer",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "4e4cc84380ccf6d4e59e53bc6d3a0a3f.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 32,
+                    "rotationCenterY": 34
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Ballerina",
+        "md5": "6051bb7008cf17c8853a6f81f04c8a0f.svg",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "dance",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            4,
+            1
+        ],
+        "json": {
+            "objName": "Ballerina",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "ballerina-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "6051bb7008cf17c8853a6f81f04c8a0f.svg",
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                },
+                {
+                    "costumeName": "ballerina-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "8bc5e47fb1439e29e11e9e3f2e20c6de.svg",
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                },
+                {
+                    "costumeName": "ballerina-c",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "6d3a07761b294f705987b0af58f8e335.svg",
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                },
+                {
+                    "costumeName": "ballerina-d",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "c3164795edf39e436272f425b4f5e487.svg",
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                }
+            ],
+            "currentCostumeIndex": 3,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Balloon1",
+        "md5": "bc96a1fb5fe794377acd44807e421ce2.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "holiday",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            3,
+            1
+        ],
+        "json": {
+            "objName": "Balloon1",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "balloon1-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "bc96a1fb5fe794377acd44807e421ce2.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 32,
+                    "rotationCenterY": 94
+                },
+                {
+                    "costumeName": "balloon1-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "d7bb51d9c38af6314bd2b4058d2a592d.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 31,
+                    "rotationCenterY": 94
+                },
+                {
+                    "costumeName": "balloon1-c",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "247cef27b665d77d9efaca69327cae77.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 31,
+                    "rotationCenterY": 94
+                }
+            ],
+            "currentCostumeIndex": 2,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Bananas",
+        "md5": "40bb8a1afe88cec78254f6fcfee98242.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            0
+        ],
+        "json": {
+            "objName": "Bananas",
+            "costumes": [
+                {
+                    "costumeName": "bananas",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "40bb8a1afe88cec78254f6fcfee98242.svg",
+                    "rotationCenterX": 36,
+                    "rotationCenterY": 37
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Baseball",
+        "md5": "6e13ef53885d2cfca9a54cc5c3f6c20f.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "sports",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Baseball",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "baseball",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "6e13ef53885d2cfca9a54cc5c3f6c20f.svg",
+                    "rotationCenterX": 34,
+                    "rotationCenterY": 31
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Basketball",
+        "md5": "ac3432618ac868309f502024aa78423c.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "sports",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            0
+        ],
+        "json": {
+            "objName": "Basketball",
+            "costumes": [
+                {
+                    "costumeName": "basketball",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "ac3432618ac868309f502024aa78423c.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 36,
+                    "rotationCenterY": 39
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Bass",
+        "md5": "bdbd2876847e54309a5ff3ee0895d724.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "music",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            8
+        ],
+        "json": {
+            "objName": "Bass",
+            "sounds": [
+                {
+                    "soundName": "C bass",
+                    "soundID": -1,
+                    "md5": "c3566ec797b483acde28f790994cc409.wav",
+                    "sampleCount": 44608,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "D bass",
+                    "soundID": -1,
+                    "md5": "5a3ae8a2665f50fdc38cc301fbac79ba.wav",
+                    "sampleCount": 40192,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "E bass",
+                    "soundID": -1,
+                    "md5": "0657e39bae81a232b01a18f727d3b891.wav",
+                    "sampleCount": 36160,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "F bass",
+                    "soundID": -1,
+                    "md5": "ea21bdae86f70d60b28f1dddcf50d104.wav",
+                    "sampleCount": 34368,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "G bass",
+                    "soundID": -1,
+                    "md5": "05c192194e8f1944514dce3833e33439.wav",
+                    "sampleCount": 30976,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "A bass",
+                    "soundID": -1,
+                    "md5": "c04ebf21e5e19342fa1535e4efcdb43b.wav",
+                    "sampleCount": 28160,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "B bass",
+                    "soundID": -1,
+                    "md5": "e31dcaf7bcdf58ac2a26533c48936c45.wav",
+                    "sampleCount": 25792,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "C2 bass",
+                    "soundID": -1,
+                    "md5": "667d6c527b79321d398e85b526f15b99.wav",
+                    "sampleCount": 24128,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "bass",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "bdbd2876847e54309a5ff3ee0895d724.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 60,
+                    "rotationCenterY": 110
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Bat1",
+        "md5": "7ad915f8e0884f497a24d5bb61ea8a4a.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "drawing",
+            "flying",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Bat1",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "bat1-a ",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "7ad915f8e0884f497a24d5bb61ea8a4a.svg",
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                },
+                {
+                    "costumeName": "bat1-b ",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "f127434672b872a902346ef3c1af45f2.svg",
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Bat2",
+        "md5": "647d4bd53163f94a7dabf623ccab7fd3.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "drawing",
+            "flying",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Bat2",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "bat2-a ",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "647d4bd53163f94a7dabf623ccab7fd3.svg",
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                },
+                {
+                    "costumeName": "bat2-b ",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "8aa1d20e4f7761becbe9bafa75290465.svg",
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Beachball",
+        "md5": "87d64cab74c64b31498cc85f07510ee4.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "sports",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Beachball",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "beachball",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "87d64cab74c64b31498cc85f07510ee4.svg",
+                    "rotationCenterX": 34,
+                    "rotationCenterY": 33
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Bear1",
+        "md5": "598722f70e86e6f9b23ef97680baaa9c.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "holiday",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Bear1",
+            "sounds": [
+                {
+                    "soundName": "plunge",
+                    "soundID": -1,
+                    "md5": "c09455ee9da0e7eeead42d4e73c2555d.wav",
+                    "sampleCount": 22400,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "bear1-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "598722f70e86e6f9b23ef97680baaa9c.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 56,
+                    "rotationCenterY": 93
+                },
+                {
+                    "costumeName": "bear1-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "76ceb0de4409f42713b50cbc1fb45af5.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 56,
+                    "rotationCenterY": 93
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Bear2",
+        "md5": "3eb8e16a983ff23c418374389c81bd30.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "holiday",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Bear2",
+            "sounds": [
+                {
+                    "soundName": "meow",
+                    "soundID": -1,
+                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
+                    "sampleCount": 18688,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "bear2-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "3eb8e16a983ff23c418374389c81bd30.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 37,
+                    "rotationCenterY": 42
+                },
+                {
+                    "costumeName": "bear2-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "12bb6960ac01b65ae9b5e5e7f79700ac.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 51,
+                    "rotationCenterY": 42
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Beetle",
+        "md5": "e1ce8f153f011fdd52486c91c6ed594d.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Beetle",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "beetle",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "e1ce8f153f011fdd52486c91c6ed594d.svg",
+                    "rotationCenterX": 43,
+                    "rotationCenterY": 38
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Bell",
+        "md5": "f35056c772395455d703773657e1da6e.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "holiday",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            2
+        ],
+        "json": {
+            "objName": "Bell",
+            "sounds": [
+                {
+                    "soundName": "xylo1",
+                    "soundID": -1,
+                    "md5": "6ac484e97c1c1fe1384642e26a125e70.wav",
+                    "sampleCount": 238232,
+                    "rate": 22050,
+                    "format": "adpcm"
+                },
+                {
+                    "soundName": "bell toll",
+                    "soundID": -1,
+                    "md5": "25d61e79cbeba4041eebeaebd7bf9598.wav",
+                    "sampleCount": 45168,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "bell1",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "f35056c772395455d703773657e1da6e.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 59,
+                    "rotationCenterY": 69
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Bells",
+        "md5": "1f151bee966df3f0c41138941713280e.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "holiday",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Bells",
+            "sounds": [
+                {
+                    "soundName": "xylo1",
+                    "soundID": -1,
+                    "md5": "5c6964021197fdd4ff46a0f107e6d624.wav",
+                    "sampleCount": 238995,
+                    "rate": 22050,
+                    "format": "adpcm"
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "bells-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "1f151bee966df3f0c41138941713280e.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 53,
+                    "rotationCenterY": 51
+                },
+                {
+                    "costumeName": "bells-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "5b3879a162881aed93169bf0a6680f45.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 48,
+                    "rotationCenterY": 31
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Bowl",
+        "md5": "86f616639846f06fef29931e6b9b59de.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            2
+        ],
+        "json": {
+            "objName": "Bowl",
+            "sounds": [
+                {
+                    "soundName": "boing",
+                    "soundID": -1,
+                    "md5": "53a3c2e27d1fb5fdb14aaf0cb41e7889.wav",
+                    "sampleCount": 6804,
+                    "rate": 22050,
+                    "format": "adpcm"
+                },
+                {
+                    "soundName": "water drop",
+                    "soundID": -1,
+                    "md5": "aa488de9e2c871e9d4faecd246ed737a.wav",
+                    "sampleCount": 8136,
+                    "rate": 22050,
+                    "format": "adpcm"
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "bowl-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "86f616639846f06fef29931e6b9b59de.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 30,
+                    "rotationCenterY": 15
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1.2500000000000002,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Bowtie",
+        "md5": "534d9924d2f9bfe240f041e3ce55ccf5.svg",
+        "type": "sprite",
+        "tags": [
+            "dress-up",
+            "things",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Bowtie",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "bowtie-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "534d9924d2f9bfe240f041e3ce55ccf5.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 11,
+                    "rotationCenterY": 4
+                },
+                {
+                    "costumeName": "bowtie-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "8be1e90e19cd1faced8a2e83c2b5c90d.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 11,
+                    "rotationCenterY": 4
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1.6,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": true,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Breakdancer1",
+        "md5": "cafd225b63d3aeeedc8df926fe5b6ab4.png",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "dance",
+            "city",
+            "drawing",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            3,
+            1
+        ],
+        "json": {
+            "objName": "Breakdancer1",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "breakdancer1-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "cafd225b63d3aeeedc8df926fe5b6ab4.png",
+                    "rotationCenterX": 113,
+                    "rotationCenterY": 90
+                },
+                {
+                    "costumeName": "breakdancer1-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "84bcb1be206e8653a7d97549733c3db5.png",
+                    "rotationCenterX": 30,
+                    "rotationCenterY": 90
+                },
+                {
+                    "costumeName": "breakdancer1-c",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "b345babf9f78b5e88a288a4b13a7ca29.png",
+                    "rotationCenterX": 35,
+                    "rotationCenterY": 90
+                }
+            ],
+            "currentCostumeIndex": 2,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Buildings",
+        "md5": "d713270e235851e5962becd73a951771.svg",
+        "type": "sprite",
+        "tags": [
+            "city",
+            "flying",
+            "things",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            10,
+            1
+        ],
+        "json": {
+            "objName": "Buildings",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "building-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "d713270e235851e5962becd73a951771.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 40,
+                    "rotationCenterY": 30
+                },
+                {
+                    "costumeName": "building-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "8c2d59c50a97d33b096f629258f02be6.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 46,
+                    "rotationCenterY": -11
+                },
+                {
+                    "costumeName": "building-c",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "7f3f51f495c39809bed95991dfa1f80d.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 25,
+                    "rotationCenterY": 17
+                },
+                {
+                    "costumeName": "building-d",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "61ba83d6bded299dd91168eb24cd379f.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 59,
+                    "rotationCenterY": -10
+                },
+                {
+                    "costumeName": "building-e",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "1beeb8f034a1128c9a799297b0b7fc26.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 36,
+                    "rotationCenterY": 55
+                },
+                {
+                    "costumeName": "building-f",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "451e0a565e95d945fe2addfe609ee9df.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 41,
+                    "rotationCenterY": 27
+                },
+                {
+                    "costumeName": "building-g",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "58b3c9b7a41dde698fa2b427b502c1fa.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 64,
+                    "rotationCenterY": -65
+                },
+                {
+                    "costumeName": "building-h",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "e952c8b14eeac894302d07d37a45ed99.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 33,
+                    "rotationCenterY": 136
+                },
+                {
+                    "costumeName": "building-i",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "b00b1123e3bfcb600242528d059ffcfb.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 31,
+                    "rotationCenterY": -12
+                },
+                {
+                    "costumeName": "building-j",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "e08fd1a7397efcfe0e3691f945693cb4.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 29,
+                    "rotationCenterY": 33
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Bus",
+        "md5": "66895930177178ea01d9e610917f8acf.png",
+        "type": "sprite",
+        "tags": [
+            "transportation",
+            "city",
+            "photo",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Bus",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "bus",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "66895930177178ea01d9e610917f8acf.png",
+                    "rotationCenterX": 120,
+                    "rotationCenterY": 35
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Butterfly1",
+        "md5": "836d4cc7889f4a1cbcb0303934f31f79.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "drawing",
+            "flying",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Butterfly1",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "butterfly1-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "836d4cc7889f4a1cbcb0303934f31f79.svg",
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                },
+                {
+                    "costumeName": "butterfly1-b ",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "55dd0671a359d7c35f7b78f4176660e8.svg",
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Butterfly2",
+        "md5": "a0216895beade6afc6d42bd5bb43faea.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "drawing",
+            "flying",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Butterfly2",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "butterfly2 ",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "a0216895beade6afc6d42bd5bb43faea.svg",
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Butterfly3",
+        "md5": "8907a43cf08b0a9134969023be2074c5.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "drawing",
+            "flying",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Butterfly3",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "butterfly3 ",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "8907a43cf08b0a9134969023be2074c5.svg",
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Button1",
+        "md5": "7ef67c5bc8cf7df64fdb3b1d6b250f71.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Button1",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "button1",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "7ef67c5bc8cf7df64fdb3b1d6b250f71.svg",
+                    "rotationCenterX": 72,
+                    "rotationCenterY": 72
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Button2",
+        "md5": "c0051ff23e9aae78295964206793c1e3.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Button2",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "button2-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "c0051ff23e9aae78295964206793c1e3.svg",
+                    "rotationCenterX": 72,
+                    "rotationCenterY": 72
+                },
+                {
+                    "costumeName": "button2-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "712a561dc0ad66e348b8247e566b50ef.svg",
+                    "rotationCenterX": 72,
+                    "rotationCenterY": 72
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Button3",
+        "md5": "ffb2a9c21084c58fdb677c8d12a97519.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Button3",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "button3-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "ffb2a9c21084c58fdb677c8d12a97519.svg",
+                    "rotationCenterX": 72,
+                    "rotationCenterY": 72
+                },
+                {
+                    "costumeName": "button3-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "7a9ccb55e4da36f48811ab125d2492e0.svg",
+                    "rotationCenterX": 72,
+                    "rotationCenterY": 72
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Button4",
+        "md5": "8782b457cdf4a10ca016ff1ec0c744ef.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Button4",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "button4-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "8782b457cdf4a10ca016ff1ec0c744ef.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 35,
+                    "rotationCenterY": 34
+                },
+                {
+                    "costumeName": "button4-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "840f4ef01849e459fd84f5470a3b0080.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 35,
+                    "rotationCenterY": 34
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Button5",
+        "md5": "71e97245b7be4fd6fe3ba8cdeecadaf1.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Button5",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "button5-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "71e97245b7be4fd6fe3ba8cdeecadaf1.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 72,
+                    "rotationCenterY": 72
+                },
+                {
+                    "costumeName": "button5-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "54cd55512f7571060e6e64168e541222.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 72,
+                    "rotationCenterY": 72
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Cake",
+        "md5": "97ab3596dc06510e963fa29795e663bf.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "holiday",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            0
+        ],
+        "json": {
+            "objName": "Cake",
+            "costumes": [
+                {
+                    "costumeName": "cake-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "97ab3596dc06510e963fa29795e663bf.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 64,
+                    "rotationCenterY": 50
+                },
+                {
+                    "costumeName": "cake-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "61d5481955a2f42cb843d09506f6744e.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 64,
+                    "rotationCenterY": 42
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Calvrett",
+        "md5": "82b2f97fec9083cad502a781fe88929b.png",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "photo",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Calvrett",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "calvrett jumping",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "82b2f97fec9083cad502a781fe88929b.png",
+                    "rotationCenterX": 84,
+                    "rotationCenterY": 108
+                },
+                {
+                    "costumeName": "calvrett thinking",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "b8d2409e58b663020353c08fb029b7e6.png",
+                    "rotationCenterX": 54,
+                    "rotationCenterY": 85
+                }
+            ],
+            "currentCostumeIndex": 1,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Candle",
+        "md5": "9bb90825b1d7c360aa47ee18883cd3cd.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "holiday",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Candle",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "candle1-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "9bb90825b1d7c360aa47ee18883cd3cd.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 12,
+                    "rotationCenterY": 32
+                },
+                {
+                    "costumeName": "candle1-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "4f2ab7fc559ecbbc61721f76639a4e44.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 12,
+                    "rotationCenterY": 32
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 0.75,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Candles1",
+        "md5": "b8432a2c0d04408b3ba58ec3b01582f0.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "holiday",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Candles1",
+            "sounds": [
+                {
+                    "soundName": "strum",
+                    "soundID": -1,
+                    "md5": "b92de59d992a655c1b542223a784cda6.wav",
+                    "sampleCount": 11247,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "candles1",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "b8432a2c0d04408b3ba58ec3b01582f0.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 52,
+                    "rotationCenterY": 37
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Candles2",
+        "md5": "76a9de5efb140fe287dc0f197a0e8d4c.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "holiday",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Candles2",
+            "sounds": [
+                {
+                    "soundName": "strum",
+                    "soundID": -1,
+                    "md5": "b92de59d992a655c1b542223a784cda6.wav",
+                    "sampleCount": 11247,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "candles2",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "76a9de5efb140fe287dc0f197a0e8d4c.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 52,
+                    "rotationCenterY": 79
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Car-Bug",
+        "md5": "c0b7d099a815f58ff6d92538856f08c1.png",
+        "type": "sprite",
+        "tags": [
+            "transportation",
+            "city",
+            "photo",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Car-Bug",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "car-bug",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "c0b7d099a815f58ff6d92538856f08c1.png",
+                    "rotationCenterX": 100,
+                    "rotationCenterY": 39
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Cassy",
+        "md5": "db4e1ee1f9102e3da5e06f2d17881df5.png",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "city",
+            "photo",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            4,
+            1
+        ],
+        "json": {
+            "objName": "Cassy",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "cassy-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "db4e1ee1f9102e3da5e06f2d17881df5.png",
+                    "rotationCenterX": 43,
+                    "rotationCenterY": 100
+                },
+                {
+                    "costumeName": "cassy-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "2f6f57d1ab69fc18a38fd30572530437.png",
+                    "rotationCenterX": 35,
+                    "rotationCenterY": 100
+                },
+                {
+                    "costumeName": "cassy-c",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "662752d56bb77544f3e79ee8c16b3f2d.png",
+                    "rotationCenterX": 70,
+                    "rotationCenterY": 58
+                },
+                {
+                    "costumeName": "cassy-d",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "24e9dac390ae4e5b0c17e7d922eb033b.png",
+                    "rotationCenterX": 72,
+                    "rotationCenterY": 100
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Cassy Dance",
+        "md5": "6cb3686db1fa658b6541cc9fa3ccfcc7.png",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "dance",
+            "city",
+            "photo",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            4,
+            1
+        ],
+        "json": {
+            "objName": "Cassy Dance",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "cassy dance-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "6cb3686db1fa658b6541cc9fa3ccfcc7.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 104,
+                    "rotationCenterY": 192
+                },
+                {
+                    "costumeName": "cassy dance-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "086dc4312d3bf4595d6b3fd4b1021b35.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 140,
+                    "rotationCenterY": 192
+                },
+                {
+                    "costumeName": "cassy dance-c",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "dffbfb382641655dbd698559ed49fd99.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 74,
+                    "rotationCenterY": 188
+                },
+                {
+                    "costumeName": "cassy dance-d",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "d0e98431c4744f684a13e8331d838203.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 94,
+                    "rotationCenterY": 180
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Cat1",
+        "md5": "f88bf1935daea28f8ca098462a31dbb0.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Cat1",
+            "sounds": [
+                {
+                    "soundName": "meow",
+                    "soundID": -1,
+                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
+                    "sampleCount": 18688,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "cat1-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "f88bf1935daea28f8ca098462a31dbb0.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 47,
+                    "rotationCenterY": 50
+                },
+                {
+                    "costumeName": "cat1-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "6e8bd9ae68fdb02b7e1e3df656a75635.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 47,
+                    "rotationCenterY": 55
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Cat1 Flying",
+        "md5": "1e81725d2d2c7de4a2dd4a145198a43c.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "drawing",
+            "flying",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Cat1 Flying",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "cat1 flying-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "1e81725d2d2c7de4a2dd4a145198a43c.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 67,
+                    "rotationCenterY": 48
+                },
+                {
+                    "costumeName": "cat1 flying-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "0d192725870ef0eda50d91cab0e3c9c5.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 42,
+                    "rotationCenterY": 44
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Cat2",
+        "md5": "01ae57fd339529445cb890978ef8a054.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Cat2",
+            "sounds": [
+                {
+                    "soundName": "meow2",
+                    "soundID": -1,
+                    "md5": "cf51a0c4088942d95bcc20af13202710.wav",
+                    "sampleCount": 6512,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "cat2",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "01ae57fd339529445cb890978ef8a054.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 87,
+                    "rotationCenterY": 39
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Catherine Dance",
+        "md5": "7f7684029e9726376aaaae1158439f3e.png",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "dance",
+            "city",
+            "photo",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            4,
+            1
+        ],
+        "json": {
+            "objName": "Catherine Dance",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "catherine-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "7f7684029e9726376aaaae1158439f3e.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 84,
+                    "rotationCenterY": 123
+                },
+                {
+                    "costumeName": "catherine-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "79052da8d59a6a16a0f6d09cd94237ae.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 179,
+                    "rotationCenterY": 133
+                },
+                {
+                    "costumeName": "catherine-c",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "6e34f695da1e18d53e6c050d95ba0e4a.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 103,
+                    "rotationCenterY": 28
+                },
+                {
+                    "costumeName": "catherine-d",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "feff7824a6fd6747391012dcfe9ac4f0.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 121,
+                    "rotationCenterY": 113
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Champ99",
+        "md5": "b940c99d8e677ac5773cb4d592b16734.png",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "dance",
+            "city",
+            "photo",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            7,
+            1
+        ],
+        "json": {
+            "objName": "Champ99",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "champ99-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "b940c99d8e677ac5773cb4d592b16734.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 248,
+                    "rotationCenterY": 306
+                },
+                {
+                    "costumeName": "champ99-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "2ebc7632bc9e665d9eeea93190fad7ad.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 164,
+                    "rotationCenterY": 290
+                },
+                {
+                    "costumeName": "champ99-c",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "bfcff80b0044c644c555ba24f2484106.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 152,
+                    "rotationCenterY": 270
+                },
+                {
+                    "costumeName": "champ99-d",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "34de53e52a768d60a96e3ae0c030dfc5.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 188,
+                    "rotationCenterY": 260
+                },
+                {
+                    "costumeName": "champ99-e",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "0cb685bf8584df9caf124da929ab3453.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 190,
+                    "rotationCenterY": 248
+                },
+                {
+                    "costumeName": "champ99-f",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "516d30b29aed8145718db421f4737953.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 114,
+                    "rotationCenterY": 250
+                },
+                {
+                    "costumeName": "champ99-g",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "49e0edcb319527d936981f06b4111d53.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 132,
+                    "rotationCenterY": 258
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Cheesy-Puffs",
+        "md5": "4c99a77ba72abaf6c961e8684f8a8a9f.png",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "photo",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Cheesy-Puffs",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "cheesy-puffs",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "4c99a77ba72abaf6c961e8684f8a8a9f.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 87,
+                    "rotationCenterY": 72
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Cloud",
+        "md5": "47005a1f20309f577a03a67abbb6b94e.svg",
+        "type": "sprite",
+        "tags": [
+            "flying",
+            "city",
+            "things",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Cloud",
+            "sounds": [
+                {
+                    "soundName": "ripples",
+                    "soundID": -1,
+                    "md5": "4da8a805673c288965e1e5535c3f7f2b.wav",
+                    "sampleCount": 10144,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "cloud",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "47005a1f20309f577a03a67abbb6b94e.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 71,
+                    "rotationCenterY": 45
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 0.9,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Clouds",
+        "md5": "c7d7de8e29179407f03b054fa640f4d0.svg",
+        "type": "sprite",
+        "tags": [
+            "flying",
+            "city",
+            "things",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            4,
+            1
+        ],
+        "json": {
+            "objName": "Clouds",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "cloud-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "c7d7de8e29179407f03b054fa640f4d0.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 76,
+                    "rotationCenterY": 19
+                },
+                {
+                    "costumeName": "cloud-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "d8595350ebb460494c9189dabb968336.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 101,
+                    "rotationCenterY": 20
+                },
+                {
+                    "costumeName": "cloud-c",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "395fc991e64ac0a4aa46758ab4bc65cb.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 97,
+                    "rotationCenterY": 9
+                },
+                {
+                    "costumeName": "cloud-d",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "1767e704acb11ffa409f77cc79ba7e86.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 87,
+                    "rotationCenterY": 21
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "CM Hip-Hop",
+        "md5": "db291ec7e061ecd4d797875e3aec0a09.png",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "dance",
+            "city",
+            "photo",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            8,
+            1
+        ],
+        "json": {
+            "objName": "CM Hip-Hop",
+            "sounds": [
+                {
+                    "soundName": "dance snare beat",
+                    "soundID": -1,
+                    "md5": "562587bdb75e3a8124cdaa46ba0f648b.wav",
+                    "sampleCount": 176401,
+                    "rate": 22050,
+                    "format": "adpcm"
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "cm top stand",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "db291ec7e061ecd4d797875e3aec0a09.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 66,
+                    "rotationCenterY": 226
+                },
+                {
+                    "costumeName": "cm top R leg",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "b5cfa26a969dc001fb38d29c5ef8f1bf.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 90,
+                    "rotationCenterY": 240
+                },
+                {
+                    "costumeName": "cm top L leg",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "9b3224263e7c828c54326d9b4f22a74b.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 116,
+                    "rotationCenterY": 238
+                },
+                {
+                    "costumeName": "cm top ready",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "ab97d9c6e3c0efe27bfd9e44ac3af497.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 84,
+                    "rotationCenterY": 180
+                },
+                {
+                    "costumeName": "cm top L cross",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "3b0538ba8b6fcc0f938013b912e34305.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 122,
+                    "rotationCenterY": 162
+                },
+                {
+                    "costumeName": "cm top R cross",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "00716f8ab864ae479db3017146d28c64.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 156,
+                    "rotationCenterY": 164
+                },
+                {
+                    "costumeName": "cm pop L arm",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "ce0928c8dbc625661b44c3503debae7e.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 136,
+                    "rotationCenterY": 243
+                },
+                {
+                    "costumeName": "cm pop R arm",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "e5555af183c643c7006632b26d851a32.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 79,
+                    "rotationCenterY": 229
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Convertible1",
+        "md5": "099953d710d842e592084765c17bda82.png",
+        "type": "sprite",
+        "tags": [
+            "transportation",
+            "city",
+            "drawing",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Convertible1",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "convertible1",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "099953d710d842e592084765c17bda82.png",
+                    "rotationCenterX": 110,
+                    "rotationCenterY": 27
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Convertible2",
+        "md5": "2091f1f3fc578189bced6b257f353995.png",
+        "type": "sprite",
+        "tags": [
+            "transportation",
+            "city",
+            "drawing",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Convertible2",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "convertible2",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "2091f1f3fc578189bced6b257f353995.png",
+                    "rotationCenterX": 90,
+                    "rotationCenterY": 22
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Convertible3",
+        "md5": "b6ac3c9e1789cba2302d2ef82d62d019.svg",
+        "type": "sprite",
+        "tags": [
+            "transportation",
+            "city",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Convertible3",
+            "sounds": [
+                {
+                    "soundName": "meow",
+                    "soundID": -1,
+                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
+                    "sampleCount": 18688,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "convertible3",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "b6ac3c9e1789cba2302d2ef82d62d019.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Cowbell",
+        "md5": "3b00920b17d43986685f3855bcb6afe7.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "music",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            2
+        ],
+        "json": {
+            "objName": "Cowbell",
+            "sounds": [
+                {
+                    "soundName": "small cowbell",
+                    "soundID": -1,
+                    "md5": "e29154f53f56f96f8a3292bdcddcec54.wav",
+                    "sampleCount": 9718,
+                    "rate": 22050,
+                    "format": "adpcm"
+                },
+                {
+                    "soundName": "large cowbell",
+                    "soundID": -1,
+                    "md5": "006316650ffc673dc02d36aa55881327.wav",
+                    "sampleCount": 20856,
+                    "rate": 22050,
+                    "format": "adpcm"
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "cowbell",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "3b00920b17d43986685f3855bcb6afe7.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 29,
+                    "rotationCenterY": 30
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Crab",
+        "md5": "114249a5660f7948663d95de575cfd8d.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "drawing",
+            "underwater",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Crab",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "crab-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "114249a5660f7948663d95de575cfd8d.svg",
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                },
+                {
+                    "costumeName": "crab-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "9bf050664e68c10d2616e85f2873be09.svg",
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Creature1",
+        "md5": "a560c6eab2e1de2462bdaeb1d698736c.svg",
+        "type": "sprite",
+        "tags": [
+            "fantasy",
+            "holiday",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            3,
+            1
+        ],
+        "json": {
+            "objName": "Creature1",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "creature1-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "a560c6eab2e1de2462bdaeb1d698736c.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 54,
+                    "rotationCenterY": 80
+                },
+                {
+                    "costumeName": "creature1-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "8042b71fc2ae322151c0a3a163701333.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 60,
+                    "rotationCenterY": 78
+                },
+                {
+                    "costumeName": "creature1-c",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "e12a83c8f1c0545b59fe8673e9fac79c.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 63,
+                    "rotationCenterY": 164
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Cymbal",
+        "md5": "532860ee3ecfd05d5f473dbe3ea69c8e.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "music",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            5
+        ],
+        "json": {
+            "objName": "Cymbal",
+            "sounds": [
+                {
+                    "soundName": "crash cymbal",
+                    "soundID": -1,
+                    "md5": "f2c47a46f614f467a7ac802ed9ec3d8e.wav",
+                    "sampleCount": 25220,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "hihat cymbal",
+                    "soundID": -1,
+                    "md5": "2d01f60d0f20ab39facbf707899c6b2a.wav",
+                    "sampleCount": 2752,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "splash cymbal",
+                    "soundID": -1,
+                    "md5": "9d63ed5be96c43b06492e8b4a9cea8d8.wav",
+                    "sampleCount": 9600,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "roll cymbal",
+                    "soundID": -1,
+                    "md5": "da8355d753cd2a5ddd19cb2bb41c1547.wav",
+                    "sampleCount": 26432,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "bell cymbal",
+                    "soundID": -1,
+                    "md5": "efddec047de95492f775a1b5b2e8d19e.wav",
+                    "sampleCount": 19328,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "cymbal-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "532860ee3ecfd05d5f473dbe3ea69c8e.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 34,
+                    "rotationCenterY": 60
+                },
+                {
+                    "costumeName": "cymbal-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "ae5b19022fa882ff95790b25279b9a3f.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 37,
+                    "rotationCenterY": 73
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "D-Money Hip-Hop",
+        "md5": "b30a60d31aebead577b73affd22bf30f.svg",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "dance",
+            "city",
+            "photo",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            13,
+            1
+        ],
+        "json": {
+            "objName": "D-Money Hip-Hop",
+            "sounds": [
+                {
+                    "soundName": "dance celebrate",
+                    "soundID": -1,
+                    "md5": "0edb8fb88af19e6e17d0f8cf64c1d136.wav",
+                    "sampleCount": 176401,
+                    "rate": 22050,
+                    "format": "adpcm"
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "dm stance",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "b30a60d31aebead577b73affd22bf30f.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 55,
+                    "rotationCenterY": 119
+                },
+                {
+                    "costumeName": "dm top stand",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "cbf035d39d0a0bb070d2eb998cebd60d.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 82,
+                    "rotationCenterY": 244
+                },
+                {
+                    "costumeName": "dm top R leg",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "fcb8c2b6cf9b7e6ce9df521b2486deb3.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 218,
+                    "rotationCenterY": 232
+                },
+                {
+                    "costumeName": "dm top L leg",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "fd8bb9665fe078d2d95dbc35bccf4046.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 230,
+                    "rotationCenterY": 240
+                },
+                {
+                    "costumeName": "dm freeze",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "31e687f186b19ea120cd5cfc9dea2a3f.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 220,
+                    "rotationCenterY": 234
+                },
+                {
+                    "costumeName": "dm pop front",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "0b2fb609d6d10decfdd5a1c3b58369b4.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 92,
+                    "rotationCenterY": 234
+                },
+                {
+                    "costumeName": "dm pop down",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "3b65ce3551f9c111794f7f1fb8f325be.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 64,
+                    "rotationCenterY": 74
+                },
+                {
+                    "costumeName": "dm pop left",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "f636510e8ef231d7c0e72a572ce91c99.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 204,
+                    "rotationCenterY": 250
+                },
+                {
+                    "costumeName": "dm pop right",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "36b32430e45e071071052ef33c637f48.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 78,
+                    "rotationCenterY": 238
+                },
+                {
+                    "costumeName": "dm pop L arm",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "426e1520efc34fef45be0596fd5f7120.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 90,
+                    "rotationCenterY": 238
+                },
+                {
+                    "costumeName": "dm pop stand",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "370cc57b40f1f1d6e52d6330b73d207f.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 100,
+                    "rotationCenterY": 244
+                },
+                {
+                    "costumeName": "dm pop R arm",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "56fe91d2cf3ecb9d1b94006aee9eff79.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 80,
+                    "rotationCenterY": 240
+                },
+                {
+                    "costumeName": "dm top R leg2",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "fcb8c2b6cf9b7e6ce9df521b2486deb3.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 218,
+                    "rotationCenterY": 232
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Dan",
+        "md5": "1baa5b126e0e14d6070a997c0deefab5.png",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "city",
+            "photo",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Dan",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "dan-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "1baa5b126e0e14d6070a997c0deefab5.png",
+                    "rotationCenterX": 36,
+                    "rotationCenterY": 100
+                },
+                {
+                    "costumeName": "dan-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "74be10ac815fd090cb42b92801002bb1.png",
+                    "rotationCenterX": 47,
+                    "rotationCenterY": 100
+                }
+            ],
+            "currentCostumeIndex": 1,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Dani",
+        "md5": "f3038fb0f4a00806b02081c6789dd8cf.svg",
+        "type": "sprite",
+        "tags": [
+            "dress-up",
+            "people",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            3,
+            1
+        ],
+        "json": {
+            "objName": "Dani",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "dani-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "f3038fb0f4a00806b02081c6789dd8cf.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 49,
+                    "rotationCenterY": 115
+                },
+                {
+                    "costumeName": "dani-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "e5c7dd4905a78e1d54087b7165dd1e8c.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 82,
+                    "rotationCenterY": 115
+                },
+                {
+                    "costumeName": "dani-c",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "cbc5f9c67022af201d498bc9b35608b8.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 49,
+                    "rotationCenterY": 113
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Dee",
+        "md5": "aa239b7ccdce6bddf06900c709525764.svg",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "city",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            5,
+            1
+        ],
+        "json": {
+            "objName": "Dee",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "dee-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "aa239b7ccdce6bddf06900c709525764.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 52,
+                    "rotationCenterY": 99
+                },
+                {
+                    "costumeName": "dee-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "62b4ac1b735599e21af77c390b178095.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 33,
+                    "rotationCenterY": 99
+                },
+                {
+                    "costumeName": "dee-c",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "6aa6196ce3245e93b8d1299f33adffcd.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 36,
+                    "rotationCenterY": 102
+                },
+                {
+                    "costumeName": "dee-d",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "2159a6be8f7ff450d0b5e938ca34a3f4.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 33,
+                    "rotationCenterY": 99
+                },
+                {
+                    "costumeName": "dee-e",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "e358d2a7e3a0a680928657161ce81a0a.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 32,
+                    "rotationCenterY": 99
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Devin",
+        "md5": "b1897e56265470b55fa65fabe2423c55.svg",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "city",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            4,
+            1
+        ],
+        "json": {
+            "objName": "Devin",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "devin-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "b1897e56265470b55fa65fabe2423c55.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 39,
+                    "rotationCenterY": 95
+                },
+                {
+                    "costumeName": "devin-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "873fbd641768c8f753a6568da97633e7.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 40,
+                    "rotationCenterY": 96
+                },
+                {
+                    "costumeName": "devin-c",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "eac3c03d86cebb42c8f30e373cb7f623.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 32,
+                    "rotationCenterY": 95
+                },
+                {
+                    "costumeName": "devin-d",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "fa6a75afb0e4b822b91d8bb20d40c68f.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 41,
+                    "rotationCenterY": 95
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Dinosaur1",
+        "md5": "286094ffce382c8383519ab896711989.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            7,
+            1
+        ],
+        "json": {
+            "objName": "Dinoaur1",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "dinosaur1-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "286094ffce382c8383519ab896711989.svg",
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 84
+                },
+                {
+                    "costumeName": "dinosaur1-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "d9eca17b8569f2cde20ef7d3ed0fe19f.svg",
+                    "rotationCenterX": 116,
+                    "rotationCenterY": 79
+                },
+                {
+                    "costumeName": "dinosaur1-c",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "ade3d2ec5029693ecdcca17974bad5fd.svg",
+                    "rotationCenterX": 65,
+                    "rotationCenterY": 89
+                },
+                {
+                    "costumeName": "dinosaur1-d",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "2aa7257a3e0a19ee315b23eaf7f56933.svg",
+                    "rotationCenterX": 45,
+                    "rotationCenterY": 87
+                },
+                {
+                    "costumeName": "dinosaur1-e",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "ed46ee11478715f7596d01fb0f98aa3f.svg",
+                    "rotationCenterX": 82,
+                    "rotationCenterY": 84
+                },
+                {
+                    "costumeName": "dinosaur1-f",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "39caf2473b1eee55edb688cfa3c240c7.svg",
+                    "rotationCenterX": 69,
+                    "rotationCenterY": 76
+                },
+                {
+                    "costumeName": "dinosaur1-g",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "f0f2aa4e8e015de497050d8d44bbfbf1.svg",
+                    "rotationCenterX": 68,
+                    "rotationCenterY": 72
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Dinosaur2",
+        "md5": "ae724a0a6d6e0a2b33dded4140219fb0.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Dinosaur2",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "dinosaur2-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "ae724a0a6d6e0a2b33dded4140219fb0.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                },
+                {
+                    "costumeName": "dinosaur2-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "a01d31caaab3b14b9bb0e2cd5a86c70c.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 67,
+                    "rotationCenterY": 67
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Dinosaur3",
+        "md5": "79bb51bbf809b412147f2a196f8c9292.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Dinosaur3",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "dinosaur3",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "79bb51bbf809b412147f2a196f8c9292.svg",
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Diver1",
+        "md5": "853803d5600b66538474909c5438c8ee.svg",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "underwater",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Diver1",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "diver1",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "853803d5600b66538474909c5438c8ee.svg",
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Diver2",
+        "md5": "248d3e69ada69a64b1077149ef6a931a.svg",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "underwater",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Diver2",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "diver2",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "248d3e69ada69a64b1077149ef6a931a.svg",
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Dog1",
+        "md5": "39ddefa0cc58f3b1b06474d63d81ef56.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "drawing",
+            "walking",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Dog1",
+            "sounds": [
+                {
+                    "soundName": "dog1",
+                    "soundID": -1,
+                    "md5": "b15adefc3c12f758b6dc6a045362532f.wav",
+                    "sampleCount": 3672,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "dog1-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "39ddefa0cc58f3b1b06474d63d81ef56.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 83,
+                    "rotationCenterY": 80
+                },
+                {
+                    "costumeName": "dog1-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "598f4aa3d8f671375d1d2b3acf753416.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 83,
+                    "rotationCenterY": 80
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Dog2",
+        "md5": "e921f865b19b27cd99e16a341dbf09c2.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "drawing",
+            "walking",
+            "vector"
+        ],
+        "info": [
+            0,
+            3,
+            1
+        ],
+        "json": {
+            "objName": "Dog2",
+            "sounds": [
+                {
+                    "soundName": "dog1",
+                    "soundID": -1,
+                    "md5": "b15adefc3c12f758b6dc6a045362532f.wav",
+                    "sampleCount": 3672,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "dog2-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "e921f865b19b27cd99e16a341dbf09c2.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                },
+                {
+                    "costumeName": "dog2-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "891f2fb7daf79ba8b224a9173eeb0a63.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                },
+                {
+                    "costumeName": "dog2-c",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "cd236d5eef4431dea82983ac9eec406b.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 0.75,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Dog Puppy",
+        "md5": "fd6c2d1d10a163bc5b7458f7275750f0.png",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "photo",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            4,
+            1
+        ],
+        "json": {
+            "objName": "Dog Puppy",
+            "sounds": [
+                {
+                    "soundName": "dog2",
+                    "soundID": -1,
+                    "md5": "cd8fa8390b0efdd281882533fbfcfcfb.wav",
+                    "sampleCount": 3168,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "dog puppy right",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "fd6c2d1d10a163bc5b7458f7275750f0.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 107,
+                    "rotationCenterY": 103
+                },
+                {
+                    "costumeName": "dog puppy sit",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "00b1589467f939b9c61f666bca2d25d1.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 87,
+                    "rotationCenterY": 112
+                },
+                {
+                    "costumeName": "dog puppy side",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "63c3d6718943ecbf48f94b3b131ae8a4.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 104,
+                    "rotationCenterY": 114
+                },
+                {
+                    "costumeName": "dog puppy back",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "88559ad0334a8a51aca31035068682f6.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 234,
+                    "rotationCenterY": 94
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Donut",
+        "md5": "9e7b4d153421dae04a24571d7e079e85.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Donut",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "donut",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "9e7b4d153421dae04a24571d7e079e85.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 73,
+                    "rotationCenterY": 15
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Dove1",
+        "md5": "6dde2b880ad6ddeaea2a53821befb86d.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "holiday",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Dove1",
+            "sounds": [
+                {
+                    "soundName": "bird",
+                    "soundID": -1,
+                    "md5": "18bd4b634a3f992a16b30344c7d810e0.wav",
+                    "sampleCount": 3840,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "dove1-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "6dde2b880ad6ddeaea2a53821befb86d.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 86,
+                    "rotationCenterY": 59
+                },
+                {
+                    "costumeName": "dove1-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "1c0bc118044d7f6033bc9cd1ef555590.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 88,
+                    "rotationCenterY": 57
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Dove2",
+        "md5": "42251c2649a073052eb4261d644281bb.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "holiday",
+            "flying",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Dove2",
+            "sounds": [
+                {
+                    "soundName": "bird",
+                    "soundID": -1,
+                    "md5": "18bd4b634a3f992a16b30344c7d810e0.wav",
+                    "sampleCount": 3840,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "dove2-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "42251c2649a073052eb4261d644281bb.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 99,
+                    "rotationCenterY": 83
+                },
+                {
+                    "costumeName": "dove2-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "469eb55a437364d831b80937c4ee1ab9.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 100,
+                    "rotationCenterY": 82
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Dragon",
+        "md5": "ee0082b436d6d5dc3de33047166e7bf2.svg",
+        "type": "sprite",
+        "tags": [
+            "fantasy",
+            "drawing",
+            "flying",
+            "castle",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            0
+        ],
+        "json": {
+            "objName": "Dragon",
+            "costumes": [
+                {
+                    "costumeName": "dragon1-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "ee0082b436d6d5dc3de33047166e7bf2.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 65,
+                    "rotationCenterY": 60
+                },
+                {
+                    "costumeName": "dragon1-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "bb58ce36997fa205a86a085f202837fd.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 84,
+                    "rotationCenterY": 56
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Drum-Bass",
+        "md5": "3308e038214f5a4adc53076a9fee9021.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "music",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            3
+        ],
+        "json": {
+            "objName": "Drum-Bass",
+            "sounds": [
+                {
+                    "soundName": "drum bass1",
+                    "soundID": -1,
+                    "md5": "48328c874353617451e4c7902cc82817.wav",
+                    "sampleCount": 6528,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "drum bass2",
+                    "soundID": -1,
+                    "md5": "711a1270d1cf2e5de9b145ee539213e4.wav",
+                    "sampleCount": 3791,
+                    "rate": 22050,
+                    "format": "adpcm"
+                },
+                {
+                    "soundName": "drum bass3",
+                    "soundID": -1,
+                    "md5": "c21704337b16359ea631b5f8eb48f765.wav",
+                    "sampleCount": 8576,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "drum bass-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "3308e038214f5a4adc53076a9fee9021.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 36,
+                    "rotationCenterY": 46
+                },
+                {
+                    "costumeName": "drum bass-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "5febb3df727fb6624946e807a665b866.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 36,
+                    "rotationCenterY": 46
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Drum-Conga",
+        "md5": "b3da94523b6d3df2dd30602399599ab4.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "music",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            4
+        ],
+        "json": {
+            "objName": "Drum-Conga",
+            "sounds": [
+                {
+                    "soundName": "high conga",
+                    "soundID": -1,
+                    "md5": "16144544de90e98a92a265d4fc3241ea.wav",
+                    "sampleCount": 8192,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "low conga",
+                    "soundID": -1,
+                    "md5": "0b6f94487cd8a1cf0bb77e15966656c3.wav",
+                    "sampleCount": 8384,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "muted conga",
+                    "soundID": -1,
+                    "md5": "1d4abbe3c9bfe198a88badb10762de75.wav",
+                    "sampleCount": 4544,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "tap conga",
+                    "soundID": -1,
+                    "md5": "fd9a67157f57f9cc6fe3cdce38a6d4a8.wav",
+                    "sampleCount": 6880,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "drums conga-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "b3da94523b6d3df2dd30602399599ab4.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 51,
+                    "rotationCenterY": 51
+                },
+                {
+                    "costumeName": "drums conga-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "d4398062ed6e09927ab52823255186d3.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 52,
+                    "rotationCenterY": 79
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Drum-Snare",
+        "md5": "868f700de73a35c4d6fa4c93507c348d.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "music",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            3
+        ],
+        "json": {
+            "objName": "Drum-Snare",
+            "sounds": [
+                {
+                    "soundName": "tap snare",
+                    "soundID": -1,
+                    "md5": "d55b3954d72c6275917f375e49b502f3.wav",
+                    "sampleCount": 3296,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "sidestick snare",
+                    "soundID": -1,
+                    "md5": "f6868ee5cf626fc4ef3ca1119dc95592.wav",
+                    "sampleCount": 2336,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "flam snare",
+                    "soundID": -1,
+                    "md5": "3b6cce9f8c56c0537ca61eee3945cd1d.wav",
+                    "sampleCount": 4416,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "drum snare-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "868f700de73a35c4d6fa4c93507c348d.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 51,
+                    "rotationCenterY": 37
+                },
+                {
+                    "costumeName": "drum snare-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "93738cb485ef57cbd4b9bff386d0bba2.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 57,
+                    "rotationCenterY": 59
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Drum-Tabla",
+        "md5": "68ce53b53fcc68744584c28d20144c4f.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "music",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            4
+        ],
+        "json": {
+            "objName": "Drum-Tabla",
+            "sounds": [
+                {
+                    "soundName": "hi na tabla",
+                    "soundID": -1,
+                    "md5": "35b42d98c43404a5b1b52fb232a62bd7.wav",
+                    "sampleCount": 4096,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "hi tun tabla",
+                    "soundID": -1,
+                    "md5": "da734693dfa6a9a7eccdc7f9a0ca9840.wav",
+                    "sampleCount": 18656,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "lo gliss tabla",
+                    "soundID": -1,
+                    "md5": "d7cd24689737569c93e7ea7344ba6b0e.wav",
+                    "sampleCount": 7008,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "lo geh tabla",
+                    "soundID": -1,
+                    "md5": "9205359ab69d042ed3da8a160a651690.wav",
+                    "sampleCount": 30784,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "tabla-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "68ce53b53fcc68744584c28d20144c4f.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 45
+                },
+                {
+                    "costumeName": "tabla-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "01b6ffb8691d32be10fabc77ddfb55b0.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 78,
+                    "rotationCenterY": 48
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Drum1",
+        "md5": "daad8bc865f55200844dbce476d2f1e9.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "music",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            2
+        ],
+        "json": {
+            "objName": "Drum1",
+            "sounds": [
+                {
+                    "soundName": "high tom",
+                    "soundID": -1,
+                    "md5": "d623f99b3c8d33932eb2c6c9cfd817c5.wav",
+                    "sampleCount": 12320,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "low tom",
+                    "soundID": -1,
+                    "md5": "1569bbbd8952b0575e5a5cb5aefb50ba.wav",
+                    "sampleCount": 20000,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "drum1-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "daad8bc865f55200844dbce476d2f1e9.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 49,
+                    "rotationCenterY": 44
+                },
+                {
+                    "costumeName": "drum1-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "8a2e9596b02ecdc195d76c1f34a48f76.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 60,
+                    "rotationCenterY": 61
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Drum2",
+        "md5": "68baa189ac7afb9426db1818aa88be8e.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "music",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            2
+        ],
+        "json": {
+            "objName": "Drum2",
+            "sounds": [
+                {
+                    "soundName": "high tom",
+                    "soundID": -1,
+                    "md5": "d623f99b3c8d33932eb2c6c9cfd817c5.wav",
+                    "sampleCount": 12320,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "low tom",
+                    "soundID": -1,
+                    "md5": "1569bbbd8952b0575e5a5cb5aefb50ba.wav",
+                    "sampleCount": 20000,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "drum2-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "68baa189ac7afb9426db1818aa88be8e.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 47,
+                    "rotationCenterY": 39
+                },
+                {
+                    "costumeName": "drum2-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "4a58fe0f173104aab03aaccdd3ce5280.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 47,
+                    "rotationCenterY": 54
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Duck",
+        "md5": "c3baf7eedfbdac8cd1e4f1f1f779dc0c.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Duck",
+            "sounds": [
+                {
+                    "soundName": "duck",
+                    "soundID": -1,
+                    "md5": "af5b039e1b05e0ccb12944f648a8884e.wav",
+                    "sampleCount": 5792,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "duck",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "c3baf7eedfbdac8cd1e4f1f1f779dc0c.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 61,
+                    "rotationCenterY": 59
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Earth",
+        "md5": "814197522984a302972998b1a7f92d91.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "space",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Earth",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "earth",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "814197522984a302972998b1a7f92d91.svg",
+                    "rotationCenterX": 72,
+                    "rotationCenterY": 72
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Elephant",
+        "md5": "b3515b3805938b0fae4e527aa0b4524e.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "drawing",
+            "nature",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Elephant",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "elephant-a ",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "b3515b3805938b0fae4e527aa0b4524e.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 107,
+                    "rotationCenterY": 33
+                },
+                {
+                    "costumeName": "elephant-b ",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "bce91fa266220d3679a4c19c4e38b1f7.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 95,
+                    "rotationCenterY": 40
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Fire hydrant",
+        "md5": "5542c53bb0ba87b39eba6ff743b8115c.png",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "photo",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Fire hydrant",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "fire hydrant",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "5542c53bb0ba87b39eba6ff743b8115c.png",
+                    "rotationCenterX": 40,
+                    "rotationCenterY": 83
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Fish1",
+        "md5": "df78f8195f72372846d96dc70cb0ad95.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "drawing",
+            "underwater",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Fish1",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "fish1",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "df78f8195f72372846d96dc70cb0ad95.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Fish2",
+        "md5": "f3dd9cb79cce497a90900241cf726367.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "drawing",
+            "underwater",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Fish2",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "fish2",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "f3dd9cb79cce497a90900241cf726367.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Fish3",
+        "md5": "aec949cefb15ddd1330f3b633734d4d3.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "drawing",
+            "underwater",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Fish3",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "fish3",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "aec949cefb15ddd1330f3b633734d4d3.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Flower Shape",
+        "md5": "7905272bf89ee61cd9d3680a67732815.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Flower Shape",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "flower shape",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "7905272bf89ee61cd9d3680a67732815.svg",
+                    "rotationCenterX": 39,
+                    "rotationCenterY": 41
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Football",
+        "md5": "422b34b6e5a2fdb8d0ac00aca91ec714.png",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "sports",
+            "photo",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Football",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "football running",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "422b34b6e5a2fdb8d0ac00aca91ec714.png",
+                    "rotationCenterX": 47,
+                    "rotationCenterY": 100
+                },
+                {
+                    "costumeName": "football standing",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "1f57154842f68aa55577edc90a6f2b32.png",
+                    "rotationCenterX": 37,
+                    "rotationCenterY": 100
+                }
+            ],
+            "currentCostumeIndex": 1,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Fortune Cookie",
+        "md5": "d47f0be24acf78130af2e03572a3f9d3.png",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "photo",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Fortune Cookie",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "fortunecookie",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "d47f0be24acf78130af2e03572a3f9d3.png",
+                    "rotationCenterX": 30,
+                    "rotationCenterY": 31
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Fox",
+        "md5": "dd19959dc4d453813299f496124d50ff.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Fox",
+            "sounds": [
+                {
+                    "soundName": "meow",
+                    "soundID": -1,
+                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
+                    "sampleCount": 18688,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "fox",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "dd19959dc4d453813299f496124d50ff.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Frog",
+        "md5": "285483a688eed2ff8010c65112f99c41.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Frog",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "frog",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "285483a688eed2ff8010c65112f99c41.svg",
+                    "rotationCenterX": 48,
+                    "rotationCenterY": 30
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Fruit Platter",
+        "md5": "c6e2f673debcff91de8e3749ddf674b9.png",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "photo",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Fruit Platter",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "fruit_platter",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "c6e2f673debcff91de8e3749ddf674b9.png",
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 40
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Fruit Salad",
+        "md5": "dbf8cc34f7ca18b4a008d2890dba56b7.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Fruit Salad",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "fruitsalad",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "dbf8cc34f7ca18b4a008d2890dba56b7.svg",
+                    "rotationCenterX": 30,
+                    "rotationCenterY": 22
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Ghost1",
+        "md5": "c88579c578f2d171de78612f2ff9c9d9.svg",
+        "type": "sprite",
+        "tags": [
+            "fantasy",
+            "drawing",
+            "castle",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Ghost1",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "ghost1 ",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "c88579c578f2d171de78612f2ff9c9d9.svg",
+                    "rotationCenterX": 60,
+                    "rotationCenterY": 63
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Ghost2",
+        "md5": "607be245da950af1a4e4d79acfda46e3.svg",
+        "type": "sprite",
+        "tags": [
+            "fantasy",
+            "drawing",
+            "castle",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Ghost2",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "ghost2-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "607be245da950af1a4e4d79acfda46e3.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                },
+                {
+                    "costumeName": "ghost2-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "b9e2ebbe17c617ac182abd8bc1627693.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Ghoul",
+        "md5": "70ef3e78079cf4a1c9abf32b5d982b71.svg",
+        "type": "sprite",
+        "tags": [
+            "fantasy",
+            "drawing",
+            "castle",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Ghoul",
+            "sounds": [
+                {
+                    "soundName": "meow",
+                    "soundID": -1,
+                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
+                    "sampleCount": 18688,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "ghoul-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "70ef3e78079cf4a1c9abf32b5d982b71.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                },
+                {
+                    "costumeName": "ghoul-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "6e962f1248f7a7201eb24d376d804093.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                }
+            ],
+            "currentCostumeIndex": 1,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Gift",
+        "md5": "abeae2217b3ce67b1ff761cd7a89274d.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "holiday",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            0
+        ],
+        "json": {
+            "objName": "Gift",
+            "costumes": [
+                {
+                    "costumeName": "gift-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "abeae2217b3ce67b1ff761cd7a89274d.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 33,
+                    "rotationCenterY": 25
+                },
+                {
+                    "costumeName": "gift-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "5cae973c98f2d98b51e6c6b3c9602f8c.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 33,
+                    "rotationCenterY": 26
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Giga",
+        "md5": "93cb048a1d199f92424b9c097fa5fa38.svg",
+        "type": "sprite",
+        "tags": [
+            "fantasy",
+            "space",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            4,
+            1
+        ],
+        "json": {
+            "objName": "Giga",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "giga-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "93cb048a1d199f92424b9c097fa5fa38.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 72,
+                    "rotationCenterY": 96
+                },
+                {
+                    "costumeName": "giga-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "528613711a7eae3a929025be04db081c.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 72,
+                    "rotationCenterY": 96
+                },
+                {
+                    "costumeName": "giga-c",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "ee4dd21d7ca6d1b889ee25d245cbcc66.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 73,
+                    "rotationCenterY": 96
+                },
+                {
+                    "costumeName": "giga-d",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "7708e2d9f83a01476ee6d17aa540ddf1.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 73,
+                    "rotationCenterY": 96
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Giga walking",
+        "md5": "f76bc420011db2cdb2de378c1536f6da.svg",
+        "type": "sprite",
+        "tags": [
+            "fantasy",
+            "space",
+            "drawing",
+            "walking",
+            "vector"
+        ],
+        "info": [
+            0,
+            4,
+            1
+        ],
+        "json": {
+            "objName": "Giga walking",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "Giga walk1",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "f76bc420011db2cdb2de378c1536f6da.svg",
+                    "rotationCenterX": 70,
+                    "rotationCenterY": 107
+                },
+                {
+                    "costumeName": "Giga walk2",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "43b5874e8a54f93bd02727f0abf6905b.svg",
+                    "rotationCenterX": 71,
+                    "rotationCenterY": 107
+                },
+                {
+                    "costumeName": "Giga walk3",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "9aab3bbb375765391978be4f6d478ab3.svg",
+                    "rotationCenterX": 71,
+                    "rotationCenterY": 107
+                },
+                {
+                    "costumeName": "Giga walk4",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "22e4ae40919cf0fe6b4d7649d14a6e71.svg",
+                    "rotationCenterX": 73,
+                    "rotationCenterY": 110
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Glass Water",
+        "md5": "c364b9e1f4bcdc61705032d89eaaa0a1.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Glass Water",
+            "sounds": [
+                {
+                    "soundName": "water drop",
+                    "soundID": -1,
+                    "md5": "aa488de9e2c871e9d4faecd246ed737a.wav",
+                    "sampleCount": 8136,
+                    "rate": 22050,
+                    "format": "adpcm"
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "glass water-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "c364b9e1f4bcdc61705032d89eaaa0a1.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 39,
+                    "rotationCenterY": 48
+                },
+                {
+                    "costumeName": "glass water-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "bc07ce6a2004ac91ce704531a1c526e5.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 39,
+                    "rotationCenterY": 48
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 0.6,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Glasses",
+        "md5": "5fcf716b53f223bc86b10ab0eca3e162.svg",
+        "type": "sprite",
+        "tags": [
+            "dress-up",
+            "things",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Glasses",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "glasses",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "5fcf716b53f223bc86b10ab0eca3e162.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 16,
+                    "rotationCenterY": 9
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": true,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Gobo",
+        "md5": "1f5ea0d12f85aed2e471cdd21b0bd6d7.svg",
+        "type": "sprite",
+        "tags": [
+            "fantasy",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            3,
+            1
+        ],
+        "json": {
+            "objName": "Gobo",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "gobo-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "1f5ea0d12f85aed2e471cdd21b0bd6d7.svg",
+                    "rotationCenterX": 47,
+                    "rotationCenterY": 55
+                },
+                {
+                    "costumeName": "gobo-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "73e493e4abd5d0954b677b97abcb7116.svg",
+                    "rotationCenterX": 47,
+                    "rotationCenterY": 55
+                },
+                {
+                    "costumeName": "gobo-c",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "bc68a6bdf300df7b53d73b38f74c844e.svg",
+                    "rotationCenterX": 47,
+                    "rotationCenterY": 55
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Green Flag",
+        "md5": "173e20ac537d2c278ed621be3db3fc87.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "vector",
+            "drawing"
+        ],
+        "info": [
+            0,
+            1,
+            0
+        ],
+        "json": {
+            "objName": "Green Flag",
+            "costumes": [
+                {
+                    "costumeName": "green flag",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "173e20ac537d2c278ed621be3db3fc87.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 70,
+                    "rotationCenterY": 30
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Guitar",
+        "md5": "dfa85e2a962b725ee53f61cea2edc1fb.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "music",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            8
+        ],
+        "json": {
+            "objName": "Guitar",
+            "sounds": [
+                {
+                    "soundName": "C guitar",
+                    "soundID": -1,
+                    "md5": "22baa07795a9a524614075cdea543793.wav",
+                    "sampleCount": 44864,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "D guitar",
+                    "soundID": -1,
+                    "md5": "2dbcfae6a55738f94bbb40aa5fcbf7ce.wav",
+                    "sampleCount": 41120,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "E guitar",
+                    "soundID": -1,
+                    "md5": "4b5d1da83e59bf35578324573c991666.wav",
+                    "sampleCount": 38400,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "F guitar",
+                    "soundID": -1,
+                    "md5": "b51d086aeb1921ec405561df52ecbc50.wav",
+                    "sampleCount": 36416,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "G guitar",
+                    "soundID": -1,
+                    "md5": "98a835713ecea2f3ef9f4f442d52ad20.wav",
+                    "sampleCount": 33600,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "A guitar",
+                    "soundID": -1,
+                    "md5": "ee753e87d212d4b2fb650ca660f1e839.wav",
+                    "sampleCount": 31872,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "B guitar",
+                    "soundID": -1,
+                    "md5": "2ae2d67de62df8ca54d638b4ad2466c3.wav",
+                    "sampleCount": 29504,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "C2 guitar",
+                    "soundID": -1,
+                    "md5": "c8d2851bd99d8e0ce6c1f05e4acc7f34.wav",
+                    "sampleCount": 27712,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "guitar",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "dfa85e2a962b725ee53f61cea2edc1fb.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 37,
+                    "rotationCenterY": 98
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Guitar-Bass",
+        "md5": "83cf122ec4a291e2a17910f718b583a5.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "music",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            8
+        ],
+        "json": {
+            "objName": "Guitar-Bass",
+            "sounds": [
+                {
+                    "soundName": "C elec bass",
+                    "soundID": -1,
+                    "md5": "69eee3d038ea0f1c34ec9156a789236d.wav",
+                    "sampleCount": 5216,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "D elec bass",
+                    "soundID": -1,
+                    "md5": "67a6d1aa68233a2fa641aee88c7f051f.wav",
+                    "sampleCount": 5568,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "E elec bass",
+                    "soundID": -1,
+                    "md5": "0704b8ceabe54f1dcedda8c98f1119fd.wav",
+                    "sampleCount": 5691,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "F elec bass",
+                    "soundID": -1,
+                    "md5": "45eedb4ce62a9cbbd2207824b94a4641.wav",
+                    "sampleCount": 5312,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "G elec bass",
+                    "soundID": -1,
+                    "md5": "97b187d72219b994a6ef6a5a6b09605c.wav",
+                    "sampleCount": 5568,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "A elec bass",
+                    "soundID": -1,
+                    "md5": "5cb46ddd903fc2c9976ff881df9273c9.wav",
+                    "sampleCount": 5920,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "B elec bass",
+                    "soundID": -1,
+                    "md5": "5a0701d0a914223b5288300ac94e90e4.wav",
+                    "sampleCount": 6208,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "C2 elec bass",
+                    "soundID": -1,
+                    "md5": "56fc995b8860e713c5948ecd1c2ae572.wav",
+                    "sampleCount": 5792,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "guitar bass",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "83cf122ec4a291e2a17910f718b583a5.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 53,
+                    "rotationCenterY": 145
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Guitar-Electric",
+        "md5": "18d7b47368ba1ead0d1ca436b8369211.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "music",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            8
+        ],
+        "json": {
+            "objName": "Guitar-Electric",
+            "sounds": [
+                {
+                    "soundName": "C elec guitar",
+                    "soundID": -1,
+                    "md5": "0d340de02e14bebaf8dfa0e43eb3f1f9.wav",
+                    "sampleCount": 44100,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "D elec guitar",
+                    "soundID": -1,
+                    "md5": "1b5de9866801eb2f9d4f57c7c3b473f5.wav",
+                    "sampleCount": 44100,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "E elec guitar",
+                    "soundID": -1,
+                    "md5": "2e6a6ae3e0f72bf78c74def8130f459a.wav",
+                    "sampleCount": 44100,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "F elec guitar",
+                    "soundID": -1,
+                    "md5": "5eb00f15f21f734986aa45156d44478d.wav",
+                    "sampleCount": 44100,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "G elec guitar",
+                    "soundID": -1,
+                    "md5": "cd0d0e7dad415b2ffa2ba7a61860eaf8.wav",
+                    "sampleCount": 44100,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "A elec guitar",
+                    "soundID": -1,
+                    "md5": "fa5f7fea601e9368dd68449d9a54c995.wav",
+                    "sampleCount": 44100,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "B elec guitar",
+                    "soundID": -1,
+                    "md5": "81f142d0b00189703d7fe9b1f13f6f87.wav",
+                    "sampleCount": 44100,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "C2 elec guitar",
+                    "soundID": -1,
+                    "md5": "3a8ed3129f22cba5b0810bc030d16b5f.wav",
+                    "sampleCount": 44100,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "guitar electric",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "18d7b47368ba1ead0d1ca436b8369211.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 37,
+                    "rotationCenterY": 114
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Hannah",
+        "md5": "b983d99560313e38b4b3cd36cbd5f0d1.png",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "city",
+            "drawing",
+            "bitmap",
+            "sports"
+        ],
+        "info": [
+            0,
+            3,
+            1
+        ],
+        "json": {
+            "objName": "Hannah",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "hannah-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "b983d99560313e38b4b3cd36cbd5f0d1.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 138,
+                    "rotationCenterY": 126
+                },
+                {
+                    "costumeName": "hannah-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "d0c3b4b24fbf1152de3ebb68f6b875ae.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 48,
+                    "rotationCenterY": 160
+                },
+                {
+                    "costumeName": "hannah-c",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "5fdce07935156bbcf943793fa84e826c.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 170,
+                    "rotationCenterY": 130
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Hat",
+        "md5": "b3beb1f52d371428d70b65a0c4c5c001.svg",
+        "type": "sprite",
+        "tags": [
+            "dress-up",
+            "things",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Hat",
+            "sounds": [
+                {
+                    "soundName": "meow",
+                    "soundID": -1,
+                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
+                    "sampleCount": 18688,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "Hat",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "b3beb1f52d371428d70b65a0c4c5c001.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 52,
+                    "rotationCenterY": 60
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": true,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Hat Beanie",
+        "md5": "3271da33e4108ed08a303c2244739fbf.svg",
+        "type": "sprite",
+        "tags": [
+            "dress-up",
+            "things",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Hat Beanie",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "hat beanie",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "3271da33e4108ed08a303c2244739fbf.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 28,
+                    "rotationCenterY": 19
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": true,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Hat Party1",
+        "md5": "70a7f535d8857cf9175492415361c361.svg",
+        "type": "sprite",
+        "tags": [
+            "dress-up",
+            "things",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Hat Party1",
+            "sounds": [
+                {
+                    "soundName": "meow",
+                    "soundID": -1,
+                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
+                    "sampleCount": 18688,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "partyhat1",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "70a7f535d8857cf9175492415361c361.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Hat Party2",
+        "md5": "9b7a84fe3e50621752917e4e484a1e2f.svg",
+        "type": "sprite",
+        "tags": [
+            "dress-up",
+            "things",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Hat Party2",
+            "sounds": [
+                {
+                    "soundName": "meow",
+                    "soundID": -1,
+                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
+                    "sampleCount": 18688,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "hat party2-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "9b7a84fe3e50621752917e4e484a1e2f.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Hat Winter",
+        "md5": "6c2ee1b97f6ec2b3457a25a3975a2009.svg",
+        "type": "sprite",
+        "tags": [
+            "dress-up",
+            "things",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            2
+        ],
+        "json": {
+            "objName": "Hat Winter",
+            "sounds": [
+                {
+                    "soundName": "meow",
+                    "soundID": -1,
+                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
+                    "sampleCount": 18688,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "xylo3",
+                    "soundID": -1,
+                    "md5": "3395cade6d7c0cc9ce73a8c12f40319b.wav",
+                    "sampleCount": 209502,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "hat winter",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "6c2ee1b97f6ec2b3457a25a3975a2009.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 26,
+                    "rotationCenterY": 101
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 0.9,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Hat Wizard",
+        "md5": "581571e8c8f5adeb01565e12b1b77b58.svg",
+        "type": "sprite",
+        "tags": [
+            "dress-up",
+            "fantasy",
+            "things",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Hat Wizard",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "hat wizard",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "581571e8c8f5adeb01565e12b1b77b58.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 76,
+                    "rotationCenterY": 69
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Headband",
+        "md5": "961148d1605a1bd8ce80ed8d39e831c2.svg",
+        "type": "sprite",
+        "tags": [
+            "dress-up",
+            "things",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Headband",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "headband",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "961148d1605a1bd8ce80ed8d39e831c2.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 53,
+                    "rotationCenterY": 43
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": true,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Heart",
+        "md5": "6e79e087c866a016f99ee482e1aeba47.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "flying",
+            "holiday",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Heart",
+            "sounds": [
+                {
+                    "soundName": "tom drum",
+                    "soundID": -1,
+                    "md5": "ca350a536d60bb8ed50f24677d65eed8.wav",
+                    "sampleCount": 33920,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "heart red",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "6e79e087c866a016f99ee482e1aeba47.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 65,
+                    "rotationCenterY": 56
+                },
+                {
+                    "costumeName": "heart purple",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "b15362bb6b02a59e364db9081ccf19aa.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 66,
+                    "rotationCenterY": 62
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 0.55,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Heart Candy",
+        "md5": "d448acd247f10f32bef7823cd433f928.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "holiday",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            4,
+            1
+        ],
+        "json": {
+            "objName": "Heart Candy",
+            "sounds": [
+                {
+                    "soundName": "tom drum",
+                    "soundID": -1,
+                    "md5": "ca350a536d60bb8ed50f24677d65eed8.wav",
+                    "sampleCount": 33920,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "heart love it",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "d448acd247f10f32bef7823cd433f928.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 58,
+                    "rotationCenterY": 61
+                },
+                {
+                    "costumeName": "heart code",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "497c5df9e02467202ff93096dccaf91f.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 58,
+                    "rotationCenterY": 61
+                },
+                {
+                    "costumeName": "heart sweet",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "a39d78d33b051e8b12a4b2a10d77b249.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 58,
+                    "rotationCenterY": 61
+                },
+                {
+                    "costumeName": "heart smile",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "74a8f75d139d330b715787edbbacd83d.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 58,
+                    "rotationCenterY": 61
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 0.55,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Heart Face",
+        "md5": "4ab84263da32069cf97cc0fa52729a0d.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "holiday",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Heart Face",
+            "sounds": [
+                {
+                    "soundName": "tom drum",
+                    "soundID": -1,
+                    "md5": "ca350a536d60bb8ed50f24677d65eed8.wav",
+                    "sampleCount": 33920,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "heart face",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "4ab84263da32069cf97cc0fa52729a0d.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 59,
+                    "rotationCenterY": 52
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 0.55,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Heart Scratch",
+        "md5": "2bfa5c3b41d4be160ab0c157ce0f96a9.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "holiday",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Heart Scratch",
+            "sounds": [
+                {
+                    "soundName": "dance snare beat",
+                    "soundID": -1,
+                    "md5": "562587bdb75e3a8124cdaa46ba0f648b.wav",
+                    "sampleCount": 176401,
+                    "rate": 22050,
+                    "format": "adpcm"
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "heart scratch",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "2bfa5c3b41d4be160ab0c157ce0f96a9.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 81,
+                    "rotationCenterY": 77
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 0.55,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Helicopter",
+        "md5": "8847e2d3383906dbabbf7ffa98945a7b.png",
+        "type": "sprite",
+        "tags": [
+            "transportation",
+            "flying",
+            "city",
+            "drawing",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Helicopter",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "helicopter",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "8847e2d3383906dbabbf7ffa98945a7b.png",
+                    "rotationCenterX": 90,
+                    "rotationCenterY": 64
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Hippo1",
+        "md5": "c1353c4a5eec5e6f32ed053e6f6e8f99.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "flying",
+            "fantasy",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Hippo1",
+            "sounds": [
+                {
+                    "soundName": "meow",
+                    "soundID": -1,
+                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
+                    "sampleCount": 18688,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "hippo1-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "c1353c4a5eec5e6f32ed053e6f6e8f99.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 69,
+                    "rotationCenterY": 65
+                },
+                {
+                    "costumeName": "hippo1-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "e65ed93bbb9cccf698fc7e774ab609a6.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 69,
+                    "rotationCenterY": 68
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Holly",
+        "md5": "1d8583ca1b5c687f3de004c27110a130.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "holiday",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Holly",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "holly1",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "1d8583ca1b5c687f3de004c27110a130.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 29,
+                    "rotationCenterY": 44
+                },
+                {
+                    "costumeName": "holly2",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "4b23f1d694ae8b400f1d7216dd8e49bc.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 27,
+                    "rotationCenterY": 42
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Home Button",
+        "md5": "1bac530a0701a8fc88bb0802ae6787a3.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Home Button",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "home button",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "1bac530a0701a8fc88bb0802ae6787a3.svg",
+                    "rotationCenterX": 72,
+                    "rotationCenterY": 72
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Horse1",
+        "md5": "32f4d80477cd070cb0848e555d374060.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "transportation",
+            "vector",
+            "drawing"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Horse1",
+            "sounds": [
+                {
+                    "soundName": "meow",
+                    "soundID": -1,
+                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
+                    "sampleCount": 18688,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "horse1-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "32f4d80477cd070cb0848e555d374060.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 119,
+                    "rotationCenterY": 83
+                },
+                {
+                    "costumeName": "horse1-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "ffa6431c5ef2a4e975ecffacdb0efea7.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 103,
+                    "rotationCenterY": 97
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Jaime",
+        "md5": "3ddc912edef87ae29121f57294fa0cb5.png",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "city",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Jaime",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "jaime-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "3ddc912edef87ae29121f57294fa0cb5.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 76,
+                    "rotationCenterY": 154
+                },
+                {
+                    "costumeName": "jaime-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "5a683f4536abca0f83a77bc341df4c9a.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 68,
+                    "rotationCenterY": 154
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Jaime Walking",
+        "md5": "d6cc9814f7a6640e4c2b1a4276987dc5.png",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "city",
+            "walking",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            5,
+            1
+        ],
+        "json": {
+            "objName": "Jaime Walking",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "jaime walking-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "d6cc9814f7a6640e4c2b1a4276987dc5.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 106,
+                    "rotationCenterY": 172
+                },
+                {
+                    "costumeName": "jaime walking-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "7fb579a98d6db257f1b16109d3c4609a.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 52,
+                    "rotationCenterY": 176
+                },
+                {
+                    "costumeName": "jaime walking-c",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "5883bdefba451aaeac8d77c798d41eb0.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 88,
+                    "rotationCenterY": 170
+                },
+                {
+                    "costumeName": "jaime walking-d",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "4b9d2162e30dbb924840575ed35fddb0.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 46,
+                    "rotationCenterY": 174
+                },
+                {
+                    "costumeName": "jaime walking-e",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "63e56d28cc3e3d9b735e1f1d51248cc0.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 84,
+                    "rotationCenterY": 172
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Jay",
+        "md5": "cf32a87b2c9d7c2553f5a1ed17966504.gif",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "city",
+            "photo",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Jay",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "jay",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "cf32a87b2c9d7c2553f5a1ed17966504.gif",
+                    "rotationCenterX": 70,
+                    "rotationCenterY": 100
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Jeans",
+        "md5": "4e283da8c59bcbb9803bdc0016b14c21.svg",
+        "type": "sprite",
+        "tags": [
+            "dress-up",
+            "things",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Jeans",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "jeans-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "4e283da8c59bcbb9803bdc0016b14c21.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 22,
+                    "rotationCenterY": 25
+                },
+                {
+                    "costumeName": "jeans-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "01732aa03a48482093fbed3ea402c4a9.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 22,
+                    "rotationCenterY": 25
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": true,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Jodi",
+        "md5": "a8ae8b69caa6a837f49aa950055ef29a.gif",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "sports",
+            "photo",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Jodi",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "jodi",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "a8ae8b69caa6a837f49aa950055ef29a.gif",
+                    "rotationCenterX": 54,
+                    "rotationCenterY": 75
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Jouvi Hip-Hop",
+        "md5": "cb4bf65491eaa9e8aeb1c1fdfe37e84a.png",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "dance",
+            "city",
+            "photo",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            13,
+            1
+        ],
+        "json": {
+            "objName": "Jouvi Hip-Hop",
+            "sounds": [
+                {
+                    "soundName": "dance celebrate2",
+                    "soundID": -1,
+                    "md5": "0edb8fb88af19e6e17d0f8cf64c1d136.wav",
+                    "sampleCount": 176401,
+                    "rate": 22050,
+                    "format": "adpcm"
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "jo stance",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "cb4bf65491eaa9e8aeb1c1fdfe37e84a.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 94,
+                    "rotationCenterY": 240
+                },
+                {
+                    "costumeName": "jo top stand",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "a91fe6e180b524d27688aa0cd82cd629.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 68,
+                    "rotationCenterY": 260
+                },
+                {
+                    "costumeName": "jo top R leg",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "de64c526a57355af5fd6ff28f27b67ea.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 218,
+                    "rotationCenterY": 262
+                },
+                {
+                    "costumeName": "jo top L leg",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "987a667cd7984d9e5429c26b8a4cab2d.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 208,
+                    "rotationCenterY": 268
+                },
+                {
+                    "costumeName": "jo top R cross",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "ddbd8751df020cc32231ecb4e7b5388d.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 144,
+                    "rotationCenterY": 270
+                },
+                {
+                    "costumeName": "jo top L cross",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "33660046a3d37fa762f4a634ee3df75d.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 84,
+                    "rotationCenterY": 268
+                },
+                {
+                    "costumeName": "jo pop front",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "0503f4d712bc3184cf1b5f830d0df993.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 70,
+                    "rotationCenterY": 228
+                },
+                {
+                    "costumeName": "jo pop down",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "95a0f1bb3d8055a283aecc6bcb6303c9.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 68,
+                    "rotationCenterY": 74
+                },
+                {
+                    "costumeName": "jo pop left",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "98e8c2f9869f9356204ed19e43ae01cc.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 196,
+                    "rotationCenterY": 226
+                },
+                {
+                    "costumeName": "jo pop right",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "7bf1600ee75facb510c2922f899fb97c.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 66,
+                    "rotationCenterY": 242
+                },
+                {
+                    "costumeName": "jo pop L arm",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "2a907e6edf8a101addb2c27d0568896a.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 108,
+                    "rotationCenterY": 258
+                },
+                {
+                    "costumeName": "jo pop stand",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "361d1884737ef734f6a39fd66fc269ec.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 78,
+                    "rotationCenterY": 262
+                },
+                {
+                    "costumeName": "jo pop R arm",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "e633eb002deb20108bb5100d4b3a8fc5.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 108,
+                    "rotationCenterY": 260
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Kai",
+        "md5": "6e007fde15e49c66ee7996561f80b452.png",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "city",
+            "drawing",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Kai",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "kai-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "6e007fde15e49c66ee7996561f80b452.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 68,
+                    "rotationCenterY": 160
+                },
+                {
+                    "costumeName": "kai-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "c1e1149f6d7e308e3e4eba14ccc8a751.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 82,
+                    "rotationCenterY": 158
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Key",
+        "md5": "af35300cef35803e11f4ed744dc5e818.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Key",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "key",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "af35300cef35803e11f4ed744dc5e818.svg",
+                    "rotationCenterX": 42,
+                    "rotationCenterY": 27
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Khalid Dance",
+        "md5": "d0018780c7458f002b6fec6d1fea3570.png",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "dance",
+            "city",
+            "photo",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            4,
+            1
+        ],
+        "json": {
+            "objName": "Khalid Dance",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "khalid-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "d0018780c7458f002b6fec6d1fea3570.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 79,
+                    "rotationCenterY": 101
+                },
+                {
+                    "costumeName": "Khalid-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "88023269142bfc3ecab5b13cc8cbddb9.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 69,
+                    "rotationCenterY": 103
+                },
+                {
+                    "costumeName": "khalid-c",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "30dbce950a2d2dddc0ea53d1462d116b.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 69,
+                    "rotationCenterY": 109
+                },
+                {
+                    "costumeName": "khalid-d",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "e189aec22f4cb57a90f75457615fbbd8.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 66,
+                    "rotationCenterY": 63
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Knight",
+        "md5": "f2c5e8bc24d001b81566879dbf2f1a13.svg",
+        "type": "sprite",
+        "tags": [
+            "fantasy",
+            "drawing",
+            "castle",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Knight",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "knight",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "f2c5e8bc24d001b81566879dbf2f1a13.svg",
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Ladybug1",
+        "md5": "f16a1ccc69a4a8190a927f1595aa7bfa.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Ladybug1",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "ladybug2",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "f16a1ccc69a4a8190a927f1595aa7bfa.svg",
+                    "rotationCenterX": 41,
+                    "rotationCenterY": 43
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Ladybug2",
+        "md5": "c018a3eed966d5f92c69f2188dfd2aae.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Ladybug2",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "ladybug2-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "c018a3eed966d5f92c69f2188dfd2aae.svg",
+                    "rotationCenterX": 49,
+                    "rotationCenterY": 28
+                },
+                {
+                    "costumeName": "ladybug2-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "a2bb15ace808e070a2b815502952b292.svg",
+                    "rotationCenterX": 49,
+                    "rotationCenterY": 28
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Lamp",
+        "md5": "4885678710301cda511018ad7e420c9c.png",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "photo",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Lamp",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "lamp",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "4885678710301cda511018ad7e420c9c.png",
+                    "rotationCenterX": 25,
+                    "rotationCenterY": 41
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Laptop",
+        "md5": "76f456b30b98eeefd7c942b27b524e31.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Laptop",
+            "sounds": [
+                {
+                    "soundName": "meow",
+                    "soundID": -1,
+                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
+                    "sampleCount": 18688,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "laptop",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "76f456b30b98eeefd7c942b27b524e31.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "LB Hip-Hop",
+        "md5": "61b464a77536f75490d8891fb877819a.png",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "dance",
+            "city",
+            "photo",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            13,
+            1
+        ],
+        "json": {
+            "objName": "LB Hip-Hop",
+            "sounds": [
+                {
+                    "soundName": "dance celebrate",
+                    "soundID": -1,
+                    "md5": "0edb8fb88af19e6e17d0f8cf64c1d136.wav",
+                    "sampleCount": 176401,
+                    "rate": 22050,
+                    "format": "adpcm"
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "lb stance",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "61b464a77536f75490d8891fb877819a.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 54,
+                    "rotationCenterY": 244
+                },
+                {
+                    "costumeName": "lb top stand",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "dfe3628ddf46a67dcc21c63be65a8e40.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 70,
+                    "rotationCenterY": 248
+                },
+                {
+                    "costumeName": "lb top R leg",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "e824768a109691b5a3c577d3506ed70c.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 244,
+                    "rotationCenterY": 250
+                },
+                {
+                    "costumeName": "lb top L leg",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "350472368e2310efe6fa734b79f0ff41.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 234,
+                    "rotationCenterY": 286
+                },
+                {
+                    "costumeName": "lb top L cross",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "5a151c4d4e2e2f870d9096d5fce6ed48.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 148,
+                    "rotationCenterY": 258
+                },
+                {
+                    "costumeName": "lb top R cross",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "99acf468000c6fcbaf344e4531725efc.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 174,
+                    "rotationCenterY": 256
+                },
+                {
+                    "costumeName": "lb pop front",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "e34a166807a3ffbf8d147b12aa49dd19.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 66,
+                    "rotationCenterY": 272
+                },
+                {
+                    "costumeName": "lb pop down",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "8e41de92cb932a6898782a39a0d7d300.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 56,
+                    "rotationCenterY": 90
+                },
+                {
+                    "costumeName": "lb pop left",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "ff1b96d1047d4be459a4614ce7c7c94c.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 198,
+                    "rotationCenterY": 266
+                },
+                {
+                    "costumeName": "lb pop right",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "d6d5534c628ac5d5fe3cbf1b76b71252.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 76,
+                    "rotationCenterY": 264
+                },
+                {
+                    "costumeName": "lb pop L arm",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "c1fd31607619b8c98a286a650f248511.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 100,
+                    "rotationCenterY": 262
+                },
+                {
+                    "costumeName": "lb pop stand",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "51fe5962fe4d2af7f6fad7abaa692069.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 66,
+                    "rotationCenterY": 268
+                },
+                {
+                    "costumeName": "lb pop R arm",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "aa57575fde5ff8b13041e3a7b1499fe0.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 78,
+                    "rotationCenterY": 258
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Lightning",
+        "md5": "c2d636ab2b491e591536afc3d49cbecd.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "castle",
+            "nature",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Lightning",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "lightning",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "c2d636ab2b491e591536afc3d49cbecd.svg",
+                    "rotationCenterX": 21,
+                    "rotationCenterY": 83
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Lion",
+        "md5": "692a3c84366bf8ae4d16858e20e792f5.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Lion",
+            "sounds": [
+                {
+                    "soundName": "meow",
+                    "soundID": -1,
+                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
+                    "sampleCount": 18688,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "lion-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "692a3c84366bf8ae4d16858e20e792f5.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                },
+                {
+                    "costumeName": "lion-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "a519ef168a345a2846d0201bf092a6d0.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                }
+            ],
+            "currentCostumeIndex": 1,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Lionness",
+        "md5": "8b5f49d4f91f61fbdcb4abac53ab5c7c.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Lionness",
+            "sounds": [
+                {
+                    "soundName": "meow",
+                    "soundID": -1,
+                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
+                    "sampleCount": 18688,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "lioness",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "8b5f49d4f91f61fbdcb4abac53ab5c7c.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Lornz OdetoCode",
+        "md5": "bf911c597995031014bbf32a8eb9d997.png",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "dance",
+            "photo",
+            "bitmap"
+        ],
+        "info": [
+            1,
+            8,
+            1
+        ],
+        "json": {
+            "objName": "Lornz OdetoCode",
+            "scripts": [
+                [
+                    10,
+                    10,
+                    [
+                        [
+                            "whenKeyPressed",
+                            "space"
+                        ],
+                        [
+                            "nextCostume"
+                        ]
+                    ]
+                ]
+            ],
+            "sounds": [
+                {
+                    "soundName": "odesong-b",
+                    "soundID": -1,
+                    "md5": "2c41921491b1da2bfa1ebcaba34265ca.wav",
+                    "sampleCount": 212553,
+                    "rate": 22050,
+                    "format": "adpcm"
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "lorenz01",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "bf911c597995031014bbf32a8eb9d997.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 71,
+                    "rotationCenterY": 252
+                },
+                {
+                    "costumeName": "lorenz02",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "a1fb3946afc4c064503656d5d8ed0def.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 120,
+                    "rotationCenterY": 252
+                },
+                {
+                    "costumeName": "lorenz03",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "1da2ed229f84c1e6d1693bce3bf2d27f.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 125,
+                    "rotationCenterY": 252
+                },
+                {
+                    "costumeName": "lorenz04",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "6b798489bdf2c48337ccb2d31fc64c5f.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 124,
+                    "rotationCenterY": 109
+                },
+                {
+                    "costumeName": "lorenz05",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "dc4e7a7e84f20802d4c1b12423738f62.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 141,
+                    "rotationCenterY": 252
+                },
+                {
+                    "costumeName": "lorenz06",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "92db5fdd19b29f32890926d808e764af.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 132,
+                    "rotationCenterY": 250
+                },
+                {
+                    "costumeName": "lorenz07",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "6b65c2e80daf820d0f277af4f7352cbc.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 121,
+                    "rotationCenterY": 252
+                },
+                {
+                    "costumeName": "lorenz07b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "97ef7f1f07248305725f74a0cc127eba.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 115,
+                    "rotationCenterY": 252
+                }
+            ],
+            "currentCostumeIndex": 7,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Magic Carpet",
+        "md5": "66b74069378c828cb21d2dbe2227a31a.png",
+        "type": "sprite",
+        "tags": [
+            "transportation",
+            " fantasy",
+            "flying",
+            "castle",
+            "drawing",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Magic Carpet",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "magiccarpet",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "66b74069378c828cb21d2dbe2227a31a.png",
+                    "rotationCenterX": 90,
+                    "rotationCenterY": 31
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Magic Wand",
+        "md5": "3db9bfe57d561557795633c5cda44e8c.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "castle",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Magic Wand",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "magicwand",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "3db9bfe57d561557795633c5cda44e8c.svg",
+                    "rotationCenterX": 41,
+                    "rotationCenterY": 18
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Maya",
+        "md5": "8b7ff2f1190825367112c2c076e34af3.png",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "city",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Maya",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "maya",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "8b7ff2f1190825367112c2c076e34af3.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 72,
+                    "rotationCenterY": 138
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Marble Building",
+        "md5": "53608adfaea6e927dc11b53f604e2a1e.png",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "photo",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Marble Building",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "marble-building",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "53608adfaea6e927dc11b53f604e2a1e.png",
+                    "rotationCenterX": 50,
+                    "rotationCenterY": 68
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Microphone",
+        "md5": "59109aefada55997b9497c6266695830.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "music",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            10
+        ],
+        "json": {
+            "objName": "Microphone",
+            "sounds": [
+                {
+                    "soundName": "bass beatbox",
+                    "soundID": -1,
+                    "md5": "28153621d293c86da0b246d314458faf.wav",
+                    "sampleCount": 6720,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "hi beatbox",
+                    "soundID": -1,
+                    "md5": "5a07847bf246c227204728b05a3fc8f3.wav",
+                    "sampleCount": 5856,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "snare beatbox",
+                    "soundID": -1,
+                    "md5": "c642c4c00135d890998f351faec55498.wav",
+                    "sampleCount": 5630,
+                    "rate": 22050,
+                    "format": "adpcm"
+                },
+                {
+                    "soundName": "scratching beatbox",
+                    "soundID": -1,
+                    "md5": "859249563a7b1fc0f6e92e36d1db81c7.wav",
+                    "sampleCount": 11552,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "crash beatbox",
+                    "soundID": -1,
+                    "md5": "725e29369e9138a43f11e0e5eb3eb562.wav",
+                    "sampleCount": 26883,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "wub beatbox",
+                    "soundID": -1,
+                    "md5": "e1f32c057411da4237181ce72ae15d23.wav",
+                    "sampleCount": 7392,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "hihat beatbox",
+                    "soundID": -1,
+                    "md5": "0c77025e2e874f05cd3c7d850874d56d.wav",
+                    "sampleCount": 4274,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "rim beatbox",
+                    "soundID": -1,
+                    "md5": "7ede1382b578d8fc32850b48d082d914.wav",
+                    "sampleCount": 4960,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "clap beatbox",
+                    "soundID": -1,
+                    "md5": "abc70bb390f8e55f22f32265500d814a.wav",
+                    "sampleCount": 4224,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "wah beatbox",
+                    "soundID": -1,
+                    "md5": "9021b7bb06f2399f18e2db4fb87095dc.wav",
+                    "sampleCount": 6624,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "microphone",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "59109aefada55997b9497c6266695830.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 27,
+                    "rotationCenterY": 31
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Microphone Stand",
+        "md5": "fe85f2d5a94d27b6d793361c3fddcf77.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "music",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            10
+        ],
+        "json": {
+            "objName": "Microphone Stand",
+            "sounds": [
+                {
+                    "soundName": "bass beatbox",
+                    "soundID": -1,
+                    "md5": "28153621d293c86da0b246d314458faf.wav",
+                    "sampleCount": 6720,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "hi beatbox",
+                    "soundID": -1,
+                    "md5": "5a07847bf246c227204728b05a3fc8f3.wav",
+                    "sampleCount": 5856,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "snare beatbox",
+                    "soundID": -1,
+                    "md5": "726fea2968a387ef566c03d163f17668.wav",
+                    "sampleCount": 6102,
+                    "rate": 22050,
+                    "format": "adpcm"
+                },
+                {
+                    "soundName": "scratching beatbox",
+                    "soundID": -1,
+                    "md5": "859249563a7b1fc0f6e92e36d1db81c7.wav",
+                    "sampleCount": 11552,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "crash beatbox",
+                    "soundID": -1,
+                    "md5": "725e29369e9138a43f11e0e5eb3eb562.wav",
+                    "sampleCount": 26883,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "wub beatbox",
+                    "soundID": -1,
+                    "md5": "e1f32c057411da4237181ce72ae15d23.wav",
+                    "sampleCount": 7392,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "hihat beatbox",
+                    "soundID": -1,
+                    "md5": "0c77025e2e874f05cd3c7d850874d56d.wav",
+                    "sampleCount": 4274,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "rim beatbox",
+                    "soundID": -1,
+                    "md5": "7ede1382b578d8fc32850b48d082d914.wav",
+                    "sampleCount": 4960,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "clap beatbox",
+                    "soundID": -1,
+                    "md5": "abc70bb390f8e55f22f32265500d814a.wav",
+                    "sampleCount": 4224,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "wah beatbox",
+                    "soundID": -1,
+                    "md5": "9021b7bb06f2399f18e2db4fb87095dc.wav",
+                    "sampleCount": 6624,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "microphonestand",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "fe85f2d5a94d27b6d793361c3fddcf77.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 57,
+                    "rotationCenterY": 55
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Monkey1",
+        "md5": "d0819570ed955416190eab2e020071ca.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Monkey1",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "monkey1-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "d0819570ed955416190eab2e020071ca.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 44,
+                    "rotationCenterY": 45
+                },
+                {
+                    "costumeName": "monkey1-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "dc361fc5c8645e68c7bab9db3df6bc9d.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 51,
+                    "rotationCenterY": 46
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Monkey2",
+        "md5": "6e4de762dbd52cd2b6356694a9668211.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            3,
+            1
+        ],
+        "json": {
+            "objName": "Monkey2",
+            "sounds": [
+                {
+                    "soundName": "chee chee",
+                    "soundID": -1,
+                    "md5": "25f4826cdd61e0a1c623ec2324c16ca0.wav",
+                    "sampleCount": 34560,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "monkey2-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "6e4de762dbd52cd2b6356694a9668211.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 68,
+                    "rotationCenterY": 99
+                },
+                {
+                    "costumeName": "monkey2-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "7662a3a0f4c6fa21fdf2de33bd80fe5f.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 68,
+                    "rotationCenterY": 99
+                },
+                {
+                    "costumeName": "monkey2-c",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "db8eb50b948047181922310bb94511fb.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 68,
+                    "rotationCenterY": 99
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 0.75,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Mori",
+        "md5": "350a86adb24247003cc7e047bdba3c1d.png",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "city",
+            "drawing",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Mori",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "mori",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "350a86adb24247003cc7e047bdba3c1d.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 42,
+                    "rotationCenterY": 160
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Mouse1",
+        "md5": "e1f0c26afecbe9d4b9923d8e6bf489a8.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Mouse1",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "mouse1-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "e1f0c26afecbe9d4b9923d8e6bf489a8.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 50,
+                    "rotationCenterY": 27
+                },
+                {
+                    "costumeName": "mouse1-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "f5e477a3f94fc98ba3cd927228405646.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 65,
+                    "rotationCenterY": 21
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Muffin",
+        "md5": "e00161f08c77d10e72e44b6e01243e63.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Muffin",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "muffin-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "e00161f08c77d10e72e44b6e01243e63.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 85,
+                    "rotationCenterY": 48
+                },
+                {
+                    "costumeName": "muffin-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "fb60c3f8d6a892813299daa33b91df23.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 85,
+                    "rotationCenterY": 48
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Nano",
+        "md5": "02c5433118f508038484bbc5b111e187.svg",
+        "type": "sprite",
+        "tags": [
+            "fantasy",
+            "space",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            4,
+            1
+        ],
+        "json": {
+            "objName": "Nano",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "nano-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "02c5433118f508038484bbc5b111e187.svg",
+                    "rotationCenterX": 61,
+                    "rotationCenterY": 60
+                },
+                {
+                    "costumeName": "nano-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "10d6d9130618cd092ae02158cde2e113.svg",
+                    "rotationCenterX": 61,
+                    "rotationCenterY": 60
+                },
+                {
+                    "costumeName": "nano-c",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "85e762d45bc626ca2edb3472c7cfaa32.svg",
+                    "rotationCenterX": 61,
+                    "rotationCenterY": 60
+                },
+                {
+                    "costumeName": "nano-d",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "b10925346da8080443f27e7dfaeff6f7.svg",
+                    "rotationCenterX": 61,
+                    "rotationCenterY": 60
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Neigh Pony",
+        "md5": "176c4fb4df80df899ca28a48bd1f0edf.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Neigh Pony",
+            "sounds": [
+                {
+                    "soundName": "horse",
+                    "soundID": -1,
+                    "md5": "45ffcf97ee2edca0199ff5aa71a5b72e.wav",
+                    "sampleCount": 14464,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "neigh pony",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "176c4fb4df80df899ca28a48bd1f0edf.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 74,
+                    "rotationCenterY": 78
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Octopus",
+        "md5": "bb68d2e29d8572ef9de06f8033e668d9.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "drawing",
+            "vector",
+            "underwater"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Octopus",
+            "sounds": [
+                {
+                    "soundName": "meow",
+                    "soundID": -1,
+                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
+                    "sampleCount": 18688,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "octopus-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "bb68d2e29d8572ef9de06f8033e668d9.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                },
+                {
+                    "costumeName": "octopus-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "b52bd3bc12553bb31b1395516c3cec4d.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                }
+            ],
+            "currentCostumeIndex": 1,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Orange",
+        "md5": "780ee2ef342f79a81b4c353725331138.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Orange",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "orange",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "780ee2ef342f79a81b4c353725331138.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 19,
+                    "rotationCenterY": 18
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Orange2",
+        "md5": "89b11d2a404c3972b65743f743cc968a.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            3,
+            1
+        ],
+        "json": {
+            "objName": "Orange2",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "orange2-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "89b11d2a404c3972b65743f743cc968a.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 49,
+                    "rotationCenterY": 24
+                },
+                {
+                    "costumeName": "orange2-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "5f7998e007dfa70e70bbd8d43199ebba.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 49,
+                    "rotationCenterY": 27
+                },
+                {
+                    "costumeName": "orange2-c",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "466e9e2d62ee135a2dabd5593e6f8407.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 49,
+                    "rotationCenterY": 33
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Paddle",
+        "md5": "5cda5ed5ffabc3d06322551656427b06.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            0
+        ],
+        "json": {
+            "objName": "Paddle",
+            "costumes": [
+                {
+                    "costumeName": "paddle",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "5cda5ed5ffabc3d06322551656427b06.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 39,
+                    "rotationCenterY": 8
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 0.85000000000001,
+            "direction": -90,
+            "rotationStyle": "none",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Palmtree",
+        "md5": "6d9c18c296edc8a01e4c611b573b5723.gif",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "nature",
+            "photo",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Palmtree",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "palmtree",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "6d9c18c296edc8a01e4c611b573b5723.gif",
+                    "rotationCenterX": 58,
+                    "rotationCenterY": 100
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Parrot",
+        "md5": "098570b8e1aa85b32f9b4eb07bea3af2.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "drawing",
+            "flying",
+            "nature",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Parrot",
+            "sounds": [
+                {
+                    "soundName": "bird",
+                    "soundID": -1,
+                    "md5": "18bd4b634a3f992a16b30344c7d810e0.wav",
+                    "sampleCount": 3840,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "parrot-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "098570b8e1aa85b32f9b4eb07bea3af2.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 86,
+                    "rotationCenterY": 106
+                },
+                {
+                    "costumeName": "parrot-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "721255a0733c9d8d2ba518ff09b3b7cb.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 49,
+                    "rotationCenterY": 31
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Parrot2",
+        "md5": "aba6f5539a5ac21863a3495d89947e66.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "drawing",
+            "flying",
+            "nature",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            2
+        ],
+        "json": {
+            "objName": "Parrot2",
+            "sounds": [
+                {
+                    "soundName": "squawk",
+                    "soundID": -1,
+                    "md5": "e140d7ff07de8fa35c3d1595bba835ac.wav",
+                    "sampleCount": 8208,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "bird",
+                    "soundID": -1,
+                    "md5": "18bd4b634a3f992a16b30344c7d810e0.wav",
+                    "sampleCount": 3840,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "parrot2-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "aba6f5539a5ac21863a3495d89947e66.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 106,
+                    "rotationCenterY": 66
+                },
+                {
+                    "costumeName": "parrot2-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "9f0aac24e6b600b542613ab5c1461ae8.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 83,
+                    "rotationCenterY": 13
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Paul",
+        "md5": "4092b43b067ef01ce76a395637fe020a.gif",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "city",
+            "photo",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Paul",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "paul",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "4092b43b067ef01ce76a395637fe020a.gif",
+                    "rotationCenterX": 41,
+                    "rotationCenterY": 100
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Pencil",
+        "md5": "4495fcb0443cebc5d43e66243a88f1ac.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Pencil",
+            "sounds": [
+                {
+                    "soundName": "meow",
+                    "soundID": -1,
+                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
+                    "sampleCount": 18688,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "pencil-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "4495fcb0443cebc5d43e66243a88f1ac.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 49,
+                    "rotationCenterY": 54
+                },
+                {
+                    "costumeName": "pencil-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "21088922dbe127f6d2e58e2e83fb632e.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 48,
+                    "rotationCenterY": 68
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Penguin1",
+        "md5": "c17d9e4bdb59c574e0c34aa70af516da.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Penguin1",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "penguin1",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "c17d9e4bdb59c574e0c34aa70af516da.svg",
+                    "rotationCenterX": 54,
+                    "rotationCenterY": 61
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Penguin1 Talk",
+        "md5": "35fec7aa5f60cca945fe0615413f1f08.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Penguin1 Talk",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "penguin1 talk-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "35fec7aa5f60cca945fe0615413f1f08.svg",
+                    "rotationCenterX": 48,
+                    "rotationCenterY": 62
+                },
+                {
+                    "costumeName": "penguin1 talk-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "18fa51a64ebd5518f0c5c465525346e5.svg",
+                    "rotationCenterX": 48,
+                    "rotationCenterY": 61
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Penguin2",
+        "md5": "eaaaa7068e78a51d73ba437f1ec5763e.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Penguin2",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "penguin2",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "eaaaa7068e78a51d73ba437f1ec5763e.svg",
+                    "rotationCenterX": 49,
+                    "rotationCenterY": 79
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Penguin2 Talk",
+        "md5": "5a80f4b2fd20d43e4f7cb4189c08d99c.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Penguin2 Talk",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "penguin2 talk-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "5a80f4b2fd20d43e4f7cb4189c08d99c.svg",
+                    "rotationCenterX": 45,
+                    "rotationCenterY": 79
+                },
+                {
+                    "costumeName": "penguin2 talk-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "394e79f5f9a462064ece2a9a6606a07d.svg",
+                    "rotationCenterX": 50,
+                    "rotationCenterY": 78
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Penguin3",
+        "md5": "3f1173e00f664fca5f493b408e1e6d69.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "holiday",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            3,
+            1
+        ],
+        "json": {
+            "objName": "Penguin3",
+            "scripts": [
+                [
+                    142,
+                    432,
+                    [
+                        [
+                            "setSizeTo:",
+                            100
+                        ]
+                    ]
+                ]
+            ],
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "penguin3-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "3f1173e00f664fca5f493b408e1e6d69.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 59,
+                    "rotationCenterY": 98
+                },
+                {
+                    "costumeName": "penguin3-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "814c2ea372e64b98d5de97b75773f54b.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 57,
+                    "rotationCenterY": 97
+                },
+                {
+                    "costumeName": "penguin3-c",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "e28cd8b76b23db393d06c3a057e2dc68.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 64,
+                    "rotationCenterY": 98
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Piano",
+        "md5": "a79a9794c290e5aa533230cc3d13795b.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "music",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            8
+        ],
+        "json": {
+            "objName": "Piano",
+            "sounds": [
+                {
+                    "soundName": "C piano",
+                    "soundID": -1,
+                    "md5": "d27ed8d953fe8f03c00f4d733d31d2cc.wav",
+                    "sampleCount": 44100,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "D piano",
+                    "soundID": -1,
+                    "md5": "51381ac422605ee8c7d64cfcbfd75efc.wav",
+                    "sampleCount": 44100,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "E piano",
+                    "soundID": -1,
+                    "md5": "c818fdfaf8a0efcb562e24e794700a57.wav",
+                    "sampleCount": 44100,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "F piano",
+                    "soundID": -1,
+                    "md5": "cdab3cce84f74ecf53e3941c6a003b5e.wav",
+                    "sampleCount": 44100,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "G piano",
+                    "soundID": -1,
+                    "md5": "42bb2ed28e7023e111b33220e1594a6f.wav",
+                    "sampleCount": 44100,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "A piano",
+                    "soundID": -1,
+                    "md5": "0727959edb2ea0525feed9b0c816991c.wav",
+                    "sampleCount": 44100,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "B piano",
+                    "soundID": -1,
+                    "md5": "86826c6022a46370ed1afae69f1ab1b9.wav",
+                    "sampleCount": 44100,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "C2 piano",
+                    "soundID": -1,
+                    "md5": "75d7d2c9b5d40dd4e1cb268111abf1a2.wav",
+                    "sampleCount": 44100,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "piano",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "a79a9794c290e5aa533230cc3d13795b.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 142,
+                    "rotationCenterY": 88
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Piano-Electric",
+        "md5": "337368e789abc17beb1a2bacbb9d3bdc.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "music",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            4,
+            8
+        ],
+        "json": {
+            "objName": "Piano-Electric",
+            "sounds": [
+                {
+                    "soundName": "C elec piano",
+                    "soundID": -1,
+                    "md5": "8366ee963cc57ad24a8a35a26f722c2b.wav",
+                    "sampleCount": 44100,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "D elec piano",
+                    "soundID": -1,
+                    "md5": "835f136ca8d346a17b4d4baf8405be37.wav",
+                    "sampleCount": 44100,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "E elec piano",
+                    "soundID": -1,
+                    "md5": "ab3c198f8e36efff14f0a5bad35fa3cd.wav",
+                    "sampleCount": 44100,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "F elec piano",
+                    "soundID": -1,
+                    "md5": "dc5e368fc0d0dad1da609bfc3e29aa15.wav",
+                    "sampleCount": 44100,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "G elec piano",
+                    "soundID": -1,
+                    "md5": "39525f6545d62a95d05153f92d63301a.wav",
+                    "sampleCount": 44100,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "A elec piano",
+                    "soundID": -1,
+                    "md5": "0cfa8e84d6a5cd63afa31d541625a9ef.wav",
+                    "sampleCount": 44100,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "B elec piano",
+                    "soundID": -1,
+                    "md5": "9cc77167419f228503dd57fddaa5b2a6.wav",
+                    "sampleCount": 44100,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "C2 elec piano",
+                    "soundID": -1,
+                    "md5": "366c7edbd4dd5cca68bf62902999bd66.wav",
+                    "sampleCount": 44100,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "keyboard-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "337368e789abc17beb1a2bacbb9d3bdc.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 88,
+                    "rotationCenterY": 24
+                },
+                {
+                    "costumeName": "keyboard-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "290216dfdf0cffea57743d91f130b2c7.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 89,
+                    "rotationCenterY": 24
+                },
+                {
+                    "costumeName": "keyboard-c",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "750cbbcd66cb893cd5a66ee0a663e486.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 89,
+                    "rotationCenterY": 24
+                },
+                {
+                    "costumeName": "keyboard-d",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "46b0d833ad845d88585fbd0cb4b070ee.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 89,
+                    "rotationCenterY": 24
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Pico",
+        "md5": "0579fe60bb3717c49dfd7743caa84ada.svg",
+        "type": "sprite",
+        "tags": [
+            "fantasy",
+            "space",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            4,
+            1
+        ],
+        "json": {
+            "objName": "Pico",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "pico-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "0579fe60bb3717c49dfd7743caa84ada.svg",
+                    "rotationCenterX": 55,
+                    "rotationCenterY": 66
+                },
+                {
+                    "costumeName": "pico-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "26c688d7544757225ff51cd2fb1519b5.svg",
+                    "rotationCenterX": 55,
+                    "rotationCenterY": 66
+                },
+                {
+                    "costumeName": "pico-c",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "adf61e2090f8060e1e8b2b0604d03751.svg",
+                    "rotationCenterX": 55,
+                    "rotationCenterY": 66
+                },
+                {
+                    "costumeName": "pico-d",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "594704bf12e3c4d9e83bb91661ad709a.svg",
+                    "rotationCenterX": 55,
+                    "rotationCenterY": 66
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Pico walking",
+        "md5": "8eab5fe20dd249bf22964298b1d377eb.svg",
+        "type": "sprite",
+        "tags": [
+            "fantasy",
+            "space",
+            "drawing",
+            "walking",
+            "vector"
+        ],
+        "info": [
+            0,
+            4,
+            1
+        ],
+        "json": {
+            "objName": "Pico walking",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "Pico walk1",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "8eab5fe20dd249bf22964298b1d377eb.svg",
+                    "rotationCenterX": 54,
+                    "rotationCenterY": 71
+                },
+                {
+                    "costumeName": "Pico walk2",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "39ecd3c38d3f2cd81e3a17ee6c25699f.svg",
+                    "rotationCenterX": 54,
+                    "rotationCenterY": 71
+                },
+                {
+                    "costumeName": "Pico walk3",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "43f7d92dcf9eadf77c07a6fc1eb4104f.svg",
+                    "rotationCenterX": 54,
+                    "rotationCenterY": 70
+                },
+                {
+                    "costumeName": "Pico walk4",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "2582d012d57bca59bc0315c5c5954958.svg",
+                    "rotationCenterX": 54,
+                    "rotationCenterY": 70
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Planet2",
+        "md5": "978784738c1d9dd4b1d397fd18bdf406.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "space",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Planet2",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "planet2",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "978784738c1d9dd4b1d397fd18bdf406.svg",
+                    "rotationCenterX": 72,
+                    "rotationCenterY": 72
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Prince",
+        "md5": "a760bed1cfc28a30b2dc7fd045c90792.svg",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "fantasy",
+            "castle",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Prince",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "prince",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "a760bed1cfc28a30b2dc7fd045c90792.svg",
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Princess",
+        "md5": "75c96829e4b9f89378dfde0dee78db5f.svg",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "fantasy",
+            "castle",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Princess",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "princess",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "75c96829e4b9f89378dfde0dee78db5f.svg",
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Rainbow",
+        "md5": "680a806bd87a28c8b25b5f9b6347f022.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "flying",
+            "city",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Rainbow",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "rainbow",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "680a806bd87a28c8b25b5f9b6347f022.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 72,
+                    "rotationCenterY": 36
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Referee",
+        "md5": "b510bc924622795216154727e18dd38e.gif",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "sports",
+            "photo",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Referee",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "referee",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "b510bc924622795216154727e18dd38e.gif",
+                    "rotationCenterX": 41,
+                    "rotationCenterY": 100
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Reindeer",
+        "md5": "0fff0b181cc4d9250b5b985cc283b049.svg",
+        "type": "sprite",
+        "tags": [
+            "fantasy",
+            "holiday",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Reindeer",
+            "sounds": [
+                {
+                    "soundName": "meow",
+                    "soundID": -1,
+                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
+                    "sampleCount": 18688,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "reindeer",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "0fff0b181cc4d9250b5b985cc283b049.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 39,
+                    "rotationCenterY": 70
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Robot1",
+        "md5": "882919259f26462d74106e11d7c7e5c0.svg",
+        "type": "sprite",
+        "tags": [
+            "fantasy",
+            "drawing",
+            "space",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Robot1",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "robot1",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "882919259f26462d74106e11d7c7e5c0.svg",
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Rocks",
+        "md5": "82c79fdb6a7d9c49ab7f70ee79a3d7f8.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "nature",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Rocks",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "rocks",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "82c79fdb6a7d9c49ab7f70ee79a3d7f8.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 59,
+                    "rotationCenterY": 15
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Rory",
+        "md5": "7cca95c0a56646dd65771247ea288612.png",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "city",
+            "drawing",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Rory",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "rory",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "7cca95c0a56646dd65771247ea288612.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 82,
+                    "rotationCenterY": 160
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Ruby",
+        "md5": "c30210e8f719c3a4d2c7cc6917a39300.png",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "city",
+            "drawing",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Ruby",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "ruby-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "c30210e8f719c3a4d2c7cc6917a39300.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 54,
+                    "rotationCenterY": 172
+                },
+                {
+                    "costumeName": "ruby-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "fc15fdbcc535473f6140cab28197f3be.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 76,
+                    "rotationCenterY": 142
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Sailboat",
+        "md5": "8f8d0ea2f0ab5ca533f33f0da1eecfa6.png",
+        "type": "sprite",
+        "tags": [
+            "transportation",
+            "photo",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Sailboat",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "sail-boat",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "8f8d0ea2f0ab5ca533f33f0da1eecfa6.png",
+                    "rotationCenterX": 112,
+                    "rotationCenterY": 91
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Sam",
+        "md5": "1d33952fec0abe4ef6adee9fd065d3a8.gif",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "city",
+            "photo",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Sam",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "sam",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "1d33952fec0abe4ef6adee9fd065d3a8.gif",
+                    "rotationCenterX": 58,
+                    "rotationCenterY": 90
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Saxophone",
+        "md5": "a09b114b0652006ac66def94548073a9.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "music",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            8
+        ],
+        "json": {
+            "objName": "Saxophone",
+            "sounds": [
+                {
+                    "soundName": "C sax",
+                    "soundID": -1,
+                    "md5": "4d2c939d6953b5f241a27a62cf72de64.wav",
+                    "sampleCount": 9491,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "D sax",
+                    "soundID": -1,
+                    "md5": "39f41954a73c0e15d842061e1a4c5e1d.wav",
+                    "sampleCount": 9555,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "E sax",
+                    "soundID": -1,
+                    "md5": "3568b7dfe173fab6877a9ff1dcbcf1aa.wav",
+                    "sampleCount": 7489,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "F sax",
+                    "soundID": -1,
+                    "md5": "2ae3083817bcd595e26ea2884b6684d5.wav",
+                    "sampleCount": 7361,
+                    "rate": 22050,
+                    "format": "adpcm"
+                },
+                {
+                    "soundName": "G sax",
+                    "soundID": -1,
+                    "md5": "cefba5de46adfe5702485e0934bb1e13.wav",
+                    "sampleCount": 7349,
+                    "rate": 22050,
+                    "format": "adpcm"
+                },
+                {
+                    "soundName": "A sax",
+                    "soundID": -1,
+                    "md5": "420991e0d6d99292c6d736963842536a.wav",
+                    "sampleCount": 6472,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "B sax",
+                    "soundID": -1,
+                    "md5": "653ebe92d491b49ad5d8101d629f567b.wav",
+                    "sampleCount": 9555,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "C2 sax",
+                    "soundID": -1,
+                    "md5": "ea8d34b18c3d8fe328cea201666458bf.wav",
+                    "sampleCount": 7349,
+                    "rate": 22050,
+                    "format": "adpcm"
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "saxophone-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "a09b114b0652006ac66def94548073a9.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 69,
+                    "rotationCenterY": 80
+                },
+                {
+                    "costumeName": "saxophone-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "366c42cc65497f5007c9377a2d4d854b.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 69,
+                    "rotationCenterY": 80
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Scarf1",
+        "md5": "9db18d2a2b3c9859654fc1b4832e6076.svg",
+        "type": "sprite",
+        "tags": [
+            "dress-up",
+            "things",
+            "holiday",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Scarf1",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "scarf1",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "9db18d2a2b3c9859654fc1b4832e6076.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 54,
+                    "rotationCenterY": 36
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 0.9,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Scarf2",
+        "md5": "ce66662165e2756070f1b12e0a7cb5db.svg",
+        "type": "sprite",
+        "tags": [
+            "dress-up",
+            "things",
+            "holiday",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Scarf2",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "scarf2",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "ce66662165e2756070f1b12e0a7cb5db.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 23,
+                    "rotationCenterY": 16
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": true,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Scratch Logo",
+        "md5": "978b16d68fa7834dfb327fa3e2c4ba3b.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Scratch Logo",
+            "sounds": [
+                {
+                    "soundName": "meow",
+                    "soundID": -1,
+                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
+                    "sampleCount": 18688,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "scratch logo",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "978b16d68fa7834dfb327fa3e2c4ba3b.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 85,
+                    "rotationCenterY": 26
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Shark",
+        "md5": "7c0a907eae79462f69f8e2af8e7df828.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "drawing",
+            "underwater",
+            "vector"
+        ],
+        "info": [
+            0,
+            3,
+            1
+        ],
+        "json": {
+            "objName": "Shark",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "shark-a ",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "7c0a907eae79462f69f8e2af8e7df828.svg",
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                },
+                {
+                    "costumeName": "shark-b ",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "cff9ae87a93294693a0650b38a7a33d2.svg",
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                },
+                {
+                    "costumeName": "shark-c ",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "afeae3f998598424f7c50918507f6ce6.svg",
+                    "rotationCenterX": 77,
+                    "rotationCenterY": 37
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Shirt",
+        "md5": "dbb0eaa9d7af0f5971afdee0192c8b51.svg",
+        "type": "sprite",
+        "tags": [
+            "dress-up",
+            "things",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Shirt",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "shirt-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "dbb0eaa9d7af0f5971afdee0192c8b51.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 39,
+                    "rotationCenterY": 48
+                },
+                {
+                    "costumeName": "shirt-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "92d009fb104990da9798378ae5e4e1cb.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 48,
+                    "rotationCenterY": 48
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": true,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Shirt2",
+        "md5": "5946e7a1e36c6d97ae47d41dd8595a41.svg",
+        "type": "sprite",
+        "tags": [
+            "dress-up",
+            "things",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Shirt2",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "shirt2-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "5946e7a1e36c6d97ae47d41dd8595a41.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 39,
+                    "rotationCenterY": 48
+                },
+                {
+                    "costumeName": "shirt2-a2",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "5b78ab09592126b6bbe2d4907d203909.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 39,
+                    "rotationCenterY": 48
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": true,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Shirt Blouse",
+        "md5": "918a507af6bbae9e7f36f0d949900838.svg",
+        "type": "sprite",
+        "tags": [
+            "dress-up",
+            "things",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            0
+        ],
+        "json": {
+            "objName": "Shirt Blouse",
+            "costumes": [
+                {
+                    "costumeName": "shirt blouse",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "918a507af6bbae9e7f36f0d949900838.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 35,
+                    "rotationCenterY": 28
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": true,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Shirt Collar",
+        "md5": "b7ecf6503e27e9ab5c086eaf07d22b94.svg",
+        "type": "sprite",
+        "tags": [
+            "dress-up",
+            "things",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            3,
+            1
+        ],
+        "json": {
+            "objName": "Shirt Collar",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "shirt collar-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "b7ecf6503e27e9ab5c086eaf07d22b94.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 30,
+                    "rotationCenterY": 57
+                },
+                {
+                    "costumeName": "shirt collar-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "f1b20c3350e8a7e92a2fb1925ad4158b.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 30,
+                    "rotationCenterY": 57
+                },
+                {
+                    "costumeName": "shirt collar-c",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "5f04b99416a794e04d0855f446780f18.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 30,
+                    "rotationCenterY": 57
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": true,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Shirt-T",
+        "md5": "5d7fa4f1788f03d2962f1624d6eac800.svg",
+        "type": "sprite",
+        "tags": [
+            "dress-up",
+            "things",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            0
+        ],
+        "json": {
+            "objName": "Shirt-T",
+            "costumes": [
+                {
+                    "costumeName": "shirt-t",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "5d7fa4f1788f03d2962f1624d6eac800.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 39,
+                    "rotationCenterY": 28
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": true,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Shoes1",
+        "md5": "ffab4cc284070b50ac317e515f59f7d8.svg",
+        "type": "sprite",
+        "tags": [
+            "dress-up",
+            "things",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Shoes1",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "shoes1",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "ffab4cc284070b50ac317e515f59f7d8.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 36,
+                    "rotationCenterY": 23
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": true,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Shoes2",
+        "md5": "1dc5d568d98405c370b91a230397a7f9.svg",
+        "type": "sprite",
+        "tags": [
+            "dress-up",
+            "things",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Shoes2",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "shoes2",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "1dc5d568d98405c370b91a230397a7f9.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 40,
+                    "rotationCenterY": 8
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": true,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Singer1",
+        "md5": "e47ef1af3b925e5ac9e3b3f809d440b3.svg",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "music",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Singer1",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "Singer1",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "e47ef1af3b925e5ac9e3b3f809d440b3.svg",
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Skates",
+        "md5": "00e5e173400662875a26bb7d6556346a.svg",
+        "type": "sprite",
+        "tags": [
+            "dress-up",
+            "things",
+            "holiday",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Skates",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "skates",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "00e5e173400662875a26bb7d6556346a.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 44,
+                    "rotationCenterY": -21
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 0.9,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "SL Hip-Hop",
+        "md5": "2d2b577a12a51aa4448ad3e7e2a07079.png",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "dance",
+            "city",
+            "photo",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            8,
+            1
+        ],
+        "json": {
+            "objName": "SL Hip-Hop",
+            "sounds": [
+                {
+                    "soundName": "dance celebrate",
+                    "soundID": -1,
+                    "md5": "0edb8fb88af19e6e17d0f8cf64c1d136.wav",
+                    "sampleCount": 176401,
+                    "rate": 22050,
+                    "format": "adpcm"
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "sl top stand",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "2d2b577a12a51aa4448ad3e7e2a07079.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 64,
+                    "rotationCenterY": 233
+                },
+                {
+                    "costumeName": "sl top R leg",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "ba01e9c4448285b7b8a63e98d89ac1d7.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 54,
+                    "rotationCenterY": 230
+                },
+                {
+                    "costumeName": "sl top L leg",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "b274db2a4fa913555dae028f327e7423.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 149,
+                    "rotationCenterY": 245
+                },
+                {
+                    "costumeName": "sl top ready",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "3df3afb72314807fc6c58075da124b84.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 74,
+                    "rotationCenterY": 198
+                },
+                {
+                    "costumeName": "sl top L cross",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "f26ea2f0d0baaa5aaed3cd96d7843206.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 50,
+                    "rotationCenterY": 214
+                },
+                {
+                    "costumeName": "sl top R cross",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "b46163522a53150fdb6a44461738e9ae.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 110,
+                    "rotationCenterY": 200
+                },
+                {
+                    "costumeName": "sl pop L arm",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "48fcc33505fbd3c65d1f7bfbb4745a13.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 145,
+                    "rotationCenterY": 174
+                },
+                {
+                    "costumeName": "sl pop R arm",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "ffae2eb189d6efc97efc91e93ed4d8bf.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 66,
+                    "rotationCenterY": 237
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Snowflake",
+        "md5": "67de2af723246de37d7379b76800ee0b.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "holiday",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Snowflake",
+            "sounds": [
+                {
+                    "soundName": "meow",
+                    "soundID": -1,
+                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
+                    "sampleCount": 18688,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "snowflake",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "67de2af723246de37d7379b76800ee0b.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 104,
+                    "rotationCenterY": 103
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 0.65,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Snowman",
+        "md5": "56c71c31c17b9bc66a2aab0342cf94b2.svg",
+        "type": "sprite",
+        "tags": [
+            "fantasy",
+            "holiday",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Snowman",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "snowman",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "56c71c31c17b9bc66a2aab0342cf94b2.svg",
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Soccer Ball",
+        "md5": "4e4cc84380ccf6d4e59e53bc6d3a0a3f.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "sports",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Soccer Ball",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "soccer ball",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "4e4cc84380ccf6d4e59e53bc6d3a0a3f.svg",
+                    "rotationCenterX": 32,
+                    "rotationCenterY": 34
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Spaceship",
+        "md5": "028b6d5210a4a94d5cd3d2001fd3d74d.svg",
+        "type": "sprite",
+        "tags": [
+            "transportation",
+            "space",
+            "fantasy",
+            "flying",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Spaceship",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "spaceship-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "028b6d5210a4a94d5cd3d2001fd3d74d.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 59,
+                    "rotationCenterY": 84
+                },
+                {
+                    "costumeName": "spaceship-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "55e3d48245934393402ab214c122ed8f.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 62,
+                    "rotationCenterY": 83
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Speaker",
+        "md5": "44dc3a2ec161999545914d1f77332d76.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "music",
+            "dance",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            1,
+            1,
+            7
+        ],
+        "json": {
+            "objName": "Speaker",
+            "variables": [
+                {
+                    "name": "scale degree",
+                    "value": 1,
+                    "isPersistent": false
+                },
+                {
+                    "name": "octave",
+                    "value": 0,
+                    "isPersistent": false
+                },
+                {
+                    "name": "note number",
+                    "value": 62,
+                    "isPersistent": false
+                },
+                {
+                    "name": "loop number",
+                    "value": 1,
+                    "isPersistent": false
+                }
+            ],
+            "scripts": [
+                [
+                    890,
+                    496,
+                    [
+                        [
+                            "procDef",
+                            "play major scale note %n for %n beats",
+                            [
+                                "note",
+                                "beats"
+                            ],
+                            [
+                                1,
+                                1
+                            ],
+                            false
+                        ],
+                        [
+                            "setVar:to:",
+                            "scale degree",
+                            [
+                                "%",
+                                [
+                                    "-",
+                                    [
+                                        "getParam",
+                                        "note",
+                                        "r"
+                                    ],
+                                    1
+                                ],
+                                7
+                            ]
+                        ],
+                        [
+                            "setVar:to:",
+                            "octave",
+                            [
+                                "computeFunction:of:",
+                                "floor",
+                                [
+                                    "/",
+                                    [
+                                        "-",
+                                        [
+                                            "getParam",
+                                            "note",
+                                            "r"
+                                        ],
+                                        1
+                                    ],
+                                    7
+                                ]
+                            ]
+                        ],
+                        [
+                            "doIf",
+                            [
+                                "=",
+                                [
+                                    "readVariable",
+                                    "scale degree"
+                                ],
+                                "0"
+                            ],
+                            [
+                                [
+                                    "setVar:to:",
+                                    "note number",
+                                    0
+                                ]
+                            ]
+                        ],
+                        [
+                            "doIf",
+                            [
+                                "=",
+                                [
+                                    "readVariable",
+                                    "scale degree"
+                                ],
+                                "1"
+                            ],
+                            [
+                                [
+                                    "setVar:to:",
+                                    "note number",
+                                    "2"
+                                ]
+                            ]
+                        ],
+                        [
+                            "doIf",
+                            [
+                                "=",
+                                [
+                                    "readVariable",
+                                    "scale degree"
+                                ],
+                                "2"
+                            ],
+                            [
+                                [
+                                    "setVar:to:",
+                                    "note number",
+                                    "4"
+                                ]
+                            ]
+                        ],
+                        [
+                            "doIf",
+                            [
+                                "=",
+                                [
+                                    "readVariable",
+                                    "scale degree"
+                                ],
+                                "3"
+                            ],
+                            [
+                                [
+                                    "setVar:to:",
+                                    "note number",
+                                    "5"
+                                ]
+                            ]
+                        ],
+                        [
+                            "doIf",
+                            [
+                                "=",
+                                [
+                                    "readVariable",
+                                    "scale degree"
+                                ],
+                                "4"
+                            ],
+                            [
+                                [
+                                    "setVar:to:",
+                                    "note number",
+                                    "7"
+                                ]
+                            ]
+                        ],
+                        [
+                            "doIf",
+                            [
+                                "=",
+                                [
+                                    "readVariable",
+                                    "scale degree"
+                                ],
+                                "5"
+                            ],
+                            [
+                                [
+                                    "setVar:to:",
+                                    "note number",
+                                    "9"
+                                ]
+                            ]
+                        ],
+                        [
+                            "doIf",
+                            [
+                                "=",
+                                [
+                                    "readVariable",
+                                    "scale degree"
+                                ],
+                                "6"
+                            ],
+                            [
+                                [
+                                    "setVar:to:",
+                                    "note number",
+                                    "11"
+                                ]
+                            ]
+                        ],
+                        [
+                            "changeVar:by:",
+                            "note number",
+                            60
+                        ],
+                        [
+                            "changeVar:by:",
+                            "note number",
+                            [
+                                "*",
+                                [
+                                    "readVariable",
+                                    "octave"
+                                ],
+                                12
+                            ]
+                        ],
+                        [
+                            "noteOn:duration:elapsed:from:",
+                            [
+                                "readVariable",
+                                "note number"
+                            ],
+                            [
+                                "getParam",
+                                "beats",
+                                "r"
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+            "sounds": [
+                {
+                    "soundName": "drive around",
+                    "soundID": -1,
+                    "md5": "a3a85fb8564b0266f50a9c091087b7aa.wav",
+                    "sampleCount": 44096,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "scratchy beat",
+                    "soundID": -1,
+                    "md5": "289dc558e076971e74dd1a0bd55719b1.wav",
+                    "sampleCount": 44096,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "drum jam",
+                    "soundID": -1,
+                    "md5": "8b5486ccc806e97e83049d25b071f7e4.wav",
+                    "sampleCount": 44288,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "cymbal echo",
+                    "soundID": -1,
+                    "md5": "bb243badd1201b2607bf2513df10cd97.wav",
+                    "sampleCount": 44326,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "drum satellite",
+                    "soundID": -1,
+                    "md5": "079067d7909f791b29f8be1c00fc2131.wav",
+                    "sampleCount": 44096,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "kick back",
+                    "soundID": -1,
+                    "md5": "9cd340d9d568b1479f731e69e103b3ce.wav",
+                    "sampleCount": 44748,
+                    "rate": 22050,
+                    "format": "adpcm"
+                },
+                {
+                    "soundName": "drum funky",
+                    "soundID": -1,
+                    "md5": "fb56022366d21b299cbc3fd5e16000c2.wav",
+                    "sampleCount": 44748,
+                    "rate": 22050,
+                    "format": "adpcm"
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "speaker",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "44dc3a2ec161999545914d1f77332d76.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 53,
+                    "rotationCenterY": 79
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Squirrel",
+        "md5": "7e24c99c1b853e52f8e7f9004416fa34.png",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "bitmap",
+            "photo"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Squirrel",
+            "sounds": [
+                {
+                    "soundName": "meow",
+                    "soundID": -1,
+                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
+                    "sampleCount": 18688,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "squirrel1",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "7e24c99c1b853e52f8e7f9004416fa34.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 158,
+                    "rotationCenterY": 146
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Star1",
+        "md5": "ab0914e53e360477275e58b83ec4d423.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "holiday",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Star1",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "star1",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "ab0914e53e360477275e58b83ec4d423.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 21,
+                    "rotationCenterY": 19
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 0.9,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Star2",
+        "md5": "0a0ef50bb5a59be1785c8bb12cdacae6.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "holiday",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Star2",
+            "sounds": [
+                {
+                    "soundName": "meow",
+                    "soundID": -1,
+                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
+                    "sampleCount": 18688,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "star2",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "0a0ef50bb5a59be1785c8bb12cdacae6.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 25,
+                    "rotationCenterY": 27
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Star3",
+        "md5": "04da262057dfe130860086031e5018ef.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "holiday",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            0
+        ],
+        "json": {
+            "objName": "Star3",
+            "costumes": [
+                {
+                    "costumeName": "star3-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "04da262057dfe130860086031e5018ef.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 54,
+                    "rotationCenterY": 55
+                },
+                {
+                    "costumeName": "star3-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "a082be13c0e5d17230f448dd55029a7d.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 33,
+                    "rotationCenterY": 34
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Starfish",
+        "md5": "3d1101bbc24ae292a36356af325f660c.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "drawing",
+            "underwater",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Starfish",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "starfish-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "3d1101bbc24ae292a36356af325f660c.svg",
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                },
+                {
+                    "costumeName": "starfish-b ",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "ad8007f4e63693984d4adc466ffa3ad2.svg",
+                    "rotationCenterX": 53,
+                    "rotationCenterY": 60
+                }
+            ],
+            "currentCostumeIndex": 1,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Stop",
+        "md5": "5b9e3e8edffb0bd4914113609eec5e04.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "vector",
+            "drawing"
+        ],
+        "info": [
+            0,
+            1,
+            0
+        ],
+        "json": {
+            "objName": "Stop",
+            "costumes": [
+                {
+                    "costumeName": "stop",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "5b9e3e8edffb0bd4914113609eec5e04.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 25,
+                    "rotationCenterY": 25
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Street Cleaner",
+        "md5": "e3699b3f2f7d67a9f48ea9b71fd3733a.png",
+        "type": "sprite",
+        "tags": [
+            "transportation",
+            "city",
+            "photo",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Street Cleaner",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "street-cleaner-mit",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "e3699b3f2f7d67a9f48ea9b71fd3733a.png",
+                    "rotationCenterX": 100,
+                    "rotationCenterY": 59
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Sun",
+        "md5": "55c931c65456822c0c56a2b30e3e550d.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "space",
+            "drawing",
+            "vector",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Sun",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "sun",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "55c931c65456822c0c56a2b30e3e550d.svg",
+                    "rotationCenterX": 72,
+                    "rotationCenterY": 72
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Sunglasses1",
+        "md5": "424393e8705aeadcfecb8559ce4dcea2.svg",
+        "type": "sprite",
+        "tags": [
+            "dress-up",
+            "things",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Sunglasses1",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "sunglasses1",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "424393e8705aeadcfecb8559ce4dcea2.svg",
+                    "rotationCenterX": 37,
+                    "rotationCenterY": 14
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Sunglasses2",
+        "md5": "3185d2295bbf2c5ebd0688c9e4f13076.svg",
+        "type": "sprite",
+        "tags": [
+            "dress-up",
+            "things",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Sunglasses2",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "sunglasses2",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "3185d2295bbf2c5ebd0688c9e4f13076.svg",
+                    "rotationCenterX": 29,
+                    "rotationCenterY": 10
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Taco",
+        "md5": "d224b30c54bd4d6000c935938c7f5d7e.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "flying",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Taco",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "taco-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "d224b30c54bd4d6000c935938c7f5d7e.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 20,
+                    "rotationCenterY": 15
+                },
+                {
+                    "costumeName": "taco-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "6dee4f866d79e6475d9824ba11973037.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 56,
+                    "rotationCenterY": 15
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Tennis Ball",
+        "md5": "38d3048bf7ec9f4ec3fd24dc38a03eea.png",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "sports",
+            "photo",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Tennis Ball",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "tennisball",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "38d3048bf7ec9f4ec3fd24dc38a03eea.png",
+                    "rotationCenterX": 15,
+                    "rotationCenterY": 15
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Tera",
+        "md5": "b54a4a9087435863ab6f6c908f1cac99.svg",
+        "type": "sprite",
+        "tags": [
+            "fantasy",
+            "space",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            4,
+            1
+        ],
+        "json": {
+            "objName": "Tera",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "tera-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "b54a4a9087435863ab6f6c908f1cac99.svg",
+                    "rotationCenterX": 49,
+                    "rotationCenterY": 63
+                },
+                {
+                    "costumeName": "tera-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "1e6b3a29351cda80d1a70a3cc0e499f2.svg",
+                    "rotationCenterX": 49,
+                    "rotationCenterY": 64
+                },
+                {
+                    "costumeName": "tera-c",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "7edf116cbb7111292361431521ae699e.svg",
+                    "rotationCenterX": 49,
+                    "rotationCenterY": 63
+                },
+                {
+                    "costumeName": "tera-d",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "7c3c9c8b5f4ac77de2036175712a777a.svg",
+                    "rotationCenterX": 49,
+                    "rotationCenterY": 63
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Text",
+        "md5": "5ebbfead1d5728f6e93a4259b699f2e9.svg",
+        "type": "sprite",
+        "tags": [
+            "letters",
+            "things",
+            "vector"
+        ],
+        "info": [
+            0,
+            4,
+            0
+        ],
+        "json": {
+            "objName": "Text",
+            "costumes": [
+                {
+                    "costumeName": "text awesome",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "5ebbfead1d5728f6e93a4259b699f2e9.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 109,
+                    "rotationCenterY": 32
+                },
+                {
+                    "costumeName": "text keep scratching",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "b3de9a77e2c1bb2f3e29f29a03d869ea.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 135,
+                    "rotationCenterY": 24
+                },
+                {
+                    "costumeName": "text valentine's day",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "a765b830814192ab323b5893a65cabfa.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 172,
+                    "rotationCenterY": 30
+                },
+                {
+                    "costumeName": "text Halloween",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "7aee725d72bc077424690a0acce8589b.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 165,
+                    "rotationCenterY": 34
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {},
+            "sounds": [
+                {
+                    "soundName": "boing",
+                    "soundID": 0,
+                    "md5": "53a3c2e27d1fb5fdb14aaf0cb41e7889.wav",
+                    "sampleCount": 6804,
+                    "rate": 22050,
+                    "format": "adpcm"
+                },
+                {
+                    "soundName": "chomp",
+                    "soundID": 1,
+                    "md5": "0b1e3033140d094563248e61de4039e5.wav",
+                    "sampleCount": 2912,
+                    "rate": 11025,
+                    "format": ""
+                },
+                {
+                    "soundName": "gong",
+                    "soundID": 2,
+                    "md5": "6af567714db37721a11c55d2a2648aec.wav",
+                    "sampleCount": 46848,
+                    "rate": 11025,
+                    "format": ""
+                },
+                {
+                    "soundName": "pop",
+                    "soundID": 3,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                },
+                {
+                    "soundName": "space ripple",
+                    "soundID": 4,
+                    "md5": "ff8b8c3bf841a11fd5fe3afaa92be1b5.wav",
+                    "sampleCount": 41149,
+                    "rate": 11025,
+                    "format": ""
+                },
+                {
+                    "soundName": "beeps",
+                    "soundID": 5,
+                    "md5": "3be0a558370fedba3a6b315e0ca15b33.wav",
+                    "sampleCount": 9536,
+                    "rate": 11025,
+                    "format": ""
+                },
+                {
+                    "soundName": "woof",
+                    "soundID": 6,
+                    "md5": "cd8fa8390b0efdd281882533fbfcfcfb.wav",
+                    "sampleCount": 3168,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "squawk",
+                    "soundID": 7,
+                    "md5": "e140d7ff07de8fa35c3d1595bba835ac.wav",
+                    "sampleCount": 8208,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "cheer",
+                    "soundID": 8,
+                    "md5": "4b36eebf22be4667fc2f15b78c805b4c.wav",
+                    "sampleCount": 62528,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "wub",
+                    "soundID": 9,
+                    "md5": "e1f32c057411da4237181ce72ae15d23.wav",
+                    "sampleCount": 7392,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "hey",
+                    "soundID": 10,
+                    "md5": "ec7c272faa862c9f8f731792e686e3c9.wav",
+                    "sampleCount": 5414,
+                    "rate": 22050,
+                    "format": "adpcm"
+                },
+                {
+                    "soundName": "C major ukulele",
+                    "soundID": 11,
+                    "md5": "aa2ca112507b59b5337f341aaa75fb08.wav",
+                    "sampleCount": 18203,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "dance loop",
+                    "soundID": 12,
+                    "md5": "e936679bac519b1df3ddea3f5db7594f.wav",
+                    "sampleCount": 92800,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "funky loop",
+                    "soundID": 13,
+                    "md5": "fb56022366d21b299cbc3fd5e16000c2.wav",
+                    "sampleCount": 44748,
+                    "rate": 22050,
+                    "format": "adpcm"
+                }
+            ]
+        }
+    },
+    {
+        "name": "Trampoline",
+        "md5": "20b16bcb61396df304cad5e8886ceb46.png",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "photo",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Trampoline",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "trampoline",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "20b16bcb61396df304cad5e8886ceb46.png",
+                    "rotationCenterX": 100,
+                    "rotationCenterY": 41
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Tree1",
+        "md5": "8c40e2662c55d17bc384f47165ac43c1.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "holiday",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Tree1",
+            "sounds": [
+                {
+                    "soundName": "tom drum",
+                    "soundID": -1,
+                    "md5": "5a8b8678d37a860dd6c08082d5cda3c2.wav",
+                    "sampleCount": 35803,
+                    "rate": 22050,
+                    "format": "adpcm"
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "tree1",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "8c40e2662c55d17bc384f47165ac43c1.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 77,
+                    "rotationCenterY": 126
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 0.95,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Tree2",
+        "md5": "d4cafdb83f5ff518383f7174817243e6.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "holiday",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Tree2",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "tree2",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "d4cafdb83f5ff518383f7174817243e6.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 82,
+                    "rotationCenterY": 104
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 0.9,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Tree-lights",
+        "md5": "177682396be2961367a50289a5552314.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "holiday",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Tree-lights",
+            "sounds": [
+                {
+                    "soundName": "meow",
+                    "soundID": -1,
+                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
+                    "sampleCount": 18688,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "tree-lights-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "177682396be2961367a50289a5552314.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 59,
+                    "rotationCenterY": 77
+                },
+                {
+                    "costumeName": "tree-lights-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "b0282c029046fd1ed0541675911fe8bb.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 58,
+                    "rotationCenterY": 76
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1.3000000000000005,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Trees",
+        "md5": "866ed2c2971bb04157e14e935ac8521c.svg",
+        "type": "sprite",
+        "tags": [
+            "city",
+            "flying",
+            "things",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Trees",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "trees-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "866ed2c2971bb04157e14e935ac8521c.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 49,
+                    "rotationCenterY": 94
+                },
+                {
+                    "costumeName": "trees-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "f1393dde1bb0fc512577995b27616d86.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 36,
+                    "rotationCenterY": 87
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Trombone",
+        "md5": "7d7098a45ab54def8d919141e90db4c5.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "music",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            8
+        ],
+        "json": {
+            "objName": "Trombone",
+            "sounds": [
+                {
+                    "soundName": "C trombone",
+                    "soundID": -1,
+                    "md5": "821b23a489201a0f21f47ba8528ba47f.wav",
+                    "sampleCount": 19053,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "D trombone",
+                    "soundID": -1,
+                    "md5": "f3afca380ba74372d611d3f518c2f35b.wav",
+                    "sampleCount": 17339,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "E trombone",
+                    "soundID": -1,
+                    "md5": "c859fb0954acaa25c4b329df5fb76434.wav",
+                    "sampleCount": 16699,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "F trombone",
+                    "soundID": -1,
+                    "md5": "d6758470457aac2aa712717a676a5163.wav",
+                    "sampleCount": 19373,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "G trombone",
+                    "soundID": -1,
+                    "md5": "9436fd7a0eacb4a6067e7db14236dde1.wav",
+                    "sampleCount": 17179,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "A trombone",
+                    "soundID": -1,
+                    "md5": "863ccc8ba66e6dabbce2a1261c22be0f.wav",
+                    "sampleCount": 17227,
+                    "rate": 22050,
+                    "format": "adpcm"
+                },
+                {
+                    "soundName": "B trombone",
+                    "soundID": -1,
+                    "md5": "85b663229525b73d9f6647f78eb23e0a.wav",
+                    "sampleCount": 15522,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "C2 trombone",
+                    "soundID": -1,
+                    "md5": "68aec107bd3633b2ee40c532eedc3897.wav",
+                    "sampleCount": 13904,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "trombone-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "7d7098a45ab54def8d919141e90db4c5.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 73,
+                    "rotationCenterY": 43
+                },
+                {
+                    "costumeName": "trombone-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "08edef976dbc09e8b62bce0f4607ea4a.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 73,
+                    "rotationCenterY": 43
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Trumpet",
+        "md5": "3bcbd84df7924b6f97a2fa5d9bce56c8.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "music",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            8
+        ],
+        "json": {
+            "objName": "Trumpet",
+            "sounds": [
+                {
+                    "soundName": "C trumpet",
+                    "soundID": -1,
+                    "md5": "8970afcdc4e47bb54959a81fe27522bd.wav",
+                    "sampleCount": 13118,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "D trumpet",
+                    "soundID": -1,
+                    "md5": "0b1345b8fe2ba3076fedb4f3ae48748a.wav",
+                    "sampleCount": 12702,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "E trumpet",
+                    "soundID": -1,
+                    "md5": "494295a92314cadb220945a6711c568c.wav",
+                    "sampleCount": 8680,
+                    "rate": 22050,
+                    "format": "adpcm"
+                },
+                {
+                    "soundName": "F trumpet",
+                    "soundID": -1,
+                    "md5": "5fa3108b119ca266029b4caa340a7cd0.wav",
+                    "sampleCount": 12766,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "G trumpet",
+                    "soundID": -1,
+                    "md5": "e84afda25975f14b364118591538ccf4.wav",
+                    "sampleCount": 14640,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "A trumpet",
+                    "soundID": -1,
+                    "md5": "d2dd6b4372ca17411965dc92d52b2172.wav",
+                    "sampleCount": 13911,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "B trumpet",
+                    "soundID": -1,
+                    "md5": "cad2bc57729942ed9b605145fc9ea65d.wav",
+                    "sampleCount": 14704,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "C2 trumpet",
+                    "soundID": -1,
+                    "md5": "df08249ed5446cc5e10b7ac62faac89b.wav",
+                    "sampleCount": 15849,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "trumpet-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "3bcbd84df7924b6f97a2fa5d9bce56c8.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 84,
+                    "rotationCenterY": 25
+                },
+                {
+                    "costumeName": "trumpet-a2",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "5c0db80c63a72e8ab07d047183575378.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 84,
+                    "rotationCenterY": 25
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Ukulele",
+        "md5": "39215565394d6280c6c81e7ad86c7ca0.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "music",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            4
+        ],
+        "json": {
+            "objName": "Ukulele",
+            "variables": [
+                {
+                    "name": "counter",
+                    "value": 5,
+                    "isPersistent": false
+                }
+            ],
+            "sounds": [
+                {
+                    "soundName": "C major ukulele",
+                    "soundID": -1,
+                    "md5": "aa2ca112507b59b5337f341aaa75fb08.wav",
+                    "sampleCount": 18203,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "F major ukulele",
+                    "soundID": -1,
+                    "md5": "cd0ab5d1b0120c6ed92a1654ccf81376.wav",
+                    "sampleCount": 18235,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "A minor ukulele",
+                    "soundID": -1,
+                    "md5": "69d25af0fd065da39c71439174efc589.wav",
+                    "sampleCount": 18267,
+                    "rate": 22050,
+                    "format": ""
+                },
+                {
+                    "soundName": "G ukulele",
+                    "soundID": -1,
+                    "md5": "d20218f92ee606277658959005538e2d.wav",
+                    "sampleCount": 18235,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "ukulele",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "39215565394d6280c6c81e7ad86c7ca0.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 30,
+                    "rotationCenterY": 78
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Umbrella",
+        "md5": "2ae6d0c3a8cb500e63c11a95eee80fa7.png",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "photo",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Umbrella",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "umbrella",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "2ae6d0c3a8cb500e63c11a95eee80fa7.png",
+                    "rotationCenterX": 85,
+                    "rotationCenterY": 62
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Unicorn",
+        "md5": "a04def38351e7fd805226345cac4fbfe.svg",
+        "type": "sprite",
+        "tags": [
+            "flying",
+            "fantasy",
+            "drawing",
+            "castle",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Unicorn",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "unicorn",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "a04def38351e7fd805226345cac4fbfe.svg",
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Vest",
+        "md5": "f8285ca9564451c62a0e3d75b8a714e8.svg",
+        "type": "sprite",
+        "tags": [
+            "dress-up",
+            "things",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Vest",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "vest-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "f8285ca9564451c62a0e3d75b8a714e8.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 18,
+                    "rotationCenterY": 62
+                },
+                {
+                    "costumeName": "vest-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "77d553eea3910ab8f5bac3d2da601061.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 18,
+                    "rotationCenterY": 62
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": true,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Wanda",
+        "md5": "450bc8fbd5ab6bc2e83576aad58cd07c.svg",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "city",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Wanda",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "wanda",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "450bc8fbd5ab6bc2e83576aad58cd07c.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 49,
+                    "rotationCenterY": 68
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Watermelon",
+        "md5": "26fecef75cf3b6e0d98bff5c06475036.svg",
+        "type": "sprite",
+        "tags": [
+            "things",
+            "vector",
+            "drawing"
+        ],
+        "info": [
+            0,
+            3,
+            1
+        ],
+        "json": {
+            "objName": "Watermelon",
+            "sounds": [
+                {
+                    "soundName": "meow",
+                    "soundID": -1,
+                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
+                    "sampleCount": 18688,
+                    "rate": 22050,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "watermelon-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "26fecef75cf3b6e0d98bff5c06475036.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 40,
+                    "rotationCenterY": 27
+                },
+                {
+                    "costumeName": "watermelon-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "fbdaf4d1d349edd3ddf3a1c4528aa9ec.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 22,
+                    "rotationCenterY": 27
+                },
+                {
+                    "costumeName": "watermelon-c",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "5976c10412306fc093c1d1930fa05119.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 21,
+                    "rotationCenterY": 15
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Witch",
+        "md5": "c991196a708294535a1dbdce7189c23c.svg",
+        "type": "sprite",
+        "tags": [
+            "flying",
+            "people",
+            "fantasy",
+            "castle",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Witch",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "witch",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "c991196a708294535a1dbdce7189c23c.svg",
+                    "rotationCenterX": 74,
+                    "rotationCenterY": 59
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Wizard",
+        "md5": "4df1dd733f6ee4a2d8842478ac2c4661.svg",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "fantasy",
+            "castle",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Wizard",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "wizard",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "4df1dd733f6ee4a2d8842478ac2c4661.svg",
+                    "rotationCenterX": 76,
+                    "rotationCenterY": 86
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Wizard1",
+        "md5": "e085c97691d16f0cc8a595ce1137e26c.svg",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "fantasy",
+            "castle",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Wizard1",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "wizard1",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "e085c97691d16f0cc8a595ce1137e26c.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 134,
+                    "rotationCenterY": 153
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Wizard2",
+        "md5": "6db4d9e4229dc50a1b1c91c3c8311d40.svg",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "fantasy",
+            "castle",
+            "drawing",
+            "vector"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Wizard2",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "wizard2",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "6db4d9e4229dc50a1b1c91c3c8311d40.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 69,
+                    "rotationCenterY": 93
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Zara",
+        "md5": "ad7b145d46e933125bd9c928d784fcdc.png",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "city",
+            "drawing",
+            "bitmap"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Zara",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "zara-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "ad7b145d46e933125bd9c928d784fcdc.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 50,
+                    "rotationCenterY": 170
+                },
+                {
+                    "costumeName": "zara-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "6fba793b512069a67096a82aa85a5c12.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 86,
+                    "rotationCenterY": 168
+                }
+            ],
+            "currentCostumeIndex": 1,
+            "scratchX": 0,
+            "scratchY": 0,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 100000,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
         "name": "A-block",
         "md5": "602a16930a8050e1298e1a0ae844363e.svg",
         "type": "sprite",
@@ -19252,15295 +34541,6 @@
                 }
             ],
             "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Abby",
-        "md5": "afab2d2141e9811bd89e385e9628cb5f.svg",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "city",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            4,
-            1
-        ],
-        "json": {
-            "objName": "Abby",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "abby-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "afab2d2141e9811bd89e385e9628cb5f.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 31,
-                    "rotationCenterY": 100
-                },
-                {
-                    "costumeName": "abby-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "1e0116c7c2e5e80c679d0b33f1f5cfb7.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 31,
-                    "rotationCenterY": 100
-                },
-                {
-                    "costumeName": "abby-c",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "b6e23922f23b49ddc6f62f675e77417c.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 32,
-                    "rotationCenterY": 100
-                },
-                {
-                    "costumeName": "abby-d",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "2193cf08f74b8354f7c4fac37a06ea24.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 31,
-                    "rotationCenterY": 100
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Airplane",
-        "md5": "58bcb130f226bda9017f1a443360a78a.png",
-        "type": "sprite",
-        "tags": [
-            "transportation",
-            "flying",
-            "city",
-            "photo",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Airplane",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "airplane2",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "58bcb130f226bda9017f1a443360a78a.png",
-                    "rotationCenterX": 100,
-                    "rotationCenterY": 32
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Amon",
-        "md5": "8d508770c1991fe05959c9b3b5167036.gif",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "flying",
-            "photo",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Amon",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "amon",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "8d508770c1991fe05959c9b3b5167036.gif",
-                    "rotationCenterX": 87,
-                    "rotationCenterY": 81
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Anina Hip-Hop",
-        "md5": "6d01c961449223f9e61dda9281100806.png",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "dance",
-            "city",
-            "photo",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            13,
-            1
-        ],
-        "json": {
-            "objName": "Anina Hip-Hop",
-            "sounds": [
-                {
-                    "soundName": "dance celebrate",
-                    "soundID": -1,
-                    "md5": "0edb8fb88af19e6e17d0f8cf64c1d136.wav",
-                    "sampleCount": 176401,
-                    "rate": 22050,
-                    "format": "adpcm"
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "anina stance",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "6d01c961449223f9e61dda9281100806.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 76,
-                    "rotationCenterY": 252
-                },
-                {
-                    "costumeName": "anina top stand",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "34d6362cb4030d92be6fec73300f0aec.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 74,
-                    "rotationCenterY": 280
-                },
-                {
-                    "costumeName": "anina top R step",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "0477f7105d02b9a902382eca080476dc.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 248,
-                    "rotationCenterY": 272
-                },
-                {
-                    "costumeName": "anina top L step",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "62a89d8c6f7680e342132fcde59b2a5d.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 228,
-                    "rotationCenterY": 274
-                },
-                {
-                    "costumeName": "anina top freeze",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "dd67565519bdebea1b931deb19621384.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 110,
-                    "rotationCenterY": 268
-                },
-                {
-                    "costumeName": "anina R cross",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "22f3ca23b2f0ac67f8ebc36a8c3116a0.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 126,
-                    "rotationCenterY": 268
-                },
-                {
-                    "costumeName": "anina pop front",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "c163f1002f61421816386e52522b9133.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 68,
-                    "rotationCenterY": 270
-                },
-                {
-                    "costumeName": "anina pop down",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "e9e54ff1fa61c71507e25540d0326177.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 74,
-                    "rotationCenterY": 156
-                },
-                {
-                    "costumeName": "anina pop left",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "9fda30f66d51b2ad5f6fe11d57e199d6.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 238,
-                    "rotationCenterY": 266
-                },
-                {
-                    "costumeName": "anina pop right",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "cc2594e9278494e82f725be34369f178.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 66,
-                    "rotationCenterY": 268
-                },
-                {
-                    "costumeName": "anina pop L arm",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "843bff4a5ee3d61fd8cbd419cb2797a3.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 68,
-                    "rotationCenterY": 274
-                },
-                {
-                    "costumeName": "anina pop stand",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "de7cab2c8d567d49a5a1f378b5709bb4.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 76,
-                    "rotationCenterY": 276
-                },
-                {
-                    "costumeName": "anina pop R arm",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "e7e1a86233b7ad28d6ee9970b152be20.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 88,
-                    "rotationCenterY": 272
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Anna",
-        "md5": "23ab3e9be3be672fa2c43571e92b2b3e.png",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "city",
-            "photo",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Anna",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "anna-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "23ab3e9be3be672fa2c43571e92b2b3e.png",
-                    "rotationCenterX": 76,
-                    "rotationCenterY": 87
-                },
-                {
-                    "costumeName": "anna-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "25b8d4f7eae0add3bc24c20f5f17ada9.png",
-                    "rotationCenterX": 57,
-                    "rotationCenterY": 110
-                }
-            ],
-            "currentCostumeIndex": 1,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Anna Ode to Code",
-        "md5": "74b5e9c882deb81d88c175d548b8ff66.png",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "dance",
-            "photo",
-            "bitmap"
-        ],
-        "info": [
-            1,
-            14,
-            1
-        ],
-        "json": {
-            "objName": "Anna Ode to Code",
-            "scripts": [
-                [
-                    8,
-                    77.65,
-                    [
-                        [
-                            "whenKeyPressed",
-                            "space"
-                        ],
-                        [
-                            "nextCostume"
-                        ]
-                    ]
-                ]
-            ],
-            "sounds": [
-                {
-                    "soundName": "odesong-b",
-                    "soundID": -1,
-                    "md5": "2c41921491b1da2bfa1ebcaba34265ca.wav",
-                    "sampleCount": 212553,
-                    "rate": 22050,
-                    "format": "adpcm"
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "anna01",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "74b5e9c882deb81d88c175d548b8ff66.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 78,
-                    "rotationCenterY": 190
-                },
-                {
-                    "costumeName": "anna02",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "ece557e1c4500b30fd0e22b0d693cf4c.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 132,
-                    "rotationCenterY": 260
-                },
-                {
-                    "costumeName": "anna03",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "2e97d9d9d6bc1f174d3fc897638e8a46.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 138,
-                    "rotationCenterY": 242
-                },
-                {
-                    "costumeName": "anna04",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "69da72a9a29181425944e7963eb4f32a.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 138,
-                    "rotationCenterY": 70
-                },
-                {
-                    "costumeName": "anna05",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "1b396abf1336bceddb01166d975dad3b.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 134,
-                    "rotationCenterY": 246
-                },
-                {
-                    "costumeName": "anna06",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "d32ac2b2e9c8fa2f7b251275d8eec8c9.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 118,
-                    "rotationCenterY": 224
-                },
-                {
-                    "costumeName": "anna07",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "c0961caabfa8545b6080ea7825d6fc66.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 124,
-                    "rotationCenterY": 224
-                },
-                {
-                    "costumeName": "anna07b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "c21f0ef20be25af3b7c1ed42e974c75f.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 202,
-                    "rotationCenterY": 224
-                },
-                {
-                    "costumeName": "anna07c",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "54ed739e6ea31d128c319e8a3401af71.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 58,
-                    "rotationCenterY": 218
-                },
-                {
-                    "costumeName": "anna08",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "2d9bffdb6cda1ce0c77cfb3e001598f3.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 126,
-                    "rotationCenterY": 212
-                },
-                {
-                    "costumeName": "anna09",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "91f689627fa18d43ff6362ef872d90e2.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 130,
-                    "rotationCenterY": 220
-                },
-                {
-                    "costumeName": "anna10",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "eab5b5e2c4be253de024dd3deab68a66.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 148,
-                    "rotationCenterY": 260
-                },
-                {
-                    "costumeName": "anna11",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "859f95864d28fdb49d4170ce30fdd031.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 46,
-                    "rotationCenterY": 278
-                },
-                {
-                    "costumeName": "anna12",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "66133f695a23f669cc0fa6f06f275ab7.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 42,
-                    "rotationCenterY": 206
-                }
-            ],
-            "currentCostumeIndex": 13,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Apple",
-        "md5": "831ccd4741a7a56d85f6698a21f4ca69.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Apple",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "apple",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "831ccd4741a7a56d85f6698a21f4ca69.svg",
-                    "rotationCenterX": 31,
-                    "rotationCenterY": 31
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Arrow1",
-        "md5": "62f8794dd120e9b4ead4d098d50fc64b.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            4,
-            1
-        ],
-        "json": {
-            "objName": "Arrow1",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "arrow1-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "62f8794dd120e9b4ead4d098d50fc64b.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 28,
-                    "rotationCenterY": 23
-                },
-                {
-                    "costumeName": "arrow1-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "a157dc7e33d7c7a048af933de999e397.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 28,
-                    "rotationCenterY": 23
-                },
-                {
-                    "costumeName": "arrow1-c",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "d3b389e91f7beb22b2b1a80af09990ee.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 23,
-                    "rotationCenterY": 28
-                },
-                {
-                    "costumeName": "arrow1-d",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "412717ff731e9f19003a5840054057eb.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 23,
-                    "rotationCenterY": 28
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Avery",
-        "md5": "21393c9114c7d34b1df7ccd12c793672.svg",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "city",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Avery",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "avery-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "21393c9114c7d34b1df7ccd12c793672.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 39,
-                    "rotationCenterY": 94
-                },
-                {
-                    "costumeName": "avery-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "cc55f2f09599edc4ae0876e8b3d187d0.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 39,
-                    "rotationCenterY": 94
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Avery Walking",
-        "md5": "ed334e546806dfbf26d2591d7ddb12d0.svg",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "city",
-            "walking",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            4,
-            1
-        ],
-        "json": {
-            "objName": "Avery Walking",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "avery walking-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "ed334e546806dfbf26d2591d7ddb12d0.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 50,
-                    "rotationCenterY": 95
-                },
-                {
-                    "costumeName": "avery walking-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "c295731e8666ad2e1575fb4b4f82988d.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 50,
-                    "rotationCenterY": 102
-                },
-                {
-                    "costumeName": "avery walking-c",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "597a834225c9949e419dff7db1bc2453.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 48,
-                    "rotationCenterY": 95
-                },
-                {
-                    "costumeName": "avery walking-d",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "ce9622d11d24607eec7988196b38c3c6.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 50,
-                    "rotationCenterY": 101
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "leftRight",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "AZ Hip-Hop",
-        "md5": "e64363afc7f1e6951cb7967f50de2ba7.png",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "dance",
-            "city",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            13,
-            1
-        ],
-        "json": {
-            "objName": "AZ Hip-Hop",
-            "sounds": [
-                {
-                    "soundName": "dance celebrate",
-                    "soundID": -1,
-                    "md5": "0edb8fb88af19e6e17d0f8cf64c1d136.wav",
-                    "sampleCount": 176401,
-                    "rate": 22050,
-                    "format": "adpcm"
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "AZ stance",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "e64363afc7f1e6951cb7967f50de2ba7.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 70,
-                    "rotationCenterY": 278
-                },
-                {
-                    "costumeName": "AZ top stand",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "75b370524c92025cfa6f9071a6333e00.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 74,
-                    "rotationCenterY": 274
-                },
-                {
-                    "costumeName": "AZ top R step",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "3769dbe6e19b0e19ebf9416ba8660b88.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 200,
-                    "rotationCenterY": 270
-                },
-                {
-                    "costumeName": "AZ top L step",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "3d618085bce1a68829fa2cd5deab7871.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 144,
-                    "rotationCenterY": 266
-                },
-                {
-                    "costumeName": "AZ top freeze",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "ea33d5c631d8308b47685f1963becd4c.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 54,
-                    "rotationCenterY": 258
-                },
-                {
-                    "costumeName": "AZ top R cross",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "44216804569454067953fdd5c6b72928.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 206,
-                    "rotationCenterY": 252
-                },
-                {
-                    "costumeName": "AZ pop front",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "97c14e52551ae65679d61de6c94f0ec8.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 72,
-                    "rotationCenterY": 266
-                },
-                {
-                    "costumeName": "AZ pop down",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "2f8d07b568c8c67a0d211b5de09295d3.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 74,
-                    "rotationCenterY": 188
-                },
-                {
-                    "costumeName": "AZ pop left",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "4e7e43a86f1f09f1194e3579e7f385f5.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 184,
-                    "rotationCenterY": 266
-                },
-                {
-                    "costumeName": "AZ pop right",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "15a9d503613c649ca3a55829dbd98869.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 78,
-                    "rotationCenterY": 276
-                },
-                {
-                    "costumeName": "AZ pop L arm",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "0f6462025c20ac346a7f54164832d495.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 100,
-                    "rotationCenterY": 280
-                },
-                {
-                    "costumeName": "AZ pop stand",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "34b67b9e4db3aacbae735ade6a0539c2.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 92,
-                    "rotationCenterY": 280
-                },
-                {
-                    "costumeName": "AZ pop R arm",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "129472ac2779eb6bc2dd9bfbf0d33f56.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 74,
-                    "rotationCenterY": 278
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Ball",
-        "md5": "10117ddaefa98d819f2b1df93805622f.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "drawing",
-            "sports",
-            "vector"
-        ],
-        "info": [
-            0,
-            5,
-            1
-        ],
-        "json": {
-            "objName": "Ball",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "ball-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "10117ddaefa98d819f2b1df93805622f.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 22,
-                    "rotationCenterY": 22
-                },
-                {
-                    "costumeName": "ball-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "6e6330cad7750ea7e9dc88402661deb8.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 22,
-                    "rotationCenterY": 22
-                },
-                {
-                    "costumeName": "ball-c",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "bb45ed5db278f15c17c012c34a6b160f.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 22,
-                    "rotationCenterY": 22
-                },
-                {
-                    "costumeName": "ball-d",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "5d494659deae5c0de06b5885f5524276.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 22,
-                    "rotationCenterY": 22
-                },
-                {
-                    "costumeName": "ball-e",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "e80c98bc62fd32e8df81642af11ffb1a.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 22,
-                    "rotationCenterY": 22
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Ball-Soccer",
-        "md5": "4e4cc84380ccf6d4e59e53bc6d3a0a3f.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "drawing",
-            "sports",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Ball-Soccer",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "ball-soccer",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "4e4cc84380ccf6d4e59e53bc6d3a0a3f.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 32,
-                    "rotationCenterY": 34
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Ballerina",
-        "md5": "6051bb7008cf17c8853a6f81f04c8a0f.svg",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "dance",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            4,
-            1
-        ],
-        "json": {
-            "objName": "Ballerina",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "ballerina-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "6051bb7008cf17c8853a6f81f04c8a0f.svg",
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                },
-                {
-                    "costumeName": "ballerina-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "8bc5e47fb1439e29e11e9e3f2e20c6de.svg",
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                },
-                {
-                    "costumeName": "ballerina-c",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "6d3a07761b294f705987b0af58f8e335.svg",
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                },
-                {
-                    "costumeName": "ballerina-d",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "c3164795edf39e436272f425b4f5e487.svg",
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                }
-            ],
-            "currentCostumeIndex": 3,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Balloon1",
-        "md5": "bc96a1fb5fe794377acd44807e421ce2.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "holiday",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            3,
-            1
-        ],
-        "json": {
-            "objName": "Balloon1",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "balloon1-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "bc96a1fb5fe794377acd44807e421ce2.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 32,
-                    "rotationCenterY": 94
-                },
-                {
-                    "costumeName": "balloon1-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "d7bb51d9c38af6314bd2b4058d2a592d.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 31,
-                    "rotationCenterY": 94
-                },
-                {
-                    "costumeName": "balloon1-c",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "247cef27b665d77d9efaca69327cae77.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 31,
-                    "rotationCenterY": 94
-                }
-            ],
-            "currentCostumeIndex": 2,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Bananas",
-        "md5": "40bb8a1afe88cec78254f6fcfee98242.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            0
-        ],
-        "json": {
-            "objName": "Bananas",
-            "costumes": [
-                {
-                    "costumeName": "bananas",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "40bb8a1afe88cec78254f6fcfee98242.svg",
-                    "rotationCenterX": 36,
-                    "rotationCenterY": 37
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Baseball",
-        "md5": "6e13ef53885d2cfca9a54cc5c3f6c20f.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "sports",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Baseball",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "baseball",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "6e13ef53885d2cfca9a54cc5c3f6c20f.svg",
-                    "rotationCenterX": 34,
-                    "rotationCenterY": 31
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Basketball",
-        "md5": "ac3432618ac868309f502024aa78423c.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "sports",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            0
-        ],
-        "json": {
-            "objName": "Basketball",
-            "costumes": [
-                {
-                    "costumeName": "basketball",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "ac3432618ac868309f502024aa78423c.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 36,
-                    "rotationCenterY": 39
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Bass",
-        "md5": "bdbd2876847e54309a5ff3ee0895d724.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "music",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            8
-        ],
-        "json": {
-            "objName": "Bass",
-            "sounds": [
-                {
-                    "soundName": "C bass",
-                    "soundID": -1,
-                    "md5": "c3566ec797b483acde28f790994cc409.wav",
-                    "sampleCount": 44608,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "D bass",
-                    "soundID": -1,
-                    "md5": "5a3ae8a2665f50fdc38cc301fbac79ba.wav",
-                    "sampleCount": 40192,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "E bass",
-                    "soundID": -1,
-                    "md5": "0657e39bae81a232b01a18f727d3b891.wav",
-                    "sampleCount": 36160,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "F bass",
-                    "soundID": -1,
-                    "md5": "ea21bdae86f70d60b28f1dddcf50d104.wav",
-                    "sampleCount": 34368,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "G bass",
-                    "soundID": -1,
-                    "md5": "05c192194e8f1944514dce3833e33439.wav",
-                    "sampleCount": 30976,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "A bass",
-                    "soundID": -1,
-                    "md5": "c04ebf21e5e19342fa1535e4efcdb43b.wav",
-                    "sampleCount": 28160,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "B bass",
-                    "soundID": -1,
-                    "md5": "e31dcaf7bcdf58ac2a26533c48936c45.wav",
-                    "sampleCount": 25792,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "C2 bass",
-                    "soundID": -1,
-                    "md5": "667d6c527b79321d398e85b526f15b99.wav",
-                    "sampleCount": 24128,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "bass",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "bdbd2876847e54309a5ff3ee0895d724.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 60,
-                    "rotationCenterY": 110
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Bat1",
-        "md5": "7ad915f8e0884f497a24d5bb61ea8a4a.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "drawing",
-            "flying",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Bat1",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "bat1-a ",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "7ad915f8e0884f497a24d5bb61ea8a4a.svg",
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                },
-                {
-                    "costumeName": "bat1-b ",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "f127434672b872a902346ef3c1af45f2.svg",
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Bat2",
-        "md5": "647d4bd53163f94a7dabf623ccab7fd3.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "drawing",
-            "flying",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Bat2",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "bat2-a ",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "647d4bd53163f94a7dabf623ccab7fd3.svg",
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                },
-                {
-                    "costumeName": "bat2-b ",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "8aa1d20e4f7761becbe9bafa75290465.svg",
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Beachball",
-        "md5": "87d64cab74c64b31498cc85f07510ee4.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "sports",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Beachball",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "beachball",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "87d64cab74c64b31498cc85f07510ee4.svg",
-                    "rotationCenterX": 34,
-                    "rotationCenterY": 33
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Bear1",
-        "md5": "598722f70e86e6f9b23ef97680baaa9c.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "holiday",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Bear1",
-            "sounds": [
-                {
-                    "soundName": "plunge",
-                    "soundID": -1,
-                    "md5": "c09455ee9da0e7eeead42d4e73c2555d.wav",
-                    "sampleCount": 22400,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "bear1-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "598722f70e86e6f9b23ef97680baaa9c.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 56,
-                    "rotationCenterY": 93
-                },
-                {
-                    "costumeName": "bear1-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "76ceb0de4409f42713b50cbc1fb45af5.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 56,
-                    "rotationCenterY": 93
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Bear2",
-        "md5": "3eb8e16a983ff23c418374389c81bd30.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "holiday",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Bear2",
-            "sounds": [
-                {
-                    "soundName": "meow",
-                    "soundID": -1,
-                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
-                    "sampleCount": 18688,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "bear2-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "3eb8e16a983ff23c418374389c81bd30.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 37,
-                    "rotationCenterY": 42
-                },
-                {
-                    "costumeName": "bear2-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "12bb6960ac01b65ae9b5e5e7f79700ac.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 51,
-                    "rotationCenterY": 42
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Beetle",
-        "md5": "e1ce8f153f011fdd52486c91c6ed594d.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Beetle",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "beetle",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "e1ce8f153f011fdd52486c91c6ed594d.svg",
-                    "rotationCenterX": 43,
-                    "rotationCenterY": 38
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Bell",
-        "md5": "f35056c772395455d703773657e1da6e.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "holiday",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            2
-        ],
-        "json": {
-            "objName": "Bell",
-            "sounds": [
-                {
-                    "soundName": "xylo1",
-                    "soundID": -1,
-                    "md5": "6ac484e97c1c1fe1384642e26a125e70.wav",
-                    "sampleCount": 238232,
-                    "rate": 22050,
-                    "format": "adpcm"
-                },
-                {
-                    "soundName": "bell toll",
-                    "soundID": -1,
-                    "md5": "25d61e79cbeba4041eebeaebd7bf9598.wav",
-                    "sampleCount": 45168,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "bell1",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "f35056c772395455d703773657e1da6e.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 59,
-                    "rotationCenterY": 69
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Bells",
-        "md5": "1f151bee966df3f0c41138941713280e.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "holiday",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Bells",
-            "sounds": [
-                {
-                    "soundName": "xylo1",
-                    "soundID": -1,
-                    "md5": "5c6964021197fdd4ff46a0f107e6d624.wav",
-                    "sampleCount": 238995,
-                    "rate": 22050,
-                    "format": "adpcm"
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "bells-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "1f151bee966df3f0c41138941713280e.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 53,
-                    "rotationCenterY": 51
-                },
-                {
-                    "costumeName": "bells-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "5b3879a162881aed93169bf0a6680f45.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 48,
-                    "rotationCenterY": 31
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Bowl",
-        "md5": "86f616639846f06fef29931e6b9b59de.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            2
-        ],
-        "json": {
-            "objName": "Bowl",
-            "sounds": [
-                {
-                    "soundName": "boing",
-                    "soundID": -1,
-                    "md5": "53a3c2e27d1fb5fdb14aaf0cb41e7889.wav",
-                    "sampleCount": 6804,
-                    "rate": 22050,
-                    "format": "adpcm"
-                },
-                {
-                    "soundName": "water drop",
-                    "soundID": -1,
-                    "md5": "aa488de9e2c871e9d4faecd246ed737a.wav",
-                    "sampleCount": 8136,
-                    "rate": 22050,
-                    "format": "adpcm"
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "bowl-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "86f616639846f06fef29931e6b9b59de.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 30,
-                    "rotationCenterY": 15
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1.2500000000000002,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Bowtie",
-        "md5": "534d9924d2f9bfe240f041e3ce55ccf5.svg",
-        "type": "sprite",
-        "tags": [
-            "dress-up",
-            "things",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Bowtie",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "bowtie-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "534d9924d2f9bfe240f041e3ce55ccf5.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 11,
-                    "rotationCenterY": 4
-                },
-                {
-                    "costumeName": "bowtie-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "8be1e90e19cd1faced8a2e83c2b5c90d.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 11,
-                    "rotationCenterY": 4
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1.6,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": true,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Breakdancer1",
-        "md5": "cafd225b63d3aeeedc8df926fe5b6ab4.png",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "dance",
-            "city",
-            "drawing",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            3,
-            1
-        ],
-        "json": {
-            "objName": "Breakdancer1",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "breakdancer1-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "cafd225b63d3aeeedc8df926fe5b6ab4.png",
-                    "rotationCenterX": 113,
-                    "rotationCenterY": 90
-                },
-                {
-                    "costumeName": "breakdancer1-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "84bcb1be206e8653a7d97549733c3db5.png",
-                    "rotationCenterX": 30,
-                    "rotationCenterY": 90
-                },
-                {
-                    "costumeName": "breakdancer1-c",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "b345babf9f78b5e88a288a4b13a7ca29.png",
-                    "rotationCenterX": 35,
-                    "rotationCenterY": 90
-                }
-            ],
-            "currentCostumeIndex": 2,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Buildings",
-        "md5": "d713270e235851e5962becd73a951771.svg",
-        "type": "sprite",
-        "tags": [
-            "city",
-            "flying",
-            "things",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            10,
-            1
-        ],
-        "json": {
-            "objName": "Buildings",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "building-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "d713270e235851e5962becd73a951771.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 40,
-                    "rotationCenterY": 30
-                },
-                {
-                    "costumeName": "building-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "8c2d59c50a97d33b096f629258f02be6.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 46,
-                    "rotationCenterY": -11
-                },
-                {
-                    "costumeName": "building-c",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "7f3f51f495c39809bed95991dfa1f80d.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 25,
-                    "rotationCenterY": 17
-                },
-                {
-                    "costumeName": "building-d",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "61ba83d6bded299dd91168eb24cd379f.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 59,
-                    "rotationCenterY": -10
-                },
-                {
-                    "costumeName": "building-e",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "1beeb8f034a1128c9a799297b0b7fc26.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 36,
-                    "rotationCenterY": 55
-                },
-                {
-                    "costumeName": "building-f",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "451e0a565e95d945fe2addfe609ee9df.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 41,
-                    "rotationCenterY": 27
-                },
-                {
-                    "costumeName": "building-g",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "58b3c9b7a41dde698fa2b427b502c1fa.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 64,
-                    "rotationCenterY": -65
-                },
-                {
-                    "costumeName": "building-h",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "e952c8b14eeac894302d07d37a45ed99.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 33,
-                    "rotationCenterY": 136
-                },
-                {
-                    "costumeName": "building-i",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "b00b1123e3bfcb600242528d059ffcfb.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 31,
-                    "rotationCenterY": -12
-                },
-                {
-                    "costumeName": "building-j",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "e08fd1a7397efcfe0e3691f945693cb4.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 29,
-                    "rotationCenterY": 33
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Bus",
-        "md5": "66895930177178ea01d9e610917f8acf.png",
-        "type": "sprite",
-        "tags": [
-            "transportation",
-            "city",
-            "photo",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Bus",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "bus",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "66895930177178ea01d9e610917f8acf.png",
-                    "rotationCenterX": 120,
-                    "rotationCenterY": 35
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Butterfly1",
-        "md5": "836d4cc7889f4a1cbcb0303934f31f79.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "drawing",
-            "flying",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Butterfly1",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "butterfly1-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "836d4cc7889f4a1cbcb0303934f31f79.svg",
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                },
-                {
-                    "costumeName": "butterfly1-b ",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "55dd0671a359d7c35f7b78f4176660e8.svg",
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Butterfly2",
-        "md5": "a0216895beade6afc6d42bd5bb43faea.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "drawing",
-            "flying",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Butterfly2",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "butterfly2 ",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "a0216895beade6afc6d42bd5bb43faea.svg",
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Butterfly3",
-        "md5": "8907a43cf08b0a9134969023be2074c5.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "drawing",
-            "flying",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Butterfly3",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "butterfly3 ",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "8907a43cf08b0a9134969023be2074c5.svg",
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Button1",
-        "md5": "7ef67c5bc8cf7df64fdb3b1d6b250f71.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Button1",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "button1",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "7ef67c5bc8cf7df64fdb3b1d6b250f71.svg",
-                    "rotationCenterX": 72,
-                    "rotationCenterY": 72
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Button2",
-        "md5": "c0051ff23e9aae78295964206793c1e3.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Button2",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "button2-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "c0051ff23e9aae78295964206793c1e3.svg",
-                    "rotationCenterX": 72,
-                    "rotationCenterY": 72
-                },
-                {
-                    "costumeName": "button2-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "712a561dc0ad66e348b8247e566b50ef.svg",
-                    "rotationCenterX": 72,
-                    "rotationCenterY": 72
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Button3",
-        "md5": "ffb2a9c21084c58fdb677c8d12a97519.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Button3",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "button3-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "ffb2a9c21084c58fdb677c8d12a97519.svg",
-                    "rotationCenterX": 72,
-                    "rotationCenterY": 72
-                },
-                {
-                    "costumeName": "button3-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "7a9ccb55e4da36f48811ab125d2492e0.svg",
-                    "rotationCenterX": 72,
-                    "rotationCenterY": 72
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Button4",
-        "md5": "8782b457cdf4a10ca016ff1ec0c744ef.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Button4",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "button4-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "8782b457cdf4a10ca016ff1ec0c744ef.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 35,
-                    "rotationCenterY": 34
-                },
-                {
-                    "costumeName": "button4-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "840f4ef01849e459fd84f5470a3b0080.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 35,
-                    "rotationCenterY": 34
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Button5",
-        "md5": "71e97245b7be4fd6fe3ba8cdeecadaf1.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Button5",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "button5-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "71e97245b7be4fd6fe3ba8cdeecadaf1.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 72,
-                    "rotationCenterY": 72
-                },
-                {
-                    "costumeName": "button5-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "54cd55512f7571060e6e64168e541222.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 72,
-                    "rotationCenterY": 72
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Cake",
-        "md5": "97ab3596dc06510e963fa29795e663bf.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "holiday",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            0
-        ],
-        "json": {
-            "objName": "Cake",
-            "costumes": [
-                {
-                    "costumeName": "cake-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "97ab3596dc06510e963fa29795e663bf.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 64,
-                    "rotationCenterY": 50
-                },
-                {
-                    "costumeName": "cake-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "61d5481955a2f42cb843d09506f6744e.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 64,
-                    "rotationCenterY": 42
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Calvrett",
-        "md5": "82b2f97fec9083cad502a781fe88929b.png",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "photo",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Calvrett",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "calvrett jumping",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "82b2f97fec9083cad502a781fe88929b.png",
-                    "rotationCenterX": 84,
-                    "rotationCenterY": 108
-                },
-                {
-                    "costumeName": "calvrett thinking",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "b8d2409e58b663020353c08fb029b7e6.png",
-                    "rotationCenterX": 54,
-                    "rotationCenterY": 85
-                }
-            ],
-            "currentCostumeIndex": 1,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Candle",
-        "md5": "9bb90825b1d7c360aa47ee18883cd3cd.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "holiday",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Candle",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "candle1-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "9bb90825b1d7c360aa47ee18883cd3cd.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 12,
-                    "rotationCenterY": 32
-                },
-                {
-                    "costumeName": "candle1-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "4f2ab7fc559ecbbc61721f76639a4e44.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 12,
-                    "rotationCenterY": 32
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 0.75,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Candles1",
-        "md5": "b8432a2c0d04408b3ba58ec3b01582f0.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "holiday",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Candles1",
-            "sounds": [
-                {
-                    "soundName": "strum",
-                    "soundID": -1,
-                    "md5": "b92de59d992a655c1b542223a784cda6.wav",
-                    "sampleCount": 11247,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "candles1",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "b8432a2c0d04408b3ba58ec3b01582f0.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 52,
-                    "rotationCenterY": 37
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Candles2",
-        "md5": "76a9de5efb140fe287dc0f197a0e8d4c.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "holiday",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Candles2",
-            "sounds": [
-                {
-                    "soundName": "strum",
-                    "soundID": -1,
-                    "md5": "b92de59d992a655c1b542223a784cda6.wav",
-                    "sampleCount": 11247,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "candles2",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "76a9de5efb140fe287dc0f197a0e8d4c.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 52,
-                    "rotationCenterY": 79
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Car-Bug",
-        "md5": "c0b7d099a815f58ff6d92538856f08c1.png",
-        "type": "sprite",
-        "tags": [
-            "transportation",
-            "city",
-            "photo",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Car-Bug",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "car-bug",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "c0b7d099a815f58ff6d92538856f08c1.png",
-                    "rotationCenterX": 100,
-                    "rotationCenterY": 39
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Cassy",
-        "md5": "db4e1ee1f9102e3da5e06f2d17881df5.png",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "city",
-            "photo",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            4,
-            1
-        ],
-        "json": {
-            "objName": "Cassy",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "cassy-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "db4e1ee1f9102e3da5e06f2d17881df5.png",
-                    "rotationCenterX": 43,
-                    "rotationCenterY": 100
-                },
-                {
-                    "costumeName": "cassy-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "2f6f57d1ab69fc18a38fd30572530437.png",
-                    "rotationCenterX": 35,
-                    "rotationCenterY": 100
-                },
-                {
-                    "costumeName": "cassy-c",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "662752d56bb77544f3e79ee8c16b3f2d.png",
-                    "rotationCenterX": 70,
-                    "rotationCenterY": 58
-                },
-                {
-                    "costumeName": "cassy-d",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "24e9dac390ae4e5b0c17e7d922eb033b.png",
-                    "rotationCenterX": 72,
-                    "rotationCenterY": 100
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Cassy Dance",
-        "md5": "6cb3686db1fa658b6541cc9fa3ccfcc7.png",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "dance",
-            "city",
-            "photo",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            4,
-            1
-        ],
-        "json": {
-            "objName": "Cassy Dance",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "cassy dance-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "6cb3686db1fa658b6541cc9fa3ccfcc7.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 104,
-                    "rotationCenterY": 192
-                },
-                {
-                    "costumeName": "cassy dance-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "086dc4312d3bf4595d6b3fd4b1021b35.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 140,
-                    "rotationCenterY": 192
-                },
-                {
-                    "costumeName": "cassy dance-c",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "dffbfb382641655dbd698559ed49fd99.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 74,
-                    "rotationCenterY": 188
-                },
-                {
-                    "costumeName": "cassy dance-d",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "d0e98431c4744f684a13e8331d838203.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 94,
-                    "rotationCenterY": 180
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Cat1",
-        "md5": "f88bf1935daea28f8ca098462a31dbb0.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Cat1",
-            "sounds": [
-                {
-                    "soundName": "meow",
-                    "soundID": -1,
-                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
-                    "sampleCount": 18688,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "cat1-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "f88bf1935daea28f8ca098462a31dbb0.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 47,
-                    "rotationCenterY": 50
-                },
-                {
-                    "costumeName": "cat1-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "6e8bd9ae68fdb02b7e1e3df656a75635.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 47,
-                    "rotationCenterY": 55
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Cat1 Flying",
-        "md5": "1e81725d2d2c7de4a2dd4a145198a43c.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "drawing",
-            "flying",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Cat1 Flying",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "cat1 flying-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "1e81725d2d2c7de4a2dd4a145198a43c.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 67,
-                    "rotationCenterY": 48
-                },
-                {
-                    "costumeName": "cat1 flying-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "0d192725870ef0eda50d91cab0e3c9c5.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 42,
-                    "rotationCenterY": 44
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Cat2",
-        "md5": "01ae57fd339529445cb890978ef8a054.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Cat2",
-            "sounds": [
-                {
-                    "soundName": "meow2",
-                    "soundID": -1,
-                    "md5": "cf51a0c4088942d95bcc20af13202710.wav",
-                    "sampleCount": 6512,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "cat2",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "01ae57fd339529445cb890978ef8a054.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 87,
-                    "rotationCenterY": 39
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Catherine Dance",
-        "md5": "7f7684029e9726376aaaae1158439f3e.png",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "dance",
-            "city",
-            "photo",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            4,
-            1
-        ],
-        "json": {
-            "objName": "Catherine Dance",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "catherine-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "7f7684029e9726376aaaae1158439f3e.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 84,
-                    "rotationCenterY": 123
-                },
-                {
-                    "costumeName": "catherine-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "79052da8d59a6a16a0f6d09cd94237ae.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 179,
-                    "rotationCenterY": 133
-                },
-                {
-                    "costumeName": "catherine-c",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "6e34f695da1e18d53e6c050d95ba0e4a.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 103,
-                    "rotationCenterY": 28
-                },
-                {
-                    "costumeName": "catherine-d",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "feff7824a6fd6747391012dcfe9ac4f0.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 121,
-                    "rotationCenterY": 113
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Champ99",
-        "md5": "b940c99d8e677ac5773cb4d592b16734.png",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "dance",
-            "city",
-            "photo",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            7,
-            1
-        ],
-        "json": {
-            "objName": "Champ99",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "champ99-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "b940c99d8e677ac5773cb4d592b16734.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 248,
-                    "rotationCenterY": 306
-                },
-                {
-                    "costumeName": "champ99-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "2ebc7632bc9e665d9eeea93190fad7ad.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 164,
-                    "rotationCenterY": 290
-                },
-                {
-                    "costumeName": "champ99-c",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "bfcff80b0044c644c555ba24f2484106.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 152,
-                    "rotationCenterY": 270
-                },
-                {
-                    "costumeName": "champ99-d",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "34de53e52a768d60a96e3ae0c030dfc5.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 188,
-                    "rotationCenterY": 260
-                },
-                {
-                    "costumeName": "champ99-e",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "0cb685bf8584df9caf124da929ab3453.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 190,
-                    "rotationCenterY": 248
-                },
-                {
-                    "costumeName": "champ99-f",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "516d30b29aed8145718db421f4737953.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 114,
-                    "rotationCenterY": 250
-                },
-                {
-                    "costumeName": "champ99-g",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "49e0edcb319527d936981f06b4111d53.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 132,
-                    "rotationCenterY": 258
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Cheesy-Puffs",
-        "md5": "4c99a77ba72abaf6c961e8684f8a8a9f.png",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "photo",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Cheesy-Puffs",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "cheesy-puffs",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "4c99a77ba72abaf6c961e8684f8a8a9f.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 87,
-                    "rotationCenterY": 72
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Cloud",
-        "md5": "47005a1f20309f577a03a67abbb6b94e.svg",
-        "type": "sprite",
-        "tags": [
-            "flying",
-            "city",
-            "things",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Cloud",
-            "sounds": [
-                {
-                    "soundName": "ripples",
-                    "soundID": -1,
-                    "md5": "4da8a805673c288965e1e5535c3f7f2b.wav",
-                    "sampleCount": 10144,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "cloud",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "47005a1f20309f577a03a67abbb6b94e.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 71,
-                    "rotationCenterY": 45
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 0.9,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Clouds",
-        "md5": "c7d7de8e29179407f03b054fa640f4d0.svg",
-        "type": "sprite",
-        "tags": [
-            "flying",
-            "city",
-            "things",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            4,
-            1
-        ],
-        "json": {
-            "objName": "Clouds",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "cloud-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "c7d7de8e29179407f03b054fa640f4d0.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 76,
-                    "rotationCenterY": 19
-                },
-                {
-                    "costumeName": "cloud-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "d8595350ebb460494c9189dabb968336.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 101,
-                    "rotationCenterY": 20
-                },
-                {
-                    "costumeName": "cloud-c",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "395fc991e64ac0a4aa46758ab4bc65cb.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 97,
-                    "rotationCenterY": 9
-                },
-                {
-                    "costumeName": "cloud-d",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "1767e704acb11ffa409f77cc79ba7e86.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 87,
-                    "rotationCenterY": 21
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "CM Hip-Hop",
-        "md5": "db291ec7e061ecd4d797875e3aec0a09.png",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "dance",
-            "city",
-            "photo",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            8,
-            1
-        ],
-        "json": {
-            "objName": "CM Hip-Hop",
-            "sounds": [
-                {
-                    "soundName": "dance snare beat",
-                    "soundID": -1,
-                    "md5": "562587bdb75e3a8124cdaa46ba0f648b.wav",
-                    "sampleCount": 176401,
-                    "rate": 22050,
-                    "format": "adpcm"
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "cm top stand",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "db291ec7e061ecd4d797875e3aec0a09.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 66,
-                    "rotationCenterY": 226
-                },
-                {
-                    "costumeName": "cm top R leg",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "b5cfa26a969dc001fb38d29c5ef8f1bf.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 90,
-                    "rotationCenterY": 240
-                },
-                {
-                    "costumeName": "cm top L leg",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "9b3224263e7c828c54326d9b4f22a74b.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 116,
-                    "rotationCenterY": 238
-                },
-                {
-                    "costumeName": "cm top ready",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "ab97d9c6e3c0efe27bfd9e44ac3af497.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 84,
-                    "rotationCenterY": 180
-                },
-                {
-                    "costumeName": "cm top L cross",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "3b0538ba8b6fcc0f938013b912e34305.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 122,
-                    "rotationCenterY": 162
-                },
-                {
-                    "costumeName": "cm top R cross",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "00716f8ab864ae479db3017146d28c64.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 156,
-                    "rotationCenterY": 164
-                },
-                {
-                    "costumeName": "cm pop L arm",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "ce0928c8dbc625661b44c3503debae7e.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 136,
-                    "rotationCenterY": 243
-                },
-                {
-                    "costumeName": "cm pop R arm",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "e5555af183c643c7006632b26d851a32.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 79,
-                    "rotationCenterY": 229
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Convertible1",
-        "md5": "099953d710d842e592084765c17bda82.png",
-        "type": "sprite",
-        "tags": [
-            "transportation",
-            "city",
-            "drawing",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Convertible1",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "convertible1",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "099953d710d842e592084765c17bda82.png",
-                    "rotationCenterX": 110,
-                    "rotationCenterY": 27
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Convertible2",
-        "md5": "2091f1f3fc578189bced6b257f353995.png",
-        "type": "sprite",
-        "tags": [
-            "transportation",
-            "city",
-            "drawing",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Convertible2",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "convertible2",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "2091f1f3fc578189bced6b257f353995.png",
-                    "rotationCenterX": 90,
-                    "rotationCenterY": 22
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Convertible3",
-        "md5": "b6ac3c9e1789cba2302d2ef82d62d019.svg",
-        "type": "sprite",
-        "tags": [
-            "transportation",
-            "city",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Convertible3",
-            "sounds": [
-                {
-                    "soundName": "meow",
-                    "soundID": -1,
-                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
-                    "sampleCount": 18688,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "convertible3",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "b6ac3c9e1789cba2302d2ef82d62d019.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Cowbell",
-        "md5": "3b00920b17d43986685f3855bcb6afe7.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "music",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            2
-        ],
-        "json": {
-            "objName": "Cowbell",
-            "sounds": [
-                {
-                    "soundName": "small cowbell",
-                    "soundID": -1,
-                    "md5": "e29154f53f56f96f8a3292bdcddcec54.wav",
-                    "sampleCount": 9718,
-                    "rate": 22050,
-                    "format": "adpcm"
-                },
-                {
-                    "soundName": "large cowbell",
-                    "soundID": -1,
-                    "md5": "006316650ffc673dc02d36aa55881327.wav",
-                    "sampleCount": 20856,
-                    "rate": 22050,
-                    "format": "adpcm"
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "cowbell",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "3b00920b17d43986685f3855bcb6afe7.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 29,
-                    "rotationCenterY": 30
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Crab",
-        "md5": "114249a5660f7948663d95de575cfd8d.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "drawing",
-            "underwater",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Crab",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "crab-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "114249a5660f7948663d95de575cfd8d.svg",
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                },
-                {
-                    "costumeName": "crab-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "9bf050664e68c10d2616e85f2873be09.svg",
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Creature1",
-        "md5": "a560c6eab2e1de2462bdaeb1d698736c.svg",
-        "type": "sprite",
-        "tags": [
-            "fantasy",
-            "holiday",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            3,
-            1
-        ],
-        "json": {
-            "objName": "Creature1",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "creature1-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "a560c6eab2e1de2462bdaeb1d698736c.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 54,
-                    "rotationCenterY": 80
-                },
-                {
-                    "costumeName": "creature1-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "8042b71fc2ae322151c0a3a163701333.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 60,
-                    "rotationCenterY": 78
-                },
-                {
-                    "costumeName": "creature1-c",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "e12a83c8f1c0545b59fe8673e9fac79c.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 63,
-                    "rotationCenterY": 164
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Cymbal",
-        "md5": "532860ee3ecfd05d5f473dbe3ea69c8e.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "music",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            5
-        ],
-        "json": {
-            "objName": "Cymbal",
-            "sounds": [
-                {
-                    "soundName": "crash cymbal",
-                    "soundID": -1,
-                    "md5": "f2c47a46f614f467a7ac802ed9ec3d8e.wav",
-                    "sampleCount": 25220,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "hihat cymbal",
-                    "soundID": -1,
-                    "md5": "2d01f60d0f20ab39facbf707899c6b2a.wav",
-                    "sampleCount": 2752,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "splash cymbal",
-                    "soundID": -1,
-                    "md5": "9d63ed5be96c43b06492e8b4a9cea8d8.wav",
-                    "sampleCount": 9600,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "roll cymbal",
-                    "soundID": -1,
-                    "md5": "da8355d753cd2a5ddd19cb2bb41c1547.wav",
-                    "sampleCount": 26432,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "bell cymbal",
-                    "soundID": -1,
-                    "md5": "efddec047de95492f775a1b5b2e8d19e.wav",
-                    "sampleCount": 19328,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "cymbal-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "532860ee3ecfd05d5f473dbe3ea69c8e.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 34,
-                    "rotationCenterY": 60
-                },
-                {
-                    "costumeName": "cymbal-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "ae5b19022fa882ff95790b25279b9a3f.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 37,
-                    "rotationCenterY": 73
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "D-Money Hip-Hop",
-        "md5": "b30a60d31aebead577b73affd22bf30f.svg",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "dance",
-            "city",
-            "photo",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            13,
-            1
-        ],
-        "json": {
-            "objName": "D-Money Hip-Hop",
-            "sounds": [
-                {
-                    "soundName": "dance celebrate",
-                    "soundID": -1,
-                    "md5": "0edb8fb88af19e6e17d0f8cf64c1d136.wav",
-                    "sampleCount": 176401,
-                    "rate": 22050,
-                    "format": "adpcm"
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "dm stance",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "b30a60d31aebead577b73affd22bf30f.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 55,
-                    "rotationCenterY": 119
-                },
-                {
-                    "costumeName": "dm top stand",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "cbf035d39d0a0bb070d2eb998cebd60d.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 82,
-                    "rotationCenterY": 244
-                },
-                {
-                    "costumeName": "dm top R leg",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "fcb8c2b6cf9b7e6ce9df521b2486deb3.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 218,
-                    "rotationCenterY": 232
-                },
-                {
-                    "costumeName": "dm top L leg",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "fd8bb9665fe078d2d95dbc35bccf4046.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 230,
-                    "rotationCenterY": 240
-                },
-                {
-                    "costumeName": "dm freeze",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "31e687f186b19ea120cd5cfc9dea2a3f.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 220,
-                    "rotationCenterY": 234
-                },
-                {
-                    "costumeName": "dm pop front",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "0b2fb609d6d10decfdd5a1c3b58369b4.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 92,
-                    "rotationCenterY": 234
-                },
-                {
-                    "costumeName": "dm pop down",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "3b65ce3551f9c111794f7f1fb8f325be.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 64,
-                    "rotationCenterY": 74
-                },
-                {
-                    "costumeName": "dm pop left",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "f636510e8ef231d7c0e72a572ce91c99.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 204,
-                    "rotationCenterY": 250
-                },
-                {
-                    "costumeName": "dm pop right",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "36b32430e45e071071052ef33c637f48.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 78,
-                    "rotationCenterY": 238
-                },
-                {
-                    "costumeName": "dm pop L arm",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "426e1520efc34fef45be0596fd5f7120.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 90,
-                    "rotationCenterY": 238
-                },
-                {
-                    "costumeName": "dm pop stand",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "370cc57b40f1f1d6e52d6330b73d207f.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 100,
-                    "rotationCenterY": 244
-                },
-                {
-                    "costumeName": "dm pop R arm",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "56fe91d2cf3ecb9d1b94006aee9eff79.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 80,
-                    "rotationCenterY": 240
-                },
-                {
-                    "costumeName": "dm top R leg2",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "fcb8c2b6cf9b7e6ce9df521b2486deb3.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 218,
-                    "rotationCenterY": 232
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Dan",
-        "md5": "1baa5b126e0e14d6070a997c0deefab5.png",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "city",
-            "photo",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Dan",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "dan-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "1baa5b126e0e14d6070a997c0deefab5.png",
-                    "rotationCenterX": 36,
-                    "rotationCenterY": 100
-                },
-                {
-                    "costumeName": "dan-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "74be10ac815fd090cb42b92801002bb1.png",
-                    "rotationCenterX": 47,
-                    "rotationCenterY": 100
-                }
-            ],
-            "currentCostumeIndex": 1,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Dani",
-        "md5": "f3038fb0f4a00806b02081c6789dd8cf.svg",
-        "type": "sprite",
-        "tags": [
-            "dress-up",
-            "people",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            3,
-            1
-        ],
-        "json": {
-            "objName": "Dani",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "dani-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "f3038fb0f4a00806b02081c6789dd8cf.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 49,
-                    "rotationCenterY": 115
-                },
-                {
-                    "costumeName": "dani-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "e5c7dd4905a78e1d54087b7165dd1e8c.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 82,
-                    "rotationCenterY": 115
-                },
-                {
-                    "costumeName": "dani-c",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "cbc5f9c67022af201d498bc9b35608b8.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 49,
-                    "rotationCenterY": 113
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Dee",
-        "md5": "aa239b7ccdce6bddf06900c709525764.svg",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "city",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            5,
-            1
-        ],
-        "json": {
-            "objName": "Dee",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "dee-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "aa239b7ccdce6bddf06900c709525764.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 52,
-                    "rotationCenterY": 99
-                },
-                {
-                    "costumeName": "dee-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "62b4ac1b735599e21af77c390b178095.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 33,
-                    "rotationCenterY": 99
-                },
-                {
-                    "costumeName": "dee-c",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "6aa6196ce3245e93b8d1299f33adffcd.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 36,
-                    "rotationCenterY": 102
-                },
-                {
-                    "costumeName": "dee-d",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "2159a6be8f7ff450d0b5e938ca34a3f4.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 33,
-                    "rotationCenterY": 99
-                },
-                {
-                    "costumeName": "dee-e",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "e358d2a7e3a0a680928657161ce81a0a.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 32,
-                    "rotationCenterY": 99
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Devin",
-        "md5": "b1897e56265470b55fa65fabe2423c55.svg",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "city",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            4,
-            1
-        ],
-        "json": {
-            "objName": "Devin",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "devin-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "b1897e56265470b55fa65fabe2423c55.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 39,
-                    "rotationCenterY": 95
-                },
-                {
-                    "costumeName": "devin-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "873fbd641768c8f753a6568da97633e7.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 40,
-                    "rotationCenterY": 96
-                },
-                {
-                    "costumeName": "devin-c",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "eac3c03d86cebb42c8f30e373cb7f623.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 32,
-                    "rotationCenterY": 95
-                },
-                {
-                    "costumeName": "devin-d",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "fa6a75afb0e4b822b91d8bb20d40c68f.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 41,
-                    "rotationCenterY": 95
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Dinosaur1",
-        "md5": "286094ffce382c8383519ab896711989.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            7,
-            1
-        ],
-        "json": {
-            "objName": "Dinoaur1",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "dinosaur1-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "286094ffce382c8383519ab896711989.svg",
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 84
-                },
-                {
-                    "costumeName": "dinosaur1-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "d9eca17b8569f2cde20ef7d3ed0fe19f.svg",
-                    "rotationCenterX": 116,
-                    "rotationCenterY": 79
-                },
-                {
-                    "costumeName": "dinosaur1-c",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "ade3d2ec5029693ecdcca17974bad5fd.svg",
-                    "rotationCenterX": 65,
-                    "rotationCenterY": 89
-                },
-                {
-                    "costumeName": "dinosaur1-d",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "2aa7257a3e0a19ee315b23eaf7f56933.svg",
-                    "rotationCenterX": 45,
-                    "rotationCenterY": 87
-                },
-                {
-                    "costumeName": "dinosaur1-e",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "ed46ee11478715f7596d01fb0f98aa3f.svg",
-                    "rotationCenterX": 82,
-                    "rotationCenterY": 84
-                },
-                {
-                    "costumeName": "dinosaur1-f",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "39caf2473b1eee55edb688cfa3c240c7.svg",
-                    "rotationCenterX": 69,
-                    "rotationCenterY": 76
-                },
-                {
-                    "costumeName": "dinosaur1-g",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "f0f2aa4e8e015de497050d8d44bbfbf1.svg",
-                    "rotationCenterX": 68,
-                    "rotationCenterY": 72
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Dinosaur2",
-        "md5": "ae724a0a6d6e0a2b33dded4140219fb0.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Dinosaur2",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "dinosaur2-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "ae724a0a6d6e0a2b33dded4140219fb0.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                },
-                {
-                    "costumeName": "dinosaur2-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "a01d31caaab3b14b9bb0e2cd5a86c70c.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 67,
-                    "rotationCenterY": 67
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Dinosaur3",
-        "md5": "79bb51bbf809b412147f2a196f8c9292.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Dinosaur3",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "dinosaur3",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "79bb51bbf809b412147f2a196f8c9292.svg",
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Diver1",
-        "md5": "853803d5600b66538474909c5438c8ee.svg",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "underwater",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Diver1",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "diver1",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "853803d5600b66538474909c5438c8ee.svg",
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Diver2",
-        "md5": "248d3e69ada69a64b1077149ef6a931a.svg",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "underwater",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Diver2",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "diver2",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "248d3e69ada69a64b1077149ef6a931a.svg",
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Dog1",
-        "md5": "39ddefa0cc58f3b1b06474d63d81ef56.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "drawing",
-            "walking",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Dog1",
-            "sounds": [
-                {
-                    "soundName": "dog1",
-                    "soundID": -1,
-                    "md5": "b15adefc3c12f758b6dc6a045362532f.wav",
-                    "sampleCount": 3672,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "dog1-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "39ddefa0cc58f3b1b06474d63d81ef56.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 83,
-                    "rotationCenterY": 80
-                },
-                {
-                    "costumeName": "dog1-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "598f4aa3d8f671375d1d2b3acf753416.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 83,
-                    "rotationCenterY": 80
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Dog2",
-        "md5": "e921f865b19b27cd99e16a341dbf09c2.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "drawing",
-            "walking",
-            "vector"
-        ],
-        "info": [
-            0,
-            3,
-            1
-        ],
-        "json": {
-            "objName": "Dog2",
-            "sounds": [
-                {
-                    "soundName": "dog1",
-                    "soundID": -1,
-                    "md5": "b15adefc3c12f758b6dc6a045362532f.wav",
-                    "sampleCount": 3672,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "dog2-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "e921f865b19b27cd99e16a341dbf09c2.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                },
-                {
-                    "costumeName": "dog2-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "891f2fb7daf79ba8b224a9173eeb0a63.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                },
-                {
-                    "costumeName": "dog2-c",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "cd236d5eef4431dea82983ac9eec406b.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 0.75,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Dog Puppy",
-        "md5": "fd6c2d1d10a163bc5b7458f7275750f0.png",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "photo",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            4,
-            1
-        ],
-        "json": {
-            "objName": "Dog Puppy",
-            "sounds": [
-                {
-                    "soundName": "dog2",
-                    "soundID": -1,
-                    "md5": "cd8fa8390b0efdd281882533fbfcfcfb.wav",
-                    "sampleCount": 3168,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "dog puppy right",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "fd6c2d1d10a163bc5b7458f7275750f0.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 107,
-                    "rotationCenterY": 103
-                },
-                {
-                    "costumeName": "dog puppy sit",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "00b1589467f939b9c61f666bca2d25d1.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 87,
-                    "rotationCenterY": 112
-                },
-                {
-                    "costumeName": "dog puppy side",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "63c3d6718943ecbf48f94b3b131ae8a4.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 104,
-                    "rotationCenterY": 114
-                },
-                {
-                    "costumeName": "dog puppy back",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "88559ad0334a8a51aca31035068682f6.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 234,
-                    "rotationCenterY": 94
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Donut",
-        "md5": "9e7b4d153421dae04a24571d7e079e85.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Donut",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "donut",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "9e7b4d153421dae04a24571d7e079e85.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 73,
-                    "rotationCenterY": 15
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Dove1",
-        "md5": "6dde2b880ad6ddeaea2a53821befb86d.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "holiday",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Dove1",
-            "sounds": [
-                {
-                    "soundName": "bird",
-                    "soundID": -1,
-                    "md5": "18bd4b634a3f992a16b30344c7d810e0.wav",
-                    "sampleCount": 3840,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "dove1-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "6dde2b880ad6ddeaea2a53821befb86d.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 86,
-                    "rotationCenterY": 59
-                },
-                {
-                    "costumeName": "dove1-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "1c0bc118044d7f6033bc9cd1ef555590.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 88,
-                    "rotationCenterY": 57
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Dove2",
-        "md5": "42251c2649a073052eb4261d644281bb.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "holiday",
-            "flying",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Dove2",
-            "sounds": [
-                {
-                    "soundName": "bird",
-                    "soundID": -1,
-                    "md5": "18bd4b634a3f992a16b30344c7d810e0.wav",
-                    "sampleCount": 3840,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "dove2-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "42251c2649a073052eb4261d644281bb.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 99,
-                    "rotationCenterY": 83
-                },
-                {
-                    "costumeName": "dove2-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "469eb55a437364d831b80937c4ee1ab9.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 100,
-                    "rotationCenterY": 82
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Dragon",
-        "md5": "ee0082b436d6d5dc3de33047166e7bf2.svg",
-        "type": "sprite",
-        "tags": [
-            "fantasy",
-            "drawing",
-            "flying",
-            "castle",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            0
-        ],
-        "json": {
-            "objName": "Dragon",
-            "costumes": [
-                {
-                    "costumeName": "dragon1-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "ee0082b436d6d5dc3de33047166e7bf2.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 65,
-                    "rotationCenterY": 60
-                },
-                {
-                    "costumeName": "dragon1-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "bb58ce36997fa205a86a085f202837fd.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 84,
-                    "rotationCenterY": 56
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Drum-Bass",
-        "md5": "3308e038214f5a4adc53076a9fee9021.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "music",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            3
-        ],
-        "json": {
-            "objName": "Drum-Bass",
-            "sounds": [
-                {
-                    "soundName": "drum bass1",
-                    "soundID": -1,
-                    "md5": "48328c874353617451e4c7902cc82817.wav",
-                    "sampleCount": 6528,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "drum bass2",
-                    "soundID": -1,
-                    "md5": "711a1270d1cf2e5de9b145ee539213e4.wav",
-                    "sampleCount": 3791,
-                    "rate": 22050,
-                    "format": "adpcm"
-                },
-                {
-                    "soundName": "drum bass3",
-                    "soundID": -1,
-                    "md5": "c21704337b16359ea631b5f8eb48f765.wav",
-                    "sampleCount": 8576,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "drum bass-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "3308e038214f5a4adc53076a9fee9021.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 36,
-                    "rotationCenterY": 46
-                },
-                {
-                    "costumeName": "drum bass-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "5febb3df727fb6624946e807a665b866.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 36,
-                    "rotationCenterY": 46
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Drum-Conga",
-        "md5": "b3da94523b6d3df2dd30602399599ab4.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "music",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            4
-        ],
-        "json": {
-            "objName": "Drum-Conga",
-            "sounds": [
-                {
-                    "soundName": "high conga",
-                    "soundID": -1,
-                    "md5": "16144544de90e98a92a265d4fc3241ea.wav",
-                    "sampleCount": 8192,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "low conga",
-                    "soundID": -1,
-                    "md5": "0b6f94487cd8a1cf0bb77e15966656c3.wav",
-                    "sampleCount": 8384,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "muted conga",
-                    "soundID": -1,
-                    "md5": "1d4abbe3c9bfe198a88badb10762de75.wav",
-                    "sampleCount": 4544,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "tap conga",
-                    "soundID": -1,
-                    "md5": "fd9a67157f57f9cc6fe3cdce38a6d4a8.wav",
-                    "sampleCount": 6880,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "drums conga-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "b3da94523b6d3df2dd30602399599ab4.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 51,
-                    "rotationCenterY": 51
-                },
-                {
-                    "costumeName": "drums conga-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "d4398062ed6e09927ab52823255186d3.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 52,
-                    "rotationCenterY": 79
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Drum-Snare",
-        "md5": "868f700de73a35c4d6fa4c93507c348d.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "music",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            3
-        ],
-        "json": {
-            "objName": "Drum-Snare",
-            "sounds": [
-                {
-                    "soundName": "tap snare",
-                    "soundID": -1,
-                    "md5": "d55b3954d72c6275917f375e49b502f3.wav",
-                    "sampleCount": 3296,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "sidestick snare",
-                    "soundID": -1,
-                    "md5": "f6868ee5cf626fc4ef3ca1119dc95592.wav",
-                    "sampleCount": 2336,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "flam snare",
-                    "soundID": -1,
-                    "md5": "3b6cce9f8c56c0537ca61eee3945cd1d.wav",
-                    "sampleCount": 4416,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "drum snare-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "868f700de73a35c4d6fa4c93507c348d.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 51,
-                    "rotationCenterY": 37
-                },
-                {
-                    "costumeName": "drum snare-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "93738cb485ef57cbd4b9bff386d0bba2.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 57,
-                    "rotationCenterY": 59
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Drum-Tabla",
-        "md5": "68ce53b53fcc68744584c28d20144c4f.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "music",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            4
-        ],
-        "json": {
-            "objName": "Drum-Tabla",
-            "sounds": [
-                {
-                    "soundName": "hi na tabla",
-                    "soundID": -1,
-                    "md5": "35b42d98c43404a5b1b52fb232a62bd7.wav",
-                    "sampleCount": 4096,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "hi tun tabla",
-                    "soundID": -1,
-                    "md5": "da734693dfa6a9a7eccdc7f9a0ca9840.wav",
-                    "sampleCount": 18656,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "lo gliss tabla",
-                    "soundID": -1,
-                    "md5": "d7cd24689737569c93e7ea7344ba6b0e.wav",
-                    "sampleCount": 7008,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "lo geh tabla",
-                    "soundID": -1,
-                    "md5": "9205359ab69d042ed3da8a160a651690.wav",
-                    "sampleCount": 30784,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "tabla-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "68ce53b53fcc68744584c28d20144c4f.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 45
-                },
-                {
-                    "costumeName": "tabla-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "01b6ffb8691d32be10fabc77ddfb55b0.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 78,
-                    "rotationCenterY": 48
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Drum1",
-        "md5": "daad8bc865f55200844dbce476d2f1e9.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "music",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            2
-        ],
-        "json": {
-            "objName": "Drum1",
-            "sounds": [
-                {
-                    "soundName": "high tom",
-                    "soundID": -1,
-                    "md5": "d623f99b3c8d33932eb2c6c9cfd817c5.wav",
-                    "sampleCount": 12320,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "low tom",
-                    "soundID": -1,
-                    "md5": "1569bbbd8952b0575e5a5cb5aefb50ba.wav",
-                    "sampleCount": 20000,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "drum1-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "daad8bc865f55200844dbce476d2f1e9.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 49,
-                    "rotationCenterY": 44
-                },
-                {
-                    "costumeName": "drum1-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "8a2e9596b02ecdc195d76c1f34a48f76.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 60,
-                    "rotationCenterY": 61
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Drum2",
-        "md5": "68baa189ac7afb9426db1818aa88be8e.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "music",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            2
-        ],
-        "json": {
-            "objName": "Drum2",
-            "sounds": [
-                {
-                    "soundName": "high tom",
-                    "soundID": -1,
-                    "md5": "d623f99b3c8d33932eb2c6c9cfd817c5.wav",
-                    "sampleCount": 12320,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "low tom",
-                    "soundID": -1,
-                    "md5": "1569bbbd8952b0575e5a5cb5aefb50ba.wav",
-                    "sampleCount": 20000,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "drum2-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "68baa189ac7afb9426db1818aa88be8e.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 47,
-                    "rotationCenterY": 39
-                },
-                {
-                    "costumeName": "drum2-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "4a58fe0f173104aab03aaccdd3ce5280.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 47,
-                    "rotationCenterY": 54
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Duck",
-        "md5": "c3baf7eedfbdac8cd1e4f1f1f779dc0c.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Duck",
-            "sounds": [
-                {
-                    "soundName": "duck",
-                    "soundID": -1,
-                    "md5": "af5b039e1b05e0ccb12944f648a8884e.wav",
-                    "sampleCount": 5792,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "duck",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "c3baf7eedfbdac8cd1e4f1f1f779dc0c.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 61,
-                    "rotationCenterY": 59
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Earth",
-        "md5": "814197522984a302972998b1a7f92d91.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "space",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Earth",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "earth",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "814197522984a302972998b1a7f92d91.svg",
-                    "rotationCenterX": 72,
-                    "rotationCenterY": 72
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Elephant",
-        "md5": "b3515b3805938b0fae4e527aa0b4524e.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "drawing",
-            "nature",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Elephant",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "elephant-a ",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "b3515b3805938b0fae4e527aa0b4524e.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 107,
-                    "rotationCenterY": 33
-                },
-                {
-                    "costumeName": "elephant-b ",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "bce91fa266220d3679a4c19c4e38b1f7.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 95,
-                    "rotationCenterY": 40
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Fire hydrant",
-        "md5": "5542c53bb0ba87b39eba6ff743b8115c.png",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "photo",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Fire hydrant",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "fire hydrant",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "5542c53bb0ba87b39eba6ff743b8115c.png",
-                    "rotationCenterX": 40,
-                    "rotationCenterY": 83
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Fish1",
-        "md5": "df78f8195f72372846d96dc70cb0ad95.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "drawing",
-            "underwater",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Fish1",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "fish1",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "df78f8195f72372846d96dc70cb0ad95.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Fish2",
-        "md5": "f3dd9cb79cce497a90900241cf726367.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "drawing",
-            "underwater",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Fish2",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "fish2",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "f3dd9cb79cce497a90900241cf726367.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Fish3",
-        "md5": "aec949cefb15ddd1330f3b633734d4d3.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "drawing",
-            "underwater",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Fish3",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "fish3",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "aec949cefb15ddd1330f3b633734d4d3.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Flower Shape",
-        "md5": "7905272bf89ee61cd9d3680a67732815.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Flower Shape",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "flower shape",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "7905272bf89ee61cd9d3680a67732815.svg",
-                    "rotationCenterX": 39,
-                    "rotationCenterY": 41
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Football",
-        "md5": "422b34b6e5a2fdb8d0ac00aca91ec714.png",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "sports",
-            "photo",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Football",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "football running",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "422b34b6e5a2fdb8d0ac00aca91ec714.png",
-                    "rotationCenterX": 47,
-                    "rotationCenterY": 100
-                },
-                {
-                    "costumeName": "football standing",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "1f57154842f68aa55577edc90a6f2b32.png",
-                    "rotationCenterX": 37,
-                    "rotationCenterY": 100
-                }
-            ],
-            "currentCostumeIndex": 1,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Fortune Cookie",
-        "md5": "d47f0be24acf78130af2e03572a3f9d3.png",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "photo",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Fortune Cookie",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "fortunecookie",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "d47f0be24acf78130af2e03572a3f9d3.png",
-                    "rotationCenterX": 30,
-                    "rotationCenterY": 31
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Fox",
-        "md5": "dd19959dc4d453813299f496124d50ff.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Fox",
-            "sounds": [
-                {
-                    "soundName": "meow",
-                    "soundID": -1,
-                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
-                    "sampleCount": 18688,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "fox",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "dd19959dc4d453813299f496124d50ff.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Frog",
-        "md5": "285483a688eed2ff8010c65112f99c41.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Frog",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "frog",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "285483a688eed2ff8010c65112f99c41.svg",
-                    "rotationCenterX": 48,
-                    "rotationCenterY": 30
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Fruit Platter",
-        "md5": "c6e2f673debcff91de8e3749ddf674b9.png",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "photo",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Fruit Platter",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "fruit_platter",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "c6e2f673debcff91de8e3749ddf674b9.png",
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 40
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Fruit Salad",
-        "md5": "dbf8cc34f7ca18b4a008d2890dba56b7.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Fruit Salad",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "fruitsalad",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "dbf8cc34f7ca18b4a008d2890dba56b7.svg",
-                    "rotationCenterX": 30,
-                    "rotationCenterY": 22
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Ghost1",
-        "md5": "c88579c578f2d171de78612f2ff9c9d9.svg",
-        "type": "sprite",
-        "tags": [
-            "fantasy",
-            "drawing",
-            "castle",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Ghost1",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "ghost1 ",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "c88579c578f2d171de78612f2ff9c9d9.svg",
-                    "rotationCenterX": 60,
-                    "rotationCenterY": 63
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Ghost2",
-        "md5": "607be245da950af1a4e4d79acfda46e3.svg",
-        "type": "sprite",
-        "tags": [
-            "fantasy",
-            "drawing",
-            "castle",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Ghost2",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "ghost2-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "607be245da950af1a4e4d79acfda46e3.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                },
-                {
-                    "costumeName": "ghost2-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "b9e2ebbe17c617ac182abd8bc1627693.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Ghoul",
-        "md5": "70ef3e78079cf4a1c9abf32b5d982b71.svg",
-        "type": "sprite",
-        "tags": [
-            "fantasy",
-            "drawing",
-            "castle",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Ghoul",
-            "sounds": [
-                {
-                    "soundName": "meow",
-                    "soundID": -1,
-                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
-                    "sampleCount": 18688,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "ghoul-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "70ef3e78079cf4a1c9abf32b5d982b71.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                },
-                {
-                    "costumeName": "ghoul-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "6e962f1248f7a7201eb24d376d804093.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                }
-            ],
-            "currentCostumeIndex": 1,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Gift",
-        "md5": "abeae2217b3ce67b1ff761cd7a89274d.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "holiday",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            0
-        ],
-        "json": {
-            "objName": "Gift",
-            "costumes": [
-                {
-                    "costumeName": "gift-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "abeae2217b3ce67b1ff761cd7a89274d.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 33,
-                    "rotationCenterY": 25
-                },
-                {
-                    "costumeName": "gift-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "5cae973c98f2d98b51e6c6b3c9602f8c.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 33,
-                    "rotationCenterY": 26
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Giga",
-        "md5": "93cb048a1d199f92424b9c097fa5fa38.svg",
-        "type": "sprite",
-        "tags": [
-            "fantasy",
-            "space",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            4,
-            1
-        ],
-        "json": {
-            "objName": "Giga",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "giga-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "93cb048a1d199f92424b9c097fa5fa38.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 72,
-                    "rotationCenterY": 96
-                },
-                {
-                    "costumeName": "giga-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "528613711a7eae3a929025be04db081c.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 72,
-                    "rotationCenterY": 96
-                },
-                {
-                    "costumeName": "giga-c",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "ee4dd21d7ca6d1b889ee25d245cbcc66.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 73,
-                    "rotationCenterY": 96
-                },
-                {
-                    "costumeName": "giga-d",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "7708e2d9f83a01476ee6d17aa540ddf1.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 73,
-                    "rotationCenterY": 96
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Giga walking",
-        "md5": "f76bc420011db2cdb2de378c1536f6da.svg",
-        "type": "sprite",
-        "tags": [
-            "fantasy",
-            "space",
-            "drawing",
-            "walking",
-            "vector"
-        ],
-        "info": [
-            0,
-            4,
-            1
-        ],
-        "json": {
-            "objName": "Giga walking",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "Giga walk1",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "f76bc420011db2cdb2de378c1536f6da.svg",
-                    "rotationCenterX": 70,
-                    "rotationCenterY": 107
-                },
-                {
-                    "costumeName": "Giga walk2",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "43b5874e8a54f93bd02727f0abf6905b.svg",
-                    "rotationCenterX": 71,
-                    "rotationCenterY": 107
-                },
-                {
-                    "costumeName": "Giga walk3",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "9aab3bbb375765391978be4f6d478ab3.svg",
-                    "rotationCenterX": 71,
-                    "rotationCenterY": 107
-                },
-                {
-                    "costumeName": "Giga walk4",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "22e4ae40919cf0fe6b4d7649d14a6e71.svg",
-                    "rotationCenterX": 73,
-                    "rotationCenterY": 110
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Glass Water",
-        "md5": "c364b9e1f4bcdc61705032d89eaaa0a1.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Glass Water",
-            "sounds": [
-                {
-                    "soundName": "water drop",
-                    "soundID": -1,
-                    "md5": "aa488de9e2c871e9d4faecd246ed737a.wav",
-                    "sampleCount": 8136,
-                    "rate": 22050,
-                    "format": "adpcm"
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "glass water-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "c364b9e1f4bcdc61705032d89eaaa0a1.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 39,
-                    "rotationCenterY": 48
-                },
-                {
-                    "costumeName": "glass water-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "bc07ce6a2004ac91ce704531a1c526e5.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 39,
-                    "rotationCenterY": 48
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 0.6,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Glasses",
-        "md5": "5fcf716b53f223bc86b10ab0eca3e162.svg",
-        "type": "sprite",
-        "tags": [
-            "dress-up",
-            "things",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Glasses",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "glasses",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "5fcf716b53f223bc86b10ab0eca3e162.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 16,
-                    "rotationCenterY": 9
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": true,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Gobo",
-        "md5": "1f5ea0d12f85aed2e471cdd21b0bd6d7.svg",
-        "type": "sprite",
-        "tags": [
-            "fantasy",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            3,
-            1
-        ],
-        "json": {
-            "objName": "Gobo",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "gobo-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "1f5ea0d12f85aed2e471cdd21b0bd6d7.svg",
-                    "rotationCenterX": 47,
-                    "rotationCenterY": 55
-                },
-                {
-                    "costumeName": "gobo-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "73e493e4abd5d0954b677b97abcb7116.svg",
-                    "rotationCenterX": 47,
-                    "rotationCenterY": 55
-                },
-                {
-                    "costumeName": "gobo-c",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "bc68a6bdf300df7b53d73b38f74c844e.svg",
-                    "rotationCenterX": 47,
-                    "rotationCenterY": 55
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Green Flag",
-        "md5": "173e20ac537d2c278ed621be3db3fc87.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "vector",
-            "drawing"
-        ],
-        "info": [
-            0,
-            1,
-            0
-        ],
-        "json": {
-            "objName": "Green Flag",
-            "costumes": [
-                {
-                    "costumeName": "green flag",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "173e20ac537d2c278ed621be3db3fc87.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 70,
-                    "rotationCenterY": 30
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Guitar",
-        "md5": "dfa85e2a962b725ee53f61cea2edc1fb.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "music",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            8
-        ],
-        "json": {
-            "objName": "Guitar",
-            "sounds": [
-                {
-                    "soundName": "C guitar",
-                    "soundID": -1,
-                    "md5": "22baa07795a9a524614075cdea543793.wav",
-                    "sampleCount": 44864,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "D guitar",
-                    "soundID": -1,
-                    "md5": "2dbcfae6a55738f94bbb40aa5fcbf7ce.wav",
-                    "sampleCount": 41120,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "E guitar",
-                    "soundID": -1,
-                    "md5": "4b5d1da83e59bf35578324573c991666.wav",
-                    "sampleCount": 38400,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "F guitar",
-                    "soundID": -1,
-                    "md5": "b51d086aeb1921ec405561df52ecbc50.wav",
-                    "sampleCount": 36416,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "G guitar",
-                    "soundID": -1,
-                    "md5": "98a835713ecea2f3ef9f4f442d52ad20.wav",
-                    "sampleCount": 33600,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "A guitar",
-                    "soundID": -1,
-                    "md5": "ee753e87d212d4b2fb650ca660f1e839.wav",
-                    "sampleCount": 31872,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "B guitar",
-                    "soundID": -1,
-                    "md5": "2ae2d67de62df8ca54d638b4ad2466c3.wav",
-                    "sampleCount": 29504,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "C2 guitar",
-                    "soundID": -1,
-                    "md5": "c8d2851bd99d8e0ce6c1f05e4acc7f34.wav",
-                    "sampleCount": 27712,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "guitar",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "dfa85e2a962b725ee53f61cea2edc1fb.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 37,
-                    "rotationCenterY": 98
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Guitar-Bass",
-        "md5": "83cf122ec4a291e2a17910f718b583a5.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "music",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            8
-        ],
-        "json": {
-            "objName": "Guitar-Bass",
-            "sounds": [
-                {
-                    "soundName": "C elec bass",
-                    "soundID": -1,
-                    "md5": "69eee3d038ea0f1c34ec9156a789236d.wav",
-                    "sampleCount": 5216,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "D elec bass",
-                    "soundID": -1,
-                    "md5": "67a6d1aa68233a2fa641aee88c7f051f.wav",
-                    "sampleCount": 5568,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "E elec bass",
-                    "soundID": -1,
-                    "md5": "0704b8ceabe54f1dcedda8c98f1119fd.wav",
-                    "sampleCount": 5691,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "F elec bass",
-                    "soundID": -1,
-                    "md5": "45eedb4ce62a9cbbd2207824b94a4641.wav",
-                    "sampleCount": 5312,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "G elec bass",
-                    "soundID": -1,
-                    "md5": "97b187d72219b994a6ef6a5a6b09605c.wav",
-                    "sampleCount": 5568,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "A elec bass",
-                    "soundID": -1,
-                    "md5": "5cb46ddd903fc2c9976ff881df9273c9.wav",
-                    "sampleCount": 5920,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "B elec bass",
-                    "soundID": -1,
-                    "md5": "5a0701d0a914223b5288300ac94e90e4.wav",
-                    "sampleCount": 6208,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "C2 elec bass",
-                    "soundID": -1,
-                    "md5": "56fc995b8860e713c5948ecd1c2ae572.wav",
-                    "sampleCount": 5792,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "guitar bass",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "83cf122ec4a291e2a17910f718b583a5.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 53,
-                    "rotationCenterY": 145
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Guitar-Electric",
-        "md5": "18d7b47368ba1ead0d1ca436b8369211.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "music",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            8
-        ],
-        "json": {
-            "objName": "Guitar-Electric",
-            "sounds": [
-                {
-                    "soundName": "C elec guitar",
-                    "soundID": -1,
-                    "md5": "0d340de02e14bebaf8dfa0e43eb3f1f9.wav",
-                    "sampleCount": 44100,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "D elec guitar",
-                    "soundID": -1,
-                    "md5": "1b5de9866801eb2f9d4f57c7c3b473f5.wav",
-                    "sampleCount": 44100,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "E elec guitar",
-                    "soundID": -1,
-                    "md5": "2e6a6ae3e0f72bf78c74def8130f459a.wav",
-                    "sampleCount": 44100,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "F elec guitar",
-                    "soundID": -1,
-                    "md5": "5eb00f15f21f734986aa45156d44478d.wav",
-                    "sampleCount": 44100,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "G elec guitar",
-                    "soundID": -1,
-                    "md5": "cd0d0e7dad415b2ffa2ba7a61860eaf8.wav",
-                    "sampleCount": 44100,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "A elec guitar",
-                    "soundID": -1,
-                    "md5": "fa5f7fea601e9368dd68449d9a54c995.wav",
-                    "sampleCount": 44100,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "B elec guitar",
-                    "soundID": -1,
-                    "md5": "81f142d0b00189703d7fe9b1f13f6f87.wav",
-                    "sampleCount": 44100,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "C2 elec guitar",
-                    "soundID": -1,
-                    "md5": "3a8ed3129f22cba5b0810bc030d16b5f.wav",
-                    "sampleCount": 44100,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "guitar electric",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "18d7b47368ba1ead0d1ca436b8369211.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 37,
-                    "rotationCenterY": 114
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Hannah",
-        "md5": "b983d99560313e38b4b3cd36cbd5f0d1.png",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "city",
-            "drawing",
-            "bitmap",
-            "sports"
-        ],
-        "info": [
-            0,
-            3,
-            1
-        ],
-        "json": {
-            "objName": "Hannah",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "hannah-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "b983d99560313e38b4b3cd36cbd5f0d1.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 138,
-                    "rotationCenterY": 126
-                },
-                {
-                    "costumeName": "hannah-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "d0c3b4b24fbf1152de3ebb68f6b875ae.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 48,
-                    "rotationCenterY": 160
-                },
-                {
-                    "costumeName": "hannah-c",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "5fdce07935156bbcf943793fa84e826c.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 170,
-                    "rotationCenterY": 130
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Hat",
-        "md5": "b3beb1f52d371428d70b65a0c4c5c001.svg",
-        "type": "sprite",
-        "tags": [
-            "dress-up",
-            "things",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Hat",
-            "sounds": [
-                {
-                    "soundName": "meow",
-                    "soundID": -1,
-                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
-                    "sampleCount": 18688,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "Hat",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "b3beb1f52d371428d70b65a0c4c5c001.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 52,
-                    "rotationCenterY": 60
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": true,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Hat Beanie",
-        "md5": "3271da33e4108ed08a303c2244739fbf.svg",
-        "type": "sprite",
-        "tags": [
-            "dress-up",
-            "things",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Hat Beanie",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "hat beanie",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "3271da33e4108ed08a303c2244739fbf.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 28,
-                    "rotationCenterY": 19
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": true,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Hat Party1",
-        "md5": "70a7f535d8857cf9175492415361c361.svg",
-        "type": "sprite",
-        "tags": [
-            "dress-up",
-            "things",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Hat Party1",
-            "sounds": [
-                {
-                    "soundName": "meow",
-                    "soundID": -1,
-                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
-                    "sampleCount": 18688,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "partyhat1",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "70a7f535d8857cf9175492415361c361.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Hat Party2",
-        "md5": "9b7a84fe3e50621752917e4e484a1e2f.svg",
-        "type": "sprite",
-        "tags": [
-            "dress-up",
-            "things",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Hat Party2",
-            "sounds": [
-                {
-                    "soundName": "meow",
-                    "soundID": -1,
-                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
-                    "sampleCount": 18688,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "hat party2-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "9b7a84fe3e50621752917e4e484a1e2f.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Hat Winter",
-        "md5": "6c2ee1b97f6ec2b3457a25a3975a2009.svg",
-        "type": "sprite",
-        "tags": [
-            "dress-up",
-            "things",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            2
-        ],
-        "json": {
-            "objName": "Hat Winter",
-            "sounds": [
-                {
-                    "soundName": "meow",
-                    "soundID": -1,
-                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
-                    "sampleCount": 18688,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "xylo3",
-                    "soundID": -1,
-                    "md5": "3395cade6d7c0cc9ce73a8c12f40319b.wav",
-                    "sampleCount": 209502,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "hat winter",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "6c2ee1b97f6ec2b3457a25a3975a2009.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 26,
-                    "rotationCenterY": 101
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 0.9,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Hat Wizard",
-        "md5": "581571e8c8f5adeb01565e12b1b77b58.svg",
-        "type": "sprite",
-        "tags": [
-            "dress-up",
-            "fantasy",
-            "things",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Hat Wizard",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "hat wizard",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "581571e8c8f5adeb01565e12b1b77b58.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 76,
-                    "rotationCenterY": 69
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Headband",
-        "md5": "961148d1605a1bd8ce80ed8d39e831c2.svg",
-        "type": "sprite",
-        "tags": [
-            "dress-up",
-            "things",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Headband",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "headband",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "961148d1605a1bd8ce80ed8d39e831c2.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 53,
-                    "rotationCenterY": 43
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": true,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Heart",
-        "md5": "6e79e087c866a016f99ee482e1aeba47.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "flying",
-            "holiday",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Heart",
-            "sounds": [
-                {
-                    "soundName": "tom drum",
-                    "soundID": -1,
-                    "md5": "ca350a536d60bb8ed50f24677d65eed8.wav",
-                    "sampleCount": 33920,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "heart red",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "6e79e087c866a016f99ee482e1aeba47.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 65,
-                    "rotationCenterY": 56
-                },
-                {
-                    "costumeName": "heart purple",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "b15362bb6b02a59e364db9081ccf19aa.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 66,
-                    "rotationCenterY": 62
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 0.55,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Heart Candy",
-        "md5": "d448acd247f10f32bef7823cd433f928.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "holiday",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            4,
-            1
-        ],
-        "json": {
-            "objName": "Heart Candy",
-            "sounds": [
-                {
-                    "soundName": "tom drum",
-                    "soundID": -1,
-                    "md5": "ca350a536d60bb8ed50f24677d65eed8.wav",
-                    "sampleCount": 33920,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "heart love it",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "d448acd247f10f32bef7823cd433f928.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 58,
-                    "rotationCenterY": 61
-                },
-                {
-                    "costumeName": "heart code",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "497c5df9e02467202ff93096dccaf91f.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 58,
-                    "rotationCenterY": 61
-                },
-                {
-                    "costumeName": "heart sweet",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "a39d78d33b051e8b12a4b2a10d77b249.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 58,
-                    "rotationCenterY": 61
-                },
-                {
-                    "costumeName": "heart smile",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "74a8f75d139d330b715787edbbacd83d.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 58,
-                    "rotationCenterY": 61
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 0.55,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Heart Face",
-        "md5": "4ab84263da32069cf97cc0fa52729a0d.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "holiday",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Heart Face",
-            "sounds": [
-                {
-                    "soundName": "tom drum",
-                    "soundID": -1,
-                    "md5": "ca350a536d60bb8ed50f24677d65eed8.wav",
-                    "sampleCount": 33920,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "heart face",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "4ab84263da32069cf97cc0fa52729a0d.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 59,
-                    "rotationCenterY": 52
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 0.55,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Heart Scratch",
-        "md5": "2bfa5c3b41d4be160ab0c157ce0f96a9.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "holiday",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Heart Scratch",
-            "sounds": [
-                {
-                    "soundName": "dance snare beat",
-                    "soundID": -1,
-                    "md5": "562587bdb75e3a8124cdaa46ba0f648b.wav",
-                    "sampleCount": 176401,
-                    "rate": 22050,
-                    "format": "adpcm"
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "heart scratch",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "2bfa5c3b41d4be160ab0c157ce0f96a9.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 81,
-                    "rotationCenterY": 77
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 0.55,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Helicopter",
-        "md5": "8847e2d3383906dbabbf7ffa98945a7b.png",
-        "type": "sprite",
-        "tags": [
-            "transportation",
-            "flying",
-            "city",
-            "drawing",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Helicopter",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "helicopter",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "8847e2d3383906dbabbf7ffa98945a7b.png",
-                    "rotationCenterX": 90,
-                    "rotationCenterY": 64
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Hippo1",
-        "md5": "c1353c4a5eec5e6f32ed053e6f6e8f99.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "flying",
-            "fantasy",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Hippo1",
-            "sounds": [
-                {
-                    "soundName": "meow",
-                    "soundID": -1,
-                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
-                    "sampleCount": 18688,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "hippo1-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "c1353c4a5eec5e6f32ed053e6f6e8f99.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 69,
-                    "rotationCenterY": 65
-                },
-                {
-                    "costumeName": "hippo1-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "e65ed93bbb9cccf698fc7e774ab609a6.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 69,
-                    "rotationCenterY": 68
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Holly",
-        "md5": "1d8583ca1b5c687f3de004c27110a130.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "holiday",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Holly",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "holly1",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "1d8583ca1b5c687f3de004c27110a130.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 29,
-                    "rotationCenterY": 44
-                },
-                {
-                    "costumeName": "holly2",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "4b23f1d694ae8b400f1d7216dd8e49bc.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 27,
-                    "rotationCenterY": 42
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Home Button",
-        "md5": "1bac530a0701a8fc88bb0802ae6787a3.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Home Button",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "home button",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "1bac530a0701a8fc88bb0802ae6787a3.svg",
-                    "rotationCenterX": 72,
-                    "rotationCenterY": 72
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Horse1",
-        "md5": "32f4d80477cd070cb0848e555d374060.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "transportation",
-            "vector",
-            "drawing"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Horse1",
-            "sounds": [
-                {
-                    "soundName": "meow",
-                    "soundID": -1,
-                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
-                    "sampleCount": 18688,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "horse1-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "32f4d80477cd070cb0848e555d374060.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 119,
-                    "rotationCenterY": 83
-                },
-                {
-                    "costumeName": "horse1-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "ffa6431c5ef2a4e975ecffacdb0efea7.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 103,
-                    "rotationCenterY": 97
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Jaime",
-        "md5": "3ddc912edef87ae29121f57294fa0cb5.png",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "city",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Jaime",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "jaime-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "3ddc912edef87ae29121f57294fa0cb5.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 76,
-                    "rotationCenterY": 154
-                },
-                {
-                    "costumeName": "jaime-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "5a683f4536abca0f83a77bc341df4c9a.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 68,
-                    "rotationCenterY": 154
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Jaime Walking",
-        "md5": "d6cc9814f7a6640e4c2b1a4276987dc5.png",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "city",
-            "walking",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            5,
-            1
-        ],
-        "json": {
-            "objName": "Jaime Walking",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "jaime walking-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "d6cc9814f7a6640e4c2b1a4276987dc5.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 106,
-                    "rotationCenterY": 172
-                },
-                {
-                    "costumeName": "jaime walking-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "7fb579a98d6db257f1b16109d3c4609a.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 52,
-                    "rotationCenterY": 176
-                },
-                {
-                    "costumeName": "jaime walking-c",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "5883bdefba451aaeac8d77c798d41eb0.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 88,
-                    "rotationCenterY": 170
-                },
-                {
-                    "costumeName": "jaime walking-d",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "4b9d2162e30dbb924840575ed35fddb0.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 46,
-                    "rotationCenterY": 174
-                },
-                {
-                    "costumeName": "jaime walking-e",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "63e56d28cc3e3d9b735e1f1d51248cc0.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 84,
-                    "rotationCenterY": 172
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Jay",
-        "md5": "cf32a87b2c9d7c2553f5a1ed17966504.gif",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "city",
-            "photo",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Jay",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "jay",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "cf32a87b2c9d7c2553f5a1ed17966504.gif",
-                    "rotationCenterX": 70,
-                    "rotationCenterY": 100
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Jeans",
-        "md5": "4e283da8c59bcbb9803bdc0016b14c21.svg",
-        "type": "sprite",
-        "tags": [
-            "dress-up",
-            "things",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Jeans",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "jeans-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "4e283da8c59bcbb9803bdc0016b14c21.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 22,
-                    "rotationCenterY": 25
-                },
-                {
-                    "costumeName": "jeans-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "01732aa03a48482093fbed3ea402c4a9.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 22,
-                    "rotationCenterY": 25
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": true,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Jodi",
-        "md5": "a8ae8b69caa6a837f49aa950055ef29a.gif",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "sports",
-            "photo",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Jodi",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "jodi",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "a8ae8b69caa6a837f49aa950055ef29a.gif",
-                    "rotationCenterX": 54,
-                    "rotationCenterY": 75
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Jouvi Hip-Hop",
-        "md5": "cb4bf65491eaa9e8aeb1c1fdfe37e84a.png",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "dance",
-            "city",
-            "photo",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            13,
-            1
-        ],
-        "json": {
-            "objName": "Jouvi Hip-Hop",
-            "sounds": [
-                {
-                    "soundName": "dance celebrate2",
-                    "soundID": -1,
-                    "md5": "0edb8fb88af19e6e17d0f8cf64c1d136.wav",
-                    "sampleCount": 176401,
-                    "rate": 22050,
-                    "format": "adpcm"
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "jo stance",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "cb4bf65491eaa9e8aeb1c1fdfe37e84a.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 94,
-                    "rotationCenterY": 240
-                },
-                {
-                    "costumeName": "jo top stand",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "a91fe6e180b524d27688aa0cd82cd629.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 68,
-                    "rotationCenterY": 260
-                },
-                {
-                    "costumeName": "jo top R leg",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "de64c526a57355af5fd6ff28f27b67ea.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 218,
-                    "rotationCenterY": 262
-                },
-                {
-                    "costumeName": "jo top L leg",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "987a667cd7984d9e5429c26b8a4cab2d.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 208,
-                    "rotationCenterY": 268
-                },
-                {
-                    "costumeName": "jo top R cross",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "ddbd8751df020cc32231ecb4e7b5388d.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 144,
-                    "rotationCenterY": 270
-                },
-                {
-                    "costumeName": "jo top L cross",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "33660046a3d37fa762f4a634ee3df75d.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 84,
-                    "rotationCenterY": 268
-                },
-                {
-                    "costumeName": "jo pop front",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "0503f4d712bc3184cf1b5f830d0df993.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 70,
-                    "rotationCenterY": 228
-                },
-                {
-                    "costumeName": "jo pop down",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "95a0f1bb3d8055a283aecc6bcb6303c9.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 68,
-                    "rotationCenterY": 74
-                },
-                {
-                    "costumeName": "jo pop left",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "98e8c2f9869f9356204ed19e43ae01cc.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 196,
-                    "rotationCenterY": 226
-                },
-                {
-                    "costumeName": "jo pop right",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "7bf1600ee75facb510c2922f899fb97c.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 66,
-                    "rotationCenterY": 242
-                },
-                {
-                    "costumeName": "jo pop L arm",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "2a907e6edf8a101addb2c27d0568896a.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 108,
-                    "rotationCenterY": 258
-                },
-                {
-                    "costumeName": "jo pop stand",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "361d1884737ef734f6a39fd66fc269ec.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 78,
-                    "rotationCenterY": 262
-                },
-                {
-                    "costumeName": "jo pop R arm",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "e633eb002deb20108bb5100d4b3a8fc5.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 108,
-                    "rotationCenterY": 260
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Kai",
-        "md5": "6e007fde15e49c66ee7996561f80b452.png",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "city",
-            "drawing",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Kai",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "kai-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "6e007fde15e49c66ee7996561f80b452.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 68,
-                    "rotationCenterY": 160
-                },
-                {
-                    "costumeName": "kai-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "c1e1149f6d7e308e3e4eba14ccc8a751.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 82,
-                    "rotationCenterY": 158
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Key",
-        "md5": "af35300cef35803e11f4ed744dc5e818.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Key",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "key",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "af35300cef35803e11f4ed744dc5e818.svg",
-                    "rotationCenterX": 42,
-                    "rotationCenterY": 27
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Khalid Dance",
-        "md5": "d0018780c7458f002b6fec6d1fea3570.png",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "dance",
-            "city",
-            "photo",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            4,
-            1
-        ],
-        "json": {
-            "objName": "Khalid Dance",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "khalid-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "d0018780c7458f002b6fec6d1fea3570.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 79,
-                    "rotationCenterY": 101
-                },
-                {
-                    "costumeName": "Khalid-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "88023269142bfc3ecab5b13cc8cbddb9.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 69,
-                    "rotationCenterY": 103
-                },
-                {
-                    "costumeName": "khalid-c",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "30dbce950a2d2dddc0ea53d1462d116b.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 69,
-                    "rotationCenterY": 109
-                },
-                {
-                    "costumeName": "khalid-d",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "e189aec22f4cb57a90f75457615fbbd8.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 66,
-                    "rotationCenterY": 63
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Knight",
-        "md5": "f2c5e8bc24d001b81566879dbf2f1a13.svg",
-        "type": "sprite",
-        "tags": [
-            "fantasy",
-            "drawing",
-            "castle",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Knight",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "knight",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "f2c5e8bc24d001b81566879dbf2f1a13.svg",
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Ladybug1",
-        "md5": "f16a1ccc69a4a8190a927f1595aa7bfa.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Ladybug1",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "ladybug2",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "f16a1ccc69a4a8190a927f1595aa7bfa.svg",
-                    "rotationCenterX": 41,
-                    "rotationCenterY": 43
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Ladybug2",
-        "md5": "c018a3eed966d5f92c69f2188dfd2aae.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Ladybug2",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "ladybug2-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "c018a3eed966d5f92c69f2188dfd2aae.svg",
-                    "rotationCenterX": 49,
-                    "rotationCenterY": 28
-                },
-                {
-                    "costumeName": "ladybug2-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "a2bb15ace808e070a2b815502952b292.svg",
-                    "rotationCenterX": 49,
-                    "rotationCenterY": 28
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Lamp",
-        "md5": "4885678710301cda511018ad7e420c9c.png",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "photo",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Lamp",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "lamp",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "4885678710301cda511018ad7e420c9c.png",
-                    "rotationCenterX": 25,
-                    "rotationCenterY": 41
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Laptop",
-        "md5": "76f456b30b98eeefd7c942b27b524e31.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Laptop",
-            "sounds": [
-                {
-                    "soundName": "meow",
-                    "soundID": -1,
-                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
-                    "sampleCount": 18688,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "laptop",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "76f456b30b98eeefd7c942b27b524e31.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "LB Hip-Hop",
-        "md5": "61b464a77536f75490d8891fb877819a.png",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "dance",
-            "city",
-            "photo",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            13,
-            1
-        ],
-        "json": {
-            "objName": "LB Hip-Hop",
-            "sounds": [
-                {
-                    "soundName": "dance celebrate",
-                    "soundID": -1,
-                    "md5": "0edb8fb88af19e6e17d0f8cf64c1d136.wav",
-                    "sampleCount": 176401,
-                    "rate": 22050,
-                    "format": "adpcm"
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "lb stance",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "61b464a77536f75490d8891fb877819a.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 54,
-                    "rotationCenterY": 244
-                },
-                {
-                    "costumeName": "lb top stand",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "dfe3628ddf46a67dcc21c63be65a8e40.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 70,
-                    "rotationCenterY": 248
-                },
-                {
-                    "costumeName": "lb top R leg",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "e824768a109691b5a3c577d3506ed70c.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 244,
-                    "rotationCenterY": 250
-                },
-                {
-                    "costumeName": "lb top L leg",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "350472368e2310efe6fa734b79f0ff41.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 234,
-                    "rotationCenterY": 286
-                },
-                {
-                    "costumeName": "lb top L cross",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "5a151c4d4e2e2f870d9096d5fce6ed48.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 148,
-                    "rotationCenterY": 258
-                },
-                {
-                    "costumeName": "lb top R cross",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "99acf468000c6fcbaf344e4531725efc.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 174,
-                    "rotationCenterY": 256
-                },
-                {
-                    "costumeName": "lb pop front",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "e34a166807a3ffbf8d147b12aa49dd19.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 66,
-                    "rotationCenterY": 272
-                },
-                {
-                    "costumeName": "lb pop down",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "8e41de92cb932a6898782a39a0d7d300.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 56,
-                    "rotationCenterY": 90
-                },
-                {
-                    "costumeName": "lb pop left",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "ff1b96d1047d4be459a4614ce7c7c94c.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 198,
-                    "rotationCenterY": 266
-                },
-                {
-                    "costumeName": "lb pop right",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "d6d5534c628ac5d5fe3cbf1b76b71252.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 76,
-                    "rotationCenterY": 264
-                },
-                {
-                    "costumeName": "lb pop L arm",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "c1fd31607619b8c98a286a650f248511.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 100,
-                    "rotationCenterY": 262
-                },
-                {
-                    "costumeName": "lb pop stand",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "51fe5962fe4d2af7f6fad7abaa692069.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 66,
-                    "rotationCenterY": 268
-                },
-                {
-                    "costumeName": "lb pop R arm",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "aa57575fde5ff8b13041e3a7b1499fe0.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 78,
-                    "rotationCenterY": 258
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Lightning",
-        "md5": "c2d636ab2b491e591536afc3d49cbecd.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "castle",
-            "nature",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Lightning",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "lightning",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "c2d636ab2b491e591536afc3d49cbecd.svg",
-                    "rotationCenterX": 21,
-                    "rotationCenterY": 83
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Lion",
-        "md5": "692a3c84366bf8ae4d16858e20e792f5.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Lion",
-            "sounds": [
-                {
-                    "soundName": "meow",
-                    "soundID": -1,
-                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
-                    "sampleCount": 18688,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "lion-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "692a3c84366bf8ae4d16858e20e792f5.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                },
-                {
-                    "costumeName": "lion-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "a519ef168a345a2846d0201bf092a6d0.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                }
-            ],
-            "currentCostumeIndex": 1,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Lionness",
-        "md5": "8b5f49d4f91f61fbdcb4abac53ab5c7c.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Lionness",
-            "sounds": [
-                {
-                    "soundName": "meow",
-                    "soundID": -1,
-                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
-                    "sampleCount": 18688,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "lioness",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "8b5f49d4f91f61fbdcb4abac53ab5c7c.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Lornz OdetoCode",
-        "md5": "bf911c597995031014bbf32a8eb9d997.png",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "dance",
-            "photo",
-            "bitmap"
-        ],
-        "info": [
-            1,
-            8,
-            1
-        ],
-        "json": {
-            "objName": "Lornz OdetoCode",
-            "scripts": [
-                [
-                    10,
-                    10,
-                    [
-                        [
-                            "whenKeyPressed",
-                            "space"
-                        ],
-                        [
-                            "nextCostume"
-                        ]
-                    ]
-                ]
-            ],
-            "sounds": [
-                {
-                    "soundName": "odesong-b",
-                    "soundID": -1,
-                    "md5": "2c41921491b1da2bfa1ebcaba34265ca.wav",
-                    "sampleCount": 212553,
-                    "rate": 22050,
-                    "format": "adpcm"
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "lorenz01",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "bf911c597995031014bbf32a8eb9d997.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 71,
-                    "rotationCenterY": 252
-                },
-                {
-                    "costumeName": "lorenz02",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "a1fb3946afc4c064503656d5d8ed0def.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 120,
-                    "rotationCenterY": 252
-                },
-                {
-                    "costumeName": "lorenz03",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "1da2ed229f84c1e6d1693bce3bf2d27f.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 125,
-                    "rotationCenterY": 252
-                },
-                {
-                    "costumeName": "lorenz04",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "6b798489bdf2c48337ccb2d31fc64c5f.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 124,
-                    "rotationCenterY": 109
-                },
-                {
-                    "costumeName": "lorenz05",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "dc4e7a7e84f20802d4c1b12423738f62.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 141,
-                    "rotationCenterY": 252
-                },
-                {
-                    "costumeName": "lorenz06",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "92db5fdd19b29f32890926d808e764af.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 132,
-                    "rotationCenterY": 250
-                },
-                {
-                    "costumeName": "lorenz07",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "6b65c2e80daf820d0f277af4f7352cbc.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 121,
-                    "rotationCenterY": 252
-                },
-                {
-                    "costumeName": "lorenz07b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "97ef7f1f07248305725f74a0cc127eba.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 115,
-                    "rotationCenterY": 252
-                }
-            ],
-            "currentCostumeIndex": 7,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Magic Carpet",
-        "md5": "66b74069378c828cb21d2dbe2227a31a.png",
-        "type": "sprite",
-        "tags": [
-            "transportation",
-            " fantasy",
-            "flying",
-            "castle",
-            "drawing",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Magic Carpet",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "magiccarpet",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "66b74069378c828cb21d2dbe2227a31a.png",
-                    "rotationCenterX": 90,
-                    "rotationCenterY": 31
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Magic Wand",
-        "md5": "3db9bfe57d561557795633c5cda44e8c.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "castle",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Magic Wand",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "magicwand",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "3db9bfe57d561557795633c5cda44e8c.svg",
-                    "rotationCenterX": 41,
-                    "rotationCenterY": 18
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Maya",
-        "md5": "8b7ff2f1190825367112c2c076e34af3.png",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "city",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Maya",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "maya",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "8b7ff2f1190825367112c2c076e34af3.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 72,
-                    "rotationCenterY": 138
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Marble Building",
-        "md5": "53608adfaea6e927dc11b53f604e2a1e.png",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "photo",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Marble Building",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "marble-building",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "53608adfaea6e927dc11b53f604e2a1e.png",
-                    "rotationCenterX": 50,
-                    "rotationCenterY": 68
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Microphone",
-        "md5": "59109aefada55997b9497c6266695830.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "music",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            10
-        ],
-        "json": {
-            "objName": "Microphone",
-            "sounds": [
-                {
-                    "soundName": "bass beatbox",
-                    "soundID": -1,
-                    "md5": "28153621d293c86da0b246d314458faf.wav",
-                    "sampleCount": 6720,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "hi beatbox",
-                    "soundID": -1,
-                    "md5": "5a07847bf246c227204728b05a3fc8f3.wav",
-                    "sampleCount": 5856,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "snare beatbox",
-                    "soundID": -1,
-                    "md5": "c642c4c00135d890998f351faec55498.wav",
-                    "sampleCount": 5630,
-                    "rate": 22050,
-                    "format": "adpcm"
-                },
-                {
-                    "soundName": "scratching beatbox",
-                    "soundID": -1,
-                    "md5": "859249563a7b1fc0f6e92e36d1db81c7.wav",
-                    "sampleCount": 11552,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "crash beatbox",
-                    "soundID": -1,
-                    "md5": "725e29369e9138a43f11e0e5eb3eb562.wav",
-                    "sampleCount": 26883,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "wub beatbox",
-                    "soundID": -1,
-                    "md5": "e1f32c057411da4237181ce72ae15d23.wav",
-                    "sampleCount": 7392,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "hihat beatbox",
-                    "soundID": -1,
-                    "md5": "0c77025e2e874f05cd3c7d850874d56d.wav",
-                    "sampleCount": 4274,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "rim beatbox",
-                    "soundID": -1,
-                    "md5": "7ede1382b578d8fc32850b48d082d914.wav",
-                    "sampleCount": 4960,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "clap beatbox",
-                    "soundID": -1,
-                    "md5": "abc70bb390f8e55f22f32265500d814a.wav",
-                    "sampleCount": 4224,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "wah beatbox",
-                    "soundID": -1,
-                    "md5": "9021b7bb06f2399f18e2db4fb87095dc.wav",
-                    "sampleCount": 6624,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "microphone",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "59109aefada55997b9497c6266695830.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 27,
-                    "rotationCenterY": 31
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Microphone Stand",
-        "md5": "fe85f2d5a94d27b6d793361c3fddcf77.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "music",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            10
-        ],
-        "json": {
-            "objName": "Microphone Stand",
-            "sounds": [
-                {
-                    "soundName": "bass beatbox",
-                    "soundID": -1,
-                    "md5": "28153621d293c86da0b246d314458faf.wav",
-                    "sampleCount": 6720,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "hi beatbox",
-                    "soundID": -1,
-                    "md5": "5a07847bf246c227204728b05a3fc8f3.wav",
-                    "sampleCount": 5856,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "snare beatbox",
-                    "soundID": -1,
-                    "md5": "726fea2968a387ef566c03d163f17668.wav",
-                    "sampleCount": 6102,
-                    "rate": 22050,
-                    "format": "adpcm"
-                },
-                {
-                    "soundName": "scratching beatbox",
-                    "soundID": -1,
-                    "md5": "859249563a7b1fc0f6e92e36d1db81c7.wav",
-                    "sampleCount": 11552,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "crash beatbox",
-                    "soundID": -1,
-                    "md5": "725e29369e9138a43f11e0e5eb3eb562.wav",
-                    "sampleCount": 26883,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "wub beatbox",
-                    "soundID": -1,
-                    "md5": "e1f32c057411da4237181ce72ae15d23.wav",
-                    "sampleCount": 7392,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "hihat beatbox",
-                    "soundID": -1,
-                    "md5": "0c77025e2e874f05cd3c7d850874d56d.wav",
-                    "sampleCount": 4274,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "rim beatbox",
-                    "soundID": -1,
-                    "md5": "7ede1382b578d8fc32850b48d082d914.wav",
-                    "sampleCount": 4960,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "clap beatbox",
-                    "soundID": -1,
-                    "md5": "abc70bb390f8e55f22f32265500d814a.wav",
-                    "sampleCount": 4224,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "wah beatbox",
-                    "soundID": -1,
-                    "md5": "9021b7bb06f2399f18e2db4fb87095dc.wav",
-                    "sampleCount": 6624,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "microphonestand",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "fe85f2d5a94d27b6d793361c3fddcf77.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 57,
-                    "rotationCenterY": 55
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Monkey1",
-        "md5": "d0819570ed955416190eab2e020071ca.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Monkey1",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "monkey1-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "d0819570ed955416190eab2e020071ca.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 44,
-                    "rotationCenterY": 45
-                },
-                {
-                    "costumeName": "monkey1-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "dc361fc5c8645e68c7bab9db3df6bc9d.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 51,
-                    "rotationCenterY": 46
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Monkey2",
-        "md5": "6e4de762dbd52cd2b6356694a9668211.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            3,
-            1
-        ],
-        "json": {
-            "objName": "Monkey2",
-            "sounds": [
-                {
-                    "soundName": "chee chee",
-                    "soundID": -1,
-                    "md5": "25f4826cdd61e0a1c623ec2324c16ca0.wav",
-                    "sampleCount": 34560,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "monkey2-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "6e4de762dbd52cd2b6356694a9668211.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 68,
-                    "rotationCenterY": 99
-                },
-                {
-                    "costumeName": "monkey2-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "7662a3a0f4c6fa21fdf2de33bd80fe5f.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 68,
-                    "rotationCenterY": 99
-                },
-                {
-                    "costumeName": "monkey2-c",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "db8eb50b948047181922310bb94511fb.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 68,
-                    "rotationCenterY": 99
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 0.75,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Mori",
-        "md5": "350a86adb24247003cc7e047bdba3c1d.png",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "city",
-            "drawing",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Mori",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "mori",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "350a86adb24247003cc7e047bdba3c1d.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 42,
-                    "rotationCenterY": 160
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Mouse1",
-        "md5": "e1f0c26afecbe9d4b9923d8e6bf489a8.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Mouse1",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "mouse1-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "e1f0c26afecbe9d4b9923d8e6bf489a8.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 50,
-                    "rotationCenterY": 27
-                },
-                {
-                    "costumeName": "mouse1-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "f5e477a3f94fc98ba3cd927228405646.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 65,
-                    "rotationCenterY": 21
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Muffin",
-        "md5": "e00161f08c77d10e72e44b6e01243e63.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Muffin",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "muffin-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "e00161f08c77d10e72e44b6e01243e63.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 85,
-                    "rotationCenterY": 48
-                },
-                {
-                    "costumeName": "muffin-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "fb60c3f8d6a892813299daa33b91df23.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 85,
-                    "rotationCenterY": 48
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Nano",
-        "md5": "02c5433118f508038484bbc5b111e187.svg",
-        "type": "sprite",
-        "tags": [
-            "fantasy",
-            "space",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            4,
-            1
-        ],
-        "json": {
-            "objName": "Nano",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "nano-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "02c5433118f508038484bbc5b111e187.svg",
-                    "rotationCenterX": 61,
-                    "rotationCenterY": 60
-                },
-                {
-                    "costumeName": "nano-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "10d6d9130618cd092ae02158cde2e113.svg",
-                    "rotationCenterX": 61,
-                    "rotationCenterY": 60
-                },
-                {
-                    "costumeName": "nano-c",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "85e762d45bc626ca2edb3472c7cfaa32.svg",
-                    "rotationCenterX": 61,
-                    "rotationCenterY": 60
-                },
-                {
-                    "costumeName": "nano-d",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "b10925346da8080443f27e7dfaeff6f7.svg",
-                    "rotationCenterX": 61,
-                    "rotationCenterY": 60
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Neigh Pony",
-        "md5": "176c4fb4df80df899ca28a48bd1f0edf.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Neigh Pony",
-            "sounds": [
-                {
-                    "soundName": "horse",
-                    "soundID": -1,
-                    "md5": "45ffcf97ee2edca0199ff5aa71a5b72e.wav",
-                    "sampleCount": 14464,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "neigh pony",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "176c4fb4df80df899ca28a48bd1f0edf.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 74,
-                    "rotationCenterY": 78
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Octopus",
-        "md5": "bb68d2e29d8572ef9de06f8033e668d9.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "drawing",
-            "vector",
-            "underwater"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Octopus",
-            "sounds": [
-                {
-                    "soundName": "meow",
-                    "soundID": -1,
-                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
-                    "sampleCount": 18688,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "octopus-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "bb68d2e29d8572ef9de06f8033e668d9.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                },
-                {
-                    "costumeName": "octopus-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "b52bd3bc12553bb31b1395516c3cec4d.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                }
-            ],
-            "currentCostumeIndex": 1,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Orange",
-        "md5": "780ee2ef342f79a81b4c353725331138.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Orange",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "orange",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "780ee2ef342f79a81b4c353725331138.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 19,
-                    "rotationCenterY": 18
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Orange2",
-        "md5": "89b11d2a404c3972b65743f743cc968a.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            3,
-            1
-        ],
-        "json": {
-            "objName": "Orange2",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "orange2-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "89b11d2a404c3972b65743f743cc968a.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 49,
-                    "rotationCenterY": 24
-                },
-                {
-                    "costumeName": "orange2-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "5f7998e007dfa70e70bbd8d43199ebba.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 49,
-                    "rotationCenterY": 27
-                },
-                {
-                    "costumeName": "orange2-c",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "466e9e2d62ee135a2dabd5593e6f8407.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 49,
-                    "rotationCenterY": 33
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Paddle",
-        "md5": "5cda5ed5ffabc3d06322551656427b06.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            0
-        ],
-        "json": {
-            "objName": "Paddle",
-            "costumes": [
-                {
-                    "costumeName": "paddle",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "5cda5ed5ffabc3d06322551656427b06.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 39,
-                    "rotationCenterY": 8
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 0.85000000000001,
-            "direction": -90,
-            "rotationStyle": "none",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Palmtree",
-        "md5": "6d9c18c296edc8a01e4c611b573b5723.gif",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "nature",
-            "photo",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Palmtree",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "palmtree",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "6d9c18c296edc8a01e4c611b573b5723.gif",
-                    "rotationCenterX": 58,
-                    "rotationCenterY": 100
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Parrot",
-        "md5": "098570b8e1aa85b32f9b4eb07bea3af2.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "drawing",
-            "flying",
-            "nature",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Parrot",
-            "sounds": [
-                {
-                    "soundName": "bird",
-                    "soundID": -1,
-                    "md5": "18bd4b634a3f992a16b30344c7d810e0.wav",
-                    "sampleCount": 3840,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "parrot-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "098570b8e1aa85b32f9b4eb07bea3af2.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 86,
-                    "rotationCenterY": 106
-                },
-                {
-                    "costumeName": "parrot-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "721255a0733c9d8d2ba518ff09b3b7cb.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 49,
-                    "rotationCenterY": 31
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Parrot2",
-        "md5": "aba6f5539a5ac21863a3495d89947e66.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "drawing",
-            "flying",
-            "nature",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            2
-        ],
-        "json": {
-            "objName": "Parrot2",
-            "sounds": [
-                {
-                    "soundName": "squawk",
-                    "soundID": -1,
-                    "md5": "e140d7ff07de8fa35c3d1595bba835ac.wav",
-                    "sampleCount": 8208,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "bird",
-                    "soundID": -1,
-                    "md5": "18bd4b634a3f992a16b30344c7d810e0.wav",
-                    "sampleCount": 3840,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "parrot2-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "aba6f5539a5ac21863a3495d89947e66.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 106,
-                    "rotationCenterY": 66
-                },
-                {
-                    "costumeName": "parrot2-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "9f0aac24e6b600b542613ab5c1461ae8.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 83,
-                    "rotationCenterY": 13
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Paul",
-        "md5": "4092b43b067ef01ce76a395637fe020a.gif",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "city",
-            "photo",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Paul",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "paul",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "4092b43b067ef01ce76a395637fe020a.gif",
-                    "rotationCenterX": 41,
-                    "rotationCenterY": 100
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Pencil",
-        "md5": "4495fcb0443cebc5d43e66243a88f1ac.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Pencil",
-            "sounds": [
-                {
-                    "soundName": "meow",
-                    "soundID": -1,
-                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
-                    "sampleCount": 18688,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "pencil-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "4495fcb0443cebc5d43e66243a88f1ac.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 49,
-                    "rotationCenterY": 54
-                },
-                {
-                    "costumeName": "pencil-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "21088922dbe127f6d2e58e2e83fb632e.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 48,
-                    "rotationCenterY": 68
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Penguin1",
-        "md5": "c17d9e4bdb59c574e0c34aa70af516da.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Penguin1",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "penguin1",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "c17d9e4bdb59c574e0c34aa70af516da.svg",
-                    "rotationCenterX": 54,
-                    "rotationCenterY": 61
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Penguin1 Talk",
-        "md5": "35fec7aa5f60cca945fe0615413f1f08.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Penguin1 Talk",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "penguin1 talk-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "35fec7aa5f60cca945fe0615413f1f08.svg",
-                    "rotationCenterX": 48,
-                    "rotationCenterY": 62
-                },
-                {
-                    "costumeName": "penguin1 talk-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "18fa51a64ebd5518f0c5c465525346e5.svg",
-                    "rotationCenterX": 48,
-                    "rotationCenterY": 61
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Penguin2",
-        "md5": "eaaaa7068e78a51d73ba437f1ec5763e.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Penguin2",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "penguin2",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "eaaaa7068e78a51d73ba437f1ec5763e.svg",
-                    "rotationCenterX": 49,
-                    "rotationCenterY": 79
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Penguin2 Talk",
-        "md5": "5a80f4b2fd20d43e4f7cb4189c08d99c.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Penguin2 Talk",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "penguin2 talk-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "5a80f4b2fd20d43e4f7cb4189c08d99c.svg",
-                    "rotationCenterX": 45,
-                    "rotationCenterY": 79
-                },
-                {
-                    "costumeName": "penguin2 talk-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "394e79f5f9a462064ece2a9a6606a07d.svg",
-                    "rotationCenterX": 50,
-                    "rotationCenterY": 78
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Penguin3",
-        "md5": "3f1173e00f664fca5f493b408e1e6d69.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "holiday",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            3,
-            1
-        ],
-        "json": {
-            "objName": "Penguin3",
-            "scripts": [
-                [
-                    142,
-                    432,
-                    [
-                        [
-                            "setSizeTo:",
-                            100
-                        ]
-                    ]
-                ]
-            ],
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "penguin3-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "3f1173e00f664fca5f493b408e1e6d69.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 59,
-                    "rotationCenterY": 98
-                },
-                {
-                    "costumeName": "penguin3-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "814c2ea372e64b98d5de97b75773f54b.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 57,
-                    "rotationCenterY": 97
-                },
-                {
-                    "costumeName": "penguin3-c",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "e28cd8b76b23db393d06c3a057e2dc68.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 64,
-                    "rotationCenterY": 98
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Piano",
-        "md5": "a79a9794c290e5aa533230cc3d13795b.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "music",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            8
-        ],
-        "json": {
-            "objName": "Piano",
-            "sounds": [
-                {
-                    "soundName": "C piano",
-                    "soundID": -1,
-                    "md5": "d27ed8d953fe8f03c00f4d733d31d2cc.wav",
-                    "sampleCount": 44100,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "D piano",
-                    "soundID": -1,
-                    "md5": "51381ac422605ee8c7d64cfcbfd75efc.wav",
-                    "sampleCount": 44100,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "E piano",
-                    "soundID": -1,
-                    "md5": "c818fdfaf8a0efcb562e24e794700a57.wav",
-                    "sampleCount": 44100,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "F piano",
-                    "soundID": -1,
-                    "md5": "cdab3cce84f74ecf53e3941c6a003b5e.wav",
-                    "sampleCount": 44100,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "G piano",
-                    "soundID": -1,
-                    "md5": "42bb2ed28e7023e111b33220e1594a6f.wav",
-                    "sampleCount": 44100,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "A piano",
-                    "soundID": -1,
-                    "md5": "0727959edb2ea0525feed9b0c816991c.wav",
-                    "sampleCount": 44100,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "B piano",
-                    "soundID": -1,
-                    "md5": "86826c6022a46370ed1afae69f1ab1b9.wav",
-                    "sampleCount": 44100,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "C2 piano",
-                    "soundID": -1,
-                    "md5": "75d7d2c9b5d40dd4e1cb268111abf1a2.wav",
-                    "sampleCount": 44100,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "piano",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "a79a9794c290e5aa533230cc3d13795b.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 142,
-                    "rotationCenterY": 88
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Piano-Electric",
-        "md5": "337368e789abc17beb1a2bacbb9d3bdc.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "music",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            4,
-            8
-        ],
-        "json": {
-            "objName": "Piano-Electric",
-            "sounds": [
-                {
-                    "soundName": "C elec piano",
-                    "soundID": -1,
-                    "md5": "8366ee963cc57ad24a8a35a26f722c2b.wav",
-                    "sampleCount": 44100,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "D elec piano",
-                    "soundID": -1,
-                    "md5": "835f136ca8d346a17b4d4baf8405be37.wav",
-                    "sampleCount": 44100,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "E elec piano",
-                    "soundID": -1,
-                    "md5": "ab3c198f8e36efff14f0a5bad35fa3cd.wav",
-                    "sampleCount": 44100,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "F elec piano",
-                    "soundID": -1,
-                    "md5": "dc5e368fc0d0dad1da609bfc3e29aa15.wav",
-                    "sampleCount": 44100,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "G elec piano",
-                    "soundID": -1,
-                    "md5": "39525f6545d62a95d05153f92d63301a.wav",
-                    "sampleCount": 44100,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "A elec piano",
-                    "soundID": -1,
-                    "md5": "0cfa8e84d6a5cd63afa31d541625a9ef.wav",
-                    "sampleCount": 44100,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "B elec piano",
-                    "soundID": -1,
-                    "md5": "9cc77167419f228503dd57fddaa5b2a6.wav",
-                    "sampleCount": 44100,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "C2 elec piano",
-                    "soundID": -1,
-                    "md5": "366c7edbd4dd5cca68bf62902999bd66.wav",
-                    "sampleCount": 44100,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "keyboard-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "337368e789abc17beb1a2bacbb9d3bdc.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 88,
-                    "rotationCenterY": 24
-                },
-                {
-                    "costumeName": "keyboard-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "290216dfdf0cffea57743d91f130b2c7.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 89,
-                    "rotationCenterY": 24
-                },
-                {
-                    "costumeName": "keyboard-c",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "750cbbcd66cb893cd5a66ee0a663e486.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 89,
-                    "rotationCenterY": 24
-                },
-                {
-                    "costumeName": "keyboard-d",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "46b0d833ad845d88585fbd0cb4b070ee.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 89,
-                    "rotationCenterY": 24
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Pico",
-        "md5": "0579fe60bb3717c49dfd7743caa84ada.svg",
-        "type": "sprite",
-        "tags": [
-            "fantasy",
-            "space",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            4,
-            1
-        ],
-        "json": {
-            "objName": "Pico",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "pico-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "0579fe60bb3717c49dfd7743caa84ada.svg",
-                    "rotationCenterX": 55,
-                    "rotationCenterY": 66
-                },
-                {
-                    "costumeName": "pico-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "26c688d7544757225ff51cd2fb1519b5.svg",
-                    "rotationCenterX": 55,
-                    "rotationCenterY": 66
-                },
-                {
-                    "costumeName": "pico-c",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "adf61e2090f8060e1e8b2b0604d03751.svg",
-                    "rotationCenterX": 55,
-                    "rotationCenterY": 66
-                },
-                {
-                    "costumeName": "pico-d",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "594704bf12e3c4d9e83bb91661ad709a.svg",
-                    "rotationCenterX": 55,
-                    "rotationCenterY": 66
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Pico walking",
-        "md5": "8eab5fe20dd249bf22964298b1d377eb.svg",
-        "type": "sprite",
-        "tags": [
-            "fantasy",
-            "space",
-            "drawing",
-            "walking",
-            "vector"
-        ],
-        "info": [
-            0,
-            4,
-            1
-        ],
-        "json": {
-            "objName": "Pico walking",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "Pico walk1",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "8eab5fe20dd249bf22964298b1d377eb.svg",
-                    "rotationCenterX": 54,
-                    "rotationCenterY": 71
-                },
-                {
-                    "costumeName": "Pico walk2",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "39ecd3c38d3f2cd81e3a17ee6c25699f.svg",
-                    "rotationCenterX": 54,
-                    "rotationCenterY": 71
-                },
-                {
-                    "costumeName": "Pico walk3",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "43f7d92dcf9eadf77c07a6fc1eb4104f.svg",
-                    "rotationCenterX": 54,
-                    "rotationCenterY": 70
-                },
-                {
-                    "costumeName": "Pico walk4",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "2582d012d57bca59bc0315c5c5954958.svg",
-                    "rotationCenterX": 54,
-                    "rotationCenterY": 70
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Planet2",
-        "md5": "978784738c1d9dd4b1d397fd18bdf406.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "space",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Planet2",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "planet2",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "978784738c1d9dd4b1d397fd18bdf406.svg",
-                    "rotationCenterX": 72,
-                    "rotationCenterY": 72
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Prince",
-        "md5": "a760bed1cfc28a30b2dc7fd045c90792.svg",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "fantasy",
-            "castle",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Prince",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "prince",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "a760bed1cfc28a30b2dc7fd045c90792.svg",
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Princess",
-        "md5": "75c96829e4b9f89378dfde0dee78db5f.svg",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "fantasy",
-            "castle",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Princess",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "princess",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "75c96829e4b9f89378dfde0dee78db5f.svg",
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Rainbow",
-        "md5": "680a806bd87a28c8b25b5f9b6347f022.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "flying",
-            "city",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Rainbow",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "rainbow",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "680a806bd87a28c8b25b5f9b6347f022.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 72,
-                    "rotationCenterY": 36
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Referee",
-        "md5": "b510bc924622795216154727e18dd38e.gif",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "sports",
-            "photo",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Referee",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "referee",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "b510bc924622795216154727e18dd38e.gif",
-                    "rotationCenterX": 41,
-                    "rotationCenterY": 100
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Reindeer",
-        "md5": "0fff0b181cc4d9250b5b985cc283b049.svg",
-        "type": "sprite",
-        "tags": [
-            "fantasy",
-            "holiday",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Reindeer",
-            "sounds": [
-                {
-                    "soundName": "meow",
-                    "soundID": -1,
-                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
-                    "sampleCount": 18688,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "reindeer",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "0fff0b181cc4d9250b5b985cc283b049.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 39,
-                    "rotationCenterY": 70
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Robot1",
-        "md5": "882919259f26462d74106e11d7c7e5c0.svg",
-        "type": "sprite",
-        "tags": [
-            "fantasy",
-            "drawing",
-            "space",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Robot1",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "robot1",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "882919259f26462d74106e11d7c7e5c0.svg",
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Rocks",
-        "md5": "82c79fdb6a7d9c49ab7f70ee79a3d7f8.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "nature",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Rocks",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "rocks",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "82c79fdb6a7d9c49ab7f70ee79a3d7f8.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 59,
-                    "rotationCenterY": 15
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Rory",
-        "md5": "7cca95c0a56646dd65771247ea288612.png",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "city",
-            "drawing",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Rory",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "rory",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "7cca95c0a56646dd65771247ea288612.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 82,
-                    "rotationCenterY": 160
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Ruby",
-        "md5": "c30210e8f719c3a4d2c7cc6917a39300.png",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "city",
-            "drawing",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Ruby",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "ruby-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "c30210e8f719c3a4d2c7cc6917a39300.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 54,
-                    "rotationCenterY": 172
-                },
-                {
-                    "costumeName": "ruby-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "fc15fdbcc535473f6140cab28197f3be.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 76,
-                    "rotationCenterY": 142
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Sailboat",
-        "md5": "8f8d0ea2f0ab5ca533f33f0da1eecfa6.png",
-        "type": "sprite",
-        "tags": [
-            "transportation",
-            "photo",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Sailboat",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "sail-boat",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "8f8d0ea2f0ab5ca533f33f0da1eecfa6.png",
-                    "rotationCenterX": 112,
-                    "rotationCenterY": 91
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Sam",
-        "md5": "1d33952fec0abe4ef6adee9fd065d3a8.gif",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "city",
-            "photo",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Sam",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "sam",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "1d33952fec0abe4ef6adee9fd065d3a8.gif",
-                    "rotationCenterX": 58,
-                    "rotationCenterY": 90
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Saxophone",
-        "md5": "a09b114b0652006ac66def94548073a9.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "music",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            8
-        ],
-        "json": {
-            "objName": "Saxophone",
-            "sounds": [
-                {
-                    "soundName": "C sax",
-                    "soundID": -1,
-                    "md5": "4d2c939d6953b5f241a27a62cf72de64.wav",
-                    "sampleCount": 9491,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "D sax",
-                    "soundID": -1,
-                    "md5": "39f41954a73c0e15d842061e1a4c5e1d.wav",
-                    "sampleCount": 9555,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "E sax",
-                    "soundID": -1,
-                    "md5": "3568b7dfe173fab6877a9ff1dcbcf1aa.wav",
-                    "sampleCount": 7489,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "F sax",
-                    "soundID": -1,
-                    "md5": "2ae3083817bcd595e26ea2884b6684d5.wav",
-                    "sampleCount": 7361,
-                    "rate": 22050,
-                    "format": "adpcm"
-                },
-                {
-                    "soundName": "G sax",
-                    "soundID": -1,
-                    "md5": "cefba5de46adfe5702485e0934bb1e13.wav",
-                    "sampleCount": 7349,
-                    "rate": 22050,
-                    "format": "adpcm"
-                },
-                {
-                    "soundName": "A sax",
-                    "soundID": -1,
-                    "md5": "420991e0d6d99292c6d736963842536a.wav",
-                    "sampleCount": 6472,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "B sax",
-                    "soundID": -1,
-                    "md5": "653ebe92d491b49ad5d8101d629f567b.wav",
-                    "sampleCount": 9555,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "C2 sax",
-                    "soundID": -1,
-                    "md5": "ea8d34b18c3d8fe328cea201666458bf.wav",
-                    "sampleCount": 7349,
-                    "rate": 22050,
-                    "format": "adpcm"
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "saxophone-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "a09b114b0652006ac66def94548073a9.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 69,
-                    "rotationCenterY": 80
-                },
-                {
-                    "costumeName": "saxophone-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "366c42cc65497f5007c9377a2d4d854b.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 69,
-                    "rotationCenterY": 80
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Scarf1",
-        "md5": "9db18d2a2b3c9859654fc1b4832e6076.svg",
-        "type": "sprite",
-        "tags": [
-            "dress-up",
-            "things",
-            "holiday",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Scarf1",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "scarf1",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "9db18d2a2b3c9859654fc1b4832e6076.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 54,
-                    "rotationCenterY": 36
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 0.9,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Scarf2",
-        "md5": "ce66662165e2756070f1b12e0a7cb5db.svg",
-        "type": "sprite",
-        "tags": [
-            "dress-up",
-            "things",
-            "holiday",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Scarf2",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "scarf2",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "ce66662165e2756070f1b12e0a7cb5db.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 23,
-                    "rotationCenterY": 16
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": true,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Scratch Logo",
-        "md5": "978b16d68fa7834dfb327fa3e2c4ba3b.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Scratch Logo",
-            "sounds": [
-                {
-                    "soundName": "meow",
-                    "soundID": -1,
-                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
-                    "sampleCount": 18688,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "scratch logo",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "978b16d68fa7834dfb327fa3e2c4ba3b.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 85,
-                    "rotationCenterY": 26
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Shark",
-        "md5": "7c0a907eae79462f69f8e2af8e7df828.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "drawing",
-            "underwater",
-            "vector"
-        ],
-        "info": [
-            0,
-            3,
-            1
-        ],
-        "json": {
-            "objName": "Shark",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "shark-a ",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "7c0a907eae79462f69f8e2af8e7df828.svg",
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                },
-                {
-                    "costumeName": "shark-b ",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "cff9ae87a93294693a0650b38a7a33d2.svg",
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                },
-                {
-                    "costumeName": "shark-c ",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "afeae3f998598424f7c50918507f6ce6.svg",
-                    "rotationCenterX": 77,
-                    "rotationCenterY": 37
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Shirt",
-        "md5": "dbb0eaa9d7af0f5971afdee0192c8b51.svg",
-        "type": "sprite",
-        "tags": [
-            "dress-up",
-            "things",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Shirt",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "shirt-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "dbb0eaa9d7af0f5971afdee0192c8b51.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 39,
-                    "rotationCenterY": 48
-                },
-                {
-                    "costumeName": "shirt-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "92d009fb104990da9798378ae5e4e1cb.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 48,
-                    "rotationCenterY": 48
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": true,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Shirt2",
-        "md5": "5946e7a1e36c6d97ae47d41dd8595a41.svg",
-        "type": "sprite",
-        "tags": [
-            "dress-up",
-            "things",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Shirt2",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "shirt2-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "5946e7a1e36c6d97ae47d41dd8595a41.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 39,
-                    "rotationCenterY": 48
-                },
-                {
-                    "costumeName": "shirt2-a2",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "5b78ab09592126b6bbe2d4907d203909.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 39,
-                    "rotationCenterY": 48
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": true,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Shirt Blouse",
-        "md5": "918a507af6bbae9e7f36f0d949900838.svg",
-        "type": "sprite",
-        "tags": [
-            "dress-up",
-            "things",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            0
-        ],
-        "json": {
-            "objName": "Shirt Blouse",
-            "costumes": [
-                {
-                    "costumeName": "shirt blouse",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "918a507af6bbae9e7f36f0d949900838.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 35,
-                    "rotationCenterY": 28
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": true,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Shirt Collar",
-        "md5": "b7ecf6503e27e9ab5c086eaf07d22b94.svg",
-        "type": "sprite",
-        "tags": [
-            "dress-up",
-            "things",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            3,
-            1
-        ],
-        "json": {
-            "objName": "Shirt Collar",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "shirt collar-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "b7ecf6503e27e9ab5c086eaf07d22b94.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 30,
-                    "rotationCenterY": 57
-                },
-                {
-                    "costumeName": "shirt collar-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "f1b20c3350e8a7e92a2fb1925ad4158b.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 30,
-                    "rotationCenterY": 57
-                },
-                {
-                    "costumeName": "shirt collar-c",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "5f04b99416a794e04d0855f446780f18.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 30,
-                    "rotationCenterY": 57
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": true,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Shirt-T",
-        "md5": "5d7fa4f1788f03d2962f1624d6eac800.svg",
-        "type": "sprite",
-        "tags": [
-            "dress-up",
-            "things",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            0
-        ],
-        "json": {
-            "objName": "Shirt-T",
-            "costumes": [
-                {
-                    "costumeName": "shirt-t",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "5d7fa4f1788f03d2962f1624d6eac800.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 39,
-                    "rotationCenterY": 28
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": true,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Shoes1",
-        "md5": "ffab4cc284070b50ac317e515f59f7d8.svg",
-        "type": "sprite",
-        "tags": [
-            "dress-up",
-            "things",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Shoes1",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "shoes1",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "ffab4cc284070b50ac317e515f59f7d8.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 36,
-                    "rotationCenterY": 23
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": true,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Shoes2",
-        "md5": "1dc5d568d98405c370b91a230397a7f9.svg",
-        "type": "sprite",
-        "tags": [
-            "dress-up",
-            "things",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Shoes2",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "shoes2",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "1dc5d568d98405c370b91a230397a7f9.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 40,
-                    "rotationCenterY": 8
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": true,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Singer1",
-        "md5": "e47ef1af3b925e5ac9e3b3f809d440b3.svg",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "music",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Singer1",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "Singer1",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "e47ef1af3b925e5ac9e3b3f809d440b3.svg",
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Skates",
-        "md5": "00e5e173400662875a26bb7d6556346a.svg",
-        "type": "sprite",
-        "tags": [
-            "dress-up",
-            "things",
-            "holiday",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Skates",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "skates",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "00e5e173400662875a26bb7d6556346a.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 44,
-                    "rotationCenterY": -21
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 0.9,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "SL Hip-Hop",
-        "md5": "2d2b577a12a51aa4448ad3e7e2a07079.png",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "dance",
-            "city",
-            "photo",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            8,
-            1
-        ],
-        "json": {
-            "objName": "SL Hip-Hop",
-            "sounds": [
-                {
-                    "soundName": "dance celebrate",
-                    "soundID": -1,
-                    "md5": "0edb8fb88af19e6e17d0f8cf64c1d136.wav",
-                    "sampleCount": 176401,
-                    "rate": 22050,
-                    "format": "adpcm"
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "sl top stand",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "2d2b577a12a51aa4448ad3e7e2a07079.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 64,
-                    "rotationCenterY": 233
-                },
-                {
-                    "costumeName": "sl top R leg",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "ba01e9c4448285b7b8a63e98d89ac1d7.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 54,
-                    "rotationCenterY": 230
-                },
-                {
-                    "costumeName": "sl top L leg",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "b274db2a4fa913555dae028f327e7423.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 149,
-                    "rotationCenterY": 245
-                },
-                {
-                    "costumeName": "sl top ready",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "3df3afb72314807fc6c58075da124b84.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 74,
-                    "rotationCenterY": 198
-                },
-                {
-                    "costumeName": "sl top L cross",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "f26ea2f0d0baaa5aaed3cd96d7843206.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 50,
-                    "rotationCenterY": 214
-                },
-                {
-                    "costumeName": "sl top R cross",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "b46163522a53150fdb6a44461738e9ae.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 110,
-                    "rotationCenterY": 200
-                },
-                {
-                    "costumeName": "sl pop L arm",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "48fcc33505fbd3c65d1f7bfbb4745a13.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 145,
-                    "rotationCenterY": 174
-                },
-                {
-                    "costumeName": "sl pop R arm",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "ffae2eb189d6efc97efc91e93ed4d8bf.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 66,
-                    "rotationCenterY": 237
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Snowflake",
-        "md5": "67de2af723246de37d7379b76800ee0b.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "holiday",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Snowflake",
-            "sounds": [
-                {
-                    "soundName": "meow",
-                    "soundID": -1,
-                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
-                    "sampleCount": 18688,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "snowflake",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "67de2af723246de37d7379b76800ee0b.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 104,
-                    "rotationCenterY": 103
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 0.65,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Snowman",
-        "md5": "56c71c31c17b9bc66a2aab0342cf94b2.svg",
-        "type": "sprite",
-        "tags": [
-            "fantasy",
-            "holiday",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Snowman",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "snowman",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "56c71c31c17b9bc66a2aab0342cf94b2.svg",
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Soccer Ball",
-        "md5": "4e4cc84380ccf6d4e59e53bc6d3a0a3f.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "sports",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Soccer Ball",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "soccer ball",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "4e4cc84380ccf6d4e59e53bc6d3a0a3f.svg",
-                    "rotationCenterX": 32,
-                    "rotationCenterY": 34
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Spaceship",
-        "md5": "028b6d5210a4a94d5cd3d2001fd3d74d.svg",
-        "type": "sprite",
-        "tags": [
-            "transportation",
-            "space",
-            "fantasy",
-            "flying",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Spaceship",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "spaceship-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "028b6d5210a4a94d5cd3d2001fd3d74d.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 59,
-                    "rotationCenterY": 84
-                },
-                {
-                    "costumeName": "spaceship-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "55e3d48245934393402ab214c122ed8f.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 62,
-                    "rotationCenterY": 83
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Speaker",
-        "md5": "44dc3a2ec161999545914d1f77332d76.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "music",
-            "dance",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            1,
-            1,
-            7
-        ],
-        "json": {
-            "objName": "Speaker",
-            "variables": [
-                {
-                    "name": "scale degree",
-                    "value": 1,
-                    "isPersistent": false
-                },
-                {
-                    "name": "octave",
-                    "value": 0,
-                    "isPersistent": false
-                },
-                {
-                    "name": "note number",
-                    "value": 62,
-                    "isPersistent": false
-                },
-                {
-                    "name": "loop number",
-                    "value": 1,
-                    "isPersistent": false
-                }
-            ],
-            "scripts": [
-                [
-                    890,
-                    496,
-                    [
-                        [
-                            "procDef",
-                            "play major scale note %n for %n beats",
-                            [
-                                "note",
-                                "beats"
-                            ],
-                            [
-                                1,
-                                1
-                            ],
-                            false
-                        ],
-                        [
-                            "setVar:to:",
-                            "scale degree",
-                            [
-                                "%",
-                                [
-                                    "-",
-                                    [
-                                        "getParam",
-                                        "note",
-                                        "r"
-                                    ],
-                                    1
-                                ],
-                                7
-                            ]
-                        ],
-                        [
-                            "setVar:to:",
-                            "octave",
-                            [
-                                "computeFunction:of:",
-                                "floor",
-                                [
-                                    "/",
-                                    [
-                                        "-",
-                                        [
-                                            "getParam",
-                                            "note",
-                                            "r"
-                                        ],
-                                        1
-                                    ],
-                                    7
-                                ]
-                            ]
-                        ],
-                        [
-                            "doIf",
-                            [
-                                "=",
-                                [
-                                    "readVariable",
-                                    "scale degree"
-                                ],
-                                "0"
-                            ],
-                            [
-                                [
-                                    "setVar:to:",
-                                    "note number",
-                                    0
-                                ]
-                            ]
-                        ],
-                        [
-                            "doIf",
-                            [
-                                "=",
-                                [
-                                    "readVariable",
-                                    "scale degree"
-                                ],
-                                "1"
-                            ],
-                            [
-                                [
-                                    "setVar:to:",
-                                    "note number",
-                                    "2"
-                                ]
-                            ]
-                        ],
-                        [
-                            "doIf",
-                            [
-                                "=",
-                                [
-                                    "readVariable",
-                                    "scale degree"
-                                ],
-                                "2"
-                            ],
-                            [
-                                [
-                                    "setVar:to:",
-                                    "note number",
-                                    "4"
-                                ]
-                            ]
-                        ],
-                        [
-                            "doIf",
-                            [
-                                "=",
-                                [
-                                    "readVariable",
-                                    "scale degree"
-                                ],
-                                "3"
-                            ],
-                            [
-                                [
-                                    "setVar:to:",
-                                    "note number",
-                                    "5"
-                                ]
-                            ]
-                        ],
-                        [
-                            "doIf",
-                            [
-                                "=",
-                                [
-                                    "readVariable",
-                                    "scale degree"
-                                ],
-                                "4"
-                            ],
-                            [
-                                [
-                                    "setVar:to:",
-                                    "note number",
-                                    "7"
-                                ]
-                            ]
-                        ],
-                        [
-                            "doIf",
-                            [
-                                "=",
-                                [
-                                    "readVariable",
-                                    "scale degree"
-                                ],
-                                "5"
-                            ],
-                            [
-                                [
-                                    "setVar:to:",
-                                    "note number",
-                                    "9"
-                                ]
-                            ]
-                        ],
-                        [
-                            "doIf",
-                            [
-                                "=",
-                                [
-                                    "readVariable",
-                                    "scale degree"
-                                ],
-                                "6"
-                            ],
-                            [
-                                [
-                                    "setVar:to:",
-                                    "note number",
-                                    "11"
-                                ]
-                            ]
-                        ],
-                        [
-                            "changeVar:by:",
-                            "note number",
-                            60
-                        ],
-                        [
-                            "changeVar:by:",
-                            "note number",
-                            [
-                                "*",
-                                [
-                                    "readVariable",
-                                    "octave"
-                                ],
-                                12
-                            ]
-                        ],
-                        [
-                            "noteOn:duration:elapsed:from:",
-                            [
-                                "readVariable",
-                                "note number"
-                            ],
-                            [
-                                "getParam",
-                                "beats",
-                                "r"
-                            ]
-                        ]
-                    ]
-                ]
-            ],
-            "sounds": [
-                {
-                    "soundName": "drive around",
-                    "soundID": -1,
-                    "md5": "a3a85fb8564b0266f50a9c091087b7aa.wav",
-                    "sampleCount": 44096,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "scratchy beat",
-                    "soundID": -1,
-                    "md5": "289dc558e076971e74dd1a0bd55719b1.wav",
-                    "sampleCount": 44096,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "drum jam",
-                    "soundID": -1,
-                    "md5": "8b5486ccc806e97e83049d25b071f7e4.wav",
-                    "sampleCount": 44288,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "cymbal echo",
-                    "soundID": -1,
-                    "md5": "bb243badd1201b2607bf2513df10cd97.wav",
-                    "sampleCount": 44326,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "drum satellite",
-                    "soundID": -1,
-                    "md5": "079067d7909f791b29f8be1c00fc2131.wav",
-                    "sampleCount": 44096,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "kick back",
-                    "soundID": -1,
-                    "md5": "9cd340d9d568b1479f731e69e103b3ce.wav",
-                    "sampleCount": 44748,
-                    "rate": 22050,
-                    "format": "adpcm"
-                },
-                {
-                    "soundName": "drum funky",
-                    "soundID": -1,
-                    "md5": "fb56022366d21b299cbc3fd5e16000c2.wav",
-                    "sampleCount": 44748,
-                    "rate": 22050,
-                    "format": "adpcm"
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "speaker",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "44dc3a2ec161999545914d1f77332d76.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 53,
-                    "rotationCenterY": 79
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Squirrel",
-        "md5": "7e24c99c1b853e52f8e7f9004416fa34.png",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "bitmap",
-            "photo"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Squirrel",
-            "sounds": [
-                {
-                    "soundName": "meow",
-                    "soundID": -1,
-                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
-                    "sampleCount": 18688,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "squirrel1",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "7e24c99c1b853e52f8e7f9004416fa34.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 158,
-                    "rotationCenterY": 146
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Star1",
-        "md5": "ab0914e53e360477275e58b83ec4d423.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "holiday",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Star1",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "star1",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "ab0914e53e360477275e58b83ec4d423.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 21,
-                    "rotationCenterY": 19
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 0.9,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Star2",
-        "md5": "0a0ef50bb5a59be1785c8bb12cdacae6.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "holiday",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Star2",
-            "sounds": [
-                {
-                    "soundName": "meow",
-                    "soundID": -1,
-                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
-                    "sampleCount": 18688,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "star2",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "0a0ef50bb5a59be1785c8bb12cdacae6.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 25,
-                    "rotationCenterY": 27
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Star3",
-        "md5": "04da262057dfe130860086031e5018ef.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "holiday",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            0
-        ],
-        "json": {
-            "objName": "Star3",
-            "costumes": [
-                {
-                    "costumeName": "star3-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "04da262057dfe130860086031e5018ef.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 54,
-                    "rotationCenterY": 55
-                },
-                {
-                    "costumeName": "star3-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "a082be13c0e5d17230f448dd55029a7d.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 33,
-                    "rotationCenterY": 34
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Starfish",
-        "md5": "3d1101bbc24ae292a36356af325f660c.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "drawing",
-            "underwater",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Starfish",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "starfish-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "3d1101bbc24ae292a36356af325f660c.svg",
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                },
-                {
-                    "costumeName": "starfish-b ",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "ad8007f4e63693984d4adc466ffa3ad2.svg",
-                    "rotationCenterX": 53,
-                    "rotationCenterY": 60
-                }
-            ],
-            "currentCostumeIndex": 1,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Stop",
-        "md5": "5b9e3e8edffb0bd4914113609eec5e04.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "vector",
-            "drawing"
-        ],
-        "info": [
-            0,
-            1,
-            0
-        ],
-        "json": {
-            "objName": "Stop",
-            "costumes": [
-                {
-                    "costumeName": "stop",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "5b9e3e8edffb0bd4914113609eec5e04.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 25,
-                    "rotationCenterY": 25
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Street Cleaner",
-        "md5": "e3699b3f2f7d67a9f48ea9b71fd3733a.png",
-        "type": "sprite",
-        "tags": [
-            "transportation",
-            "city",
-            "photo",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Street Cleaner",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "street-cleaner-mit",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "e3699b3f2f7d67a9f48ea9b71fd3733a.png",
-                    "rotationCenterX": 100,
-                    "rotationCenterY": 59
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Sun",
-        "md5": "55c931c65456822c0c56a2b30e3e550d.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "space",
-            "drawing",
-            "vector",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Sun",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "sun",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "55c931c65456822c0c56a2b30e3e550d.svg",
-                    "rotationCenterX": 72,
-                    "rotationCenterY": 72
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Sunglasses1",
-        "md5": "424393e8705aeadcfecb8559ce4dcea2.svg",
-        "type": "sprite",
-        "tags": [
-            "dress-up",
-            "things",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Sunglasses1",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "sunglasses1",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "424393e8705aeadcfecb8559ce4dcea2.svg",
-                    "rotationCenterX": 37,
-                    "rotationCenterY": 14
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Sunglasses2",
-        "md5": "3185d2295bbf2c5ebd0688c9e4f13076.svg",
-        "type": "sprite",
-        "tags": [
-            "dress-up",
-            "things",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Sunglasses2",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "sunglasses2",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "3185d2295bbf2c5ebd0688c9e4f13076.svg",
-                    "rotationCenterX": 29,
-                    "rotationCenterY": 10
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Taco",
-        "md5": "d224b30c54bd4d6000c935938c7f5d7e.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "flying",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Taco",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "taco-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "d224b30c54bd4d6000c935938c7f5d7e.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 20,
-                    "rotationCenterY": 15
-                },
-                {
-                    "costumeName": "taco-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "6dee4f866d79e6475d9824ba11973037.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 56,
-                    "rotationCenterY": 15
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Tennis Ball",
-        "md5": "38d3048bf7ec9f4ec3fd24dc38a03eea.png",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "sports",
-            "photo",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Tennis Ball",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "tennisball",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "38d3048bf7ec9f4ec3fd24dc38a03eea.png",
-                    "rotationCenterX": 15,
-                    "rotationCenterY": 15
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Tera",
-        "md5": "b54a4a9087435863ab6f6c908f1cac99.svg",
-        "type": "sprite",
-        "tags": [
-            "fantasy",
-            "space",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            4,
-            1
-        ],
-        "json": {
-            "objName": "Tera",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "tera-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "b54a4a9087435863ab6f6c908f1cac99.svg",
-                    "rotationCenterX": 49,
-                    "rotationCenterY": 63
-                },
-                {
-                    "costumeName": "tera-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "1e6b3a29351cda80d1a70a3cc0e499f2.svg",
-                    "rotationCenterX": 49,
-                    "rotationCenterY": 64
-                },
-                {
-                    "costumeName": "tera-c",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "7edf116cbb7111292361431521ae699e.svg",
-                    "rotationCenterX": 49,
-                    "rotationCenterY": 63
-                },
-                {
-                    "costumeName": "tera-d",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "7c3c9c8b5f4ac77de2036175712a777a.svg",
-                    "rotationCenterX": 49,
-                    "rotationCenterY": 63
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Text",
-        "md5": "5ebbfead1d5728f6e93a4259b699f2e9.svg",
-        "type": "sprite",
-        "tags": [
-            "letters",
-            "things",
-            "vector"
-        ],
-        "info": [
-            0,
-            4,
-            0
-        ],
-        "json": {
-            "objName": "Text",
-            "costumes": [
-                {
-                    "costumeName": "text awesome",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "5ebbfead1d5728f6e93a4259b699f2e9.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 109,
-                    "rotationCenterY": 32
-                },
-                {
-                    "costumeName": "text keep scratching",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "b3de9a77e2c1bb2f3e29f29a03d869ea.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 135,
-                    "rotationCenterY": 24
-                },
-                {
-                    "costumeName": "text valentine's day",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "a765b830814192ab323b5893a65cabfa.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 172,
-                    "rotationCenterY": 30
-                },
-                {
-                    "costumeName": "text Halloween",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "7aee725d72bc077424690a0acce8589b.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 165,
-                    "rotationCenterY": 34
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {},
-            "sounds": [
-                {
-                    "soundName": "boing",
-                    "soundID": 0,
-                    "md5": "53a3c2e27d1fb5fdb14aaf0cb41e7889.wav",
-                    "sampleCount": 6804,
-                    "rate": 22050,
-                    "format": "adpcm"
-                },
-                {
-                    "soundName": "chomp",
-                    "soundID": 1,
-                    "md5": "0b1e3033140d094563248e61de4039e5.wav",
-                    "sampleCount": 2912,
-                    "rate": 11025,
-                    "format": ""
-                },
-                {
-                    "soundName": "gong",
-                    "soundID": 2,
-                    "md5": "6af567714db37721a11c55d2a2648aec.wav",
-                    "sampleCount": 46848,
-                    "rate": 11025,
-                    "format": ""
-                },
-                {
-                    "soundName": "pop",
-                    "soundID": 3,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                },
-                {
-                    "soundName": "space ripple",
-                    "soundID": 4,
-                    "md5": "ff8b8c3bf841a11fd5fe3afaa92be1b5.wav",
-                    "sampleCount": 41149,
-                    "rate": 11025,
-                    "format": ""
-                },
-                {
-                    "soundName": "beeps",
-                    "soundID": 5,
-                    "md5": "3be0a558370fedba3a6b315e0ca15b33.wav",
-                    "sampleCount": 9536,
-                    "rate": 11025,
-                    "format": ""
-                },
-                {
-                    "soundName": "woof",
-                    "soundID": 6,
-                    "md5": "cd8fa8390b0efdd281882533fbfcfcfb.wav",
-                    "sampleCount": 3168,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "squawk",
-                    "soundID": 7,
-                    "md5": "e140d7ff07de8fa35c3d1595bba835ac.wav",
-                    "sampleCount": 8208,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "cheer",
-                    "soundID": 8,
-                    "md5": "4b36eebf22be4667fc2f15b78c805b4c.wav",
-                    "sampleCount": 62528,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "wub",
-                    "soundID": 9,
-                    "md5": "e1f32c057411da4237181ce72ae15d23.wav",
-                    "sampleCount": 7392,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "hey",
-                    "soundID": 10,
-                    "md5": "ec7c272faa862c9f8f731792e686e3c9.wav",
-                    "sampleCount": 5414,
-                    "rate": 22050,
-                    "format": "adpcm"
-                },
-                {
-                    "soundName": "C major ukulele",
-                    "soundID": 11,
-                    "md5": "aa2ca112507b59b5337f341aaa75fb08.wav",
-                    "sampleCount": 18203,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "dance loop",
-                    "soundID": 12,
-                    "md5": "e936679bac519b1df3ddea3f5db7594f.wav",
-                    "sampleCount": 92800,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "funky loop",
-                    "soundID": 13,
-                    "md5": "fb56022366d21b299cbc3fd5e16000c2.wav",
-                    "sampleCount": 44748,
-                    "rate": 22050,
-                    "format": "adpcm"
-                }
-            ]
-        }
-    },
-    {
-        "name": "Trampoline",
-        "md5": "20b16bcb61396df304cad5e8886ceb46.png",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "photo",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Trampoline",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "trampoline",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "20b16bcb61396df304cad5e8886ceb46.png",
-                    "rotationCenterX": 100,
-                    "rotationCenterY": 41
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Tree1",
-        "md5": "8c40e2662c55d17bc384f47165ac43c1.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "holiday",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Tree1",
-            "sounds": [
-                {
-                    "soundName": "tom drum",
-                    "soundID": -1,
-                    "md5": "5a8b8678d37a860dd6c08082d5cda3c2.wav",
-                    "sampleCount": 35803,
-                    "rate": 22050,
-                    "format": "adpcm"
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "tree1",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "8c40e2662c55d17bc384f47165ac43c1.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 77,
-                    "rotationCenterY": 126
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 0.95,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Tree2",
-        "md5": "d4cafdb83f5ff518383f7174817243e6.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "holiday",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Tree2",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "tree2",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "d4cafdb83f5ff518383f7174817243e6.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 82,
-                    "rotationCenterY": 104
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 0.9,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Tree-lights",
-        "md5": "177682396be2961367a50289a5552314.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "holiday",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Tree-lights",
-            "sounds": [
-                {
-                    "soundName": "meow",
-                    "soundID": -1,
-                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
-                    "sampleCount": 18688,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "tree-lights-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "177682396be2961367a50289a5552314.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 59,
-                    "rotationCenterY": 77
-                },
-                {
-                    "costumeName": "tree-lights-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "b0282c029046fd1ed0541675911fe8bb.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 58,
-                    "rotationCenterY": 76
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1.3000000000000005,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Trees",
-        "md5": "866ed2c2971bb04157e14e935ac8521c.svg",
-        "type": "sprite",
-        "tags": [
-            "city",
-            "flying",
-            "things",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Trees",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "trees-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "866ed2c2971bb04157e14e935ac8521c.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 49,
-                    "rotationCenterY": 94
-                },
-                {
-                    "costumeName": "trees-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "f1393dde1bb0fc512577995b27616d86.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 36,
-                    "rotationCenterY": 87
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Trombone",
-        "md5": "7d7098a45ab54def8d919141e90db4c5.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "music",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            8
-        ],
-        "json": {
-            "objName": "Trombone",
-            "sounds": [
-                {
-                    "soundName": "C trombone",
-                    "soundID": -1,
-                    "md5": "821b23a489201a0f21f47ba8528ba47f.wav",
-                    "sampleCount": 19053,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "D trombone",
-                    "soundID": -1,
-                    "md5": "f3afca380ba74372d611d3f518c2f35b.wav",
-                    "sampleCount": 17339,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "E trombone",
-                    "soundID": -1,
-                    "md5": "c859fb0954acaa25c4b329df5fb76434.wav",
-                    "sampleCount": 16699,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "F trombone",
-                    "soundID": -1,
-                    "md5": "d6758470457aac2aa712717a676a5163.wav",
-                    "sampleCount": 19373,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "G trombone",
-                    "soundID": -1,
-                    "md5": "9436fd7a0eacb4a6067e7db14236dde1.wav",
-                    "sampleCount": 17179,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "A trombone",
-                    "soundID": -1,
-                    "md5": "863ccc8ba66e6dabbce2a1261c22be0f.wav",
-                    "sampleCount": 17227,
-                    "rate": 22050,
-                    "format": "adpcm"
-                },
-                {
-                    "soundName": "B trombone",
-                    "soundID": -1,
-                    "md5": "85b663229525b73d9f6647f78eb23e0a.wav",
-                    "sampleCount": 15522,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "C2 trombone",
-                    "soundID": -1,
-                    "md5": "68aec107bd3633b2ee40c532eedc3897.wav",
-                    "sampleCount": 13904,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "trombone-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "7d7098a45ab54def8d919141e90db4c5.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 73,
-                    "rotationCenterY": 43
-                },
-                {
-                    "costumeName": "trombone-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "08edef976dbc09e8b62bce0f4607ea4a.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 73,
-                    "rotationCenterY": 43
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Trumpet",
-        "md5": "3bcbd84df7924b6f97a2fa5d9bce56c8.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "music",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            8
-        ],
-        "json": {
-            "objName": "Trumpet",
-            "sounds": [
-                {
-                    "soundName": "C trumpet",
-                    "soundID": -1,
-                    "md5": "8970afcdc4e47bb54959a81fe27522bd.wav",
-                    "sampleCount": 13118,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "D trumpet",
-                    "soundID": -1,
-                    "md5": "0b1345b8fe2ba3076fedb4f3ae48748a.wav",
-                    "sampleCount": 12702,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "E trumpet",
-                    "soundID": -1,
-                    "md5": "494295a92314cadb220945a6711c568c.wav",
-                    "sampleCount": 8680,
-                    "rate": 22050,
-                    "format": "adpcm"
-                },
-                {
-                    "soundName": "F trumpet",
-                    "soundID": -1,
-                    "md5": "5fa3108b119ca266029b4caa340a7cd0.wav",
-                    "sampleCount": 12766,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "G trumpet",
-                    "soundID": -1,
-                    "md5": "e84afda25975f14b364118591538ccf4.wav",
-                    "sampleCount": 14640,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "A trumpet",
-                    "soundID": -1,
-                    "md5": "d2dd6b4372ca17411965dc92d52b2172.wav",
-                    "sampleCount": 13911,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "B trumpet",
-                    "soundID": -1,
-                    "md5": "cad2bc57729942ed9b605145fc9ea65d.wav",
-                    "sampleCount": 14704,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "C2 trumpet",
-                    "soundID": -1,
-                    "md5": "df08249ed5446cc5e10b7ac62faac89b.wav",
-                    "sampleCount": 15849,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "trumpet-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "3bcbd84df7924b6f97a2fa5d9bce56c8.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 84,
-                    "rotationCenterY": 25
-                },
-                {
-                    "costumeName": "trumpet-a2",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "5c0db80c63a72e8ab07d047183575378.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 84,
-                    "rotationCenterY": 25
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Ukulele",
-        "md5": "39215565394d6280c6c81e7ad86c7ca0.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "music",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            4
-        ],
-        "json": {
-            "objName": "Ukulele",
-            "variables": [
-                {
-                    "name": "counter",
-                    "value": 5,
-                    "isPersistent": false
-                }
-            ],
-            "sounds": [
-                {
-                    "soundName": "C major ukulele",
-                    "soundID": -1,
-                    "md5": "aa2ca112507b59b5337f341aaa75fb08.wav",
-                    "sampleCount": 18203,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "F major ukulele",
-                    "soundID": -1,
-                    "md5": "cd0ab5d1b0120c6ed92a1654ccf81376.wav",
-                    "sampleCount": 18235,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "A minor ukulele",
-                    "soundID": -1,
-                    "md5": "69d25af0fd065da39c71439174efc589.wav",
-                    "sampleCount": 18267,
-                    "rate": 22050,
-                    "format": ""
-                },
-                {
-                    "soundName": "G ukulele",
-                    "soundID": -1,
-                    "md5": "d20218f92ee606277658959005538e2d.wav",
-                    "sampleCount": 18235,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "ukulele",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "39215565394d6280c6c81e7ad86c7ca0.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 30,
-                    "rotationCenterY": 78
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Umbrella",
-        "md5": "2ae6d0c3a8cb500e63c11a95eee80fa7.png",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "photo",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Umbrella",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "umbrella",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "2ae6d0c3a8cb500e63c11a95eee80fa7.png",
-                    "rotationCenterX": 85,
-                    "rotationCenterY": 62
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Unicorn",
-        "md5": "a04def38351e7fd805226345cac4fbfe.svg",
-        "type": "sprite",
-        "tags": [
-            "flying",
-            "fantasy",
-            "drawing",
-            "castle",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Unicorn",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "unicorn",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "a04def38351e7fd805226345cac4fbfe.svg",
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Vest",
-        "md5": "f8285ca9564451c62a0e3d75b8a714e8.svg",
-        "type": "sprite",
-        "tags": [
-            "dress-up",
-            "things",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Vest",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "vest-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "f8285ca9564451c62a0e3d75b8a714e8.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 18,
-                    "rotationCenterY": 62
-                },
-                {
-                    "costumeName": "vest-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "77d553eea3910ab8f5bac3d2da601061.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 18,
-                    "rotationCenterY": 62
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": true,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Wanda",
-        "md5": "450bc8fbd5ab6bc2e83576aad58cd07c.svg",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "city",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Wanda",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "wanda",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "450bc8fbd5ab6bc2e83576aad58cd07c.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 49,
-                    "rotationCenterY": 68
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Watermelon",
-        "md5": "26fecef75cf3b6e0d98bff5c06475036.svg",
-        "type": "sprite",
-        "tags": [
-            "things",
-            "vector",
-            "drawing"
-        ],
-        "info": [
-            0,
-            3,
-            1
-        ],
-        "json": {
-            "objName": "Watermelon",
-            "sounds": [
-                {
-                    "soundName": "meow",
-                    "soundID": -1,
-                    "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
-                    "sampleCount": 18688,
-                    "rate": 22050,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "watermelon-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "26fecef75cf3b6e0d98bff5c06475036.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 40,
-                    "rotationCenterY": 27
-                },
-                {
-                    "costumeName": "watermelon-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "fbdaf4d1d349edd3ddf3a1c4528aa9ec.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 22,
-                    "rotationCenterY": 27
-                },
-                {
-                    "costumeName": "watermelon-c",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "5976c10412306fc093c1d1930fa05119.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 21,
-                    "rotationCenterY": 15
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Witch",
-        "md5": "c991196a708294535a1dbdce7189c23c.svg",
-        "type": "sprite",
-        "tags": [
-            "flying",
-            "people",
-            "fantasy",
-            "castle",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Witch",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "witch",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "c991196a708294535a1dbdce7189c23c.svg",
-                    "rotationCenterX": 74,
-                    "rotationCenterY": 59
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Wizard",
-        "md5": "4df1dd733f6ee4a2d8842478ac2c4661.svg",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "fantasy",
-            "castle",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Wizard",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "wizard",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "4df1dd733f6ee4a2d8842478ac2c4661.svg",
-                    "rotationCenterX": 76,
-                    "rotationCenterY": 86
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Wizard1",
-        "md5": "e085c97691d16f0cc8a595ce1137e26c.svg",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "fantasy",
-            "castle",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Wizard1",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "wizard1",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "e085c97691d16f0cc8a595ce1137e26c.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 134,
-                    "rotationCenterY": 153
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Wizard2",
-        "md5": "6db4d9e4229dc50a1b1c91c3c8311d40.svg",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "fantasy",
-            "castle",
-            "drawing",
-            "vector"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Wizard2",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "wizard2",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "6db4d9e4229dc50a1b1c91c3c8311d40.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 69,
-                    "rotationCenterY": 93
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 0,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "indexInLibrary": 100000,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Zara",
-        "md5": "ad7b145d46e933125bd9c928d784fcdc.png",
-        "type": "sprite",
-        "tags": [
-            "people",
-            "city",
-            "drawing",
-            "bitmap"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Zara",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "zara-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "ad7b145d46e933125bd9c928d784fcdc.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 50,
-                    "rotationCenterY": 170
-                },
-                {
-                    "costumeName": "zara-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "6fba793b512069a67096a82aa85a5c12.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 86,
-                    "rotationCenterY": 168
-                }
-            ],
-            "currentCostumeIndex": 1,
             "scratchX": 0,
             "scratchY": 0,
             "scale": 1,


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_
Fixes https://github.com/LLK/scratch-gui/issues/398

### Proposed Changes

_Describe what this Pull Request does_
Puts the letter blocks back at the end of the sprite list, like they were (and are on the costume list).

### Reason for Changes

_Explain why these changes should be made_
They were promoted for the "Animate your name" playtest, but need to be put back to the default for our next playtest

### Test Coverage

_Please show how you have added tests to cover your changes_
n/a