### PR TITLE
Fix color conflict

### DIFF
--- a/src/components/language-selector/language-selector.css
+++ b/src/components/language-selector/language-selector.css
@@ -18,6 +18,6 @@
     user-select: none;
     outline: none;
     background: rgba(255, 255, 255, 0.2);
-    color: white;
+    color: black;
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 }

--- a/src/components/language-selector/language-selector.css
+++ b/src/components/language-selector/language-selector.css
@@ -9,6 +9,7 @@
 
 .language-icon {
     height:  2rem;
+    display:none;
 }
 
 .language-select {
@@ -17,7 +18,7 @@
     border: 1px solid #4c97ff;
     user-select: none;
     outline: none;
-    background: rgba(255, 255, 255, 0.2);
-    color: black;
+    background: rgba(255, 255, 255, 0.5);
+    color: #3373cc;
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 }


### PR DESCRIPTION
### Resolves

#564 - Language selector options were invisible until hovered over

### Proposed Changes

Changes the text color to black, while keeping the background color as white

### Reason for changes

So that language menu options can be instantly seen, instead of having to hover over each one to find your language.