### PR TITLE
Enable selection of sprite visibility by keyboard.

### DIFF
--- a/src/components/sprite-info/sprite-info.css
+++ b/src/components/sprite-info/sprite-info.css
@@ -62,12 +62,22 @@
     border-bottom-left-radius: $form-radius;
 }
 
+.radio-left:focus {
+    border-color: #4c97ff;
+    box-shadow: inset 0 0 0 -2px rgba(0, 0, 0, 0.1);
+}
+
 .radio-right {
     border-bottom: 1px solid $form-border;
     border-top: 1px solid $form-border;
     border-right: 1px solid $form-border;
     border-top-right-radius: $form-radius;
     border-bottom-right-radius: $form-radius;
+}
+
+.radio-right:focus {
+    border-color: #4c97ff;
+    box-shadow: inset 0 0 0 -2px rgba(0, 0, 0, 0.1);
 }
 
 .icon {

--- a/src/components/sprite-info/sprite-info.jsx
+++ b/src/components/sprite-info/sprite-info.jsx
@@ -117,8 +117,6 @@ class SpriteInfo extends React.Component {
                                 tabIndex="4"
                                 onClick={this.props.onClickVisible}
                                 onKeyPress={this.props.onPressVisible}
-                                aria-label="Show sprite"
-                                role="button"
                             >
                                 <img
                                     className={styles.icon}
@@ -138,8 +136,6 @@ class SpriteInfo extends React.Component {
                                 tabIndex="5"
                                 onClick={this.props.onClickNotVisible}
                                 onKeyPress={this.props.onPressNotVisible}
-                                aria-label="Hide sprite"
-                                role="button"
                             >
                                 <img
                                     className={styles.icon}

--- a/src/components/sprite-info/sprite-info.jsx
+++ b/src/components/sprite-info/sprite-info.jsx
@@ -116,6 +116,9 @@ class SpriteInfo extends React.Component {
                                 )}
                                 tabIndex="4"
                                 onClick={this.props.onClickVisible}
+                                onKeyPress={this.props.onPressVisible}
+                                aria-label="Show sprite"
+                                role="button"
                             >
                                 <img
                                     className={styles.icon}
@@ -132,8 +135,11 @@ class SpriteInfo extends React.Component {
                                         [styles.isDisabled]: this.props.disabled
                                     }
                                 )}
-                                tabIndex="4"
+                                tabIndex="5"
                                 onClick={this.props.onClickNotVisible}
+                                onKeyPress={this.props.onPressNotVisible}
+                                aria-label="Hide sprite"
+                                role="button"
                             >
                                 <img
                                     className={styles.icon}
@@ -151,7 +157,7 @@ class SpriteInfo extends React.Component {
                                 small
                                 disabled={this.props.disabled}
                                 label="Direction"
-                                tabIndex="5"
+                                tabIndex="6"
                                 type="text"
                                 value={this.props.disabled ? '' : this.props.direction}
                                 onSubmit={this.props.onChangeDirection}
@@ -200,6 +206,8 @@ SpriteInfo.propTypes = {
     onChangeY: PropTypes.func,
     onClickNotVisible: PropTypes.func,
     onClickVisible: PropTypes.func,
+    onPressNotVisible: PropTypes.func,
+    onPressVisible: PropTypes.func,
     rotationStyle: PropTypes.oneOf(ROTATION_STYLES),
     visible: PropTypes.bool,
     x: PropTypes.oneOfType([

--- a/src/containers/sprite-info.jsx
+++ b/src/containers/sprite-info.jsx
@@ -27,13 +27,13 @@ class SpriteInfo extends React.Component {
         this.props.onChangeVisibility(false);
     }
     handlePressVisible (e) {
-        if (e.key === " " || e.key === "Enter") {
+        if (e.key === ' ' || e.key === 'Enter') {
             e.preventDefault();
             this.props.onChangeVisibility(true);
         }
     }
     handlePressNotVisible (e) {
-        if (e.key === " " || e.key === "Enter") {
+        if (e.key === ' ' || e.key === 'Enter') {
             e.preventDefault();
             this.props.onChangeVisibility(false);
         }

--- a/src/containers/sprite-info.jsx
+++ b/src/containers/sprite-info.jsx
@@ -10,7 +10,9 @@ class SpriteInfo extends React.Component {
         bindAll(this, [
             'handleChangeRotationStyle',
             'handleClickVisible',
-            'handleClickNotVisible'
+            'handleClickNotVisible',
+            'handlePressVisible',
+            'handlePressNotVisible'
         ]);
     }
     handleChangeRotationStyle (e) {
@@ -24,6 +26,18 @@ class SpriteInfo extends React.Component {
         e.preventDefault();
         this.props.onChangeVisibility(false);
     }
+    handlePressVisible (e) {
+        if (e.key === " " || e.key === "Enter") {
+            e.preventDefault();
+            this.props.onChangeVisibility(true);
+        }
+    }
+    handlePressNotVisible (e) {
+        if (e.key === " " || e.key === "Enter") {
+            e.preventDefault();
+            this.props.onChangeVisibility(false);
+        }
+    }
     render () {
         return (
             <SpriteInfoComponent
@@ -31,6 +45,8 @@ class SpriteInfo extends React.Component {
                 onChangeRotationStyle={this.handleChangeRotationStyle}
                 onClickNotVisible={this.handleClickNotVisible}
                 onClickVisible={this.handleClickVisible}
+                onPressNotVisible={this.handlePressNotVisible}
+                onPressVisible={this.handlePressVisible}
             />
         );
     }


### PR DESCRIPTION
### Resolves

- Cannot tab to individual show/hide sprite buttons (they both have same tab index)
![image](https://user-images.githubusercontent.com/10423718/32347275-7e092ad2-bfe6-11e7-9080-39d5f7bdfc8a.png)

- Cannot use keypresses (press space or enter) to activate show/hide sprite buttons
- Show and hide buttons do not visually show focus

### Proposed Changes
- You can tab to each button individually 
- User can press space or enter to activate either of the buttons when the button has focus on it
- Buttons have a border when they currently have focus

Focused on active Show Sprite Button:
![image](https://user-images.githubusercontent.com/10423718/32347396-dd58d9d8-bfe6-11e7-8bea-3d656c9885d9.png)

Focused on inactive Show Sprite Button:
![image](https://user-images.githubusercontent.com/10423718/32347420-f6b20ddc-bfe6-11e7-8cdc-61acb9c00654.png)

Focused on active Hide Sprite Button:
![image](https://user-images.githubusercontent.com/10423718/32347435-055da6ca-bfe7-11e7-83d8-e4995ab061df.png)

Focused on inactive Hide Sprite Button:
![image](https://user-images.githubusercontent.com/10423718/32347412-e8f3a8a4-bfe6-11e7-9f65-d4dbd38b16bc.png)

### Reason for Changes

Someone with limited motor skills may not be able to use the mouse to click on the show and hide sprite buttons. Keyboard controls may be more usable. Adding visual indicators to show that focus is on the buttons provides valuable feedback to users of keyboard controls.