### PR TITLE
Update toolbox before ScratchBlocks inject and Give  IDs to some shadow blocks

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -53,7 +53,11 @@ class Blocks extends React.Component {
     componentDidMount () {
         this.ScratchBlocks.FieldColourSlider.activateEyedropper_ = this.props.onActivateColorPicker;
 
-        const workspaceConfig = defaultsDeep({}, Blocks.defaultOptions, this.props.options, {toolbox: this.props.toolboxXML});
+        const workspaceConfig = defaultsDeep({},
+            Blocks.defaultOptions,
+            this.props.options,
+            {toolbox: this.props.toolboxXML}
+        );
         this.workspace = this.ScratchBlocks.inject(this.blocks, workspaceConfig);
 
         // @todo change this when blockly supports UI events

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -53,11 +53,8 @@ class Blocks extends React.Component {
     componentDidMount () {
         this.ScratchBlocks.FieldColourSlider.activateEyedropper_ = this.props.onActivateColorPicker;
 
-        const workspaceConfig = defaultsDeep({}, Blocks.defaultOptions, this.props.options);
+        const workspaceConfig = defaultsDeep({}, Blocks.defaultOptions, this.props.options, {toolbox: this.props.toolboxXML});
         this.workspace = this.ScratchBlocks.inject(this.blocks, workspaceConfig);
-
-        // Load the toolbox from the GUI (otherwise we get the scratch-blocks default toolbox)
-        this.workspace.updateToolbox(this.props.toolboxXML);
 
         // @todo change this when blockly supports UI events
         addFunctionListener(this.workspace, 'translate', this.onWorkspaceMetricsChange);

--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -416,15 +416,15 @@ const sensing = `
         <block type="sensing_resettimer"/>
         <block id="of" type="sensing_of">
             <value name="PROPERTY">
-                <shadow type="sensing_of_property_menu"/>
+                <shadow id="sensing_of_property_menu" type="sensing_of_property_menu"/>
             </value>
             <value name="OBJECT">
-                <shadow type="sensing_of_object_menu"/>
+                <shadow id="sensing_of_object_menu" type="sensing_of_object_menu"/>
             </value>
         </block>
         <block id="current" type="sensing_current">
             <value name="CURRENTMENU">
-                <shadow type="sensing_currentmenu"/>
+                <shadow id="sensing_currentmenu" type="sensing_currentmenu"/>
             </value>
         </block>
         <block type="sensing_dayssince2000"/>


### PR DESCRIPTION
### Reason for Changes

1.Toolbox should be updated before ScratchBlocks inject to avoid repeated rendering.
2.Some monitored blocks's shadow blocks also need IDs.
