### PR TITLE
Fix selenium tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start": "npm run i18n:msgs && webpack-dev-server",
     "unit-test": "jest test/unit",
     "integration-test": "jest --runInBand test/integration",
-    "test": "npm run lint && npm run unit-test && npm run build",
+    "test": "npm run lint && npm run unit-test && npm run build && npm run integration-test",
     "watch": "webpack --progress --colors --watch"
   },
   "author": "Massachusetts Institute of Technology",

--- a/test/helpers/selenium-helper.js
+++ b/test/helpers/selenium-helper.js
@@ -32,8 +32,8 @@ class SeleniumHelper {
         return this.findByXpath(xpath).then(el => el.click());
     }
 
-    clickText (text) {
-        return this.clickXpath(`//body//*[contains(text(), '${text}')]`);
+    clickText (text, scope) {
+        return this.clickXpath(`//body//${scope || '*'}//*[contains(text(), '${text}')]`);
     }
 
     clickButton (text) {

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -18,6 +18,10 @@ const errorWhitelist = [
 
 let driver;
 
+const blocksTabScope = "*[@id='react-tabs-1']";
+const costumesTabScope = "*[@id='react-tabs-3']";
+const soundsTabScope = "*[@id='react-tabs-5']";
+
 describe('costumes, sounds and variables', () => {
     beforeAll(() => {
         driver = getDriver();
@@ -34,8 +38,8 @@ describe('costumes, sounds and variables', () => {
         const el = await findByXpath("//input[@placeholder='what are you looking for?']");
         await el.sendKeys('abb');
         await clickText('abby-a'); // Should close the modal, then click the costumes in the selector
-        await clickText('costume1');
-        await clickText('abby-a');
+        await clickText('costume1', costumesTabScope);
+        await clickText('abby-a', costumesTabScope);
         const logs = await getLogs(errorWhitelist);
         await expect(logs).toEqual([]);
     });
@@ -47,10 +51,10 @@ describe('costumes, sounds and variables', () => {
         const el = await findByXpath("//input[@placeholder='what are you looking for?']");
         await el.sendKeys('chom');
         await clickText('chomp'); // Should close the modal, then click the sounds in the selector
-        await clickText('meow');
-        await clickText('chomp');
+        await clickText('meow', soundsTabScope);
+        await clickText('chomp', soundsTabScope);
         await clickXpath('//button[@title="Play"]');
-        await clickText('meow');
+        await clickText('meow', soundsTabScope);
         await clickXpath('//button[@title="Play"]');
 
         await clickText('Louder');
@@ -79,7 +83,8 @@ describe('costumes, sounds and variables', () => {
     test('Creating variables', async () => {
         await driver.get(`file://${uri}`);
         await clickText('Blocks');
-        await clickText('Data');
+        await clickText('Data', blocksTabScope);
+        await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for scroll animation
         await clickText('Create variable...');
         let el = await findByXpath("//input[@placeholder='']");
         await el.sendKeys('score');


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/727 and restores integration tests to the build process.

### Proposed Changes

_Describe what this Pull Request does_

Fixes the problem with the integration tests. They were not flaking out, they were responding to a real change in the GUI: the strings used for `clickText` were no longer unique on the page, and their first instance (inside the now rendered looks blocks) were indeed invisible. I used the tab ids to create scoping for the `clickText` selenium helper. 

### Reason for Changes

_Explain why these changes should be made_

Integration tests are very important! As demonstrated by yesterdays broken deploy :( 

### Test Coverage

_Please show how you have added tests to cover your changes_

`npm run test` works locally, hopefully will on travis as well. 
