### PR TITLE
Fixed issue causing right click to drag sprite. 

### DIFF
--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -179,7 +179,7 @@ class Stage extends React.Component {
         this.updateRect();
         const {x, y} = getEventXY(e);
         const mousePosition = [x - this.rect.left, y - this.rect.top];
-        if (e.which === 1) {
+        if (true) {
             this.setState({
                 mouseDown: true,
                 mouseDownPosition: mousePosition,

--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -179,15 +179,16 @@ class Stage extends React.Component {
         this.updateRect();
         const {x, y} = getEventXY(e);
         const mousePosition = [x - this.rect.left, y - this.rect.top];
-        this.setState({
-            mouseDown: true,
-            mouseDownPosition: mousePosition,
-            mouseDownTimeoutId: setTimeout(
-                this.onStartDrag.bind(this, mousePosition[0], mousePosition[1]),
-                500
-            )
-        });
-
+        if (e.which !== 3) {
+            this.setState({
+                mouseDown: true,
+                mouseDownPosition: mousePosition,
+                mouseDownTimeoutId: setTimeout(
+                    this.onStartDrag.bind(this, mousePosition[0], mousePosition[1]),
+                    500
+                )
+            });
+        }
         const data = {
             isDown: true,
             x: mousePosition[0],

--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -179,14 +179,16 @@ class Stage extends React.Component {
         this.updateRect();
         const {x, y} = getEventXY(e);
         const mousePosition = [x - this.rect.left, y - this.rect.top];
-        this.setState({
-            mouseDown: true,
-            mouseDownPosition: mousePosition,
-            mouseDownTimeoutId: setTimeout(
-                this.onStartDrag.bind(this, mousePosition[0], mousePosition[1]),
-                500
-            )
-        });
+        if (e.which === 1) {
+            this.setState({
+                mouseDown: true,
+                mouseDownPosition: mousePosition,
+                mouseDownTimeoutId: setTimeout(
+                    this.onStartDrag.bind(this, mousePosition[0], mousePosition[1]),
+                    500
+                )
+            });
+        }
         const data = {
             isDown: true,
             x: mousePosition[0],

--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -179,7 +179,7 @@ class Stage extends React.Component {
         this.updateRect();
         const {x, y} = getEventXY(e);
         const mousePosition = [x - this.rect.left, y - this.rect.top];
-        if (e.which !== 3) {
+        if (e.button === 0) {
             this.setState({
                 mouseDown: true,
                 mouseDownPosition: mousePosition,

--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -179,16 +179,15 @@ class Stage extends React.Component {
         this.updateRect();
         const {x, y} = getEventXY(e);
         const mousePosition = [x - this.rect.left, y - this.rect.top];
-        if (true) {
-            this.setState({
-                mouseDown: true,
-                mouseDownPosition: mousePosition,
-                mouseDownTimeoutId: setTimeout(
-                    this.onStartDrag.bind(this, mousePosition[0], mousePosition[1]),
-                    500
-                )
-            });
-        }
+        this.setState({
+            mouseDown: true,
+            mouseDownPosition: mousePosition,
+            mouseDownTimeoutId: setTimeout(
+                this.onStartDrag.bind(this, mousePosition[0], mousePosition[1]),
+                500
+            )
+        });
+
         const data = {
             isDown: true,
             x: mousePosition[0],


### PR DESCRIPTION
### Resolves

Issue 701 (https://github.com/LLK/scratch-gui/issues/701)

### Proposed Changes

I have added an if statement to check what click is being used when clicking on the sprite. If it is a right click, the sprite is unable to be dragged.

### Reason for Changes

Before this change the user could right click the sprite, and then left click on the stage and the sprite would be dragged to where you left clicked, causing unexpected behavior.

### Test Coverage

All npm test test cases passed, this is a very small change so I did not see additional tests necessary.
