### PR TITLE
Add glideto menu

### DIFF
--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -100,6 +100,14 @@ export default function (vm) {
         this.jsonInit(json);
     };
 
+    ScratchBlocks.Blocks.motion_glideto_menu.init = function () {
+        const json = jsonForMenuBlock('TO', spriteMenu, motionColors, [
+            ['mouse-pointer', '_mouse_'],
+            ['random position', '_random_']
+        ]);
+        this.jsonInit(json);
+    };
+
     ScratchBlocks.Blocks.sensing_of_object_menu.init = function () {
         const json = jsonForMenuBlock('OBJECT', spriteMenu, sensingColors, [
             ['Stage', '_stage_']


### PR DESCRIPTION
### Resolves

LLK/scratch-gui#598

### Proposed Changes

Adds the `init` function for the glideto’s menu.

Comes with LLK/scratch-blocks#1046 and LLK/scratch-vm#662