### PR TITLE
Fix sprite position updating the toolbox blocks

### DIFF
--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -112,12 +112,12 @@ const motion = `
         </block>
         <block type="motion_gotoxy">
             <value name="X">
-                <shadow type="math_number">
+                <shadow id="movex" type="math_number">
                     <field name="NUM">0</field>
                 </shadow>
             </value>
             <value name="Y">
-                <shadow type="math_number">
+                <shadow id="movey" type="math_number">
                     <field name="NUM">0</field>
                 </shadow>
             </value>
@@ -135,12 +135,12 @@ const motion = `
                 </shadow>
             </value>
             <value name="X">
-                <shadow type="math_number">
+                <shadow id="glidex" type="math_number">
                     <field name="NUM">0</field>
                 </shadow>
             </value>
             <value name="Y">
-                <shadow type="math_number">
+                <shadow id="glidey" type="math_number">
                     <field name="NUM">0</field>
                 </shadow>
             </value>
@@ -165,7 +165,7 @@ const motion = `
         </block>
         <block type="motion_setx">
             <value name="X">
-                <shadow type="math_number">
+                <shadow id="setx" type="math_number">
                     <field name="NUM">0</field>
                 </shadow>
             </value>
@@ -179,7 +179,7 @@ const motion = `
         </block>
         <block type="motion_sety">
             <value name="Y">
-                <shadow type="math_number">
+                <shadow id="sety" type="math_number">
                     <field name="NUM">0</field>
                 </shadow>
             </value>


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

FIxes https://github.com/LLK/scratch-gui/issues/745

It was caused by a mistaken copy/paste when we moved from using the default toolbox in scratch-blocks to providing our own. The set/move/glide fields need fixed IDs so that they can be updating when a sprite moves around. So I just copied them over correctly from scratch-blocks. 

![moving-sprite-updates](https://user-images.githubusercontent.com/654102/31909546-7811dc0e-b808-11e7-802d-009e8dbd7f47.gif)




