### PR TITLE
Set costume when selected in costumes tab

### DIFF
--- a/src/containers/costume-tab.jsx
+++ b/src/containers/costume-tab.jsx
@@ -38,6 +38,7 @@ class CostumeTab extends React.Component {
     }
 
     handleSelectCostume (costumeIndex) {
+        this.props.vm.editingTarget.setCostume(costumeIndex);
         this.setState({selectedCostumeIndex: costumeIndex});
     }
 


### PR DESCRIPTION
### Resolves

#474

### Proposed Changes

Sets the active sprite's costume (in the VM) when a costume is selected in the costumes tab.

### Reason for Changes

To behave as Scratch 2.0 does.

### Test Coverage

(No tests.)
