### PR TITLE
Revert "Explicitly create variables in the VM"

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -150,6 +150,7 @@ class Blocks extends React.Component {
         if (this.props.vm.editingTarget && !this.state.workspaceMetrics[this.props.vm.editingTarget.id]) {
             this.onWorkspaceMetricsChange();
         }
+
         this.ScratchBlocks.Events.disable();
         this.workspace.clear();
 
@@ -174,7 +175,6 @@ class Blocks extends React.Component {
     }
     handlePromptCallback (data) {
         this.state.prompt.callback(data);
-        this.props.vm.createVariable(data);
         this.handlePromptClose();
     }
     handlePromptClose () {


### PR DESCRIPTION
Reverts LLK/scratch-gui#390

We no longer need to explicitly create variables in the VM, since the VM will be bound directly to scratch blocks pending https://github.com/LLK/scratch-vm/pull/614

