### PR TITLE
Fixed #604: Load project error

### DIFF
--- a/src/containers/sound-tab.jsx
+++ b/src/containers/sound-tab.jsx
@@ -106,7 +106,7 @@ class SoundTab extends React.Component {
                 onDeleteClick={this.handleDeleteSound}
                 onItemClick={this.handleSelectSound}
             >
-                {target.sounds && target.sounds.length > 0 ? (
+                {editingTarget && target.sounds && target.sounds.length > 0 ? (
                     <SoundEditor soundIndex={this.state.selectedSoundIndex} />
                 ) : null}
                 {this.props.soundRecorderVisible ? (


### PR DESCRIPTION
### Resolves

https://github.com/LLK/scratch-gui/issues/604

### Proposed Changes

The editingTarget might be null when loading new project, while target will not be null (it will be the state):
const target = editingTarget && sprites[editingTarget] ? sprites[editingTarget] : stage;

### Reason for Changes

Fixed the project load error caused by sound editor.

### Test Coverage

_Please show how you have added tests to cover your changes_
