### PR TITLE
Revert broken performance improvement and add tests

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -82,10 +82,12 @@ class Blocks extends React.Component {
             return;
         }
         // @todo hack to resize blockly manually in case resize happened while hidden
+        // @todo hack to reload the workspace due to gui bug #413
         if (this.props.isVisible) { // Scripts tab
             this.workspace.setVisible(true);
             this.props.vm.refreshWorkspace();
             window.dispatchEvent(new Event('resize'));
+            this.workspace.toolbox_.refreshSelection();
         } else {
             this.workspace.setVisible(false);
         }
@@ -176,6 +178,7 @@ class Blocks extends React.Component {
         const dom = this.ScratchBlocks.Xml.textToDom(data.xml);
         this.ScratchBlocks.Xml.domToWorkspace(dom, this.workspace);
         this.ScratchBlocks.Events.enable();
+        this.workspace.toolbox_.refreshSelection();
 
         if (this.props.vm.editingTarget && this.state.workspaceMetrics[this.props.vm.editingTarget.id]) {
             const {scrollX, scrollY, scale} = this.state.workspaceMetrics[this.props.vm.editingTarget.id];

--- a/test/helpers/selenium-helper.js
+++ b/test/helpers/selenium-helper.js
@@ -12,6 +12,7 @@ class SeleniumHelper {
             'clickText',
             'clickButton',
             'clickXpath',
+            'findByText',
             'findByXpath',
             'getDriver',
             'getLogs'
@@ -29,12 +30,16 @@ class SeleniumHelper {
         return this.driver.wait(until.elementLocated(By.xpath(xpath), 5 * 1000));
     }
 
+    findByText (text, scope) {
+        return this.findByXpath(`//body//${scope || '*'}//*[contains(text(), '${text}')]`);
+    }
+
     clickXpath (xpath) {
         return this.findByXpath(xpath).then(el => el.click());
     }
 
     clickText (text, scope) {
-        return this.clickXpath(`//body//${scope || '*'}//*[contains(text(), '${text}')]`);
+        return this.findByText(text, scope).then(el => el.click());
     }
 
     clickButton (text) {

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -5,6 +5,7 @@ const {
     clickText,
     clickButton,
     clickXpath,
+    findByText,
     findByXpath,
     getDriver,
     getLogs
@@ -21,6 +22,7 @@ let driver;
 const blocksTabScope = "*[@id='react-tabs-1']";
 const costumesTabScope = "*[@id='react-tabs-3']";
 const soundsTabScope = "*[@id='react-tabs-5']";
+const reportedValueScope = '*[@class="blocklyDropDownContent"]';
 
 describe('costumes, sounds and variables', () => {
     beforeAll(() => {
@@ -29,6 +31,18 @@ describe('costumes, sounds and variables', () => {
 
     afterAll(async () => {
         await driver.quit();
+    });
+
+
+    test('Blocks report when clicked in the toolbox', async () => {
+        await driver.get(`file://${uri}`);
+        await clickText('Blocks');
+        await clickText('Operators', blocksTabScope);
+        await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for scroll animation
+        await clickText('join', blocksTabScope); // Click "join <hello> <world>" block
+        await findByText('helloworld', reportedValueScope); // Tooltip with result
+        const logs = await getLogs(errorWhitelist);
+        await expect(logs).toEqual([]);
     });
 
     test('Adding a costume', async () => {
@@ -93,6 +107,13 @@ describe('costumes, sounds and variables', () => {
         el = await findByXpath("//input[@placeholder='']");
         await el.sendKeys('second variable');
         await clickButton('OK');
+
+        // Make sure reporting works on a new variable
+        await clickText('Data', blocksTabScope);
+        await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for scroll animation
+        await clickText('score', blocksTabScope);
+        await findByText('0', reportedValueScope); // Tooltip with result
+
         const logs = await getLogs(errorWhitelist);
         await expect(logs).toEqual([]);
     });

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -45,6 +45,19 @@ describe('costumes, sounds and variables', () => {
         await expect(logs).toEqual([]);
     });
 
+    test('Switching sprites updates the block menus', async () => {
+        await driver.get(`file://${uri}`);
+        await clickText('Sound', blocksTabScope);
+        await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for scroll animation
+        // "meow" sound block should be visible
+        await findByText('meow', blocksTabScope);
+        await clickText('Backdrops'); // Switch to the backdrop
+        // Now "pop" sound block should be visible
+        await findByText('pop', blocksTabScope);
+        const logs = await getLogs(errorWhitelist);
+        await expect(logs).toEqual([]);
+    });
+
     test('Adding a costume', async () => {
         await driver.get(`file://${uri}`);
         await clickText('Costumes');


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Resolves https://github.com/LLK/scratch-gui/issues/799, which was caused by a scratch blocks change the [has been reverted](https://github.com/LLK/scratch-blocks/pull/1168). The revert commit is to take out the corresponding "performance improvement" that went along with the now-reverted scratch-blocks PR. 

In order to make sure these problems do not happen again, I've added tests for the following things which were broken:

- Clicking on blocks to run them from the toolbox, seeing reported values.
- (same but specifically for variables, something which was also fixed recently)
- Switching sprites updating the block menus. This would have been broken if we had reverted the scratch-blocks PR but not reverted this GUI commit. 

It's all a bit complicated :( 

But the good news is we now have tests that will stop it from happening in the future. 

The bad news is we had to take a step back from the performance improvements, but we now can approach them with a much better idea of the pitfalls. 