### PR TITLE
Fix corner radius bug

### DIFF
--- a/src/components/stage/stage.css
+++ b/src/components/stage/stage.css
@@ -1,4 +1,5 @@
 @import "../../css/units.css";
+@import "../../css/colors.css";
 
 .stage {
     /*
@@ -6,8 +7,6 @@
         of the element, which messes up the chrome padding consistency
     */
     display: block;
-
-    border-radius: $space;
 
     /* @todo: This is for overriding the value being set somewhere. Where is it being set? */
     background-color: transparent;
@@ -31,6 +30,10 @@
 
 .stage-wrapper {
     position: relative;
+    border-radius: $space;
+    border: 1px solid $ui-pane-border;
+    /* Keep the canvas inside the border radius */
+    overflow: hidden;
 }
 
 .monitor-wrapper, .color-picker-wrapper {


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/805 by moving the corner radius up to the wrapper and setting `overflow: hidden` to prevent the canvas from appearing outside the corner radius. Also adds a border to make it match the other panels.


![image](https://user-images.githubusercontent.com/654102/32055439-d0411a7e-ba2f-11e7-93e3-dd8e3787f2db.png)
