### PR TITLE
localeData cleanup

### DIFF
--- a/scripts/generate-locale-messages.js
+++ b/scripts/generate-locale-messages.js
@@ -42,12 +42,11 @@ Missing locales are ignored, react-intl will use the default messages for them.
 const fs = require('fs');
 const path = require('path');
 const mkdirp = require('mkdirp');
-const languages = require('../src/languages.json');
 
+const locales = ['en', 'es', 'fr'];
 const LANG_DIR = './translations/';
 const MSGS_DIR = './locale/';
 
-const locales = Object.keys(languages);
 let messages = locales.reduce((collection, lang) => {
     let langMessages = {};
     try {

--- a/src/components/language-selector/language-selector.jsx
+++ b/src/components/language-selector/language-selector.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import Box from '../box/box.jsx';
-import languages from '../../languages.json';
+import languages from '../../locale.js';
 import languageIcon from './language-icon.svg';
 import styles from './language-selector.css';
 
@@ -27,7 +27,7 @@ const LanguageSelector = ({
                         key={locale}
                         value={locale}
                     >
-                        {languages[locale]}
+                        {languages[locale].name}
                     </option>
                 ))}
             </select>

--- a/src/languages.json
+++ b/src/languages.json
@@ -1,5 +1,0 @@
-{
-    "en": "English",
-    "es": "Español",
-    "fr": "Français"
-}

--- a/src/locale.js
+++ b/src/locale.js
@@ -1,0 +1,23 @@
+import localeDataEn from 'react-intl/locale-data/en';
+import localeDataEs from 'react-intl/locale-data/es';
+import localeDataFr from 'react-intl/locale-data/fr';
+
+import messages from '../locale/messages.json'; // eslint-disable-line import/no-unresolved
+
+export default {
+    en: {
+        name: 'English',
+        localeData: localeDataEn,
+        messages: messages.en
+    },
+    es: {
+        name: 'Español',
+        localeData: localeDataEs,
+        messages: messages.es
+    },
+    fr: {
+        name: 'Français',
+        localeData: localeDataFr,
+        messages: messages.fr
+    }
+};

--- a/src/reducers/intl.js
+++ b/src/reducers/intl.js
@@ -1,26 +1,25 @@
 import {addLocaleData} from 'react-intl';
 import {updateIntl as superUpdateIntl} from 'react-intl-redux';
-import languages from '../languages.json';
-import messages from '../../locale/messages.json'; // eslint-disable-line import/no-unresolved
-
 import {IntlProvider, intlReducer} from 'react-intl-redux';
 
-Object.keys(languages).forEach(locale => {
+import locales from '../locale.js';
+
+Object.keys(locales).forEach(locale => {
     // TODO: will need to handle locales not in the default intl - see www/custom-locales
-    import(`react-intl/locale-data/${locale}`).then(data => addLocaleData(data));
+    addLocaleData(locales[locale].localeData);
 });
 
 const intlInitialState = {
     intl: {
         defaultLocale: 'en',
         locale: 'en',
-        messages: messages.en
+        messages: locales.en.messages
     }
 };
 
 const updateIntl = locale => superUpdateIntl({
     locale: locale,
-    messages: messages[locale] || messages.en
+    messages: locales[locale].messages || locales.en.messages
 });
 
 export {


### PR DESCRIPTION
### Resolves

#557 

### Proposed Changes

move all locale data (react-intl/locale-data and gui messages) into locale.js. This also makes switching to an external node package easier because the package just needs to export the same thing as locale.js.

