### PR TITLE
Add “top” category to toolbox xml

### DIFF
--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -1,5 +1,67 @@
 const separator = '<sep gap="45"/>';
 
+const top = `
+    <category name="Top" colour="#FFFFFF" secondaryColour="#CCCCCC">
+        <block type="event_whenflagclicked"/>
+        <block type="event_whenkeypressed">
+        </block>
+        <block type="event_whenthisspriteclicked"/>
+        <block type="motion_movesteps">
+            <value name="STEPS">
+                <shadow type="math_number">
+                    <field name="NUM">10</field>
+                </shadow>
+            </value>
+        </block>
+        <block type="motion_turnright">
+            <value name="DEGREES">
+                <shadow type="math_number">
+                    <field name="NUM">15</field>
+                </shadow>
+            </value>
+        </block>
+        <block type="motion_ifonedgebounce"/>
+        <block type="sound_playuntildone">
+            <value name="SOUND_MENU">
+                <shadow type="sound_sounds_menu"/>
+            </value>
+        </block>
+        <block type="looks_changeeffectby">
+            <value name="CHANGE">
+                <shadow type="math_number">
+                    <field name="NUM">10</field>
+                </shadow>
+            </value>
+        </block>
+        <block type="control_repeat">
+            <value name="TIMES">
+                <shadow type="math_whole_number">
+                    <field name="NUM">10</field>
+                </shadow>
+            </value>
+        </block>
+        <block type="control_wait">
+            <value name="DURATION">
+                <shadow type="math_positive_number">
+                    <field name="NUM">1</field>
+                </shadow>
+            </value>
+        </block>
+        <block type="operator_random">
+            <value name="FROM">
+                <shadow type="math_number">
+                    <field name="NUM">1</field>
+                </shadow>
+            </value>
+            <value name="TO">
+                <shadow type="math_number">
+                    <field name="NUM">10</field>
+                </shadow>
+            </value>
+        </block>
+    </category>
+`;
+
 const motion = `
     <category name="Motion" colour="#4C97FF" secondaryColour="#3373CC">
         <block type="motion_movesteps">
@@ -617,6 +679,7 @@ const makeToolboxXML = function (categoriesXML) {
 
     const everything = [
         xmlOpen,
+        top, gap,
         motion, gap,
         looks, gap,
         sound, gap,


### PR DESCRIPTION
### Resolves

Progress on https://github.com/LLK/scratch-gui/issues/603

### Proposed Changes

Add a "top" category containing a set of commonly used blocks.

Note that this change omits the "say hello for 2 secs" block, because it is not yet implemented. 

Also note that this new category will not be visible on load until we merge https://github.com/LLK/scratch-gui/pull/733

### Reason for Changes

See https://github.com/LLK/scratch-gui/issues/603