### PR TITLE
Allow GUI to fit into 1024px screen widths

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "react-intl-redux": "0.6.0",
     "react-modal": "2.2.2",
     "react-redux": "5.0.6",
+    "react-responsive": "1.3.4",
     "react-style-proptype": "3.0.0",
     "react-tabs": "1.1.0",
     "react-test-renderer": "^15.5.4",

--- a/src/components/forms/input.css
+++ b/src/components/forms/input.css
@@ -35,6 +35,6 @@
 }
 
 .input-small {
-    width: 3.5rem; 
+    width: 3rem; 
     text-align: center;
 }

--- a/src/components/gui/gui.css
+++ b/src/components/gui/gui.css
@@ -112,13 +112,6 @@
     */
     display: flex;
     flex-direction: column;
-
-    /*
-        Calc the minimum width for this pane, accounting for left + right spacing.
-        If and when the width doesn't need to be fixed, we can move the spacing out
-        of this calc, and into padding instead
-    */
-    flex-basis: calc(480px + ($space * 2));
 }
 
 .stage-wrapper {

--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -2,6 +2,7 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {Tab, Tabs, TabList, TabPanel} from 'react-tabs';
+import MediaQuery from 'react-responsive';
 import tabStyles from 'react-tabs/style/react-tabs.css';
 import VM from 'scratch-vm';
 
@@ -18,6 +19,13 @@ import MenuBar from '../menu-bar/menu-bar.jsx';
 
 import styles from './gui.css';
 
+const layout = {
+    fullStageWidth: 480,
+    fullStageHeight: 360,
+    smallerStageWidth: 480 * 0.85,
+    smallerStageHeight: 360 * 0.85,
+    fullSizeMinWidth: 1096
+};
 
 const GUIComponent = props => {
     const {
@@ -87,25 +95,31 @@ const GUIComponent = props => {
                         </Tabs>
                     </Box>
 
-                    <Box className={styles.stageAndTargetWrapper} >
-                        <Box className={styles.stageMenuWrapper} >
-                            <GreenFlag vm={vm} />
-                            <StopAll vm={vm} />
-                        </Box>
+                    <MediaQuery minWidth={layout.fullSizeMinWidth}>
+                        {isFullSize => (
+                            <Box className={styles.stageAndTargetWrapper}>
+                                <Box className={styles.stageMenuWrapper}>
+                                    <GreenFlag vm={vm} />
+                                    <StopAll vm={vm} />
+                                </Box>
 
-                        <Box className={styles.stageWrapper} >
-                            <Stage
-                                shrink={0}
-                                vm={vm}
-                            />
-                        </Box>
+                                <Box className={styles.stageWrapper}>
+                                    <Stage
+                                        height={isFullSize ? layout.fullStageHeight : layout.smallerStageHeight}
+                                        shrink={0}
+                                        vm={vm}
+                                        width={isFullSize ? layout.fullStageWidth : layout.smallerStageWidth}
+                                    />
+                                </Box>
 
-                        <Box className={styles.targetWrapper} >
-                            <TargetPane
-                                vm={vm}
-                            />
-                        </Box>
-                    </Box>
+                                <Box className={styles.targetWrapper}>
+                                    <TargetPane
+                                        vm={vm}
+                                    />
+                                </Box>
+                            </Box>
+                        )}
+                    </MediaQuery>
                 </Box>
             </Box>
         </Box>

--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -17,15 +17,8 @@ import StopAll from '../../containers/stop-all.jsx';
 import Box from '../box/box.jsx';
 import MenuBar from '../menu-bar/menu-bar.jsx';
 
+import layout from '../../lib/layout-constants.js';
 import styles from './gui.css';
-
-const layout = {
-    fullStageWidth: 480,
-    fullStageHeight: 360,
-    smallerStageWidth: 480 * 0.85,
-    smallerStageHeight: 360 * 0.85,
-    fullSizeMinWidth: 1096
-};
 
 const GUIComponent = props => {
     const {
@@ -95,31 +88,27 @@ const GUIComponent = props => {
                         </Tabs>
                     </Box>
 
-                    <MediaQuery minWidth={layout.fullSizeMinWidth}>
-                        {isFullSize => (
-                            <Box className={styles.stageAndTargetWrapper}>
-                                <Box className={styles.stageMenuWrapper}>
-                                    <GreenFlag vm={vm} />
-                                    <StopAll vm={vm} />
-                                </Box>
-
-                                <Box className={styles.stageWrapper}>
-                                    <Stage
-                                        height={isFullSize ? layout.fullStageHeight : layout.smallerStageHeight}
-                                        shrink={0}
-                                        vm={vm}
-                                        width={isFullSize ? layout.fullStageWidth : layout.smallerStageWidth}
-                                    />
-                                </Box>
-
-                                <Box className={styles.targetWrapper}>
-                                    <TargetPane
-                                        vm={vm}
-                                    />
-                                </Box>
-                            </Box>
-                        )}
-                    </MediaQuery>
+                    <Box className={styles.stageAndTargetWrapper}>
+                        <Box className={styles.stageMenuWrapper}>
+                            <GreenFlag vm={vm} />
+                            <StopAll vm={vm} />
+                        </Box>
+                        <Box className={styles.stageWrapper}>
+                            <MediaQuery minWidth={layout.fullSizeMinWidth}>{isFullSize => (
+                                <Stage
+                                    height={isFullSize ? layout.fullStageHeight : layout.smallerStageHeight}
+                                    shrink={0}
+                                    vm={vm}
+                                    width={isFullSize ? layout.fullStageWidth : layout.smallerStageWidth}
+                                />
+                            )}</MediaQuery>
+                        </Box>
+                        <Box className={styles.targetWrapper}>
+                            <TargetPane
+                                vm={vm}
+                            />
+                        </Box>
+                    </Box>
                 </Box>
             </Box>
         </Box>

--- a/src/components/sprite-info/sprite-info.css
+++ b/src/components/sprite-info/sprite-info.css
@@ -79,3 +79,9 @@
     user-select: none;
     outline: none;
 }
+
+@media only screen and (max-width: 1096px) {
+    .non-essential {
+        display: none;
+    }
+}

--- a/src/components/sprite-info/sprite-info.css
+++ b/src/components/sprite-info/sprite-info.css
@@ -79,9 +79,3 @@
     user-select: none;
     outline: none;
 }
-
-@media only screen and (max-width: 1096px) {
-    .non-essential {
-        display: none;
-    }
-}

--- a/src/components/sprite-info/sprite-info.jsx
+++ b/src/components/sprite-info/sprite-info.jsx
@@ -49,7 +49,7 @@ class SpriteInfo extends React.Component {
                     </div>
 
                     <div className={styles.group}>
-                        <div className={styles.iconWrapper}>
+                        <div className={classNames(styles.iconWrapper, styles.nonEssential)}>
                             <img
                                 className={classNames(styles.xIcon, styles.icon)}
                                 src={xIcon}
@@ -69,7 +69,7 @@ class SpriteInfo extends React.Component {
                     </div>
 
                     <div className={styles.group}>
-                        <div className={styles.iconWrapper}>
+                        <div className={classNames(styles.iconWrapper, styles.nonEssential)}>
                             <img
                                 className={classNames(styles.yIcon, styles.icon)}
                                 src={yIcon}

--- a/src/components/sprite-info/sprite-info.jsx
+++ b/src/components/sprite-info/sprite-info.jsx
@@ -1,12 +1,14 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
+import MediaQuery from 'react-responsive';
 
 import Box from '../box/box.jsx';
 import Label from '../forms/label.jsx';
 import Input from '../forms/input.jsx';
 import BufferedInputHOC from '../forms/buffered-input-hoc.jsx';
 
+import layout from '../../lib/layout-constants.js';
 import styles from './sprite-info.css';
 
 import xIcon from './icon--x.svg';
@@ -49,12 +51,14 @@ class SpriteInfo extends React.Component {
                     </div>
 
                     <div className={styles.group}>
-                        <div className={classNames(styles.iconWrapper, styles.nonEssential)}>
-                            <img
-                                className={classNames(styles.xIcon, styles.icon)}
-                                src={xIcon}
-                            />
-                        </div>
+                        <MediaQuery minWidth={layout.fullSizeMinWidth}>
+                            <div className={styles.iconWrapper}>
+                                <img
+                                    className={classNames(styles.xIcon, styles.icon)}
+                                    src={xIcon}
+                                />
+                            </div>
+                        </MediaQuery>
                         <Label text="x">
                             <BufferedInput
                                 small
@@ -69,12 +73,14 @@ class SpriteInfo extends React.Component {
                     </div>
 
                     <div className={styles.group}>
-                        <div className={classNames(styles.iconWrapper, styles.nonEssential)}>
-                            <img
-                                className={classNames(styles.yIcon, styles.icon)}
-                                src={yIcon}
-                            />
-                        </div>
+                        <MediaQuery minWidth={layout.fullSizeMinWidth}>
+                            <div className={styles.iconWrapper}>
+                                <img
+                                    className={classNames(styles.yIcon, styles.icon)}
+                                    src={yIcon}
+                                />
+                            </div>
+                        </MediaQuery>
                         <Label text="y">
                             <BufferedInput
                                 small

--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -40,8 +40,8 @@ class Stage extends React.Component {
         this.audioEngine = new AudioEngine();
         this.props.vm.attachAudioEngine(this.audioEngine);
     }
-    shouldComponentUpdate () {
-        return false;
+    shouldComponentUpdate (nextProps) {
+        return this.props.width !== nextProps.width || this.props.height !== nextProps.height;
     }
     componentWillUnmount () {
         this.detachMouseEvents(this.canvas);
@@ -194,7 +194,9 @@ class Stage extends React.Component {
 }
 
 Stage.propTypes = {
-    vm: PropTypes.instanceOf(VM).isRequired
+    height: PropTypes.number,
+    vm: PropTypes.instanceOf(VM).isRequired,
+    width: PropTypes.number
 };
 
 export default Stage;

--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -69,9 +69,10 @@ class Stage extends React.Component {
         this.rect = this.canvas.getBoundingClientRect();
     }
     getScratchCoords (x, y) {
+        const nativeSize = this.renderer.getNativeSize();
         return [
-            x - (this.rect.width / 2),
-            y - (this.rect.height / 2)
+            (nativeSize[0] / this.rect.width) * (x - (this.rect.width / 2)),
+            (nativeSize[1] / this.rect.height) * (y - (this.rect.height / 2))
         ];
     }
     handleDoubleClick (e) {
@@ -127,6 +128,7 @@ class Stage extends React.Component {
         }
     }
     onMouseDown (e) {
+        this.updateRect();
         const mousePosition = [e.clientX - this.rect.left, e.clientY - this.rect.top];
         this.setState({
             mouseDown: true,

--- a/src/lib/layout-constants.js
+++ b/src/lib/layout-constants.js
@@ -1,0 +1,7 @@
+export default {
+    fullStageWidth: 480,
+    fullStageHeight: 360,
+    smallerStageWidth: 480 * 0.85,
+    smallerStageHeight: 360 * 0.85,
+    fullSizeMinWidth: 1096
+};


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/579 by shrinking the stage and some minor changes to the sprite info area (hides icons, makes inputs slightly smaller). 

Depends on https://github.com/LLK/scratch-render/pull/154

### Proposed Changes

_Describe what this Pull Request does_

Still have to review these changes with @carljbowman, but the in-progress idea is to shrink the stage and to do a bit of responsive work on the sprite info area to fit everything into 1024 layout. 

Note in the code the width of the break is actually 1096, because that is where it was previously breaking. If we put the break at 1024, it would work for [1024, 1096+], but this way it works for 1024+. 

### Reason for Changes

_Explain why these changes should be made_

Explained in https://github.com/LLK/scratch-gui/issues/579

### Test Coverage

_Please show how you have added tests to cover your changes_

I think the best way to test this might be to use the selenium tests with a browser window set to 1024 and make sure you can reach all the buttons? Not exactly sure on this though.
