### PR TITLE
Do not render invisible components

### DIFF
--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -79,10 +79,10 @@ const GUIComponent = props => {
                                 </Box>
                             </TabPanel>
                             <TabPanel className={tabClassNames.tabPanel}>
-                                <CostumeTab vm={vm} />
+                                {tabIndex === 1 ? <CostumeTab vm={vm} /> : null}
                             </TabPanel>
                             <TabPanel className={tabClassNames.tabPanel}>
-                                <SoundTab vm={vm} />
+                                {tabIndex === 2 ? <SoundTab vm={vm} /> : null}
                             </TabPanel>
                         </Tabs>
                     </Box>

--- a/src/components/library/library.jsx
+++ b/src/components/library/library.jsx
@@ -43,13 +43,11 @@ class LibraryComponent extends React.Component {
             dataItem.name.toLowerCase().indexOf(this.state.filterQuery.toLowerCase()) !== -1);
     }
     render () {
-        if (!this.props.visible) return null;
         return (
             <ModalComponent
                 className={styles.modalContent}
                 contentLabel={this.props.title}
                 filterQuery={this.state.filterQuery}
-                visible={this.props.visible}
                 onFilterChange={this.handleFilterChange}
                 onFilterClear={this.handleFilterClear}
                 onRequestClose={this.props.onRequestClose}
@@ -93,8 +91,7 @@ LibraryComponent.propTypes = {
     onItemMouseLeave: PropTypes.func,
     onItemSelected: PropTypes.func,
     onRequestClose: PropTypes.func,
-    title: PropTypes.string.isRequired,
-    visible: PropTypes.bool.isRequired
+    title: PropTypes.string.isRequired
 };
 
 export default LibraryComponent;

--- a/src/components/modal/modal.jsx
+++ b/src/components/modal/modal.jsx
@@ -13,9 +13,9 @@ class ModalComponent extends React.Component {
     render () {
         return (
             <ReactModal
+                isOpen
                 className={classNames(styles.modalContent, this.props.className)}
                 contentLabel={this.props.contentLabel}
-                isOpen={this.props.visible}
                 overlayClassName={styles.modalOverlay}
                 ref={m => (this.modal = m)}
                 onRequestClose={this.props.onRequestClose}
@@ -68,8 +68,7 @@ ModalComponent.propTypes = {
     filterQuery: PropTypes.string,
     onFilterChange: PropTypes.func,
     onFilterClear: PropTypes.func,
-    onRequestClose: PropTypes.func,
-    visible: PropTypes.bool.isRequired
+    onRequestClose: PropTypes.func
 };
 
 export default ModalComponent;

--- a/src/components/prompt/prompt.jsx
+++ b/src/components/prompt/prompt.jsx
@@ -7,7 +7,6 @@ import styles from './prompt.css';
 
 const PromptComponent = props => (
     <Modal
-        visible
         className={styles.modalContent}
         contentLabel={props.title}
         onRequestClose={props.onCancel}

--- a/src/components/record-modal/record-modal.jsx
+++ b/src/components/record-modal/record-modal.jsx
@@ -8,7 +8,6 @@ import styles from './record-modal.css';
 
 const RecordModal = props => (
     <Modal
-        visible
         className={styles.modalContent}
         contentLabel={'Record Sound'}
         onRequestClose={props.onCancel}

--- a/src/components/target-pane/target-pane.jsx
+++ b/src/components/target-pane/target-pane.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 
 import VM from 'scratch-vm';
 
-import Box from '../box/box.jsx';
 import BackdropLibrary from '../../containers/backdrop-library.jsx';
 import CostumeLibrary from '../../containers/costume-library.jsx';
 import SoundLibrary from '../../containers/sound-library.jsx';
@@ -43,7 +42,7 @@ const TargetPane = ({
     vm,
     ...componentProps
 }) => (
-    <Box
+    <div
         className={styles.targetPane}
         {...componentProps}
     >
@@ -61,7 +60,7 @@ const TargetPane = ({
             onNewSpriteClick={onNewSpriteClick}
             onSelectSprite={onSelectSprite}
         />
-        <Box className={styles.stageSelectorWrapper}>
+        <div className={styles.stageSelectorWrapper}>
             {stage.id && <StageSelector
                 assetId={
                     stage.costume &&
@@ -72,30 +71,35 @@ const TargetPane = ({
                 selected={stage.id === editingTarget}
                 onSelect={onSelectSprite}
             />}
-            <Box>
-                <SpriteLibrary
-                    visible={spriteLibraryVisible}
-                    vm={vm}
-                    onRequestClose={onRequestCloseSpriteLibrary}
-                />
-                <CostumeLibrary
-                    visible={costumeLibraryVisible}
-                    vm={vm}
-                    onRequestClose={onRequestCloseCostumeLibrary}
-                />
-                <SoundLibrary
-                    visible={soundLibraryVisible}
-                    vm={vm}
-                    onRequestClose={onRequestCloseSoundLibrary}
-                />
-                <BackdropLibrary
-                    visible={backdropLibraryVisible}
-                    vm={vm}
-                    onRequestClose={onRequestCloseBackdropLibrary}
-                />
-            </Box>
-        </Box>
-    </Box>
+            <div>
+                {spriteLibraryVisible ? (
+                    <SpriteLibrary
+                        vm={vm}
+                        onRequestClose={onRequestCloseSpriteLibrary}
+                    />
+                ) : null}
+                {costumeLibraryVisible ? (
+                    <CostumeLibrary
+                        vm={vm}
+                        onRequestClose={onRequestCloseCostumeLibrary}
+                    />
+                ) : null}
+                {soundLibraryVisible ? (
+                    <SoundLibrary
+                        vm={vm}
+                        onRequestClose={onRequestCloseSoundLibrary}
+                    />
+                ) : null}
+                {backdropLibraryVisible ? (
+                    <BackdropLibrary
+                        vm={vm}
+                        onRequestClose={onRequestCloseBackdropLibrary}
+                    />
+                ) : null}
+
+            </div>
+        </div>
+    </div>
 );
 
 const spriteShape = PropTypes.shape({

--- a/src/containers/backdrop-library.jsx
+++ b/src/containers/backdrop-library.jsx
@@ -27,9 +27,9 @@ class BackdropLibrary extends React.Component {
     render () {
         return (
             <LibraryComponent
+                visible
                 data={backdropLibraryContent}
                 title="Backdrop Library"
-                visible={this.props.visible}
                 onItemSelected={this.handleItemSelect}
                 onRequestClose={this.props.onRequestClose}
             />
@@ -39,7 +39,6 @@ class BackdropLibrary extends React.Component {
 
 BackdropLibrary.propTypes = {
     onRequestClose: PropTypes.func,
-    visible: PropTypes.bool,
     vm: PropTypes.instanceOf(VM).isRequired
 };
 

--- a/src/containers/backdrop-library.jsx
+++ b/src/containers/backdrop-library.jsx
@@ -27,7 +27,6 @@ class BackdropLibrary extends React.Component {
     render () {
         return (
             <LibraryComponent
-                visible
                 data={backdropLibraryContent}
                 title="Backdrop Library"
                 onItemSelected={this.handleItemSelect}

--- a/src/containers/costume-library.jsx
+++ b/src/containers/costume-library.jsx
@@ -27,9 +27,9 @@ class CostumeLibrary extends React.PureComponent {
     render () {
         return (
             <LibraryComponent
+                visible
                 data={costumeLibraryContent}
                 title="Costume Library"
-                visible={this.props.visible}
                 onItemSelected={this.handleItemSelected}
                 onRequestClose={this.props.onRequestClose}
             />
@@ -39,7 +39,6 @@ class CostumeLibrary extends React.PureComponent {
 
 CostumeLibrary.propTypes = {
     onRequestClose: PropTypes.func,
-    visible: PropTypes.bool,
     vm: PropTypes.instanceOf(VM).isRequired
 };
 

--- a/src/containers/costume-library.jsx
+++ b/src/containers/costume-library.jsx
@@ -27,7 +27,6 @@ class CostumeLibrary extends React.PureComponent {
     render () {
         return (
             <LibraryComponent
-                visible
                 data={costumeLibraryContent}
                 title="Costume Library"
                 onItemSelected={this.handleItemSelected}

--- a/src/containers/record-modal.jsx
+++ b/src/containers/record-modal.jsx
@@ -130,7 +130,6 @@ RecordModal.propTypes = {
 };
 
 const mapStateToProps = state => ({
-    visible: state.modals.soundRecorder,
     vm: state.vm
 });
 

--- a/src/containers/sound-library.jsx
+++ b/src/containers/sound-library.jsx
@@ -74,9 +74,9 @@ class SoundLibrary extends React.PureComponent {
 
         return (
             <LibraryComponent
+                visible
                 data={soundLibraryThumbnailData}
                 title="Sound Library"
-                visible={this.props.visible}
                 onItemMouseEnter={this.handleItemMouseEnter}
                 onItemMouseLeave={this.handleItemMouseLeave}
                 onItemSelected={this.handleItemSelected}
@@ -88,7 +88,6 @@ class SoundLibrary extends React.PureComponent {
 
 SoundLibrary.propTypes = {
     onRequestClose: PropTypes.func,
-    visible: PropTypes.bool,
     vm: PropTypes.instanceOf(VM).isRequired
 };
 

--- a/src/containers/sound-library.jsx
+++ b/src/containers/sound-library.jsx
@@ -22,9 +22,8 @@ class SoundLibrary extends React.PureComponent {
         this.audioEngine = new AudioEngine();
         this.player = this.audioEngine.createPlayer();
     }
-    componentWillReceiveProps (newProps) {
-        // Stop playing sounds if the library closes without a mouseleave (e.g. by using the escape key)
-        if (this.player && !newProps.visible) this.player.stopAllSounds();
+    componentWillUnmount () {
+        this.player.stopAllSounds();
     }
     handleItemMouseEnter (soundItem) {
         const md5ext = soundItem._md5;
@@ -74,7 +73,6 @@ class SoundLibrary extends React.PureComponent {
 
         return (
             <LibraryComponent
-                visible
                 data={soundLibraryThumbnailData}
                 title="Sound Library"
                 onItemMouseEnter={this.handleItemMouseEnter}

--- a/src/containers/sprite-library.jsx
+++ b/src/containers/sprite-library.jsx
@@ -64,9 +64,9 @@ class SpriteLibrary extends React.PureComponent {
     render () {
         return (
             <LibraryComponent
+                visible
                 data={this.state.sprites}
                 title="Sprite Library"
-                visible={this.props.visible}
                 onItemMouseEnter={this.handleMouseEnter}
                 onItemMouseLeave={this.handleMouseLeave}
                 onItemSelected={this.handleItemSelect}
@@ -78,7 +78,6 @@ class SpriteLibrary extends React.PureComponent {
 
 SpriteLibrary.propTypes = {
     onRequestClose: PropTypes.func,
-    visible: PropTypes.bool,
     vm: PropTypes.instanceOf(VM).isRequired
 };
 

--- a/src/containers/sprite-library.jsx
+++ b/src/containers/sprite-library.jsx
@@ -24,8 +24,8 @@ class SpriteLibrary extends React.PureComponent {
             sprites: spriteLibraryContent
         };
     }
-    componentWillReceiveProps (newProps) {
-        if (!newProps.visible) clearInterval(this.intervalId);
+    componentWillUnmount () {
+        clearInterval(this.intervalId);
     }
     handleItemSelect (item) {
         this.props.vm.addSprite2(JSON.stringify(item.json));
@@ -64,7 +64,6 @@ class SpriteLibrary extends React.PureComponent {
     render () {
         return (
             <LibraryComponent
-                visible
                 data={this.state.sprites}
                 title="Sprite Library"
                 onItemMouseEnter={this.handleMouseEnter}


### PR DESCRIPTION
This is a performance improvement. Reduces tick timing from ~30ms to ~18ms on my machine (in development). Also a generally good idea to not render components that aren't visible. 

Before
![image](https://user-images.githubusercontent.com/654102/29794860-d3838dd4-8c17-11e7-819a-d6d59b0f6774.png)

After
![image](https://user-images.githubusercontent.com/654102/29794857-d0e32c56-8c17-11e7-9e37-042675ad286f.png)

### Proposed Changes

_Describe what this Pull Request does_

Instead of passing `isVisible` to the library / tab components, just do not render them if they are not visible. 

The change from `Box` to `div` is because box wasn't being used for anything in particular, and it makes debugging harder. 