### PR TITLE
Add import/export rules and fix lint errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "enzyme": "^2.8.2",
     "eslint": "^3.16.1",
     "eslint-config-scratch": "^3.0.0",
+    "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-react": "^7.0.1",
     "gh-pages": "github:rschamp/gh-pages#publish-branch-to-subfolder",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "css-loader": "0.28.3",
     "enzyme": "^2.8.2",
     "eslint": "^3.16.1",
+    "eslint-config-import": "^0.13.0",
     "eslint-config-scratch": "^3.0.0",
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-react": "^7.0.1",

--- a/src/.eslintrc.js
+++ b/src/.eslintrc.js
@@ -1,10 +1,16 @@
 module.exports = {
     root: true,
-    extends: ['scratch', 'scratch/es6', 'scratch/react'],
+    extends: ['scratch', 'scratch/es6', 'scratch/react', 'import'],
     env: {
         browser: true
     },
     globals: {
         process: true
+    },
+    rules: {
+        'import/no-mutable-exports': 'error',
+        'import/no-commonjs': 'error',
+        'import/no-amd': 'error',
+        'import/no-nodejs-modules': 'error'
     }
 };

--- a/src/components/asset-panel/asset-panel.jsx
+++ b/src/components/asset-panel/asset-panel.jsx
@@ -20,4 +20,4 @@ AssetPanel.propTypes = {
     ...Selector.propTypes
 };
 
-module.exports = AssetPanel;
+export default AssetPanel;

--- a/src/components/asset-panel/selector.jsx
+++ b/src/components/asset-panel/selector.jsx
@@ -68,4 +68,4 @@ Selector.propTypes = {
     selectedItemIndex: PropTypes.number.isRequired
 };
 
-module.exports = Selector;
+export default Selector;

--- a/src/components/audio-trimmer/audio-trimmer.jsx
+++ b/src/components/audio-trimmer/audio-trimmer.jsx
@@ -67,4 +67,4 @@ AudioTrimmer.propTypes = {
     trimStart: PropTypes.number.isRequired
 };
 
-module.exports = AudioTrimmer;
+export default AudioTrimmer;

