### PR TITLE
Check if blocks exists before updating values

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -100,13 +100,13 @@ class Blocks extends React.Component {
         this.props.vm.removeListener('targetsUpdate', this.onTargetsUpdate);
     }
     updateToolboxBlockValue (id, value) {
-        this.workspace
+        const block = this.workspace
             .getFlyout()
             .getWorkspace()
-            .getBlockById(id)
-            .inputList[0]
-            .fieldRow[0]
-            .setValue(value);
+            .getBlockById(id);
+        if (block) {
+            block.inputList[0].fieldRow[0].setValue(value);
+        }
     }
     onTargetsUpdate () {
         if (this.props.vm.editingTarget) {


### PR DESCRIPTION
Fixes this error you get when dragging a sprite around with a category other than motion open:
![image](https://cloud.githubusercontent.com/assets/654102/26692044/490562d4-46cd-11e7-9156-6529019add94.png)

Didn't realize that when you are on a different category, those blocks actually just do not exist.