### PR TITLE
Add new icons for sprite and backdrop buttons

### DIFF
--- a/src/components/asset-panel/selector.jsx
+++ b/src/components/asset-panel/selector.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 import SpriteSelectorItem from '../../containers/sprite-selector-item.jsx';
 
 import Box from '../box/box.jsx';
+import IconButton from '../icon-button/icon-button.jsx';
 import styles from './selector.css';
 
 const Selector = props => {
@@ -34,19 +35,12 @@ const Selector = props => {
             </Box>
             <Box className={styles.newButtons}>
                 {buttons.map(({message, img, onClick}, index) => (
-                    <Box
-                        className={styles.newButton}
+                    <IconButton
+                        img={img}
                         key={index}
+                        title={message}
                         onClick={onClick}
-                    >
-                        <img
-                            className={styles.newButtonIcon}
-                            src={img}
-                        />
-                        <Box className={styles.newButtonLabel}>
-                            {message}
-                        </Box>
-                    </Box>
+                    />
                 ))}
             </Box>
         </Box>

--- a/src/components/icon-button/icon-button.css
+++ b/src/components/icon-button/icon-button.css
@@ -1,0 +1,24 @@
+@import "../../css/colors.css";
+
+.container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    cursor: pointer;
+    transition: 0.2s;
+    font-size: 0.75rem;
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+
+.container:hover {
+    transform: scale(1.1);
+}
+
+.container + .container {
+    margin-top: 1.25rem;
+}
+
+.title {
+    margin-top: 0.5rem;
+    color: $motion-primary;
+}

--- a/src/components/icon-button/icon-button.jsx
+++ b/src/components/icon-button/icon-button.jsx
@@ -1,8 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-
-import Box from '../box/box.jsx';
 import styles from './icon-button.css';
 
 const IconButton = ({
@@ -11,7 +9,7 @@ const IconButton = ({
     title,
     onClick
 }) => (
-    <Box
+    <div
         className={classNames(styles.container, className)}
         onClick={onClick}
     >
@@ -19,10 +17,10 @@ const IconButton = ({
             className={styles.icon}
             src={img}
         />
-        <Box className={styles.title}>
+        <div className={styles.title}>
             {title}
-        </Box>
-    </Box>
+        </div>
+    </div>
 );
 
 IconButton.propTypes = {

--- a/src/components/icon-button/icon-button.jsx
+++ b/src/components/icon-button/icon-button.jsx
@@ -1,0 +1,35 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import classNames from 'classnames';
+
+import Box from '../box/box.jsx';
+import styles from './icon-button.css';
+
+const IconButton = ({
+    img,
+    className,
+    title,
+    onClick
+}) => (
+    <Box
+        className={classNames(styles.container, className)}
+        onClick={onClick}
+    >
+        <img
+            className={styles.icon}
+            src={img}
+        />
+        <Box className={styles.title}>
+            {title}
+        </Box>
+    </Box>
+);
+
+IconButton.propTypes = {
+    className: PropTypes.string,
+    img: PropTypes.string,
+    onClick: PropTypes.func.isRequired,
+    title: PropTypes.node.isRequired
+};
+
+export default IconButton;

--- a/src/components/target-pane/icon--backdrop.svg
+++ b/src/components/target-pane/icon--backdrop.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="29px" height="25px" viewBox="0 0 29 25" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 43.2 (39069) - http://www.bohemiancoding.com/sketch -->
+    <title>add-bg</title>
+    <desc>Created with Sketch.</desc>
+    <defs>
+        <circle id="path-1" cx="21" cy="5" r="5"></circle>
+    </defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+        <g id="Desktop---1280x720" transform="translate(-1224.000000, -668.000000)">
+            <g id="Stage-Area" transform="translate(1200.000000, 460.000000)">
+                <g id="Backdrop-Area" transform="translate(0.000000, 43.000000)">
+                    <g id="backdrop-tile">
+                        <g id="add-bg" transform="translate(10.000000, 167.000000)">
+                            <g transform="translate(15.000000, 0.000000)">
+                                <path d="M19,22 L2,22 C0.9,22 0,20.9731544 0,19.7181208 L0,7.28187919 C0,6.02684564 0.9,5 2,5 L19,5 C20.1,5 21,6.02684564 21,7.28187919 L21,19.7181208 C21,20.9731544 20.1,22 19,22 Z" id="Shape" stroke="#4C97FF" stroke-width="2"></path>
+                                <path d="M21,17.5 L16.8,13.3 C16.2,12.7 15.2,12.6 14.5,13.2 L9.3,17.3 C8.5,17.9 7.4,17.8 6.8,17 L6.3,16.4 C5.7,15.6 4.5,15.5 3.8,16.1 L0,19.2 L0,20.1 C0,21.1 0.8,21.9 1.8,21.9 L19.3,21.9 C20.3,21.9 21.1,21.1 21.1,20.1 L21.1,17.5 L21,17.5 Z" id="Shape" stroke="#4C97FF" stroke-width="2" fill="#4C97FF"></path>
+                                <g id="Oval" fill-rule="nonzero">
+                                    <use fill="#4C97FF" fill-rule="evenodd" xlink:href="#path-1"></use>
+                                    <circle stroke="#FFFFFF" stroke-width="2" cx="21" cy="5" r="6"></circle>
+                                </g>
+                                <path d="M21,3 L21,7" id="Shape" stroke="#FFFFFF" stroke-width="2"></path>
+                                <path d="M23,5 L19,5" id="Shape" stroke="#FFFFFF" stroke-width="2"></path>
+                            </g>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/components/target-pane/icon--sprite.svg
+++ b/src/components/target-pane/icon--sprite.svg
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="28px" height="25px" viewBox="0 0 28 25" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 43.2 (39069) - http://www.bohemiancoding.com/sketch -->
+    <title>add-sprite</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+        <g id="Desktop---1280x720" transform="translate(-1144.000000, -669.000000)" stroke="#4C97FF">
+            <g id="Sprite-Area" transform="translate(792.000000, 460.000000)">
+                <g id="Sprite-List" transform="translate(0.000000, 78.000000)">
+                    <g id="add-sprite" transform="translate(345.000000, 132.000000)">
+                        <g transform="translate(8.000000, 0.000000)">
+                            <path d="M21,16 C21,21 16.9,23.2 11.7,23.2 C6.5,23.2 2.5,21 2.5,16 C2.5,11 5.3,6.7 11.8,6.7 C18.3,6.7 21,11 21,16 Z M11.7,23 C20.1,23 21.6,17 19.5,14.9 C17.1,12.4 14,16 11.7,16 C9.4,16 6.3,12.4 3.9,14.9 C1.8,17 3.4,23 11.7,23 Z" id="Combined-Shape" fill="#4C97FF" fill-rule="nonzero"></path>
+                            <path d="M3.7,11.1 L3,5.8 C3,5.4 3.4,5.2 3.7,5.3 L8.3,7.8" id="Shape" fill="#4C97FF" fill-rule="nonzero"></path>
+                            <path d="M19.9,11.1 L20.6,5.7 C20.6,5.3 20.2,5.1 19.9,5.2 L15.3,7.7" id="Shape" fill="#4C97FF" fill-rule="nonzero"></path>
+                            <path d="M7,17.75 L0,17.75" id="Shape" stroke-width="1.5" fill="#FFFFFF" fill-rule="nonzero"></path>
+                            <path d="M2,22 L7,20" id="Shape" stroke-width="1.5" fill="#FFFFFF" fill-rule="nonzero"></path>
+                            <path d="M16,17.75 L23,17.75" id="Shape" stroke-width="1.5" fill="#FFFFFF" fill-rule="nonzero"></path>
+                            <path d="M22,22 L16,20" id="Shape" stroke-width="1.5" fill="#FFFFFF" fill-rule="nonzero"></path>
+                            <g id="+" transform="translate(22.000000, 0.000000)" stroke-width="2">
+                                <path d="M2,0 L2,4" id="Shape"></path>
+                                <path d="M4,2 L0,2" id="Shape"></path>
+                            </g>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/components/target-pane/target-pane.css
+++ b/src/components/target-pane/target-pane.css
@@ -3,51 +3,32 @@
 .target-pane {
     /* Makes columns for the sprite library selector + and the stage selector */
     display: flex;
-    flex-direction: row; 
-    
+    flex-direction: row;
+
     height: 100%;
 }
 
 .stage-selector-wrapper {
     flex-basis: 72px;
     flex-shrink: 0;
-    margin-left: calc($space / 2); 
+    margin-left: calc($space / 2);
 }
 
 .add-button-wrapper {
-    display: flex;
     position: absolute;
-    justify-content: center;
-    align-items: center;
     z-index: 1;
-    bottom: 1rem;
-    width: 2.25rem !important;
-    height: 2.25rem !important;
-    background-color: #4c97ff;
+    bottom: 0.5rem;
     border: 0;
-    border-radius: 50% !important;
-    box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.1);
-    transition: all 0.15s ease-out; /* @todo: standardize with var */ 
+    transition: all 0.15s ease-out; /* @todo: standardize with var */
     cursor: pointer;
     user-select: none;
 }
 
-.add-button-wrapper:hover {
-    transform: scale(1.1, 1.1);
-    box-shadow: 0 0 0 4px rgba(0, 0, 0, 0.1);
-}
-
-.add-button-wrapper:focus {
-    outline: none;
-    border: 0;
-}
-
 .add-button {
-    height: 0.8rem;
-    margin: auto;
+    font-size: 0.55rem;
+    font-weight: bold;
 }
 
 /* @todo: This is hacky. Better: move buttons in their corresponding panes, and set values relatively */
 .add-button-wrapper--sprite   { right: 7rem; }
-.add-button-wrapper--stage    { right: 1.6rem; }
-.add-button-wrapper--costume  { right: 1.6rem; }
+.add-button-wrapper--stage    { right: 0.8rem; }

--- a/src/components/target-pane/target-pane.jsx
+++ b/src/components/target-pane/target-pane.jsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
+import {FormattedMessage} from 'react-intl';
 
 import VM from 'scratch-vm';
 
@@ -17,6 +18,21 @@ import styles from './target-pane.css';
 import spriteIcon from './icon--sprite.svg';
 import backdropIcon from './icon--backdrop.svg';
 
+const addSpriteMessage = (
+    <FormattedMessage
+        defaultMessage="Add Sprite"
+        description="Button to add a sprite in the target pane"
+        id="targetPane.addSprite"
+    />
+);
+
+const addBackdropMessage = (
+    <FormattedMessage
+        defaultMessage="Add Backdrop"
+        description="Button to add a backdrop in the target pane"
+        id="targetPane.addBackdrop"
+    />
+);
 
 /*
  * Pane that contains the sprite selector, sprite info, stage selector,
@@ -82,7 +98,7 @@ const TargetPane = ({
                     <IconButton
                         className={styles.addButton}
                         img={spriteIcon}
-                        title="Add Sprite"
+                        title={addSpriteMessage}
                         onClick={onNewSpriteClick}
                     />
                 </Box>
@@ -90,7 +106,7 @@ const TargetPane = ({
                     <IconButton
                         className={styles.addButton}
                         img={backdropIcon}
-                        title="Add Backdrop"
+                        title={addBackdropMessage}
                         onClick={onNewBackdropClick}
                     />
                 </Box>

--- a/src/components/target-pane/target-pane.jsx
+++ b/src/components/target-pane/target-pane.jsx
@@ -11,9 +11,12 @@ import SoundLibrary from '../../containers/sound-library.jsx';
 import SpriteLibrary from '../../containers/sprite-library.jsx';
 import SpriteSelectorComponent from '../sprite-selector/sprite-selector.jsx';
 import StageSelector from '../../containers/stage-selector.jsx';
+import IconButton from '../icon-button/icon-button.jsx';
 
 import styles from './target-pane.css';
-import addIcon from './icon--add.svg';
+import spriteIcon from './icon--sprite.svg';
+import backdropIcon from './icon--backdrop.svg';
+
 
 /*
  * Pane that contains the sprite selector, sprite info, stage selector,
@@ -75,29 +78,22 @@ const TargetPane = ({
                 onSelect={onSelectSprite}
             />}
             <Box>
-
-                <button
-                    className={classNames(styles.addButtonWrapper, styles.addButtonWrapperSprite)}
-                    title="Add sprite"
-                    onClick={onNewSpriteClick}
-                >
-                    <img
+                <Box className={classNames(styles.addButtonWrapper, styles.addButtonWrapperSprite)}>
+                    <IconButton
                         className={styles.addButton}
-                        src={addIcon}
+                        img={spriteIcon}
+                        title="Add Sprite"
+                        onClick={onNewSpriteClick}
                     />
-                </button>
-
-                <button
-                    className={classNames(styles.addButtonWrapper, styles.addButtonWrapperStage)}
-                    title="Add backdrop"
-                    onClick={onNewBackdropClick}
-                >
-                    <img
+                </Box>
+                <Box className={classNames(styles.addButtonWrapper, styles.addButtonWrapperStage)}>
+                    <IconButton
                         className={styles.addButton}
-                        src={addIcon}
+                        img={backdropIcon}
+                        title="Add Backdrop"
+                        onClick={onNewBackdropClick}
                     />
-                </button>
-
+                </Box>
                 <SpriteLibrary
                     visible={spriteLibraryVisible}
                     vm={vm}

--- a/test/unit/components/__snapshots__/icon-button.test.jsx.snap
+++ b/test/unit/components/__snapshots__/icon-button.test.jsx.snap
@@ -1,0 +1,50 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`IconButtonComponent matches snapshot 1`] = `
+<div
+  className="custom-class-name"
+  onClick={[Function]}
+  style={
+    Object {
+      "alignContent": undefined,
+      "alignItems": undefined,
+      "alignSelf": undefined,
+      "flexBasis": undefined,
+      "flexDirection": undefined,
+      "flexGrow": undefined,
+      "flexShrink": undefined,
+      "flexWrap": undefined,
+      "height": undefined,
+      "justifyContent": undefined,
+      "width": undefined,
+    }
+  }
+>
+  <img
+    className={undefined}
+    src="imgSrc"
+  />
+  <div
+    className=""
+    style={
+      Object {
+        "alignContent": undefined,
+        "alignItems": undefined,
+        "alignSelf": undefined,
+        "flexBasis": undefined,
+        "flexDirection": undefined,
+        "flexGrow": undefined,
+        "flexShrink": undefined,
+        "flexWrap": undefined,
+        "height": undefined,
+        "justifyContent": undefined,
+        "width": undefined,
+      }
+    }
+  >
+    <div>
+      Text
+    </div>
+  </div>
+</div>
+`;

--- a/test/unit/components/__snapshots__/icon-button.test.jsx.snap
+++ b/test/unit/components/__snapshots__/icon-button.test.jsx.snap
@@ -4,43 +4,13 @@ exports[`IconButtonComponent matches snapshot 1`] = `
 <div
   className="custom-class-name"
   onClick={[Function]}
-  style={
-    Object {
-      "alignContent": undefined,
-      "alignItems": undefined,
-      "alignSelf": undefined,
-      "flexBasis": undefined,
-      "flexDirection": undefined,
-      "flexGrow": undefined,
-      "flexShrink": undefined,
-      "flexWrap": undefined,
-      "height": undefined,
-      "justifyContent": undefined,
-      "width": undefined,
-    }
-  }
 >
   <img
     className={undefined}
     src="imgSrc"
   />
   <div
-    className=""
-    style={
-      Object {
-        "alignContent": undefined,
-        "alignItems": undefined,
-        "alignSelf": undefined,
-        "flexBasis": undefined,
-        "flexDirection": undefined,
-        "flexGrow": undefined,
-        "flexShrink": undefined,
-        "flexWrap": undefined,
-        "height": undefined,
-        "justifyContent": undefined,
-        "width": undefined,
-      }
-    }
+    className={undefined}
   >
     <div>
       Text

--- a/test/unit/components/icon-button.test.jsx
+++ b/test/unit/components/icon-button.test.jsx
@@ -1,0 +1,38 @@
+/* eslint-env jest */
+import React from 'react'; // eslint-disable-line no-unused-vars
+import {shallow} from 'enzyme';
+import IconButton from '../../../src/components/icon-button/icon-button'; // eslint-disable-line no-unused-vars
+import renderer from 'react-test-renderer';
+
+describe('IconButtonComponent', () => {
+    test('matches snapshot', () => {
+        const onClick = jest.fn();
+        const title = <div>Text</div>;
+        const imgSrc = 'imgSrc';
+        const className = 'custom-class-name';
+        const component = renderer.create(
+            <IconButton
+                className={className}
+                img={imgSrc}
+                title={title}
+                onClick={onClick}
+            />
+        );
+        expect(component.toJSON()).toMatchSnapshot();
+    });
+
+    test('triggers callback when clicked', () => {
+        const onClick = jest.fn();
+        const title = <div>Text</div>;
+        const imgSrc = 'imgSrc';
+        const componentShallowWrapper = shallow(
+            <IconButton
+                img={imgSrc}
+                title={title}
+                onClick={onClick}
+            />
+        );
+        componentShallowWrapper.simulate('click');
+        expect(onClick).toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

One part of https://github.com/LLK/scratch-gui/issues/514

### Proposed Changes

_Describe what this Pull Request does_

Extract out and reuse the `IconButton` pattern as a component. Use it along with the new icon images for the "add sprite" and "add backdrop" buttons

### Test Coverage

_Please show how you have added tests to cover your changes_

Added snapshot and callback testing for the new component. 

![image](https://user-images.githubusercontent.com/654102/28644949-939d3ab0-7229-11e7-8fc3-a520b9102b76.png)

---
/cc @chrisgarrity another translated component! One thing that ray and I talked about briefly was that this technically includes the same string as the other `addBackdropMessage`, but since it might change in the future and we couldn't do that without breaking the translation, we decided to use different ideas. That makes me think that (contrary to what I said when we paired earlier) I think we should prefix those IDs structurally as opposed to functionally (that is, `targetPane.addBackdrop` instead of `actions.addBackdrop`). Not vital to change right now, but I thought you might be interested in that.