### PR TITLE
Add aria label to language selector.

### DIFF
--- a/src/components/language-selector/language-selector.jsx
+++ b/src/components/language-selector/language-selector.jsx
@@ -18,10 +18,10 @@ const LanguageSelector = ({
                 src={languageIcon}
             />
             <select
+                aria-label="language selector"
                 className={styles.languageSelect}
                 value={currentLocale}
                 onChange={onChange}
-                aria-label="language selector"
             >
                 {Object.keys(locales).map(locale => (
                     <option

--- a/src/components/language-selector/language-selector.jsx
+++ b/src/components/language-selector/language-selector.jsx
@@ -21,6 +21,7 @@ const LanguageSelector = ({
                 className={styles.languageSelect}
                 value={currentLocale}
                 onChange={onChange}
+                aria-label="language selector"
             >
                 {Object.keys(locales).map(locale => (
                     <option


### PR DESCRIPTION
### Resolves

The language selector has no aria-label, meaning that a user navigating Scratch with a screen reader is forced to guess what the selector is for. 

### Proposed Changes

Add aria-label to the language selector.

### Reason for Changes

The aria-label will be read when someone is navigating the page using a screen reader and is focused on the language selector form.

### Test Coverage
On Mac, I used a screen reader to check that the label was read aloud upon navigating to the selector.
