### PR TITLE
Change default block zoom to 0.675 from 0.75

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -237,7 +237,7 @@ Blocks.defaultOptions = {
     zoom: {
         controls: true,
         wheel: true,
-        startScale: 0.75
+        startScale: 0.675
     },
     grid: {
         spacing: 40,


### PR DESCRIPTION
### Proposed Changes

_Describe what this Pull Request does_

Change default zoom (`startScale` for blockly) to 0.675 from 0.75. This is what that looks like (new on the left, old on the right, at 1280x800 window size, non-retina screen):
![image](https://user-images.githubusercontent.com/654102/28640868-1962ff72-721b-11e7-85dc-20841c67e1d8.png)

### Reason for Changes

_Explain why these changes should be made_

cc @carljbowman @thisandagain 
