### PR TITLE
Add npm run build to the test to cover for removed integration tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "lint": "eslint . --ext .js,.jsx",
     "start": "npm run i18n:msgs && webpack-dev-server",
     "unit-test": "jest test/unit",
-    "integration-test": "npm run build && jest --runInBand test/integration",
-    "test": "npm run lint && npm run unit-test",
+    "integration-test": "jest --runInBand test/integration",
+    "test": "npm run lint && npm run unit-test && npm run build",
     "watch": "webpack --progress --colors --watch"
   },
   "author": "Massachusetts Institute of Technology",


### PR DESCRIPTION
We removed the integration tests from `npm test`, which also removed `npm run build`. This adds it back so that develop can deploy again.