### PR TITLE
Use `comments` flag to disable comments in scratch-blocks

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -225,7 +225,8 @@ Blocks.propTypes = {
             insertionMarkerOpacity: PropTypes.number,
             fieldShadow: PropTypes.string,
             dragShadowOpacity: PropTypes.number
-        })
+        }),
+        comments: PropTypes.bool
     }),
     vm: PropTypes.instanceOf(VM).isRequired
 };
@@ -252,7 +253,8 @@ Blocks.defaultOptions = {
         insertionMarkerOpacity: 0.2,
         fieldShadow: 'rgba(255, 255, 255, 0.3)',
         dragShadowOpacity: 0.6
-    }
+    },
+    comments: false
 };
 
 Blocks.defaultProps = {


### PR DESCRIPTION
Disable code comments by passing a `comments: false` into scratch-blocks.

This disables the "add comment" option in the right click menu.

Commenting is not implemented in the VM and there is no design for it, so disable it the same way the playgrounds do.

