### PR TITLE
Register music extension assets

### DIFF
--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -25,6 +25,10 @@ class Storage extends ScratchStorage {
             [this.AssetType.ImageVector, this.AssetType.ImageBitmap, this.AssetType.Sound],
             asset => `${ASSET_SERVER}/internalapi/asset/${asset.assetId}.${asset.dataFormat}/get/`
         );
+        this.addWebSource(
+            [this.AssetType.Sound],
+            asset => `/static/extension-assets/scratch3_music/${asset.assetId}.${asset.dataFormat}`
+        );
         defaultProjectAssets.forEach(asset => this.cache(
             this.AssetType[asset.assetType],
             this.DataFormat[asset.dataFormat],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -108,6 +108,10 @@ module.exports = {
             to: 'static/blocks-media'
         }]),
         new CopyWebpackPlugin([{
+            from: 'node_modules/scratch-vm/dist/node/assets',
+            to: 'static/extension-assets'
+        }]),
+        new CopyWebpackPlugin([{
             from: 'extensions/**',
             to: 'static',
             context: 'src/examples'


### PR DESCRIPTION
### Resolves

Progress toward loading the drum and instrument sounds from scratch storage: https://github.com/LLK/scratch-audio/issues/48

### Proposed Changes

- Copy extension assets from the VM
- Add a web source for the music extension assets

### Reason for Changes

These changes allow us to load sound files used by the music extension from a static directory.