--- a/src/components/blocks/blocks.jsx
+++ b/src/components/blocks/blocks.jsx
@@ -19,4 +19,4 @@ const BlocksComponent = props => {
 BlocksComponent.propTypes = {
     componentRef: PropTypes.func
 };
-module.exports = BlocksComponent;
+export default BlocksComponent;

--- a/src/components/box/box.jsx
+++ b/src/components/box/box.jsx
@@ -136,4 +136,4 @@ Box.defaultProps = {
     element: 'div',
     style: {}
 };
-module.exports = Box;
+export default Box;

--- a/src/components/buffered-input/buffered-input.jsx
+++ b/src/components/buffered-input/buffered-input.jsx
@@ -49,4 +49,4 @@ BufferedInput.propTypes = {
     onSubmit: PropTypes.func.isRequired,
     value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
 };
-module.exports = BufferedInput;
+export default BufferedInput;

--- a/src/components/button/button.jsx
+++ b/src/components/button/button.jsx
@@ -28,4 +28,4 @@ ButtonComponent.propTypes = {
     className: PropTypes.string,
     onClick: PropTypes.func.isRequired
 };
-module.exports = ButtonComponent;
+export default ButtonComponent;

--- a/src/components/close-button/close-button.jsx
+++ b/src/components/close-button/close-button.jsx
@@ -37,4 +37,4 @@ CloseButton.defaultProps = {
     size: CloseButton.SIZE_LARGE
 };
 
-module.exports = CloseButton;
+export default CloseButton;

--- a/src/components/costume-canvas/costume-canvas.jsx
+++ b/src/components/costume-canvas/costume-canvas.jsx
@@ -127,4 +127,4 @@ CostumeCanvas.propTypes = {
     width: PropTypes.number
 };
 
-module.exports = CostumeCanvas;
+export default CostumeCanvas;

--- a/src/components/filter/filter.jsx
+++ b/src/components/filter/filter.jsx
@@ -54,4 +54,4 @@ FilterComponent.propTypes = {
 FilterComponent.defaultProps = {
     placeholderText: 'what are you looking for?'
 };
-module.exports = FilterComponent;
+export default FilterComponent;

--- a/src/components/green-flag/green-flag.jsx
+++ b/src/components/green-flag/green-flag.jsx
@@ -34,4 +34,4 @@ GreenFlagComponent.defaultProps = {
     active: false,
     title: 'Go'
 };
-module.exports = GreenFlagComponent;
+export default GreenFlagComponent;

--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -121,4 +121,4 @@ GUIComponent.propTypes = {
 GUIComponent.defaultProps = {
     basePath: './'
 };
-module.exports = GUIComponent;
+export default GUIComponent;

--- a/src/components/language-selector/language-selector.jsx
+++ b/src/components/language-selector/language-selector.jsx
@@ -41,4 +41,4 @@ LanguageSelector.propTypes = {
     onChange: PropTypes.func
 };
 
-module.exports = LanguageSelector;
+export default LanguageSelector;

--- a/src/components/library-item/library-item.jsx
+++ b/src/components/library-item/library-item.jsx
@@ -56,4 +56,4 @@ LibraryItem.propTypes = {
     onSelect: PropTypes.func.isRequired
 };
 
-module.exports = LibraryItem;
+export default LibraryItem;

--- a/src/components/library/library.jsx
+++ b/src/components/library/library.jsx
@@ -97,4 +97,4 @@ LibraryComponent.propTypes = {
     visible: PropTypes.bool.isRequired
 };
 
-module.exports = LibraryComponent;
+export default LibraryComponent;

--- a/src/components/load-button/load-button.jsx
+++ b/src/components/load-button/load-button.jsx
@@ -33,4 +33,4 @@ LoadButtonComponent.propTypes = {
 LoadButtonComponent.defaultProps = {
     title: 'Load'
 };
-module.exports = LoadButtonComponent;
+export default LoadButtonComponent;

--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -29,4 +29,4 @@ const MenuBar = function MenuBar () {
     );
 };
 
-module.exports = MenuBar;
+export default MenuBar;

--- a/src/components/meter/meter.jsx
+++ b/src/components/meter/meter.jsx
@@ -59,4 +59,4 @@ Meter.propTypes = {
     width: PropTypes.number
 };
 
-module.exports = Meter;
+export default Meter;

--- a/src/components/modal/modal.jsx
+++ b/src/components/modal/modal.jsx
@@ -72,4 +72,4 @@ ModalComponent.propTypes = {
     visible: PropTypes.bool.isRequired
 };
 
-module.exports = ModalComponent;
+export default ModalComponent;

--- a/src/components/monitor-list/monitor-list.jsx
+++ b/src/components/monitor-list/monitor-list.jsx
@@ -30,4 +30,4 @@ MonitorList.propTypes = {
     onMonitorChange: PropTypes.func.isRequired
 };
 
-module.exports = MonitorList;
+export default MonitorList;

--- a/src/components/monitor/monitor.jsx
+++ b/src/components/monitor/monitor.jsx
@@ -53,4 +53,4 @@ MonitorComponent.defaultProps = {
     y: 0
 };
 
-module.exports = MonitorComponent;
+export default MonitorComponent;

--- a/src/components/prompt/prompt.jsx
+++ b/src/components/prompt/prompt.jsx
@@ -53,4 +53,4 @@ PromptComponent.propTypes = {
     title: PropTypes.string.isRequired
 };
 
-module.exports = PromptComponent;
+export default PromptComponent;

--- a/src/components/record-modal/playback-step.jsx
+++ b/src/components/record-modal/playback-step.jsx
@@ -83,4 +83,4 @@ PlaybackStep.propTypes = {
     trimStart: PropTypes.number.isRequired
 };
 
-module.exports = PlaybackStep;
+export default PlaybackStep;

--- a/src/components/record-modal/record-modal.jsx
+++ b/src/components/record-modal/record-modal.jsx
@@ -63,4 +63,4 @@ RecordModal.propTypes = {
     trimStart: PropTypes.number.isRequired
 };
 
-module.exports = RecordModal;
+export default RecordModal;

--- a/src/components/record-modal/recording-step.jsx
+++ b/src/components/record-modal/recording-step.jsx
@@ -80,4 +80,4 @@ RecordingStep.propTypes = {
     recording: PropTypes.bool
 };
 
-module.exports = RecordingStep;
+export default RecordingStep;

--- a/src/components/sprite-info/sprite-info.jsx
+++ b/src/components/sprite-info/sprite-info.jsx
@@ -190,4 +190,4 @@ SpriteInfo.propTypes = {
     ])
 };
 
-module.exports = SpriteInfo;
+export default SpriteInfo;

--- a/src/components/sprite-selector-item/sprite-selector-item.jsx
+++ b/src/components/sprite-selector-item/sprite-selector-item.jsx
@@ -46,4 +46,4 @@ SpriteSelectorItem.propTypes = {
     selected: PropTypes.bool.isRequired
 };
 
-module.exports = SpriteSelectorItem;
+export default SpriteSelectorItem;

--- a/src/components/sprite-selector/sprite-selector.jsx
+++ b/src/components/sprite-selector/sprite-selector.jsx
@@ -98,4 +98,4 @@ SpriteSelectorComponent.propTypes = {
     })
 };
 
