### PR TITLE
Make escape key exit library modals

### DIFF
--- a/src/components/modal/modal.jsx
+++ b/src/components/modal/modal.jsx
@@ -18,6 +18,7 @@ class ModalComponent extends React.Component {
                 isOpen={this.props.visible}
                 overlayClassName={styles.modalOverlay}
                 ref={m => (this.modal = m)}
+                onRequestClose={this.props.onRequestClose}
             >
                 <Box
                     direction="column"


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_
Fixes https://github.com/LLK/scratch-gui/issues/425

### Proposed Changes

_Describe what this Pull Request does_
Pass `onRequestClose` to the react modal. It can handle escape-to-close automatically if you give it something to do when escape is hit. We already do this in the `Prompt` component.

### Reason for Changes

_Explain why these changes should be made_

Escape-to-close is a common expectation. @lifeinchords we have talked about implementing this, turns out it is a one-liner :) 
