### PR TITLE
Add compatibility testing example page

### DIFF
--- a/src/examples/compatibility-testing.jsx
+++ b/src/examples/compatibility-testing.jsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {connect} from 'react-redux';
+
+import AppStateHOC from '../lib/app-state-hoc.jsx';
+import Controls from '../containers/controls.jsx';
+import Stage from '../containers/stage.jsx';
+import Box from '../components/box/box.jsx';
+import GUI from '../containers/gui.jsx';
+import ProjectLoaderHOC from '../lib/project-loader-hoc.jsx';
+
+const mapStateToProps = state => ({vm: state.vm});
+
+const VMStage = connect(mapStateToProps)(Stage);
+const VMControls = connect(mapStateToProps)(Controls);
+
+class Player extends React.Component {
+    constructor (props) {
+        super(props);
+        this.updateProject = this.updateProject.bind(this);
+        this.state = {
+            projectId: window.location.hash.substring(1) || '10015059'
+        };
+    }
+    componentDidMount () {
+        window.addEventListener('hashchange', this.updateProject);
+    }
+    componentWillUnmount () {
+        window.addEventListener('hashchange', this.updateProject);
+    }
+    updateProject () {
+        this.setState({projectId: window.location.hash.substring(1)});
+    }
+    render () {
+        const width = 480;
+        const height = 360;
+        return (
+            <div style={{display: 'flex'}}>
+                <GUI
+                    {...this.props}
+                    width={width}
+                >
+                    <Box height={40}>
+                        <VMControls
+                            style={{
+                                marginRight: 10,
+                                height: 40
+                            }}
+                        />
+                    </Box>
+                    <VMStage
+                        height={height}
+                        width={width}
+                    />
+                </GUI>
+                <iframe
+                    allowFullScreen
+                    allowTransparency
+                    frameBorder="0"
+                    height="402"
+                    src={`https://scratch.mit.edu/projects/embed/${this.state.projectId}/?autostart=true`}
+                    width="485"
+                />
+            </div>
+        );
+    }
+}
+
+const App = AppStateHOC(ProjectLoaderHOC(Player));
+
+const appTarget = document.createElement('div');
+document.body.appendChild(appTarget);
+
+ReactDOM.render(<App />, appTarget);

--- a/src/examples/compatibility-testing.jsx
+++ b/src/examples/compatibility-testing.jsx
@@ -14,16 +14,22 @@ const mapStateToProps = state => ({vm: state.vm});
 const VMStage = connect(mapStateToProps)(Stage);
 const VMControls = connect(mapStateToProps)(Controls);
 
+const DEFAULT_PROJECT_ID = '10015059';
+
 class Player extends React.Component {
     constructor (props) {
         super(props);
         this.updateProject = this.updateProject.bind(this);
+
         this.state = {
-            projectId: window.location.hash.substring(1) || '10015059'
+            projectId: window.location.hash.substring(1) || DEFAULT_PROJECT_ID
         };
     }
     componentDidMount () {
         window.addEventListener('hashchange', this.updateProject);
+        if (!window.location.hash.substring(1)) {
+            window.location.hash = DEFAULT_PROJECT_ID;
+        }
     }
     componentWillUnmount () {
         window.addEventListener('hashchange', this.updateProject);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,6 +21,7 @@ module.exports = {
         lib: ['react', 'react-dom'],
         gui: './src/index.jsx',
         blocksonly: './src/examples/blocks-only.jsx',
+        compatibilitytesting: './src/examples/compatibility-testing.jsx',
         player: './src/examples/player.jsx'
     },
     output: {
@@ -89,6 +90,12 @@ module.exports = {
             template: 'src/index.ejs',
             filename: 'blocks-only.html',
             title: 'Scratch 3.0 GUI: Blocks Only Example'
+        }),
+        new HtmlWebpackPlugin({
+            chunks: ['lib', 'compatibilitytesting'],
+            template: 'src/index.ejs',
+            filename: 'compatibility-testing.html',
+            title: 'Scratch 3.0 GUI: Compatibility Testing'
         }),
         new HtmlWebpackPlugin({
             chunks: ['lib', 'player'],


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Add a simple example page `/compatibility-testing.html` that loads a project (from hash) in both scratch 3 player and an embedded iframe with the scratch 2 player. 

One note when using this locally is that I had to go into my chrome settings and whitelist `http://localhost:8601` to allow the flash player. It doesn't pop up an "allow" thing from the iframe for some reason. Will probably have to do the same thing with the deployed github url. 

![side-by-side](https://user-images.githubusercontent.com/654102/32385989-2b3af820-c096-11e7-9c92-642a4cd40563.gif)




