### PR TITLE
Hide icons from screenreader

### DIFF
--- a/src/components/close-button/close-button.jsx
+++ b/src/components/close-button/close-button.jsx
@@ -20,6 +20,7 @@ const CloseButton = props => (
         <img
             className={styles.closeIcon}
             src={closeIcon}
+            aria-hidden="true"
         />
     </div>
 );

--- a/src/components/close-button/close-button.jsx
+++ b/src/components/close-button/close-button.jsx
@@ -7,6 +7,7 @@ import closeIcon from './icon--close.svg';
 
 const CloseButton = props => (
     <div
+        aria-label="Close"
         className={classNames(
             styles.closeButton,
             props.className,
@@ -15,10 +16,10 @@ const CloseButton = props => (
                 [styles.large]: props.size === CloseButton.SIZE_LARGE
             }
         )}
+        role="button"
         onClick={props.onClick}
     >
         <img
-            aria-hidden="true"
             className={styles.closeIcon}
             src={closeIcon}
         />

--- a/src/components/close-button/close-button.jsx
+++ b/src/components/close-button/close-button.jsx
@@ -18,9 +18,9 @@ const CloseButton = props => (
         onClick={props.onClick}
     >
         <img
+            aria-hidden="true"
             className={styles.closeIcon}
             src={closeIcon}
-            aria-hidden="true"
         />
     </div>
 );

--- a/src/components/icon-button/icon-button.jsx
+++ b/src/components/icon-button/icon-button.jsx
@@ -16,6 +16,7 @@ const IconButton = ({
         <img
             className={styles.icon}
             src={img}
+            aria-hidden="true"
         />
         <div className={styles.title}>
             {title}

--- a/src/components/icon-button/icon-button.jsx
+++ b/src/components/icon-button/icon-button.jsx
@@ -11,10 +11,10 @@ const IconButton = ({
 }) => (
     <div
         className={classNames(styles.container, className)}
+        role="button"
         onClick={onClick}
     >
         <img
-            aria-hidden="true"
             className={styles.icon}
             src={img}
         />

--- a/src/components/icon-button/icon-button.jsx
+++ b/src/components/icon-button/icon-button.jsx
@@ -14,9 +14,9 @@ const IconButton = ({
         onClick={onClick}
     >
         <img
+            aria-hidden="true"
             className={styles.icon}
             src={img}
-            aria-hidden="true"
         />
         <div className={styles.title}>
             {title}

--- a/src/components/sprite-info/sprite-info.jsx
+++ b/src/components/sprite-info/sprite-info.jsx
@@ -56,6 +56,7 @@ class SpriteInfo extends React.Component {
                                 <img
                                     className={classNames(styles.xIcon, styles.icon)}
                                     src={xIcon}
+                                    aria-hidden="true"
                                 />
                             </div>
                         </MediaQuery>
@@ -78,6 +79,7 @@ class SpriteInfo extends React.Component {
                                 <img
                                     className={classNames(styles.yIcon, styles.icon)}
                                     src={yIcon}
+                                    aria-hidden="true"
                                 />
                             </div>
                         </MediaQuery>

--- a/src/components/sprite-info/sprite-info.jsx
+++ b/src/components/sprite-info/sprite-info.jsx
@@ -54,9 +54,9 @@ class SpriteInfo extends React.Component {
                         <MediaQuery minWidth={layout.fullSizeMinWidth}>
                             <div className={styles.iconWrapper}>
                                 <img
+                                    aria-hidden="true"
                                     className={classNames(styles.xIcon, styles.icon)}
                                     src={xIcon}
-                                    aria-hidden="true"
                                 />
                             </div>
                         </MediaQuery>
@@ -77,9 +77,9 @@ class SpriteInfo extends React.Component {
                         <MediaQuery minWidth={layout.fullSizeMinWidth}>
                             <div className={styles.iconWrapper}>
                                 <img
+                                    aria-hidden="true"
                                     className={classNames(styles.yIcon, styles.icon)}
                                     src={yIcon}
-                                    aria-hidden="true"
                                 />
                             </div>
                         </MediaQuery>

--- a/test/unit/components/__snapshots__/icon-button.test.jsx.snap
+++ b/test/unit/components/__snapshots__/icon-button.test.jsx.snap
@@ -4,6 +4,7 @@ exports[`IconButtonComponent matches snapshot 1`] = `
 <div
   className="custom-class-name"
   onClick={[Function]}
+  role="button"
 >
   <img
     className={undefined}

--- a/test/unit/components/__snapshots__/sound-editor.test.jsx.snap
+++ b/test/unit/components/__snapshots__/sound-editor.test.jsx.snap
@@ -341,6 +341,7 @@ exports[`Sound Editor Component matches snapshot 1`] = `
     <div
       className=""
       onClick={[Function]}
+      role="button"
     >
       <img
         className={undefined}
@@ -357,6 +358,7 @@ exports[`Sound Editor Component matches snapshot 1`] = `
     <div
       className=""
       onClick={[Function]}
+      role="button"
     >
       <img
         className={undefined}
@@ -373,6 +375,7 @@ exports[`Sound Editor Component matches snapshot 1`] = `
     <div
       className=""
       onClick={[Function]}
+      role="button"
     >
       <img
         className={undefined}
@@ -389,6 +392,7 @@ exports[`Sound Editor Component matches snapshot 1`] = `
     <div
       className=""
       onClick={[Function]}
+      role="button"
     >
       <img
         className={undefined}
@@ -405,6 +409,7 @@ exports[`Sound Editor Component matches snapshot 1`] = `
     <div
       className=""
       onClick={[Function]}
+      role="button"
     >
       <img
         className={undefined}
@@ -421,6 +426,7 @@ exports[`Sound Editor Component matches snapshot 1`] = `
     <div
       className=""
       onClick={[Function]}
+      role="button"
     >
       <img
         className={undefined}
@@ -437,6 +443,7 @@ exports[`Sound Editor Component matches snapshot 1`] = `
     <div
       className=""
       onClick={[Function]}
+      role="button"
     >
       <img
         className={undefined}

--- a/test/unit/components/__snapshots__/sprite-selector-item.test.jsx.snap
+++ b/test/unit/components/__snapshots__/sprite-selector-item.test.jsx.snap
@@ -12,8 +12,10 @@ exports[`SpriteSelectorItemComponent matches snapshot when selected 1`] = `
   onTouchStart={[Function]}
 >
   <div
+    aria-label="Close"
     className=""
     onClick={[Function]}
+    role="button"
   >
     <img
       className={undefined}


### PR DESCRIPTION
### Resolves
When using a screenreader on the Scratch GUI, images are encountered but are not meaningful (they are referred to as "/svg%3E") nor necessary.

### Proposed Changes
Have the screen reader skip over these images upon encountering them by using the aria-hidden attribute on these images.

### Reason for Changes
These images are not actionable nor necessary for the user to understand and use the Scratch GUI

### Test Coverage
I tested VoiceOver on Mac, checking that it skips over these images.
