### PR TITLE
Prevent loading duplicate extensions

### DIFF
--- a/src/components/target-pane/target-pane.jsx
+++ b/src/components/target-pane/target-pane.jsx
@@ -7,7 +7,6 @@ import BackdropLibrary from '../../containers/backdrop-library.jsx';
 import CostumeLibrary from '../../containers/costume-library.jsx';
 import SoundLibrary from '../../containers/sound-library.jsx';
 import SpriteLibrary from '../../containers/sprite-library.jsx';
-import ExtensionLibrary from '../../containers/extension-library.jsx';
 
 import SpriteSelectorComponent from '../sprite-selector/sprite-selector.jsx';
 import StageSelector from '../../containers/stage-selector.jsx';
@@ -22,7 +21,6 @@ import styles from './target-pane.css';
  */
 const TargetPane = ({
     editingTarget,
-    extensionLibraryVisible,
     backdropLibraryVisible,
     costumeLibraryVisible,
     soundLibraryVisible,
@@ -40,7 +38,6 @@ const TargetPane = ({
     onRequestCloseCostumeLibrary,
     onRequestCloseSoundLibrary,
     onRequestCloseSpriteLibrary,
-    onRequestCloseExtensionLibrary,
     onSelectSprite,
     stage,
     sprites,
@@ -78,12 +75,6 @@ const TargetPane = ({
                 onSelect={onSelectSprite}
             />}
             <div>
-                {extensionLibraryVisible ? (
-                    <ExtensionLibrary
-                        vm={vm}
-                        onRequestClose={onRequestCloseExtensionLibrary}
-                    />
-                ) : null}
                 {spriteLibraryVisible ? (
                     <SpriteLibrary
                         vm={vm}

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -8,10 +8,12 @@ import VMScratchBlocks from '../lib/blocks';
 import VM from 'scratch-vm';
 import Prompt from './prompt.jsx';
 import BlocksComponent from '../components/blocks/blocks.jsx';
+import ExtensionLibrary from './extension-library.jsx';
 
 import {connect} from 'react-redux';
 import {updateToolbox} from '../reducers/toolbox';
 import {activateColorPicker} from '../reducers/color-picker';
+import {closeExtensionLibrary} from '../reducers/modals';
 
 const addFunctionListener = (object, property, callback) => {
     const oldFn = object[property];
@@ -69,7 +71,8 @@ class Blocks extends React.Component {
         return (
             this.state.prompt !== nextState.prompt ||
             this.props.isVisible !== nextProps.isVisible ||
-            this.props.toolboxXML !== nextProps.toolboxXML
+            this.props.toolboxXML !== nextProps.toolboxXML ||
+            this.props.extensionLibraryVisible !== nextProps.extensionLibraryVisible
         );
     }
     componentDidUpdate (prevProps) {
@@ -209,11 +212,13 @@ class Blocks extends React.Component {
     render () {
         /* eslint-disable no-unused-vars */
         const {
+            extensionLibraryVisible,
             options,
             vm,
             isVisible,
             onActivateColorPicker,
             onExtensionAdded,
+            onRequestCloseExtensionLibrary,
             toolboxXML,
             ...props
         } = this.props;
@@ -233,15 +238,23 @@ class Blocks extends React.Component {
                         onOk={this.handlePromptCallback}
                     />
                 ) : null}
+                {extensionLibraryVisible ? (
+                    <ExtensionLibrary
+                        vm={vm}
+                        onRequestClose={onRequestCloseExtensionLibrary}
+                    />
+                ) : null}
             </div>
         );
     }
 }
 
 Blocks.propTypes = {
+    extensionLibraryVisible: PropTypes.bool,
     isVisible: PropTypes.bool,
     onActivateColorPicker: PropTypes.func,
     onExtensionAdded: PropTypes.func,
+    onRequestCloseExtensionLibrary: PropTypes.func,
     options: PropTypes.shape({
         media: PropTypes.string,
         zoom: PropTypes.shape({
@@ -299,6 +312,7 @@ Blocks.defaultProps = {
 };
 
 const mapStateToProps = state => ({
+    extensionLibraryVisible: state.modals.extensionLibrary,
     toolboxXML: state.toolbox.toolboxXML
 });
 
@@ -306,6 +320,9 @@ const mapDispatchToProps = dispatch => ({
     onActivateColorPicker: callback => dispatch(activateColorPicker(callback)),
     onExtensionAdded: toolboxXML => {
         dispatch(updateToolbox(toolboxXML));
+    },
+    onRequestCloseExtensionLibrary: () => {
+        dispatch(closeExtensionLibrary());
     }
 });
 

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -31,6 +31,7 @@ class Blocks extends React.Component {
         bindAll(this, [
             'attachVM',
             'detachVM',
+            'handleCategorySelected',
             'handlePromptStart',
             'handlePromptCallback',
             'handlePromptClose',
@@ -194,6 +195,9 @@ class Blocks extends React.Component {
         const toolboxXML = makeToolboxXML(dynamicBlocksXML);
         this.props.onExtensionAdded(toolboxXML);
         const categoryName = blocksInfo[0].json.category;
+        this.handleCategorySelected(categoryName);
+    }
+    handleCategorySelected (categoryName) {
         this.workspace.toolbox_.setSelectedCategoryByName(categoryName);
     }
     setBlocks (blocks) {
@@ -241,6 +245,7 @@ class Blocks extends React.Component {
                 {extensionLibraryVisible ? (
                     <ExtensionLibrary
                         vm={vm}
+                        onCategorySelected={this.handleCategorySelected}
                         onRequestClose={onRequestCloseExtensionLibrary}
                     />
                 ) : null}

--- a/src/containers/extension-library.jsx
+++ b/src/containers/extension-library.jsx
@@ -20,9 +20,10 @@ class ExtensionLibrary extends React.PureComponent {
         const url = item.extensionURL || prompt('Enter the URL of the extension');
         if (url) {
             if (this.props.vm.extensionManager.isExtensionLoaded(url)) {
-                return;
+                this.props.onCategorySelected(item.name);
+            } else {
+                this.props.vm.extensionManager.loadExtensionURL(url);
             }
-            this.props.vm.extensionManager.loadExtensionURL(url);
         }
     }
     render () {
@@ -43,6 +44,7 @@ class ExtensionLibrary extends React.PureComponent {
 }
 
 ExtensionLibrary.propTypes = {
+    onCategorySelected: PropTypes.func,
     onRequestClose: PropTypes.func,
     visible: PropTypes.bool,
     vm: PropTypes.instanceOf(VM).isRequired // eslint-disable-line react/no-unused-prop-types

--- a/src/containers/extension-library.jsx
+++ b/src/containers/extension-library.jsx
@@ -19,6 +19,9 @@ class ExtensionLibrary extends React.PureComponent {
         // eslint-disable-next-line no-alert
         const url = item.extensionURL || prompt('Enter the URL of the extension');
         if (url) {
+            if (this.props.vm.extensionManager.isExtensionLoaded(url)) {
+                return;
+            }
             this.props.vm.extensionManager.loadExtensionURL(url);
         }
     }

--- a/src/containers/target-pane.jsx
+++ b/src/containers/target-pane.jsx
@@ -7,7 +7,6 @@ import {
     openSpriteLibrary,
     closeBackdropLibrary,
     closeCostumeLibrary,
-    closeExtensionLibrary,
     closeSoundLibrary,
     closeSpriteLibrary
 } from '../reducers/modals';
@@ -97,8 +96,7 @@ const mapStateToProps = state => ({
     soundLibraryVisible: state.modals.soundLibrary,
     spriteLibraryVisible: state.modals.spriteLibrary,
     costumeLibraryVisible: state.modals.costumeLibrary,
-    backdropLibraryVisible: state.modals.backdropLibrary,
-    extensionLibraryVisible: state.modals.extensionLibrary
+    backdropLibraryVisible: state.modals.backdropLibrary
 });
 const mapDispatchToProps = dispatch => ({
     onNewSpriteClick: e => {
@@ -110,9 +108,6 @@ const mapDispatchToProps = dispatch => ({
     },
     onRequestCloseCostumeLibrary: () => {
         dispatch(closeCostumeLibrary());
-    },
-    onRequestCloseExtensionLibrary: () => {
-        dispatch(closeExtensionLibrary());
     },
     onRequestCloseSoundLibrary: () => {
         dispatch(closeSoundLibrary());

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -23,6 +23,7 @@ const blocksTabScope = "*[@id='react-tabs-1']";
 const costumesTabScope = "*[@id='react-tabs-3']";
 const soundsTabScope = "*[@id='react-tabs-5']";
 const reportedValueScope = '*[@class="blocklyDropDownContent"]';
+const modalScope = '*[@class="ReactModalPortal"]';
 
 describe('costumes, sounds and variables', () => {
     beforeAll(() => {
@@ -135,9 +136,18 @@ describe('costumes, sounds and variables', () => {
         await driver.get(`file://${uri}`);
         await clickText('Blocks');
         await clickText('Extensions');
-        await clickText('Pen'); // Modal closes
-        await clickText('Pen', blocksTabScope); // Click the new category
+        await clickText('Pen', modalScope); // Modal closes
+        await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for scroll animation
         await clickText('stamp', blocksTabScope); // Click the "stamp" block
+
+        // Make sure trying to load the extension again scrolls back down
+        await clickText('Motion', blocksTabScope); // To scroll the list back to the top
+        await clickText('Extensions');
+        await clickText('Pen', modalScope); // Modal closes
+        await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for scroll animation
+        await clickText('stamp', blocksTabScope); // Would fail if didn't scroll back
+
+
         const logs = await getLogs(errorWhitelist);
         await expect(logs).toEqual([]);
     });


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-gui/issues/821

Depends on https://github.com/LLK/scratch-vm/pull/724

### Proposed Changes

- Prevent loading duplicate extensions by checking with the VM extension manager before loading
- If the extension has already been loaded, scroll the blocks menu to that extension category
- Render the extension library in the blocks container, so that it can scroll the blocks.

### Reason for Changes

This prevents the loading of duplicate extensions, at least for internal extensions.

### Test Coverage

[test coming]
