### PR TITLE
Use sound ID coming back from decodeSound

### DIFF
--- a/src/containers/sound-editor.jsx
+++ b/src/containers/sound-editor.jsx
@@ -86,7 +86,7 @@ SoundEditor.propTypes = {
 
 const mapStateToProps = (state, {soundIndex}) => {
     const sound = state.vm.editingTarget.sprite.sounds[soundIndex];
-    const audioBuffer = state.vm.runtime.audioEngine.audioBuffers[sound.md5];
+    const audioBuffer = state.vm.getSoundBuffer(soundIndex);
     return {
         sampleRate: audioBuffer.sampleRate,
         samples: audioBuffer.getChannelData(0),

--- a/src/containers/sound-library.jsx
+++ b/src/containers/sound-library.jsx
@@ -40,8 +40,8 @@ class SoundLibrary extends React.PureComponent {
             };
             return this.audioEngine.decodeSound(sound);
         })
-        .then(() => {
-            this.player.playSound(soundItem._md5);
+        .then(soundId => {
+            this.player.playSound(soundId);
         });
     }
     handleItemMouseLeave () {


### PR DESCRIPTION
Update the way sounds are played in the library to work with these audio engine changes https://github.com/LLK/scratch-audio/pull/57. 

Now the audio engine returns a `soundId` that must be used to play the sounds instead of being played by "md5". 

See the attached issue for more context. 