### PR TITLE
Remove manual refresh for scratch-blocks workspace

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -85,12 +85,10 @@ class Blocks extends React.Component {
         }
 
         // @todo hack to resize blockly manually in case resize happened while hidden
-        // @todo hack to reload the workspace due to gui bug #413
         if (this.props.isVisible) { // Scripts tab
             this.workspace.setVisible(true);
             this.props.vm.refreshWorkspace();
             window.dispatchEvent(new Event('resize'));
-            this.workspace.toolbox_.refreshSelection();
         } else {
             this.workspace.setVisible(false);
         }
@@ -195,7 +193,6 @@ class Blocks extends React.Component {
         const dom = this.ScratchBlocks.Xml.textToDom(data.xml);
         this.ScratchBlocks.Xml.domToWorkspace(dom, this.workspace);
         this.ScratchBlocks.Events.enable();
-        this.workspace.toolbox_.refreshSelection();
 
         if (this.props.vm.editingTarget && this.state.workspaceMetrics[this.props.vm.editingTarget.id]) {
             const {scrollX, scrollY, scale} = this.state.workspaceMetrics[this.props.vm.editingTarget.id];


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Previous issues (#413) required manually refreshing the scratch-blocks workspace. It is now dealt with from within scratch-blocks, so these manual calls need to be removed for performance-sake. This removes two unnecessary calls when switching between costume/sounds => blocks tab, and one unnecessary call when switching between sprites. Further optimization to this is being tracked https://github.com/LLK/scratch-blocks/issues/1145

### Test Coverage

_Please show how you have added tests to cover your changes_

Tested manually against the scenarios from issue #413. 
