### PR TITLE
Context menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "postcss-simple-vars": "^4.0.0",
     "prop-types": "^15.5.10",
     "react": "15.5.4",
+    "react-contextmenu": "2.6.5",
     "react-dom": "15.5.4",
     "react-draggable": "2.2.6",
     "react-intl": "2.3.0",

--- a/src/components/context-menu/context-menu.css
+++ b/src/components/context-menu/context-menu.css
@@ -1,0 +1,29 @@
+@import "../../css/colors.css";
+@import "../../css/units.css";
+
+.context-menu {
+    min-width: 130px;
+    padding: 5px 0; /* The white strip at the top and bottom of the menu */
+    margin: 2px 0 0; /* To keep the menu below the cursor comfortably */
+    font-size: 0.85rem;
+    text-align: left;
+    background-color: #fff;
+    border: 1px solid $ui-pane-border;
+    border-radius: calc($space / 2);
+    box-shadow: 0px 0px 5px 1px rgba(0, 0, 0, 0.1);
+    pointer-events: none;
+    transition: opacity 0.2s ease;
+    z-index: 100;
+}
+
+.menu-item {
+    padding: 8px 12px;
+    white-space: nowrap;
+    cursor: pointer;
+    transition: 0.1s ease;
+}
+
+.menu-item:hover {
+    background: $motion-primary;
+    color: white;
+}

--- a/src/components/context-menu/context-menu.jsx
+++ b/src/components/context-menu/context-menu.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import {ContextMenu, MenuItem} from 'react-contextmenu';
+
+import styles from './context-menu.css';
+
+const StyledContextMenu = props => (
+    <ContextMenu
+        {...props}
+        className={styles.contextMenu}
+    />
+);
+
+const StyledMenuItem = props => (
+    <MenuItem
+        {...props}
+        attributes={{className: styles.menuItem}}
+    />
+);
+
+export {
+    StyledContextMenu as ContextMenu,
+    StyledMenuItem as MenuItem
+};

--- a/src/components/sprite-selector-item/sprite-selector-item.jsx
+++ b/src/components/sprite-selector-item/sprite-selector-item.jsx
@@ -2,21 +2,25 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import Box from '../box/box.jsx';
 import CostumeCanvas from '../costume-canvas/costume-canvas.jsx';
 import CloseButton from '../close-button/close-button.jsx';
 import styles from './sprite-selector-item.css';
+import {ContextMenuTrigger} from 'react-contextmenu';
+import {ContextMenu, MenuItem} from '../context-menu/context-menu.jsx';
+import {FormattedMessage} from 'react-intl';
+
+// react-contextmenu requires unique id to match trigger and context menu
+let contextMenuId = 0;
 
 const SpriteSelectorItem = props => (
-    <Box
-        className={classNames(
-            props.className,
-            styles.spriteSelectorItem,
-            {
+    <ContextMenuTrigger
+        attributes={{
+            className: classNames(props.className, styles.spriteSelectorItem, {
                 [styles.isSelected]: props.selected
-            }
-        )}
-        onClick={props.onClick}
+            }),
+            onClick: props.onClick
+        }}
+        id={`${props.name}-${contextMenuId}`}
     >
         {props.selected ? (
             <CloseButton
@@ -24,7 +28,7 @@ const SpriteSelectorItem = props => (
                 size={CloseButton.SIZE_SMALL}
                 onClick={props.onDeleteButtonClick}
             />
-        ) : null }
+            ) : null }
         {props.costumeURL ? (
             <CostumeCanvas
                 className={styles.spriteImage}
@@ -32,9 +36,18 @@ const SpriteSelectorItem = props => (
                 url={props.costumeURL}
                 width={32}
             />
-        ) : null}
+            ) : null}
         <div className={styles.spriteName}>{props.name}</div>
