### PR TITLE
Hide overflow-y on gui container

### DIFF
--- a/src/components/gui/gui.css
+++ b/src/components/gui/gui.css
@@ -19,6 +19,12 @@
     */
     flex-direction: row;
     height: 100%;
+
+    /*
+        Stop scrollbar popping in and out from scratch-blocks border issue
+        https://github.com/LLK/scratch-gui/issues/318
+    */
+    overflow-y: hidden;
 }
 
 .editor-wrapper {


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/318

### Proposed Changes

_Describe what this Pull Request does_

Hide overflow-y around the container of the blocks to prevent the border popping issue.
