### PR TITLE
Sync toolbox

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -57,7 +57,7 @@ class Blocks extends React.Component {
         this.workspace = this.ScratchBlocks.inject(this.blocks, workspaceConfig);
 
         // Load the toolbox from the GUI (otherwise we get the scratch-blocks default toolbox)
-        this.workspace.updateToolbox(makeToolboxXML());
+        this.workspace.updateToolbox(this.props.toolboxXML);
 
         // @todo change this when blockly supports UI events
         addFunctionListener(this.workspace, 'translate', this.onWorkspaceMetricsChange);

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -56,6 +56,9 @@ class Blocks extends React.Component {
         const workspaceConfig = defaultsDeep({}, Blocks.defaultOptions, this.props.options);
         this.workspace = this.ScratchBlocks.inject(this.blocks, workspaceConfig);
 
+        // Load the toolbox from the GUI (otherwise we get the scratch-blocks default toolbox)
+        this.workspace.updateToolbox(makeToolboxXML());
+
         // @todo change this when blockly supports UI events
         addFunctionListener(this.workspace, 'translate', this.onWorkspaceMetricsChange);
         addFunctionListener(this.workspace, 'zoom', this.onWorkspaceMetricsChange);

--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -332,6 +332,20 @@ const pen = `
                 </shadow>
             </value>
         </block>
+        <block type="pen_changepentransparencyby" id="pen_changepentransparencyby">
+            <value name="TRANSPARENCY">
+                <shadow type="math_number">
+                    <field name="NUM">10</field>
+            </shadow>
+          </value>
+        </block>
+        <block type="pen_setpentransparencyto" id="pen_setpentransparencyto">
+            <value name="TRANSPARENCY">
+                <shadow type="math_number">
+                    <field name="NUM">50</field>
+                </shadow>
+            </value>
+        </block>
     </category>
 `;
 

--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -620,12 +620,12 @@ const makeToolboxXML = function (categoriesXML) {
         motion, gap,
         looks, gap,
         sound, gap,
-        pen, gap,
-        data, gap,
         events, gap,
         control, gap,
         sensing, gap,
-        operators
+        pen, gap,
+        operators, gap,
+        data
     ];
 
     if (categoriesXML) {

--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -71,6 +71,17 @@ const motion = `
                 </shadow>
             </value>
         </block>
+        <block type="motion_glideto" id="motion_glideto">
+            <value name="SECS">
+                <shadow type="math_number">
+                    <field name="NUM">1</field>
+                </shadow>
+            </value>
+            <value name="TO">
+                <shadow type="motion_glideto_menu">
+                </shadow>
+            </value>
+        </block>
         <block type="motion_changexby">
             <value name="DX">
                 <shadow type="math_number">


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-gui/issues/732

### Proposed Changes

Always load the toolbox contents from the Scratch-gui toolbox XML. 

This PR also includes fixes to the existing toolbox XML to re-order the categories to spec, and to not omit the new "glide to" and pen transparency blocks.

### Reason for Changes

The toolbox was initially loaded from the Scratch-blocks default toolbox, which is now different from the Scratch-gui toolbox. 