### PR TITLE
Check for sprites before trying to update block menus

### DIFF
--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -29,19 +29,24 @@ export default function (vm) {
     };
 
     const soundsMenu = function () {
-        const sounds = vm.editingTarget.sprite.sounds;
-        if (sounds.length === 0) {
-            return [['', '']];
+        if (vm.editingTarget && vm.editingTarget.sprite.sounds.length > 0) {
+            return vm.editingTarget.sprite.sounds.map(sound => [sound.name, sound.name]);
         }
-        return sounds.map(sound => [sound.name, sound.name]);
+        return [['', '']];
     };
 
     const costumesMenu = function () {
-        return vm.editingTarget.sprite.costumes.map(costume => [costume.name, costume.name]);
+        if (vm.editingTarget && vm.editingTarget.sprite.costumes.length > 0) {
+            return vm.editingTarget.sprite.costumes.map(costume => [costume.name, costume.name]);
+        }
+        return [['', '']];
     };
 
     const backdropsMenu = function () {
-        return vm.runtime.targets[0].sprite.costumes.map(costume => [costume.name, costume.name]);
+        if (vm.runtime.targets[0] && vm.runtime.targets[0].sprite.costumes.length > 0) {
+            return vm.runtime.targets[0].sprite.costumes.map(costume => [costume.name, costume.name]);
+        }
+        return [['', '']];
     };
 
     const spriteMenu = function () {


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-gui/issues/639

### Proposed Changes

When updating menus on blocks that require information from the current editing target (names of costumes, backdrops, or sounds), avoid an error by checking first in case none is present.

### Reason for Changes

The toolbox can be loaded before the GUI, so the editing targets are not yet present at the first update.

### Test Coverage

No tests yet.