### PR TITLE
Show workspace before triggering resize

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -64,8 +64,8 @@ class Blocks extends React.Component {
 
         // @todo hack to resize blockly manually in case resize happened while hidden
         if (this.props.isVisible) { // Scripts tab
-            window.dispatchEvent(new Event('resize'));
             this.workspace.setVisible(true);
+            window.dispatchEvent(new Event('resize'));
             this.workspace.toolbox_.refreshSelection();
         } else {
             this.workspace.setVisible(false);


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes the common cases of https://github.com/LLK/scratch-blocks/issues/912. But see my long comment at the end of that bug for a full description. 

TL;DR don't trigger a window resize before making the workspace visible. 
