### PR TITLE
Wait for scroll animations correctly 

### DIFF
--- a/test/integration/examples.test.js
+++ b/test/integration/examples.test.js
@@ -72,6 +72,7 @@ describe('blocks example', () => {
         await clickText('Sensing');
         await clickText('Operators');
         await clickText('Data');
+        await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for scroll animation
         await clickText('Create variable...');
         let el = await findByXpath("//input[@placeholder='']");
         await el.sendKeys('score');


### PR DESCRIPTION
Dev is intermittently failing because the distance to scroll changed slightly messing with what used to be a lucky bit of timing.

Update the examples.test.js to wait for scroll animations, which should make the tests pass consistently again. 

Note: we wait for this scroll animation in the other tests already. 