-    </Box>
+        <ContextMenu id={`${props.name}-${contextMenuId++}`}>
+            <MenuItem onClick={props.onDeleteButtonClick}>
+                <FormattedMessage
+                    defaultMessage="delete"
+                    description="Menu item to delete in the right click menu"
+                    id="contextMenu.delete"
+                />
+            </MenuItem>
+        </ContextMenu>
+    </ContextMenuTrigger>
 );
 
 SpriteSelectorItem.propTypes = {

--- a/test/unit/components/__snapshots__/sprite-selector-item.test.jsx.snap
+++ b/test/unit/components/__snapshots__/sprite-selector-item.test.jsx.snap
@@ -2,23 +2,14 @@
 
 exports[`SpriteSelectorItemComponent matches snapshot when selected 1`] = `
 <div
-  className="ponies undefined"
+  className="react-contextmenu-wrapper ponies undefined"
   onClick={[Function]}
-  style={
-    Object {
-      "alignContent": undefined,
-      "alignItems": undefined,
-      "alignSelf": undefined,
-      "flexBasis": undefined,
-      "flexDirection": undefined,
-      "flexGrow": undefined,
-      "flexShrink": undefined,
-      "flexWrap": undefined,
-      "height": undefined,
-      "justifyContent": undefined,
-      "width": undefined,
-    }
-  }
+  onContextMenu={[Function]}
+  onMouseDown={[Function]}
+  onMouseOut={[Function]}
+  onMouseUp={[Function]}
+  onTouchEnd={[Function]}
+  onTouchStart={[Function]}
 >
   <div
     className=""
@@ -39,5 +30,35 @@ exports[`SpriteSelectorItemComponent matches snapshot when selected 1`] = `
   >
     Pony sprite
   </div>
+  <nav
+    className="react-contextmenu"
+    onContextMenu={[Function]}
+    onMouseLeave={[Function]}
+    role="menu"
+    style={
+      Object {
+        "opacity": 0,
+        "pointerEvents": "none",
+        "position": "fixed",
+      }
+    }
+    tabIndex="-1"
+  >
+    <div
+      aria-disabled="false"
+      aria-orientation={null}
+      className="react-contextmenu-item"
+      onClick={[Function]}
+      onMouseLeave={[Function]}
+      onMouseMove={[Function]}
+      onTouchEnd={[Function]}
+      role="menuitem"
+      tabIndex="-1"
+    >
+      <span>
+        delete
+      </span>
+    </div>
+  </nav>
 </div>
 `;

--- a/test/unit/components/sprite-selector-item.test.jsx
+++ b/test/unit/components/sprite-selector-item.test.jsx
@@ -1,11 +1,11 @@
 /* eslint-env jest */
 import React from 'react'; // eslint-disable-line no-unused-vars
-import {shallow} from 'enzyme';
+import {mountWithIntl, shallowWithIntl, componentWithIntl} from '../../helpers/intl-helpers';
 // eslint-disable-next-line no-unused-vars
 import SpriteSelectorItemComponent from '../../../src/components/sprite-selector-item/sprite-selector-item';
 import CostumeCanvas from '../../../src/components/costume-canvas/costume-canvas';
 import CloseButton from '../../../src/components/close-button/close-button'; // eslint-disable-line no-unused-vars
-import renderer from 'react-test-renderer';
+import {MenuItem} from '../../../src/components/context-menu/context-menu'; // eslint-disable-line no-unused-vars
 
 describe('SpriteSelectorItemComponent', () => {
     let className;
@@ -36,36 +36,46 @@ describe('SpriteSelectorItemComponent', () => {
     });
 
     test('matches snapshot when selected', () => {
-        const component = renderer.create(getComponent());
+        const component = componentWithIntl(getComponent());
         expect(component.toJSON()).toMatchSnapshot();
     });
 
     test('does not have a close box when not selected', () => {
         selected = false;
-        const componentShallowWrapper = shallow(getComponent());
-        expect(componentShallowWrapper.find(CloseButton).exists()).toBe(false);
+        const wrapper = shallowWithIntl(getComponent());
+        expect(wrapper.find(CloseButton).exists()).toBe(false);
     });
 
     test('triggers callback when Box component is clicked', () => {
-        const componentShallowWrapper = shallow(getComponent());
-        componentShallowWrapper.simulate('click');
+        // Use `mount` here because of the way ContextMenuTrigger consumes onClick
+        const wrapper = mountWithIntl(getComponent());
+        wrapper.simulate('click');
         expect(onClick).toHaveBeenCalled();
     });
 
     test('triggers callback when CloseButton component is clicked', () => {
-        const componentShallowWrapper = shallow(getComponent());
-        componentShallowWrapper.find(CloseButton).simulate('click');
+        const wrapper = shallowWithIntl(getComponent());
+        wrapper.find(CloseButton).simulate('click');
         expect(onDeleteButtonClick).toHaveBeenCalled();
     });
 
     test('creates a CostumeCanvas when a costume url is defined', () => {
-        const componentShallowWrapper = shallow(getComponent());
-        expect(componentShallowWrapper.find(CostumeCanvas).exists()).toBe(true);
+        const wrapper = shallowWithIntl(getComponent());
+        expect(wrapper.find(CostumeCanvas).exists()).toBe(true);
     });
 
     test('does not create a CostumeCanvas when a costume url is null', () => {
         costumeURL = null;
-        const componentShallowWrapper = shallow(getComponent());
-        expect(componentShallowWrapper.find(CostumeCanvas).exists()).toBe(false);
+        const wrapper = shallowWithIntl(getComponent());
+        expect(wrapper.find(CostumeCanvas).exists()).toBe(false);
+    });
+
+    test('it has a context menu with delete menu item and callback', () => {
+        const wrapper = mountWithIntl(getComponent());
+        const contextMenu = wrapper.find('ContextMenu');
+        expect(contextMenu.exists()).toBe(true);
+        
+        contextMenu.find('[children="delete"]').simulate('click');
+        expect(onDeleteButtonClick).toHaveBeenCalled();
     });
 });

--- a/test/unit/components/sprite-selector-item.test.jsx
+++ b/test/unit/components/sprite-selector-item.test.jsx
@@ -5,7 +5,6 @@ import {mountWithIntl, shallowWithIntl, componentWithIntl} from '../../helpers/i
 import SpriteSelectorItemComponent from '../../../src/components/sprite-selector-item/sprite-selector-item';
 import CostumeCanvas from '../../../src/components/costume-canvas/costume-canvas';
 import CloseButton from '../../../src/components/close-button/close-button'; // eslint-disable-line no-unused-vars
-import {MenuItem} from '../../../src/components/context-menu/context-menu'; // eslint-disable-line no-unused-vars
 
 describe('SpriteSelectorItemComponent', () => {
     let className;
@@ -74,7 +73,7 @@ describe('SpriteSelectorItemComponent', () => {
         const wrapper = mountWithIntl(getComponent());
         const contextMenu = wrapper.find('ContextMenu');
         expect(contextMenu.exists()).toBe(true);
-        
+
         contextMenu.find('[children="delete"]').simulate('click');
         expect(onDeleteButtonClick).toHaveBeenCalled();
     });

--- a/test/unit/containers/sprite-selector-item.test.jsx
+++ b/test/unit/containers/sprite-selector-item.test.jsx
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 import React from 'react'; // eslint-disable-line no-unused-vars
-import {mount} from 'enzyme';
+import {mountWithIntl} from '../../helpers/intl-helpers';
 import configureStore from 'redux-mock-store';
 import {Provider} from 'react-redux'; // eslint-disable-line no-unused-vars
 
@@ -43,7 +43,7 @@ describe('SpriteSelectorItem Container', () => {
     });
 
     test('should confirm if the user really wants to delete the sprite', () => {
-        const wrapper = mount(getContainer());
+        const wrapper = mountWithIntl(getContainer());
         wrapper.find(CloseButton).simulate('click');
         expect(global.confirm).toHaveBeenCalled();
         expect(onDeleteButtonClick).toHaveBeenCalledWith(1337);
@@ -51,7 +51,7 @@ describe('SpriteSelectorItem Container', () => {
 
     test('should not delete the sprite if the user cancels', () => {
         global.confirm = jest.fn(() => false);
-        const wrapper = mount(getContainer());
+        const wrapper = mountWithIntl(getContainer());
         wrapper.find(CloseButton).simulate('click');
         expect(global.confirm).toHaveBeenCalled();
         expect(onDeleteButtonClick).not.toHaveBeenCalled();


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Part of implementing https://github.com/LLK/scratch-gui/issues/224. Specifically, the context menu with the delete menu item. Duplicate menu item will take VM work, so this is just the structure of the context menu.

### Proposed Changes

_Describe what this Pull Request does_

Using the `react-contextmenu` package, wrap the sprite selector in a `ContextMenuTrigger` and include a `ContextMenu` with the delete menu item. 

The `react-contextmenu` package includes no styling, so I created a custom `ContextMenu` and `MenuItem` that just inject custom classnames/styles into the components provided by `react-contextmenu`. 

### Reason for Changes

_Explain why these changes should be made_

This will be the pattern we use for context menus throughout the app. 

### Test Coverage

_Please show how you have added tests to cover your changes_

Updated the sprite selector item tests because of the inclusion of an `intl` string, and added a test to make sure the right callbacks are attached to the context menu. 

![image](https://user-images.githubusercontent.com/654102/29174502-86a2e134-7db4-11e7-9e8c-d03b25d1ea6c.png)

![image](https://user-images.githubusercontent.com/654102/29174506-88dae7e4-7db4-11e7-80f1-b219b83c7ab0.png)

---

@carljbowman I tried to match the style in the mocks, but let me know if you think anything should change. Also, the package I chose for context menu triggering also includes a "long-press to activate" feature, which makes it possible to bring up the menu on touch by long-touching. 