### PR TITLE
Fix travis problems

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint . --ext .js,.jsx",
     "start": "npm run i18n:msgs && webpack-dev-server",
     "unit-test": "jest test/unit",
-    "integration-test": "npm run build && jest test/integration",
+    "integration-test": "npm run build && jest --runInBand test/integration",
     "test": "npm run lint && npm run unit-test && npm run integration-test",
     "watch": "webpack --progress --colors --watch"
   },


### PR DESCRIPTION
Travis seems to not like the way jest tries to run the tests in serial. Not sure if that is caused by a chromedriver update or a jest update. But using the `--runInBand` flag seems to make the tests stable again.