### PR TITLE
Fix eslint error from prop types

### DIFF
--- a/src/containers/recording-step.jsx
+++ b/src/containers/recording-step.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import bindAll from 'lodash.bindall';
 import RecordingStepComponent from '../components/record-modal/recording-step.jsx';
 import AudioRecorder from '../lib/audio/audio-recorder.js';
@@ -66,6 +67,10 @@ class RecordingStep extends React.Component {
     }
 }
 
-RecordingStep.propTypes = RecordingStepComponent.propTypes;
+RecordingStep.propTypes = {
+    onRecord: PropTypes.func.isRequired,
+    onStopRecording: PropTypes.func.isRequired,
+    recording: PropTypes.bool
+};
 
 export default RecordingStep;


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes the broken build on develop that came from a minor version update in eslint. 

### Proposed Changes

_Describe what this Pull Request does_

Be explicit with react proptypes, even if it involves copy/pasting :( 

### Reason for Changes

_Explain why these changes should be made_

Because the build was failing.

### Test Coverage

_Please show how you have added tests to cover your changes_

They pass now

---

Maybe worth noting that because the eslint version is not pinned to a specific version, develop was passing when the last merge was done, but something caused subsequent builds to use an in-range update to eslint, which then failed (probably because another PR updated the node_module cache?)
