### PR TITLE
"Add sprite/backdrop" buttons should have a discernible text

### DIFF
--- a/src/components/target-pane/target-pane.jsx
+++ b/src/components/target-pane/target-pane.jsx
@@ -78,6 +78,7 @@ const TargetPane = ({
 
                 <button
                     className={classNames(styles.addButtonWrapper, styles.addButtonWrapperSprite)}
+                    title="Add sprite"
                     onClick={onNewSpriteClick}
                 >
                     <img
@@ -88,6 +89,7 @@ const TargetPane = ({
 
                 <button
                     className={classNames(styles.addButtonWrapper, styles.addButtonWrapperStage)}
+                    title="Add backdrop"
                     onClick={onNewBackdropClick}
                 >
                     <img


### PR DESCRIPTION
In order to comply to WCAG 2.0[1], buttons must have discernible text that
clearly describe the purpose, so that it can be used by screen readers.

[1] https://www.w3.org/TR/2016/NOTE-WCAG20-TECHS-20161007/H65