### PR TITLE
Update webpack to 3.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "svg-url-loader": "^2.1.0",
     "wav-encoder": "1.3.0",
     "web-audio-test-api": "^0.5.2",
-    "webpack": "^3.5.4",
+    "webpack": "^3.6.0",
     "webpack-dev-server": "^2.7.0",
     "xhr": "2.4.0"
   },


### PR DESCRIPTION
Do this manually because greenkeeper failed due to other broken build issues. 

Resolves https://github.com/LLK/scratch-gui/issues/680
