### PR TITLE
Add minimum trimmable length for audio trimmer

### DIFF
--- a/src/containers/audio-trimmer.jsx
+++ b/src/containers/audio-trimmer.jsx
@@ -4,6 +4,8 @@ import bindAll from 'lodash.bindall';
 import AudioTrimmerComponent from '../components/audio-trimmer/audio-trimmer.jsx';
 import {getEventXY} from '../lib/touch-utils';
 
+const MIN_LENGTH = 0.01; // Used to stop sounds being trimmed smaller than 1%
+
 class AudioTrimmer extends React.Component {
     constructor (props) {
         super(props);
@@ -20,14 +22,14 @@ class AudioTrimmer extends React.Component {
     handleTrimStartMouseMove (e) {
         const containerSize = this.containerElement.getBoundingClientRect().width;
         const dx = (getEventXY(e).x - this.initialX) / containerSize;
-        const newTrim = Math.max(0, Math.min(this.props.trimEnd, this.initialTrim + dx));
+        const newTrim = Math.max(0, Math.min(this.props.trimEnd - MIN_LENGTH, this.initialTrim + dx));
         this.props.onSetTrimStart(newTrim);
         e.preventDefault();
     }
     handleTrimEndMouseMove (e) {
         const containerSize = this.containerElement.getBoundingClientRect().width;
         const dx = (getEventXY(e).x - this.initialX) / containerSize;
-        const newTrim = Math.min(1, Math.max(this.props.trimStart, this.initialTrim + dx));
+        const newTrim = Math.min(1, Math.max(this.props.trimStart + MIN_LENGTH, this.initialTrim + dx));
         this.props.onSetTrimEnd(newTrim);
         e.preventDefault();
     }


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/590 by preventing it from being possible to overlap the trimmers.

### Proposed Changes

_Describe what this Pull Request does_

Set a minimum trimmable length so that trimmers cannot overlap. 

### Reason for Changes

_Explain why these changes should be made_

Consulted @carljbowman, seems like a simple way to prevent the problem and avoid questions of what should happen by preventing it from happening in the first place. 
