### PR TITLE
Shrink extension button

### DIFF
--- a/src/components/gui/gui.css
+++ b/src/components/gui/gui.css
@@ -150,7 +150,7 @@
 }
 
 .extension-button-container {
-    width: 60px;
+    width: 3.25rem;
     height: 3.25rem;
     position: absolute;
     bottom: 0;


### PR DESCRIPTION
### Resolves

This is part of tightening up the category menu (https://github.com/LLK/scratch-blocks/pull/1198).

### Proposed Changes

Just make the "add extension" button a little smaller

### Reason for Changes

This makes it match the new smaller width of the category menu.

### Test Coverage

No tests.