### PR TITLE
Fix AudioContext issue in Safari

### DIFF
--- a/src/lib/audio/shared-audio-context.js
+++ b/src/lib/audio/shared-audio-context.js
@@ -1,5 +1,5 @@
 // Wrap browser AudioContext because we shouldn't create more than one
-const AUDIO_CONTEXT = new (AudioContext || window.webkitAudioContext)();
+const AUDIO_CONTEXT = new (window.AudioContext || window.webkitAudioContext)();
 
 module.exports = function () {
     return AUDIO_CONTEXT;

--- a/src/lib/audio/shared-audio-context.js
+++ b/src/lib/audio/shared-audio-context.js
@@ -1,5 +1,5 @@
 // Wrap browser AudioContext because we shouldn't create more than one
-const AUDIO_CONTEXT = new AudioContext();
+const AUDIO_CONTEXT = new (AudioContext || webkitAudioContext)();
 
 module.exports = function () {
     return AUDIO_CONTEXT;

--- a/src/lib/audio/shared-audio-context.js
+++ b/src/lib/audio/shared-audio-context.js
@@ -1,5 +1,5 @@
 // Wrap browser AudioContext because we shouldn't create more than one
-const AUDIO_CONTEXT = new (AudioContext || webkitAudioContext)();
+const AUDIO_CONTEXT = new (AudioContext || window.webkitAudioContext)();
 
 module.exports = function () {
     return AUDIO_CONTEXT;


### PR DESCRIPTION
### Resolves
Fixes white screen in Safari (and possibly old Chrome) caused by use of `AudioContext`

I didn't bother to open an issue

### Proposed Changes
Uses `webkitAudioContext` when `AudioContext` is not found

### Reason for Changes
Because people use Safari

### Test Coverage

_Please show how you have added tests to cover your changes_

???
