### PR TITLE
Use web-audio-api-shim to normalize web audio API for safari

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-dom": "^15"
   },
   "devDependencies": {
+    "@mohayonao/web-audio-api-shim": "^0.3.0",
     "autoprefixer": "7.1.2",
     "babel-core": "^6.23.1",
     "babel-eslint": "^7.1.1",

--- a/src/lib/audio/shared-audio-context.js
+++ b/src/lib/audio/shared-audio-context.js
@@ -1,3 +1,5 @@
+require('@mohayonao/web-audio-api-shim/light');
+
 // Wrap browser AudioContext because we shouldn't create more than one
 const AUDIO_CONTEXT = new (window.AudioContext || window.webkitAudioContext)();
 


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes the blank screen part of https://github.com/LLK/scratch-gui/issues/542, by using a web-audio api shim to normalize the way `decode` works and shim the panner node.

Also fixes https://github.com/LLK/scratch-gui/issues/486

Also fixes https://github.com/LLK/scratch-gui/issues/481

Also fixes https://github.com/LLK/scratch-gui/issues/388


### Proposed Changes

_Describe what this Pull Request does_
Use this library http://mohayonao.github.io/web-audio-api-shim/ to provide shimmed web audio implementations. 

### Reason for Changes

_Explain why these changes should be made_

To support safari, but really just to normalize the web audio api which has (is?) in flux.