### PR TITLE
Warn user before navigating away/unloading

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -7,6 +7,11 @@ import ProjectLoaderHOC from './lib/project-loader-hoc.jsx';
 
 import styles from './index.css';
 
+if (process.env.NODE_ENV === 'production' && typeof window === 'object') {
+    // Warn before navigating away
+    window.onbeforeunload = () => true;
+}
+
 const App = AppStateHOC(ProjectLoaderHOC(GUI));
 
 const appTarget = document.createElement('div');

--- a/test/helpers/selenium-helper.js
+++ b/test/helpers/selenium-helper.js
@@ -15,7 +15,8 @@ class SeleniumHelper {
             'findByText',
             'findByXpath',
             'getDriver',
-            'getLogs'
+            'getLogs',
+            'loadUri'
         ]);
     }
 
@@ -32,6 +33,14 @@ class SeleniumHelper {
 
     findByText (text, scope) {
         return this.findByXpath(`//body//${scope || '*'}//*[contains(text(), '${text}')]`);
+    }
+
+    loadUri (uri) {
+        return this.driver
+            .get(`file://${uri}`)
+            .then(() => (
+                this.driver.executeScript('window.onbeforeunload = undefined;')
+            ));
     }
 
     clickXpath (xpath) {

--- a/test/integration/examples.test.js
+++ b/test/integration/examples.test.js
@@ -9,7 +9,8 @@ const {
     clickXpath,
     findByXpath,
     getDriver,
-    getLogs
+    getLogs,
+    loadUri
 } = new SeleniumHelper();
 
 const errorWhitelist = [
@@ -31,7 +32,7 @@ describe('player example', () => {
 
     test('Load a project by ID', async () => {
         const projectId = '96708228';
-        await driver.get(`file://${uri}#${projectId}`);
+        await loadUri(`${uri}#${projectId}`);
         await new Promise(resolve => setTimeout(resolve, 2000));
         await clickXpath('//img[@title="Go"]');
         await new Promise(resolve => setTimeout(resolve, 2000));
@@ -54,7 +55,7 @@ describe('blocks example', () => {
 
     test('Load a project by ID', async () => {
         const projectId = '96708228';
-        await driver.get(`file://${uri}#${projectId}`);
+        await loadUri(`${uri}#${projectId}`);
         await new Promise(resolve => setTimeout(resolve, 2000));
         await clickXpath('//img[@title="Go"]');
         await new Promise(resolve => setTimeout(resolve, 2000));
@@ -64,7 +65,7 @@ describe('blocks example', () => {
     });
 
     test('Change categories', async () => {
-        await driver.get(`file://${uri}`);
+        await loadUri(`${uri}`);
         await clickText('Looks');
         await clickText('Sound');
         await clickText('Events');

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -37,6 +37,7 @@ describe('costumes, sounds and variables', () => {
 
     test('Blocks report when clicked in the toolbox', async () => {
         await driver.get(`file://${uri}`);
+        await driver.executeScript('window.onbeforeunload = undefined;');
         await clickText('Blocks');
         await clickText('Operators', blocksTabScope);
         await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for scroll animation
@@ -48,6 +49,7 @@ describe('costumes, sounds and variables', () => {
 
     test('Switching sprites updates the block menus', async () => {
         await driver.get(`file://${uri}`);
+        await driver.executeScript('window.onbeforeunload = undefined;');
         await clickText('Sound', blocksTabScope);
         await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for scroll animation
         // "meow" sound block should be visible
@@ -61,6 +63,7 @@ describe('costumes, sounds and variables', () => {
 
     test('Adding a costume', async () => {
         await driver.get(`file://${uri}`);
+        await driver.executeScript('window.onbeforeunload = undefined;');
         await clickText('Costumes');
         await clickText('Add Costume');
         const el = await findByXpath("//input[@placeholder='what are you looking for?']");
@@ -74,6 +77,7 @@ describe('costumes, sounds and variables', () => {
 
     test('Adding a sound', async () => {
         await driver.get(`file://${uri}`);
+        await driver.executeScript('window.onbeforeunload = undefined;');
         await clickText('Sounds');
         await clickText('Add Sound');
         const el = await findByXpath("//input[@placeholder='what are you looking for?']");
@@ -100,6 +104,7 @@ describe('costumes, sounds and variables', () => {
     test('Load a project by ID', async () => {
         const projectId = '96708228';
         await driver.get(`file://${uri}#${projectId}`);
+        await driver.executeScript('window.onbeforeunload = undefined;');
         await new Promise(resolve => setTimeout(resolve, 2000));
         await clickXpath('//img[@title="Go"]');
         await new Promise(resolve => setTimeout(resolve, 2000));
@@ -110,6 +115,7 @@ describe('costumes, sounds and variables', () => {
 
     test('Creating variables', async () => {
         await driver.get(`file://${uri}`);
+        await driver.executeScript('window.onbeforeunload = undefined;');
         await clickText('Blocks');
         await clickText('Data', blocksTabScope);
         await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for scroll animation
@@ -134,6 +140,7 @@ describe('costumes, sounds and variables', () => {
 
     test('Importing extensions', async () => {
         await driver.get(`file://${uri}`);
+        await driver.executeScript('window.onbeforeunload = undefined;');
         await clickText('Blocks');
         await clickText('Extensions');
         await clickText('Pen', modalScope); // Modal closes

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -8,7 +8,8 @@ const {
     findByText,
     findByXpath,
     getDriver,
-    getLogs
+    getLogs,
+    loadUri
 } = new SeleniumHelper();
 
 const uri = path.resolve(__dirname, '../../build/index.html');
@@ -36,8 +37,7 @@ describe('costumes, sounds and variables', () => {
 
 
     test('Blocks report when clicked in the toolbox', async () => {
-        await driver.get(`file://${uri}`);
-        await driver.executeScript('window.onbeforeunload = undefined;');
+        await loadUri(uri);
         await clickText('Blocks');
         await clickText('Operators', blocksTabScope);
         await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for scroll animation
@@ -48,8 +48,7 @@ describe('costumes, sounds and variables', () => {
     });
 
     test('Switching sprites updates the block menus', async () => {
-        await driver.get(`file://${uri}`);
-        await driver.executeScript('window.onbeforeunload = undefined;');
+        await loadUri(uri);
         await clickText('Sound', blocksTabScope);
         await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for scroll animation
         // "meow" sound block should be visible
@@ -62,8 +61,7 @@ describe('costumes, sounds and variables', () => {
     });
 
     test('Adding a costume', async () => {
-        await driver.get(`file://${uri}`);
-        await driver.executeScript('window.onbeforeunload = undefined;');
+        await loadUri(uri);
         await clickText('Costumes');
         await clickText('Add Costume');
         const el = await findByXpath("//input[@placeholder='what are you looking for?']");
@@ -76,8 +74,7 @@ describe('costumes, sounds and variables', () => {
     });
 
     test('Adding a sound', async () => {
-        await driver.get(`file://${uri}`);
-        await driver.executeScript('window.onbeforeunload = undefined;');
+        await loadUri(uri);
         await clickText('Sounds');
         await clickText('Add Sound');
         const el = await findByXpath("//input[@placeholder='what are you looking for?']");
@@ -103,8 +100,7 @@ describe('costumes, sounds and variables', () => {
 
     test('Load a project by ID', async () => {
         const projectId = '96708228';
-        await driver.get(`file://${uri}#${projectId}`);
-        await driver.executeScript('window.onbeforeunload = undefined;');
+        await loadUri(`${uri}#${projectId}`);
         await new Promise(resolve => setTimeout(resolve, 2000));
         await clickXpath('//img[@title="Go"]');
         await new Promise(resolve => setTimeout(resolve, 2000));
@@ -114,8 +110,7 @@ describe('costumes, sounds and variables', () => {
     });
 
     test('Creating variables', async () => {
-        await driver.get(`file://${uri}`);
-        await driver.executeScript('window.onbeforeunload = undefined;');
+        await loadUri(uri);
         await clickText('Blocks');
         await clickText('Data', blocksTabScope);
         await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for scroll animation
@@ -139,8 +134,7 @@ describe('costumes, sounds and variables', () => {
     });
 
     test('Importing extensions', async () => {
-        await driver.get(`file://${uri}`);
-        await driver.executeScript('window.onbeforeunload = undefined;');
+        await loadUri(uri);
         await clickText('Blocks');
         await clickText('Extensions');
         await clickText('Pen', modalScope); // Modal closes


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_
When you're working on your project, sometimes you accidentally swipe back or refresh when you don't mean to and you lose all your work!

### Proposed Changes

_Describe what this Pull Request does_
When the GUI is built for production, the page asks you (in modern browsers) if you really want to unload the page.  This isn't active while developing, only when the GUI is built with `NODE_ENV=production`.

### Reason for Changes

_Explain why these changes should be made_
This way you'll be able to confirm before navigating away.

### Test Coverage

_Please show how you have added tests to cover your changes_
All the tests still work now. Should I update to add a test for this alert?