### PR TITLE
Fix reducer imports

### DIFF
--- a/src/lib/vm-listener-hoc.jsx
+++ b/src/lib/vm-listener-hoc.jsx
@@ -5,8 +5,8 @@ import VM from 'scratch-vm';
 
 import {connect} from 'react-redux';
 
-import targets from '../reducers/targets';
-import monitors from '../reducers/monitors';
+import {updateEditingTarget, updateTargets} from '../reducers/targets';
+import {updateMonitors} from '../reducers/monitors';
 
 /*
  * Higher Order Component to manage events emitted by the VM
@@ -100,11 +100,11 @@ const vmListenerHOC = function (WrappedComponent) {
     });
     const mapDispatchToProps = dispatch => ({
         onTargetsUpdate: data => {
-            dispatch(targets.updateEditingTarget(data.editingTarget));
-            dispatch(targets.updateTargets(data.targetList));
+            dispatch(updateEditingTarget(data.editingTarget));
+            dispatch(updateTargets(data.targetList));
         },
         onMonitorsUpdate: monitorList => {
-            dispatch(monitors.updateMonitors(monitorList));
+            dispatch(updateMonitors(monitorList));
         }
     });
     return connect(


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

There was a place where we expected to be able to import the action creators as part of the reducer object that I missed in the import/export refactor I merged today. That broke develop slightly. 

### Proposed Changes

_Describe what this Pull Request does_

Fixes that problem.