### PR TITLE
Refresh workspace when setting it to visible

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -63,8 +63,10 @@ class Blocks extends React.Component {
         }
 
         // @todo hack to resize blockly manually in case resize happened while hidden
+        // @todo hack to reload the workspace due to gui bug #413
         if (this.props.isVisible) { // Scripts tab
             this.workspace.setVisible(true);
+            this.props.vm.refreshWorkspace();
             window.dispatchEvent(new Event('resize'));
             this.workspace.toolbox_.refreshSelection();
         } else {


### PR DESCRIPTION
### Resolves
Goes with https://github.com/LLK/scratch-vm/pull/611
Workaround for blocks bug https://github.com/LLK/scratch-blocks/issues/929

### Proposed Changes
Refresh workspace when changing to scripts tab