### PR TITLE
Deploy all branches but master to subdirectories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,33 +3,32 @@ sudo: false
 dist: trusty
 node_js:
 - 6
-- 'node'
 cache:
   directories:
   - node_modules
 env:
   global:
-  - BASE_PATH=/scratch-gui/
   - NODE_ENV=production
 install:
 - npm --production=false install
 - npm --production=false update
-after_script:
-- |
-  # RELEASE_BRANCHES and NPM_TOKEN defined in Travis settings panel
-  declare exitCode
-  $(npm bin)/travis-after-all
-  exitCode=$?
-  if [[
-    # Execute after all jobs finish successfully
-    $exitCode = 0 &&
-    # Only release on release branches
-    $RELEASE_BRANCHES =~ $TRAVIS_BRANCH &&
-    # Don't release on PR builds
-    $TRAVIS_PULL_REQUEST = "false"
-  ]]; then
-    # Publish to gh-pages as most recent committer
-    git config --global user.email $(git log --pretty=format:"%ae" -n1)
-    git config --global user.name $(git log --pretty=format:"%an" -n1)
-    npm run --silent deploy -- -x -r https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
-  fi
+jobs:
+    include:
+        - script: npm test
+        - stage: deploy
+          script: npm run build
+          before_deploy:
+            - git config --global user.email $(git log --pretty=format:"%ae" -n1)
+            - git config --global user.name $(git log --pretty=format:"%an" -n1)
+          deploy:
+            - provider: script
+              on:
+                all_branches: true
+                condition: $TRAVIS_BRANCH != master
+              skip_cleanup: true
+              script: npm run deploy -- -e $TRAVIS_BRANCH -r https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
+            - provider: script
+              on:
+                branch: master
+              skip_cleanup: true
+              script: npm run deploy -- -a -r https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,23 +12,18 @@ env:
 install:
 - npm --production=false install
 - npm --production=false update
-jobs:
-    include:
-        - script: npm test
-        - stage: deploy
-          script: npm run build
-          before_deploy:
-            - git config --global user.email $(git log --pretty=format:"%ae" -n1)
-            - git config --global user.name $(git log --pretty=format:"%an" -n1)
-          deploy:
-            - provider: script
-              on:
-                all_branches: true
-                condition: $TRAVIS_BRANCH != master
-              skip_cleanup: true
-              script: npm run deploy -- -e $TRAVIS_BRANCH -r https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
-            - provider: script
-              on:
-                branch: master
-              skip_cleanup: true
-              script: npm run deploy -- -a -r https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
+before_deploy:
+- git config --global user.email $(git log --pretty=format:"%ae" -n1)
+- git config --global user.name $(git log --pretty=format:"%an" -n1)
+deploy:
+- provider: script
+  on:
+    all_branches: true
+    condition: $TRAVIS_BRANCH != master
+  skip_cleanup: true
+  script: npm run deploy -- -x -e $TRAVIS_BRANCH -r https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
+- provider: script
+  on:
+    branch: master
+  skip_cleanup: true
+  script: npm run --silent deploy -- -x -a -r https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eslint": "^3.16.1",
     "eslint-config-scratch": "^3.0.0",
     "eslint-plugin-react": "^7.0.1",
-    "gh-pages": "github:jfschwarz/gh-pages#publish-branch-to-subfolder",
+    "gh-pages": "github:rschamp/gh-pages#publish-branch-to-subfolder",
     "html-webpack-plugin": "2.28.0",
     "immutable": "3.8.1",
     "lodash.bindall": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "deploy": "touch build/.nojekyll && gh-pages -t -d build -m \"Build for $(git log --pretty=format:%H -n1)\"",
     "lint": "eslint . --ext .js,.jsx",
     "start": "webpack-dev-server",
-    "test": "npm run lint && npm run build"
+    "test": "npm run lint",
+    "watch": "webpack --progress --colors --watch"
   },
   "author": "Massachusetts Institute of Technology",
   "license": "BSD-3-Clause",
@@ -36,7 +37,7 @@
     "eslint": "^3.16.1",
     "eslint-config-scratch": "^3.0.0",
     "eslint-plugin-react": "^7.0.1",