-module.exports = SpriteSelectorComponent;
+export default SpriteSelectorComponent;

--- a/src/components/stage-selector/stage-selector.jsx
+++ b/src/components/stage-selector/stage-selector.jsx
@@ -53,4 +53,4 @@ StageSelector.propTypes = {
     selected: PropTypes.bool.isRequired,
     url: PropTypes.string
 };
-module.exports = StageSelector;
+export default StageSelector;

--- a/src/components/stage/stage.jsx
+++ b/src/components/stage/stage.jsx
@@ -38,4 +38,4 @@ StageComponent.defaultProps = {
     width: 480,
     height: 360
 };
-module.exports = StageComponent;
+export default StageComponent;

--- a/src/components/stop-all/stop-all.jsx
+++ b/src/components/stop-all/stop-all.jsx
@@ -37,4 +37,4 @@ StopAllComponent.defaultProps = {
     title: 'Stop'
 };
 
-module.exports = StopAllComponent;
+export default StopAllComponent;

--- a/src/components/target-pane/target-pane.jsx
+++ b/src/components/target-pane/target-pane.jsx
@@ -166,4 +166,4 @@ TargetPane.propTypes = {
     vm: PropTypes.instanceOf(VM)
 };
 
-module.exports = TargetPane;
+export default TargetPane;

--- a/src/components/waveform/waveform.jsx
+++ b/src/components/waveform/waveform.jsx
@@ -48,4 +48,4 @@ Waveform.propTypes = {
     width: PropTypes.number
 };
 
-module.exports = Waveform;
+export default Waveform;

--- a/src/containers/audio-trimmer.jsx
+++ b/src/containers/audio-trimmer.jsx
@@ -69,4 +69,4 @@ AudioTrimmer.propTypes = {
     trimStart: PropTypes.number
 };
 
-module.exports = AudioTrimmer;
+export default AudioTrimmer;

--- a/src/containers/backdrop-library.jsx
+++ b/src/containers/backdrop-library.jsx
@@ -43,4 +43,4 @@ BackdropLibrary.propTypes = {
     vm: PropTypes.instanceOf(VM).isRequired
 };
 
-module.exports = BackdropLibrary;
+export default BackdropLibrary;

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -263,4 +263,4 @@ Blocks.defaultProps = {
     options: Blocks.defaultOptions
 };
 
-module.exports = Blocks;
+export default Blocks;

--- a/src/containers/costume-library.jsx
+++ b/src/containers/costume-library.jsx
@@ -43,4 +43,4 @@ CostumeLibrary.propTypes = {
     vm: PropTypes.instanceOf(VM).isRequired
 };
 
-module.exports = CostumeLibrary;
+export default CostumeLibrary;

--- a/src/containers/costume-tab.jsx
+++ b/src/containers/costume-tab.jsx
@@ -9,10 +9,10 @@ import addCostumeIcon from '../components/asset-panel/icon--add-costume-lib.svg'
 
 import {connect} from 'react-redux';
 
