### PR TITLE
importing l10n that includes paint strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "scratch-audio": "latest",
     "scratch-paint": "latest",
     "scratch-blocks": "latest",
-    "scratch-l10n": "1.0.20171013211708",
+    "scratch-l10n": "^2.0.0",
     "scratch-render": "latest",
     "scratch-storage": "^0.2.0",
     "scratch-vm": "latest",

--- a/src/reducers/intl.js
+++ b/src/reducers/intl.js
@@ -1,25 +1,30 @@
 import {addLocaleData} from 'react-intl';
 import {updateIntl as superUpdateIntl} from 'react-intl-redux';
 import {IntlProvider, intlReducer} from 'react-intl-redux';
+import defaultsDeep from 'lodash.defaultsdeep';
 
-import locales from 'scratch-l10n';
+import localeData from 'scratch-l10n';
+import guiMessages from 'scratch-l10n/locales/gui-msgs';
+import paintMessages from 'scratch-l10n/locales/paint-msgs';
 
-Object.keys(locales).forEach(locale => {
+const combinedMessages = defaultsDeep({}, guiMessages.messages, paintMessages.messages);
+
+Object.keys(localeData).forEach(locale => {
     // TODO: will need to handle locales not in the default intl - see www/custom-locales
-    addLocaleData(locales[locale].localeData);
+    addLocaleData(localeData[locale].localeData);
 });
 
 const intlInitialState = {
     intl: {
         defaultLocale: 'en',
         locale: 'en',
-        messages: locales.en.messages
+        messages: combinedMessages.en.messages
     }
 };
 
 const updateIntl = locale => superUpdateIntl({
     locale: locale,
-    messages: locales[locale].messages || locales.en.messages
+    messages: combinedMessages[locale].messages || combinedMessages.en.messages
 });
 
 export {


### PR DESCRIPTION
Uses new version of scratch-l10n that supports localization of gui and paint. Part of https://github.com/LLK/scratch-paint/issues/16. 

Goes along with https://github.com/LLK/scratch-l10n/pull/6
This will be ready as soon as there's a  published release of l10n version 2.x

