### PR TITLE
Show focus on language selector.

### DIFF
--- a/src/components/language-selector/language-selector.css
+++ b/src/components/language-selector/language-selector.css
@@ -24,6 +24,5 @@
 }
 
 .language-select:focus {
-    border-color: white;
-    box-shadow: 0 0 0 -2px white;
+    border: 1px solid white;
 }

--- a/src/components/language-selector/language-selector.css
+++ b/src/components/language-selector/language-selector.css
@@ -22,3 +22,8 @@
     color: #3373cc;
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
+
+.language-select:focus {
+    border-color: black;
+    box-shadow: inset 0 0 0 -2px rgba(0, 0, 0, 0.1);
+}

--- a/src/components/language-selector/language-selector.css
+++ b/src/components/language-selector/language-selector.css
@@ -24,6 +24,6 @@
 }
 
 .language-select:focus {
-    border-color: black;
-    box-shadow: inset 0 0 0 -2px rgba(0, 0, 0, 0.1);
+    border-color: white;
+    box-shadow: 0 0 0 -2px white;
 }


### PR DESCRIPTION
### Resolves
There is no visual indicator of focus on the language selector when tabbing through the GUI. 

### Proposed Changes
Add white ring around the selector when it has focus (e.g. you have tabbed to the language selector).
Before:
![image](https://user-images.githubusercontent.com/10423718/32346464-c98da71a-bfe3-11e7-81e6-83dc237de78c.png)
After:
![image](https://user-images.githubusercontent.com/10423718/32346459-c2234124-bfe3-11e7-85dd-47c829a31389.png)

### Reason for Changes
Upon discussion with Carl, the highlight is consistent with other ways in which the focus on elements is shown.
