### PR TITLE
Make selector column responsive to paint editor width

### DIFF
--- a/src/components/asset-panel/selector.css
+++ b/src/components/asset-panel/selector.css
@@ -1,4 +1,5 @@
 @import "../../css/colors.css";
+@import "../../css/units.css";
 
 .wrapper {
     width: 150px;
@@ -50,4 +51,15 @@
     width: 5rem;
     min-height: 5rem;
     margin: 1rem auto;
+}
+
+@media only screen and (max-width: $full-size-paint) {
+    .wrapper {
+        width: 80px;
+    }
+
+    .list-item {
+        width: 4rem;
+        min-height: 4rem;
+    }
 }

--- a/src/css/units.css
+++ b/src/css/units.css
@@ -9,3 +9,7 @@ $stage-menu-height: 2.75rem;
 $library-header-height: 4.375rem;
 
 $form-radius: calc($space / 2);
+
+/* layout contants from `layout-constants.js` */
+$full-size: 1095px;
+$full-size-paint: 1249px;

--- a/src/lib/layout-constants.js
+++ b/src/lib/layout-constants.js
@@ -3,5 +3,6 @@ export default {
     fullStageHeight: 360,
     smallerStageWidth: 480 * 0.85,
     smallerStageHeight: 360 * 0.85,
-    fullSizeMinWidth: 1096
+    fullSizeMinWidth: 1096,
+    fullSizePaintMinWidth: 1250
 };


### PR DESCRIPTION
### Resolves

This is for https://github.com/LLK/scratch-paint/pull/194, making the selector area smaller on tablet so as to create more space for the paint editor.

### Proposed Changes

This change adds a media query, set to the paint editor's minimum full width (`1250px`), to make the selector column smaller when below the minimum full width. It also adds constants to the `units.css` file that match those from the `layout-constants.js` file in order to be used on css media queries.

### Reason for Changes

In order to make the paint editor viewable and usable in tablet, we need to shrink the selector's size. This is because resizing the canvas itself is non-trivial, and we have already condensed space in the paint editor in all of the other ways we can.

/cc @carljbowman 