### PR TITLE
Fix project json loading through storage

### DIFF
--- a/src/lib/default-project/index.js
+++ b/src/lib/default-project/index.js
@@ -15,7 +15,7 @@ export default [{
     id: 0,
     assetType: 'Project',
     dataFormat: 'JSON',
-    data: projectJson
+    data: JSON.stringify(projectJson)
 }, {
     id: '83a9787d4cb6f3b7632b4ddfebf74367',
     assetType: 'Sound',

--- a/src/lib/project-loader-hoc.jsx
+++ b/src/lib/project-loader-hoc.jsx
@@ -28,7 +28,7 @@ const ProjectLoaderHOC = function (WrappedComponent) {
                 storage
                     .load(storage.AssetType.Project, this.state.projectId, storage.DataFormat.JSON)
                     .then(projectAsset => projectAsset && this.setState({
-                        projectData: JSON.stringify(projectAsset.data)
+                        projectData: projectAsset.data.toString()
                     }))
                     .catch(err => log.error(err));
             }


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Hotfix bug loading projects by ID introduced by https://github.com/LLK/scratch-gui/pull/837

### Proposed Changes

_Describe what this Pull Request does_

Data comes through storage now, meaning it isn't parsed as JSON when it arrives, it is just an array buffer that needs to be stringified. 

### Test Coverage

_Please show how you have added tests to cover your changes_

Previously we were catching errors here and just logging them. Doing this breaks the error checking in the integration tests.