### PR TITLE
Use trusty beta for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
+sudo: false
+dist: trusty
 node_js:
 - 6
 - 'node'


### PR DESCRIPTION
This allows gh-pages to work. Something changed in the precise VMs that prevents the git clone gh-pages uses from working correctly.  See https://github.com/travis-ci/travis-ci/issues/4942

On my fork, this change allowed the gh-pages deploy to succeed.

/fyi @paulkaplan @fsih