### PR TITLE
Disable record button before mic access is given

### DIFF
--- a/src/components/record-modal/record-modal.css
+++ b/src/components/record-modal/record-modal.css
@@ -64,6 +64,10 @@
     border: none;
 }
 
+.main-button-row button:disabled {
+    opacity: 0.25;
+}
+
 .main-button-row button:active, .main-button-row button:focus {
     outline: none;
 }

--- a/src/components/record-modal/recording-step.jsx
+++ b/src/components/record-modal/recording-step.jsx
@@ -27,7 +27,8 @@ const RecordingStep = props => (
                     />
                 ) : (
                     <span className={styles.helpText}>
-                        Begin recording by clicking the button below
+                        {props.listening ? 'Begin recording by clicking the button below' :
+                            '↖️ \u00A0We need your permission to use your microphone'}
                     </span>
                 )}
             </Box>
@@ -73,7 +74,7 @@ const RecordingStep = props => (
 RecordingStep.propTypes = {
     level: PropTypes.number,
     levels: PropTypes.arrayOf(PropTypes.number),
-    listening: PropTypes.bool.isRequired,
+    listening: PropTypes.bool,
     onRecord: PropTypes.func.isRequired,
     onStopRecording: PropTypes.func.isRequired,
     recording: PropTypes.bool

--- a/src/components/record-modal/recording-step.jsx
+++ b/src/components/record-modal/recording-step.jsx
@@ -35,6 +35,7 @@ const RecordingStep = props => (
         <Box className={styles.mainButtonRow}>
             <button
                 className={styles.mainButton}
+                disabled={!props.listening}
                 onClick={props.recording ? props.onStopRecording : props.onRecord}
             >
                 {props.recording ? (
@@ -72,6 +73,7 @@ const RecordingStep = props => (
 RecordingStep.propTypes = {
     level: PropTypes.number,
     levels: PropTypes.arrayOf(PropTypes.number),
+    listening: PropTypes.bool.isRequired,
     onRecord: PropTypes.func.isRequired,
     onStopRecording: PropTypes.func.isRequired,
     recording: PropTypes.bool

--- a/src/containers/recording-step.jsx
+++ b/src/containers/recording-step.jsx
@@ -9,21 +9,26 @@ class RecordingStep extends React.Component {
         bindAll(this, [
             'handleRecord',
             'handleStopRecording',
+            'handleStarted',
             'handleLevelUpdate',
             'handleRecordingError'
         ]);
 
         this.state = {
+            listening: false,
             level: 0,
             levels: null
         };
     }
     componentDidMount () {
         this.audioRecorder = new AudioRecorder();
-        this.audioRecorder.startListening(this.handleLevelUpdate, this.handleRecordingError);
+        this.audioRecorder.startListening(this.handleStarted, this.handleLevelUpdate, this.handleRecordingError);
     }
     componentWillUnmount () {
         this.audioRecorder.dispose();
+    }
+    handleStarted () {
+        this.setState({listening: true});
     }
     handleRecordingError () {
         alert('Could not start recording'); // eslint-disable-line no-alert
@@ -52,6 +57,7 @@ class RecordingStep extends React.Component {
             <RecordingStepComponent
                 level={this.state.level}
                 levels={this.state.levels}
+                listening={this.state.listening}
                 onRecord={this.handleRecord}
                 onStopRecording={this.handleStopRecording}
                 {...componentProps}

--- a/src/lib/audio/audio-recorder.js
+++ b/src/lib/audio/audio-recorder.js
@@ -12,6 +12,7 @@ class AudioRecorder {
 
         this.recordedSamples = 0;
         this.recording = false;
+        this.started = false;
         this.buffers = [];
 
         this.disposed = false;
@@ -20,13 +21,20 @@ class AudioRecorder {
     startListening (onStarted, onUpdate, onError) {
         try {
             navigator.getUserMedia({audio: true}, userMediaStream => {
-                onStarted();
-                this.attachUserMediaStream(userMediaStream, onUpdate);
+                if (!this.disposed) {
+                    this.started = true;
+                    onStarted();
+                    this.attachUserMediaStream(userMediaStream, onUpdate);
+                }
             }, e => {
-                onError(e);
+                if (!this.disposed) {
+                    onError(e);
+                }
             });
         } catch (e) {
-            onError(e);
+            if (!this.disposed) {
+                onError(e);
+            }
         }
     }
 
@@ -51,9 +59,8 @@ class AudioRecorder {
         this.sourceNode = this.audioContext.createGain();
         this.scriptProcessorNode = this.audioContext.createScriptProcessor(this.bufferLength, 2, 2);
 
-
         this.scriptProcessorNode.onaudioprocess = processEvent => {
-            if (this.recording) {
+            if (this.recording && !this.disposed) {
                 this.buffers.push(new Float32Array(processEvent.inputBuffer.getChannelData(0)));
             }
         };
@@ -118,12 +125,14 @@ class AudioRecorder {
     }
 
     dispose () {
-        this.scriptProcessorNode.onaudioprocess = null;
-        this.scriptProcessorNode.disconnect();
-        this.analyserNode.disconnect();
-        this.sourceNode.disconnect();
-        this.mediaStreamSource.disconnect();
-        this.userMediaStream.getAudioTracks()[0].stop();
+        if (this.started) {
+            this.scriptProcessorNode.onaudioprocess = null;
+            this.scriptProcessorNode.disconnect();
+            this.analyserNode.disconnect();
+            this.sourceNode.disconnect();
+            this.mediaStreamSource.disconnect();
+            this.userMediaStream.getAudioTracks()[0].stop();
+        }
         this.disposed = true;
     }
 }

--- a/src/lib/audio/audio-recorder.js
+++ b/src/lib/audio/audio-recorder.js
@@ -17,9 +17,10 @@ class AudioRecorder {
         this.disposed = false;
     }
 
-    startListening (onUpdate, onError) {
+    startListening (onStarted, onUpdate, onError) {
         try {
             navigator.getUserMedia({audio: true}, userMediaStream => {
+                onStarted();
                 this.attachUserMediaStream(userMediaStream, onUpdate);
             }, e => {
                 onError(e);


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_
Fixes https://github.com/LLK/scratch-gui/issues/503

### Proposed Changes

_Describe what this Pull Request does_
Disable the record button (and gray it out) before mic access is given.

### Reason for Changes

_Explain why these changes should be made_
It should not be possible to start the recording before mic access is given. This doesn't really address the design problem mentioned in that issue, let's make a separate issue for that. 

@carljbowman thoughts? this is what it looks like

![screen shot 2017-07-06 at 10 55 48 am](https://user-images.githubusercontent.com/654102/27917609-74e23ebc-623a-11e7-81e2-a3fdde984ae2.png)
![screen shot 2017-07-06 at 10 55 54 am](https://user-images.githubusercontent.com/654102/27917608-74e23886-623a-11e7-970d-5af1abc24729.png)

Note: the button is actually disabled, it cannot be clicked. 
