### PR TITLE
Add alternate text for Scratch logo.

### DIFF
--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -20,6 +20,7 @@ const MenuBar = function MenuBar () {
                 <img
                     className={styles.scratchLogo}
                     src={scratchLogo}
+                    alt="Scratch logo"
                 />
             </div>
             <SaveButton className={styles.menuItem} />

--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -18,7 +18,7 @@ const MenuBar = function MenuBar () {
         >
             <div className={classNames(styles.logoWrapper, styles.menuItem)}>
                 <img
-                    alt="Scratch logo"
+                    alt="Scratch"
                     className={styles.scratchLogo}
                     src={scratchLogo}
                 />

--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -18,9 +18,9 @@ const MenuBar = function MenuBar () {
         >
             <div className={classNames(styles.logoWrapper, styles.menuItem)}>
                 <img
+                    alt="Scratch logo"
                     className={styles.scratchLogo}
                     src={scratchLogo}
-                    alt="Scratch logo"
                 />
             </div>
             <SaveButton className={styles.menuItem} />


### PR DESCRIPTION
### Resolves
When a screen reader is focused on the Scratch logo, the user hears "/svg%3E" since the logo is unlabeled.

### Proposed Changes
User of screen reader on Scratch GUI hears "Scratch logo image" voiced when navigation is on the Scratch logo image.

### Reason for Changes
Provides meaningful text describing the image for those who can't see.

### Test Coverage
Tested manually using VoiceOver on Mac
