### PR TITLE
Scroll to extension category only when loading from library

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -195,8 +195,6 @@ class Blocks extends React.Component {
         const dynamicBlocksXML = this.props.vm.runtime.getBlocksXML();
         const toolboxXML = makeToolboxXML(dynamicBlocksXML);
         this.props.onExtensionAdded(toolboxXML);
-        const categoryName = blocksInfo[0].json.category;
-        this.handleCategorySelected(categoryName);
     }
     handleCategorySelected (categoryName) {
         this.workspace.toolbox_.setSelectedCategoryByName(categoryName);

--- a/src/containers/extension-library.jsx
+++ b/src/containers/extension-library.jsx
@@ -22,7 +22,9 @@ class ExtensionLibrary extends React.PureComponent {
             if (this.props.vm.extensionManager.isExtensionLoaded(url)) {
                 this.props.onCategorySelected(item.name);
             } else {
-                this.props.vm.extensionManager.loadExtensionURL(url);
+                this.props.vm.extensionManager.loadExtensionURL(url).then(() => {
+                    this.props.onCategorySelected(item.name);
+                });
             }
         }
     }


### PR DESCRIPTION
### Proposed Changes

Only scroll the blocks menu to the extension category when the extension was just loaded from the library (or when selecting an extension in the library that is already loaded).

### Reason for Changes

Previously, when an extensions was automatically loaded on project load (via https://github.com/LLK/scratch-vm/pull/756), the gui would cause the blocks menu to scroll to the extension. We do not want the blocks menu to scroll in that situation. 
