### PR TITLE
Stop refreshing the toolbox by using new batch update API

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -87,7 +87,6 @@ class Blocks extends React.Component {
             this.workspace.setVisible(true);
             this.props.vm.refreshWorkspace();
             window.dispatchEvent(new Event('resize'));
-            this.workspace.toolbox_.refreshSelection();
         } else {
             this.workspace.setVisible(false);
         }

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -172,13 +172,11 @@ class Blocks extends React.Component {
             this.onWorkspaceMetricsChange();
         }
 
-        this.ScratchBlocks.Events.disable();
-        this.workspace.clear();
-
+        // Remove and reattach the workspace listener (but allow flyout events)
+        this.workspace.removeChangeListener(this.props.vm.blockListener);
         const dom = this.ScratchBlocks.Xml.textToDom(data.xml);
-        this.ScratchBlocks.Xml.domToWorkspace(dom, this.workspace);
-        this.ScratchBlocks.Events.enable();
-        this.workspace.toolbox_.refreshSelection();
+        this.ScratchBlocks.Xml.clearWorkspaceAndLoadFromXml(dom, this.workspace);
+        this.workspace.addChangeListener(this.props.vm.blockListener);
 
         if (this.props.vm.editingTarget && this.state.workspaceMetrics[this.props.vm.editingTarget.id]) {
             const {scrollX, scrollY, scale} = this.state.workspaceMetrics[this.props.vm.editingTarget.id];


### PR DESCRIPTION
_note: this depends on https://github.com/LLK/scratch-blocks/pull/1178 and will probably fail on travis until that is deployed_

### Resolves

_What Github issue does this resolve (please include link)?_

Uses the new batch xml loading utility to load xml when changing workspaces introduced in  https://github.com/LLK/scratch-blocks/pull/1178

### Proposed Changes

_Describe what this Pull Request does_

The new batch loading guarantees that `refreshSelection` on the toolbox is called exactly once.  This requires a change to unhook the workspace vm listener during the update, instead of disabling the events from scratch-blocks, because the vm still needs to hear the toolbox events, for now.