### PR TITLE
Bring back the 'contains' operator block

### DIFF
--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -603,6 +603,18 @@ const operators = `
                 </shadow>
             </value>
         </block>
+        <block type="operator_contains" id="operator_contains">
+          <value name="STRING1">
+            <shadow type="text">
+              <field name="TEXT">hello</field>
+            </shadow>
+          </value>
+          <value name="STRING2">
+            <shadow type="text">
+              <field name="TEXT">world</field>
+            </shadow>
+          </value>
+        </block>
         ${blockSeparator}
         <block type="operator_mod">
             <value name="NUM1">


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Resolves https://github.com/LLK/scratch-gui/issues/836

### Proposed Changes

_Describe what this Pull Request does_

Brings back the new `contains` block which looks like it was lost in the shuffle between blocks xml and gui xml. 

I also noticed that the default values were wrong when this was originally implemented (`hello contains world`, while the spec says `hello world contains world`). I updated it to match the spec. @thisandagain this block is pretty wide, which makes it somewhat harder to notice that it is a boolean. Is the below screenshot ok?

![image](https://user-images.githubusercontent.com/654102/32330408-701902b0-bfb6-11e7-85f7-0d0aa6487f40.png)

h/t to @Kenny2github for noticing the regression. 