### PR TITLE
Add max width to fix flex-grow errors

### DIFF
--- a/src/components/gui/gui.css
+++ b/src/components/gui/gui.css
@@ -112,6 +112,9 @@
     */
     display: flex;
     flex-direction: column;
+
+    /* Fix the max width to max stage size (defined in layout_constants.js) + gutter size */
+    max-width: calc(480px + calc($space * 2));
 }
 
 .stage-wrapper {


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/640

### Proposed Changes

_Describe what this Pull Request does_

Adds a max width (and helpful comment to future us) about sizing the sprite selector. 

### Reason for Changes

_Explain why these changes should be made_

See screenshots in linked issue. 

### Test Coverage

_Please show how you have added tests to cover your changes_

No tests, but here is a screenshot before and after
![screen shot 2017-08-23 at 8 33 10 am](https://user-images.githubusercontent.com/654102/29615953-bb7cb942-87dd-11e7-914b-9e3f4f582db6.png)
![screen shot 2017-08-23 at 8 32 42 am](https://user-images.githubusercontent.com/654102/29615955-bd082dc8-87dd-11e7-841b-f19be871cdfa.png)
