### PR TITLE
Fix waveform in sound editor in Firefox

### DIFF
--- a/src/components/waveform/waveform.jsx
+++ b/src/components/waveform/waveform.jsx
@@ -33,7 +33,7 @@ const Waveform = props => {
             <g transform={`scale(1, -1) translate(0, -${height / 2})`}>
                 <path
                     className={styles.waveformPath}
-                    d={`M0 0${pathComponents.join(" ")}Z`}
+                    d={`M0 0${pathComponents.join(' ')}Z`}
                     strokeLinejoin={'round'}
                     strokeWidth={2}
                 />

--- a/src/components/waveform/waveform.jsx
+++ b/src/components/waveform/waveform.jsx
@@ -33,7 +33,7 @@ const Waveform = props => {
             <g transform={`scale(1, -1) translate(0, -${height / 2})`}>
                 <path
                     className={styles.waveformPath}
-                    d={`M0 0${pathComponents.join()}Z`}
+                    d={`M0 0${pathComponents.join(" ")}Z`}
                     strokeLinejoin={'round'}
                     strokeWidth={2}
                 />

--- a/test/unit/components/__snapshots__/sound-editor.test.jsx.snap
+++ b/test/unit/components/__snapshots__/sound-editor.test.jsx.snap
@@ -99,7 +99,7 @@ exports[`Sound Editor Component matches snapshot 1`] = `
         >
           <path
             className={undefined}
-            d="M0 0Q0 0 60 45,Q120 90 180 135,Q240 180 300 225,Q360 270 420 135,Q480 0 480 0,Q480 0 420 -135,Q360 -270 300 -225,Q240 -180 180 -135,Q120 -90 60 -45,Q0 0 0 0Z"
+            d="M0 0Q0 0 60 45 Q120 90 180 135 Q240 180 300 225 Q360 270 420 135 Q480 0 480 0 Q480 0 420 -135 Q360 -270 300 -225 Q240 -180 180 -135 Q120 -90 60 -45 Q0 0 0 0Z"
             strokeLinejoin="round"
             strokeWidth={2}
           />


### PR DESCRIPTION
### Resolves
Sound editor looks weird in non-Chrome #657 

_What Github issue does this resolve (please include link)?_

<https://github.com/LLK/scratch-gui/issues/657>

### Proposed Changes

add argument to `join` so SVG path output of waveform will not contain comma

### Reason for Changes

Firefox doesn't like comma (,) in SVG path. Someone has similar problem:
<https://support.mozilla.org/zh-TW/questions/878388>

### Test Coverage

_Please show how you have added tests to cover your changes_
Change test file in `test/unit/components/__snapshots__/sound-editor.test.jsx.snap` as waveform SVG path is malformed and makes Firefox angry