### PR TITLE
Use unique costume ID

### DIFF
--- a/src/containers/paint-editor-wrapper.jsx
+++ b/src/containers/paint-editor-wrapper.jsx
@@ -55,7 +55,7 @@ const mapStateToProps = (state, {selectedCostumeIndex}) => {
         name: costume && costume.name,
         rotationCenterX: costume && costume.rotationCenterX,
         rotationCenterY: costume && costume.rotationCenterY,
-        svgId: editingTarget && `${editingTarget}${selectedCostumeIndex}`
+        svgId: editingTarget && `${editingTarget}${costume.skinId}`
     };
 };
 


### PR DESCRIPTION
Fixes https://github.com/LLK/scratch-paint/issues/121
Use the skin ID rather than the costume index.

When costumes are deleted from the sprite, the costume index shifts. Skin ID tracks what we want.