### PR TITLE
Update all react deps to most recent version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "url": "git+ssh://git@github.com/LLK/scratch-gui.git"
   },
   "peerDependencies": {
-    "react": "^15.6.0",
-    "react-dom": "^15.6.0"
+    "react": "^15.6.1",
+    "react-dom": "^15.6.1"
   },
   "devDependencies": {
     "autoprefixer": "7.1.2",
@@ -65,9 +65,9 @@
     "postcss-loader": "^2.0.5",
     "postcss-simple-vars": "^4.0.0",
     "prop-types": "^15.5.10",
-    "react": "15.5.4",
+    "react": "15.6.1",
     "react-contextmenu": "2.6.5",
-    "react-dom": "15.5.4",
+    "react-dom": "15.6.1",
     "react-draggable": "2.2.6",
     "react-intl": "2.3.0",
     "react-intl-redux": "0.6.0",


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes the "peer dependency missing" errors that were being caused by greenkeeper updating the peer dependencies but not the other dependencies. 