-const {
+import {
     openCostumeLibrary,
     openBackdropLibrary
-} = require('../reducers/modals');
+} from '../reducers/modals';
 
 class CostumeTab extends React.Component {
     constructor (props) {
@@ -134,7 +134,7 @@ const mapDispatchToProps = dispatch => ({
     }
 });
 
-module.exports = connect(
+export default connect(
     mapStateToProps,
     mapDispatchToProps
 )(CostumeTab);

--- a/src/containers/green-flag.jsx
+++ b/src/containers/green-flag.jsx
@@ -69,4 +69,4 @@ GreenFlag.propTypes = {
     vm: PropTypes.instanceOf(VM)
 };
 
-module.exports = GreenFlag;
+export default GreenFlag;

--- a/src/containers/gui.jsx
+++ b/src/containers/gui.jsx
@@ -56,4 +56,4 @@ GUI.propTypes = {
 
 GUI.defaultProps = GUIComponent.defaultProps;
 
-module.exports = vmListenerHOC(GUI);
+export default vmListenerHOC(GUI);

--- a/src/containers/language-selector.jsx
+++ b/src/containers/language-selector.jsx
@@ -14,7 +14,7 @@ const mapDispatchToProps = dispatch => ({
     }
 });
 
-module.exports = connect(
+export default connect(
     mapStateToProps,
     mapDispatchToProps
 )(LanguageSelectorComponent);

--- a/src/containers/load-button.jsx
+++ b/src/containers/load-button.jsx
@@ -49,7 +49,7 @@ const mapStateToProps = state => ({
     loadProject: state.vm.fromJSON.bind(state.vm)
 });
 
-module.exports = connect(
+export default connect(
     mapStateToProps,
     () => ({}) // omit dispatch prop
 )(LoadButton);

--- a/src/containers/monitor-list.jsx
+++ b/src/containers/monitor-list.jsx
@@ -30,7 +30,7 @@ const mapStateToProps = state => ({
 });
 const mapDispatchToProps = () => ({});
 
-module.exports = connect(
+export default connect(
     mapStateToProps,
     mapDispatchToProps
 )(MonitorList);

--- a/src/containers/monitor.jsx
+++ b/src/containers/monitor.jsx
@@ -39,4 +39,4 @@ Monitor.propTypes = {
     value: PropTypes.string.isRequired // eslint-disable-line react/no-unused-prop-types
 };
 
-module.exports = Monitor;
+export default Monitor;

--- a/src/containers/playback-step.jsx
+++ b/src/containers/playback-step.jsx
@@ -53,4 +53,4 @@ PlaybackStep.propTypes = {
     ...PlaybackStepComponent.propTypes
 };
 
-module.exports = PlaybackStep;
+export default PlaybackStep;

--- a/src/containers/prompt.jsx
+++ b/src/containers/prompt.jsx
@@ -51,4 +51,4 @@ Prompt.propTypes = {
     title: PropTypes.string.isRequired
 };
 
-module.exports = Prompt;
+export default Prompt;

--- a/src/containers/record-modal.jsx
+++ b/src/containers/record-modal.jsx
@@ -7,9 +7,9 @@ import {connect} from 'react-redux';
 
 import RecordModalComponent from '../components/record-modal/record-modal.jsx';
 
-const {
+import {
     closeSoundRecorder
-} = require('../reducers/modals');
+} from '../reducers/modals';
 
 class RecordModal extends React.Component {
     constructor (props) {
@@ -139,7 +139,7 @@ const mapDispatchToProps = dispatch => ({
     }
 });
 
-module.exports = connect(
+export default connect(
     mapStateToProps,
     mapDispatchToProps
 )(RecordModal);

--- a/src/containers/recording-step.jsx
+++ b/src/containers/recording-step.jsx
@@ -68,4 +68,4 @@ class RecordingStep extends React.Component {
 
 RecordingStep.propTypes = RecordingStepComponent.propTypes;
 
-module.exports = RecordingStep;
+export default RecordingStep;

--- a/src/containers/save-button.jsx
+++ b/src/containers/save-button.jsx
@@ -56,7 +56,7 @@ const mapStateToProps = state => ({
     saveProjectSb3: state.vm.saveProjectSb3.bind(state.vm)
 });
 
-module.exports = connect(
+export default connect(
     mapStateToProps,
     () => ({}) // omit dispatch prop
 )(SaveButton);

--- a/src/containers/sound-library.jsx
+++ b/src/containers/sound-library.jsx
@@ -91,4 +91,4 @@ SoundLibrary.propTypes = {
     vm: PropTypes.instanceOf(VM).isRequired
 };
 
-module.exports = SoundLibrary;
+export default SoundLibrary;

--- a/src/containers/sound-tab.jsx
+++ b/src/containers/sound-tab.jsx
@@ -13,10 +13,10 @@ import RecordModal from './record-modal.jsx';
 
 import {connect} from 'react-redux';
 
-const {
+import {
     openSoundLibrary,
     openSoundRecorder
-} = require('../reducers/modals');
+} from '../reducers/modals';
 
 class SoundTab extends React.Component {
     constructor (props) {
@@ -153,7 +153,7 @@ const mapDispatchToProps = dispatch => ({
     }
 });
 
-module.exports = connect(
+export default connect(
     mapStateToProps,
     mapDispatchToProps
 )(SoundTab);

--- a/src/containers/sprite-info.jsx
+++ b/src/containers/sprite-info.jsx
@@ -48,4 +48,4 @@ SpriteInfo.propTypes = {
     y: PropTypes.number
 };
 
-module.exports = SpriteInfo;
+export default SpriteInfo;

--- a/src/containers/sprite-library.jsx
+++ b/src/containers/sprite-library.jsx
@@ -82,4 +82,4 @@ SpriteLibrary.propTypes = {
     vm: PropTypes.instanceOf(VM).isRequired
 };
 
-module.exports = SpriteLibrary;
+export default SpriteLibrary;

--- a/src/containers/sprite-selector-item.jsx
+++ b/src/containers/sprite-selector-item.jsx
@@ -58,6 +58,6 @@ const mapStateToProps = (state, {assetId, costumeURL}) => ({
     costumeURL: costumeURL || (assetId && state.vm.runtime.storage.get(assetId).encodeDataURI())
 });
 
-module.exports = connect(
+export default connect(
     mapStateToProps
 )(SpriteSelectorItem);

--- a/src/containers/stage-selector.jsx
+++ b/src/containers/stage-selector.jsx
@@ -44,7 +44,7 @@ const mapStateToProps = (state, {assetId}) => ({
     url: assetId && state.vm.runtime.storage.get(assetId).encodeDataURI()
 });
 
-module.exports = connect(
+export default connect(
     mapStateToProps,
     () => ({}) // omit dispatch prop
 )(StageSelector);

--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -195,4 +195,4 @@ Stage.propTypes = {
     vm: PropTypes.instanceOf(VM).isRequired
 };
 
-module.exports = Stage;
+export default Stage;

--- a/src/containers/stop-all.jsx
+++ b/src/containers/stop-all.jsx
@@ -52,4 +52,4 @@ StopAll.propTypes = {
     vm: PropTypes.instanceOf(VM)
 };
 
-module.exports = StopAll;
+export default StopAll;

--- a/src/containers/target-pane.jsx
+++ b/src/containers/target-pane.jsx
@@ -3,14 +3,14 @@ import React from 'react';
 
 import {connect} from 'react-redux';
 
-const {
+import {
     openBackdropLibrary,
     openSpriteLibrary,
     closeBackdropLibrary,
     closeCostumeLibrary,
     closeSoundLibrary,
     closeSpriteLibrary
-} = require('../reducers/modals');
+} from '../reducers/modals';
 
 import TargetPaneComponent from '../components/target-pane/target-pane.jsx';
 
@@ -117,7 +117,7 @@ const mapDispatchToProps = dispatch => ({
     }
 });
 
-module.exports = connect(
+export default connect(
     mapStateToProps,
     mapDispatchToProps
 )(TargetPane);

--- a/src/lib/audio/audio-buffer-player.js
+++ b/src/lib/audio/audio-buffer-player.js
@@ -50,4 +50,4 @@ class AudioBufferPlayer {
     }
 }
 
-module.exports = AudioBufferPlayer;
+export default AudioBufferPlayer;

--- a/src/lib/audio/audio-recorder.js
+++ b/src/lib/audio/audio-recorder.js
@@ -136,4 +136,4 @@ class AudioRecorder {
     }
 }
 
-module.exports = AudioRecorder;
+export default AudioRecorder;

--- a/src/lib/audio/shared-audio-context.js
+++ b/src/lib/audio/shared-audio-context.js
@@ -1,6 +1,6 @@
 // Wrap browser AudioContext because we shouldn't create more than one
 const AUDIO_CONTEXT = new (window.AudioContext || window.webkitAudioContext)();
 
-module.exports = function () {
+export default function () {
     return AUDIO_CONTEXT;
-};
+}

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -1,6 +1,6 @@
 import ScratchBlocks from 'scratch-blocks';
 
-module.exports = function (vm) {
+export default function (vm) {
 
     const jsonForMenuBlock = function (name, menuOptionsFn, colors, start) {
         return {
@@ -137,4 +137,4 @@ module.exports = function (vm) {
     };
 
     return ScratchBlocks;
-};
+}

--- a/src/lib/log.js
+++ b/src/lib/log.js
@@ -1,4 +1,4 @@
 import minilog from 'minilog';
 minilog.enable();
 
-module.exports = minilog('gui');
+export default minilog('gui');

--- a/src/lib/monitor-adapter.js
+++ b/src/lib/monitor-adapter.js
@@ -10,7 +10,7 @@ const MONITOR_HEIGHT = 23;
 
 const isUndefined = a => typeof a === 'undefined';
 
-module.exports = function ({id, index, opcode, params, value, x, y}) {
+export default function ({id, index, opcode, params, value, x, y}) {
     let {label, category, labelFn} = OpcodeLabels(opcode);
 
     // Use labelFn if provided for dynamic labelling (e.g. variables)
@@ -23,4 +23,4 @@ module.exports = function ({id, index, opcode, params, value, x, y}) {
     if (isUndefined(y)) y = PADDING + (index * (PADDING + MONITOR_HEIGHT));
 
     return {id, label, category, value, x, y};
-};
+}

--- a/src/lib/opcode-labels.js
+++ b/src/lib/opcode-labels.js
@@ -66,10 +66,10 @@ const opcodeMap = {
     }
 };
 
-module.exports = function (opcode) {
+export default function (opcode) {
     if (opcode in opcodeMap) return opcodeMap[opcode];
     return {
         category: 'data',
         label: opcode
     };
-};
+}

--- a/src/lib/project-loader.js
+++ b/src/lib/project-loader.js
@@ -1,6 +1,7 @@
 import xhr from 'xhr';
 
 import log from './log';
+import emptyProject from './empty-project.json';
 
 class ProjectLoader {
     constructor () {
@@ -17,6 +18,6 @@ class ProjectLoader {
     }
 }
 
-ProjectLoader.DEFAULT_PROJECT_DATA = require('./empty-project.json');
+ProjectLoader.DEFAULT_PROJECT_DATA = emptyProject;
 
-module.exports = new ProjectLoader();
+export default new ProjectLoader();

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -26,4 +26,4 @@ class Storage extends ScratchStorage {
     }
 }
 
-module.exports = Storage;
+export default Storage;

--- a/src/lib/vm-listener-hoc.jsx
+++ b/src/lib/vm-listener-hoc.jsx
@@ -113,4 +113,4 @@ const vmListenerHOC = function (WrappedComponent) {
     )(VMListener);
 };
 
-module.exports = vmListenerHOC;
+export default vmListenerHOC;

--- a/src/reducers/gui.js
+++ b/src/reducers/gui.js
@@ -6,7 +6,7 @@ import targetReducer from './targets';
 import vmReducer from './vm';
 
 
-module.exports = combineReducers({
+export default combineReducers({
     intl: intlReducer,
     modals: modalReducer,
     monitors: monitorReducer,

--- a/src/reducers/intl.js
+++ b/src/reducers/intl.js
@@ -22,4 +22,9 @@ const updateIntl = locale => superUpdateIntl({
     messages: messages[locale] || messages.en
 });
 
-export {intlReducer as default, IntlProvider, intlInitialState, updateIntl};
+export {
+    intlReducer as default,
+    IntlProvider,
+    intlInitialState,
+    updateIntl
+};

--- a/src/reducers/intl.js
+++ b/src/reducers/intl.js
@@ -1,12 +1,12 @@
 import {addLocaleData} from 'react-intl';
 import {updateIntl as superUpdateIntl} from 'react-intl-redux';
 import languages from '../languages.json';
-import messages from '../../locale/messages.json';
+import messages from '../../locale/messages.json'; // eslint-disable-line import/no-unresolved
+
 import {IntlProvider, intlReducer} from 'react-intl-redux';
 
 Object.keys(languages).forEach(locale => {
     // TODO: will need to handle locales not in the default intl - see www/custom-locales
-    // eslint-disable-line import/no-unresolved
     import(`react-intl/locale-data/${locale}`).then(data => addLocaleData(data));
 });
 

--- a/src/reducers/intl.js
+++ b/src/reducers/intl.js
@@ -6,6 +6,7 @@ import {IntlProvider, intlReducer} from 'react-intl-redux';
 
 Object.keys(languages).forEach(locale => {
     // TODO: will need to handle locales not in the default intl - see www/custom-locales
+    // eslint-disable-line import/no-unresolved
     import(`react-intl/locale-data/${locale}`).then(data => addLocaleData(data));
 });
 

--- a/src/reducers/modals.js
+++ b/src/reducers/modals.js
@@ -30,46 +30,58 @@ const reducer = function (state, action) {
         return state;
     }
 };
-reducer.openModal = function (modal) {
+const openModal = function (modal) {
     return {
         type: OPEN_MODAL,
         modal: modal
     };
 };
-reducer.closeModal = function (modal) {
+const closeModal = function (modal) {
     return {
         type: CLOSE_MODAL,
         modal: modal
     };
 };
-reducer.openBackdropLibrary = function () {
-    return reducer.openModal(MODAL_BACKDROP_LIBRARY);
+const openBackdropLibrary = function () {
+    return openModal(MODAL_BACKDROP_LIBRARY);
 };
-reducer.openCostumeLibrary = function () {
-    return reducer.openModal(MODAL_COSTUME_LIBRARY);
+const openCostumeLibrary = function () {
+    return openModal(MODAL_COSTUME_LIBRARY);
 };
-reducer.openSoundLibrary = function () {
-    return reducer.openModal(MODAL_SOUND_LIBRARY);
+const openSoundLibrary = function () {
+    return openModal(MODAL_SOUND_LIBRARY);
 };
-reducer.openSpriteLibrary = function () {
-    return reducer.openModal(MODAL_SPRITE_LIBRARY);
+const openSpriteLibrary = function () {
+    return openModal(MODAL_SPRITE_LIBRARY);
 };
-reducer.openSoundRecorder = function () {
-    return reducer.openModal(MODAL_SOUND_RECORDER);
+const openSoundRecorder = function () {
+    return openModal(MODAL_SOUND_RECORDER);
 };
-reducer.closeBackdropLibrary = function () {
-    return reducer.closeModal(MODAL_BACKDROP_LIBRARY);
+const closeBackdropLibrary = function () {
+    return closeModal(MODAL_BACKDROP_LIBRARY);
 };
-reducer.closeCostumeLibrary = function () {
-    return reducer.closeModal(MODAL_COSTUME_LIBRARY);
+const closeCostumeLibrary = function () {
+    return closeModal(MODAL_COSTUME_LIBRARY);
 };
-reducer.closeSpriteLibrary = function () {
-    return reducer.closeModal(MODAL_SPRITE_LIBRARY);
+const closeSpriteLibrary = function () {
+    return closeModal(MODAL_SPRITE_LIBRARY);
 };
-reducer.closeSoundLibrary = function () {
-    return reducer.closeModal(MODAL_SOUND_LIBRARY);
+const closeSoundLibrary = function () {
+    return closeModal(MODAL_SOUND_LIBRARY);
 };
-reducer.closeSoundRecorder = function () {
-    return reducer.closeModal(MODAL_SOUND_RECORDER);
+const closeSoundRecorder = function () {
+    return closeModal(MODAL_SOUND_RECORDER);
 };
-module.exports = reducer;
+export {
+    reducer as default,
+    openBackdropLibrary,
+    openCostumeLibrary,
+    openSoundLibrary,
+    openSpriteLibrary,
+    openSoundRecorder,
+    closeBackdropLibrary,
+    closeCostumeLibrary,
+    closeSpriteLibrary,
+    closeSoundLibrary,
+    closeSoundRecorder
+};

--- a/src/reducers/monitors.js
+++ b/src/reducers/monitors.js
@@ -13,7 +13,7 @@ const reducer = function (state, action) {
     }
 };
 
-reducer.updateMonitors = function (monitors) {
+const updateMonitors = function (monitors) {
     return {
         type: UPDATE_MONITORS,
         monitors: monitors,
@@ -23,4 +23,7 @@ reducer.updateMonitors = function (monitors) {
     };
 };
 
-module.exports = reducer;
+export {
+    reducer as default,
+    updateMonitors
+};

--- a/src/reducers/targets.js
+++ b/src/reducers/targets.js
@@ -29,7 +29,7 @@ const reducer = function (state, action) {
         return state;
     }
 };
-reducer.updateTargets = function (targetList) {
+const updateTargets = function (targetList) {
     return {
         type: UPDATE_TARGET_LIST,
         targets: targetList,
@@ -38,7 +38,7 @@ reducer.updateTargets = function (targetList) {
         }
     };
 };
-reducer.updateEditingTarget = function (editingTarget) {
+const updateEditingTarget = function (editingTarget) {
     return {
         type: UPDATE_EDITING_TARGET,
         target: editingTarget,
@@ -47,4 +47,8 @@ reducer.updateEditingTarget = function (editingTarget) {
         }
     };
 };
-module.exports = reducer;
+export {
+    reducer as default,
+    updateTargets,
+    updateEditingTarget
+};

--- a/src/reducers/vm.js
+++ b/src/reducers/vm.js
@@ -15,10 +15,13 @@ const reducer = function (state, action) {
         return state;
     }
 };
-reducer.setVM = function (vm) {
+const setVM = function (vm) {
     return {
         type: SET_VM,
         vm: vm
     };
 };
-module.exports = reducer;
+export {
+    reducer as default,
+    setVM
+};

--- a/test/unit/components/button.test.jsx
+++ b/test/unit/components/button.test.jsx
@@ -1,8 +1,8 @@
 /* eslint-env jest */
-const React = require('react'); // eslint-disable-line no-unused-vars
-const {shallow} = require('enzyme');
-const ButtonComponent = require('../../../src/components/button/button'); // eslint-disable-line no-unused-vars
-const renderer = require('react-test-renderer');
+import React from 'react'; // eslint-disable-line no-unused-vars
+import {shallow} from 'enzyme';
+import ButtonComponent from '../../../src/components/button/button'; // eslint-disable-line no-unused-vars
+import renderer from 'react-test-renderer';
 
 describe('ButtonComponent', () => {
     test('matches snapshot', () => {

--- a/test/unit/components/sprite-selector-item.test.jsx
+++ b/test/unit/components/sprite-selector-item.test.jsx
@@ -1,12 +1,11 @@
 /* eslint-env jest */
-const React = require('react'); // eslint-disable-line no-unused-vars
-const {shallow} = require('enzyme');
-const SpriteSelectorItemComponent = require( // eslint-disable-line no-unused-vars
-    '../../../src/components/sprite-selector-item/sprite-selector-item');
-const CostumeCanvas = require( // eslint-disable-line no-unused-vars
-    '../../../src/components/costume-canvas/costume-canvas');
-const CloseButton = require('../../../src/components/close-button/close-button'); // eslint-disable-line no-unused-vars
-const renderer = require('react-test-renderer');
+import React from 'react'; // eslint-disable-line no-unused-vars
+import {shallow} from 'enzyme';
+// eslint-disable-next-line no-unused-vars
+import SpriteSelectorItemComponent from '../../../src/components/sprite-selector-item/sprite-selector-item';
+import CostumeCanvas from '../../../src/components/costume-canvas/costume-canvas';
+import CloseButton from '../../../src/components/close-button/close-button'; // eslint-disable-line no-unused-vars
+import renderer from 'react-test-renderer';
 
 describe('SpriteSelectorItemComponent', () => {
     let className;

--- a/test/unit/containers/green-flag.test.jsx
+++ b/test/unit/containers/green-flag.test.jsx
@@ -1,9 +1,9 @@
 /* eslint-env jest */
-const React = require('react'); // eslint-disable-line no-unused-vars
-const {shallow} = require('enzyme');
-const GreenFlag = require('../../../src/containers/green-flag'); // eslint-disable-line no-unused-vars
-const renderer = require('react-test-renderer');
-const VM = require('scratch-vm');
+import React from 'react'; // eslint-disable-line no-unused-vars
+import {shallow} from 'enzyme';
+import GreenFlag from '../../../src/containers/green-flag'; // eslint-disable-line no-unused-vars
+import renderer from 'react-test-renderer';
+import VM from 'scratch-vm';
 
 describe('GreenFlag Container', () => {
     let vm;

--- a/test/unit/containers/sprite-selector-item.test.jsx
+++ b/test/unit/containers/sprite-selector-item.test.jsx
@@ -1,12 +1,11 @@
 /* eslint-env jest */
-const React = require('react'); // eslint-disable-line no-unused-vars
-const {mount} = require('enzyme');
+import React from 'react'; // eslint-disable-line no-unused-vars
+import {mount} from 'enzyme';
 import configureStore from 'redux-mock-store';
 import {Provider} from 'react-redux'; // eslint-disable-line no-unused-vars
 
-const SpriteSelectorItem = require( // eslint-disable-line no-unused-vars
-    '../../../src/containers/sprite-selector-item');
-const CloseButton = require('../../../src/components/close-button/close-button'); // eslint-disable-line no-unused-vars
+import SpriteSelectorItem from '../../../src/containers/sprite-selector-item'; // eslint-disable-line no-unused-vars
+import CloseButton from '../../../src/components/close-button/close-button'; // eslint-disable-line no-unused-vars
 
 describe('SpriteSelectorItem Container', () => {
     const mockStore = configureStore();


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/eslint-config-scratch/issues/9

### Proposed Changes

_Describe what this Pull Request does_

Adds the eslint plugin for import and add rules to disallow amd/commonjs style in favor of es6 import.

### Reason for Changes

_Explain why these changes should be made_

Consistency! we changed from commonjs to es6 for the imports earlier to support build features for translation, but we didn't update the export part. This makes all the required export changes and adds the relevant lint rules

### Test Coverage

_Please show how you have added tests to cover your changes_