-    "gh-pages": "^1.0.0",
+    "gh-pages": "github:jfschwarz/gh-pages#publish-branch-to-subfolder",
     "html-webpack-plugin": "2.28.0",
     "immutable": "3.8.1",
     "lodash.bindall": "4.4.0",
@@ -69,7 +70,6 @@
     "style-loader": "^0.18.0",
     "svg-to-image": "1.1.3",
     "svg-url-loader": "2.0.2",
-    "travis-after-all": "^1.4.4",
     "webpack": "^2.4.1",
     "webpack-dev-server": "^2.4.1",
     "xhr": "2.4.0"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "deploy": "touch build/.nojekyll && gh-pages -t -d build -m \"Build for $(git log --pretty=format:%H -n1)\"",
     "lint": "eslint . --ext .js,.jsx",
     "start": "webpack-dev-server",
-    "test": "npm run lint",
+    "test": "npm run lint && npm run build",
     "watch": "webpack --progress --colors --watch"
   },
   "author": "Massachusetts Institute of Technology",

--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -119,6 +119,6 @@ GUIComponent.propTypes = {
     vm: PropTypes.instanceOf(VM).isRequired
 };
 GUIComponent.defaultProps = {
-    basePath: '/'
+    basePath: './'
 };
 module.exports = GUIComponent;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,4 +1,3 @@
-const PropTypes = require('prop-types');
 const React = require('react');
 const ReactDOM = require('react-dom');
 const {Provider} = require('react-redux');
@@ -52,16 +51,11 @@ class App extends React.Component {
         if (this.state.projectData === null) return null;
         return (
             <GUI
-                basePath={this.props.basePath}
                 projectData={this.state.projectData}
             />
         );
     }
 }
-
-App.propTypes = {
-    basePath: PropTypes.string
-};
 
 const appTarget = document.createElement('div');
 appTarget.className = styles.app;
@@ -74,6 +68,6 @@ const store = applyMiddleware(
 );
 ReactDOM.render((
     <Provider store={store}>
-        <App basePath={process.env.BASE_PATH} />
+        <App />
     </Provider>
 ), appTarget);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -75,7 +75,6 @@ module.exports = {
     plugins: [
         new webpack.DefinePlugin({
             'process.env.NODE_ENV': '"' + process.env.NODE_ENV + '"',
-            'process.env.BASE_PATH': '"' + (process.env.BASE_PATH || '/') + '"',
             'process.env.DEBUG': Boolean(process.env.DEBUG)
         }),
         new webpack.optimize.CommonsChunkPlugin({


### PR DESCRIPTION
Check out the results of this PR build here! https://rschamp.github.io/scratch-gui/deploy/multi-branch/

I assigned everyone who might be interested in this change, since we may want something like this change in other repos (www?). Not everyone has to review it though.

### Proposed Changes

_Currently this works using an unmerged PR to tschaub/gh-pages. (Will update to an LLK fork if we decide to go this way until that PR is merged.)_

When deploying from Travis, push all branches except master to a subdirectory. So the build for master would be available at https://llk.github.io/scratch-gui/ but to view the build for e.g., develop, you would look at https://llk.github.io/scratch-gui/develop/.

As part of this change, stop building for multiple versions of Node, since everything is static. This allows us to get rid of travis-after-all, which makes it easier to have multiple deploy conditions.

I also removed the need for the `BASE_DIR` environment variable, so that a single build script was sufficient for viewing the build under any subdirectory. 

Also add a `watch` command, for testing out static builds.

### Reason for Changes

This will make us able to only release to https://llk.github.io/scratch-gui/ after testing it out on https://llk.github.io/scratch-gui/develop/. Any Greenkeeper PR will be automatically available on the branch published by Greenkeeper, making reviewing those PRs easier.

For PRs coming from forks, this makes it very easy to publish the results for the PR, so the reviewer doesn't have to build it themselves. And allows the contributor to make many PR builds available at once.

## To do
- [ ] Fork gh-pages to LLK for the deploy-by-branch fork
- [ ] Periodic cleanup builds to remove deleted branches from gh-pages