### PR TITLE
Update the costume name from the paint editor

### DIFF
--- a/src/containers/paint-editor-wrapper.jsx
+++ b/src/containers/paint-editor-wrapper.jsx
@@ -11,50 +11,23 @@ class PaintEditorWrapper extends React.Component {
     constructor (props) {
         super(props);
         bindAll(this, [
+            'handleUpdateName',
             'handleUpdateSvg'
         ]);
     }
-    shouldComponentUpdate (nextProps) {
-        // Only update on sprite change or costume change. No need to push the SVG to the paint
-        // editor that it just exported; it causes the paint editor to lose some state.
-        const {
-            editingTarget,
-            sprites,
-            stage
-        } = nextProps;
-        const nextTarget = editingTarget && sprites[editingTarget] ? sprites[editingTarget] : stage;
-        const currentTarget =
-            this.props.editingTarget && this.props.sprites[this.props.editingTarget] ?
-                this.props.sprites[this.props.editingTarget] :
-                this.props.stage;
-
-        if (this.props.editingTarget !== editingTarget ||
-                currentTarget.currentCostume !== nextTarget.currentCostume) {
-            return true;
-        }
-        return false;
+    handleUpdateName (name) {
+        this.props.vm.renameCostume(this.props.selectedCostumeIndex, name);
     }
     handleUpdateSvg (svg, rotationCenterX, rotationCenterY) {
         this.props.vm.updateSvg(this.props.selectedCostumeIndex, svg, rotationCenterX, rotationCenterY);
     }
     render () {
-        const {
-            editingTarget,
-            sprites,
-            stage
-        } = this.props;
-
-        const target = editingTarget && sprites[editingTarget] ? sprites[editingTarget] : stage;
-
-        if (!target || !target.costumes) {
-            return null;
-        }
-
+        if (!this.props.svgId) return null;
         return (
             <PaintEditor
-                rotationCenterX={target.costumes[this.props.selectedCostumeIndex].rotationCenterX}
-                rotationCenterY={target.costumes[this.props.selectedCostumeIndex].rotationCenterY}
+                {...this.props}
                 svg={this.props.vm.getCostumeSvg(this.props.selectedCostumeIndex)}
+                onUpdateName={this.handleUpdateName}
                 onUpdateSvg={this.handleUpdateSvg}
             />
         );
@@ -62,31 +35,29 @@ class PaintEditorWrapper extends React.Component {
 }
 
 PaintEditorWrapper.propTypes = {
-    editingTarget: PropTypes.string,
+    name: PropTypes.string,
+    rotationCenterX: PropTypes.number,
+    rotationCenterY: PropTypes.number,
     selectedCostumeIndex: PropTypes.number.isRequired,
-    sprites: PropTypes.shape({
-        id: PropTypes.shape({
-            costumes: PropTypes.arrayOf(PropTypes.shape({
-                url: PropTypes.string,
-                name: PropTypes.string.isRequired
-            }))
-        })
-    }),
-    stage: PropTypes.shape({
-        sounds: PropTypes.arrayOf(PropTypes.shape({
-            name: PropTypes.string.isRequired
-        }))
-    }),
+    svgId: PropTypes.string,
     vm: PropTypes.instanceOf(VM)
 };
 
-const mapStateToProps = state => ({
-    editingTarget: state.targets.editingTarget,
-    sprites: state.targets.sprites,
-    stage: state.targets.stage,
-    costumeLibraryVisible: state.modals.costumeLibrary,
-    backdropLibraryVisible: state.modals.backdropLibrary
-});
+const mapStateToProps = (state, {selectedCostumeIndex}) => {
+    const {
+        editingTarget,
+        sprites,
+        stage
+    } = state.targets;
+    const target = editingTarget && sprites[editingTarget] ? sprites[editingTarget] : stage;
+    const costume = target && target.costumes[selectedCostumeIndex];
+    return {
+        name: costume && costume.name,
+        rotationCenterX: costume && costume.rotationCenterX,
+        rotationCenterY: costume && costume.rotationCenterY,
+        svgId: editingTarget && `${editingTarget}${selectedCostumeIndex}`
+    };
+};
 
 export default connect(
     mapStateToProps


### PR DESCRIPTION
Integrates https://github.com/LLK/scratch-paint/pull/78, so this should not be pulled in until that's been published.  Resolves https://github.com/LLK/scratch-paint/issues/50

With the smarter handling of the `svg`/`svgId` props, `shouldComponentUpdate` is no longer needed. Clean up `PropTypes` to match.
