### PR TITLE
Prevent deleting a sound from exploding

### DIFF
--- a/src/containers/sound-tab.jsx
+++ b/src/containers/sound-tab.jsx
@@ -52,20 +52,18 @@ class SoundTab extends React.Component {
 
     render () {
         const {
-            editingTarget,
-            sprites,
-            stage,
+            vm,
             onNewSoundFromLibraryClick,
             onNewSoundFromRecordingClick
         } = this.props;
 
-        const target = editingTarget && sprites[editingTarget] ? sprites[editingTarget] : stage;
+        const sprite = vm.editingTarget.sprite;
 
-        if (!target) {
+        if (!sprite) {
             return null;
         }
 
-        const sounds = target.sounds ? target.sounds.map(sound => (
+        const sounds = sprite.sounds ? sprite.sounds.map(sound => (
             {
                 url: soundIcon,
                 name: sound.name
@@ -106,7 +104,7 @@ class SoundTab extends React.Component {
                 onDeleteClick={this.handleDeleteSound}
                 onItemClick={this.handleSelectSound}
             >
-                {editingTarget && target.sounds && target.sounds.length > 0 ? (
+                {sprite.sounds && sprite.sounds.length > 0 ? (
                     <SoundEditor soundIndex={this.state.selectedSoundIndex} />
                 ) : null}
                 {this.props.soundRecorderVisible ? (

--- a/src/containers/sound-tab.jsx
+++ b/src/containers/sound-tab.jsx
@@ -57,11 +57,11 @@ class SoundTab extends React.Component {
             onNewSoundFromRecordingClick
         } = this.props;
 
-        const sprite = vm.editingTarget.sprite;
-
-        if (!sprite) {
+        if (!vm.editingTarget) {
             return null;
         }
+
+        const sprite = vm.editingTarget.sprite;
 
         const sounds = sprite.sounds ? sprite.sounds.map(sound => (
             {

--- a/test/helpers/selenium-helper.js
+++ b/test/helpers/selenium-helper.js
@@ -4,7 +4,7 @@ import bindAll from 'lodash.bindall';
 import 'chromedriver'; // register path
 import webdriver from 'selenium-webdriver';
 
-const {By, until} = webdriver;
+const {By, until, Button} = webdriver;
 
 class SeleniumHelper {
     constructor () {
@@ -15,7 +15,8 @@ class SeleniumHelper {
             'findByText',
             'findByXpath',
             'getDriver',
-            'getLogs'
+            'getLogs',
+            'rightClickText'
         ]);
     }
 
@@ -40,6 +41,12 @@ class SeleniumHelper {
 
     clickText (text, scope) {
         return this.findByText(text, scope).then(el => el.click());
+    }
+
+    rightClickText (text, scope) {
+        return this.findByText(text, scope).then(el => this.driver.actions()
+            .click(el, Button.RIGHT)
+            .perform());
     }
 
     clickButton (text) {

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -8,7 +8,8 @@ const {
     findByText,
     findByXpath,
     getDriver,
-    getLogs
+    getLogs,
+    rightClickText
 } = new SeleniumHelper();
 
 const uri = path.resolve(__dirname, '../../build/index.html');
@@ -33,7 +34,6 @@ describe('costumes, sounds and variables', () => {
     afterAll(async () => {
         await driver.quit();
     });
-
 
     test('Blocks report when clicked in the toolbox', async () => {
         await driver.get(`file://${uri}`);
@@ -75,14 +75,19 @@ describe('costumes, sounds and variables', () => {
     test('Adding a sound', async () => {
         await driver.get(`file://${uri}`);
         await clickText('Sounds');
+
+        // Delete the sound
+        await rightClickText('meow', soundsTabScope);
+        await clickText('delete', soundsTabScope);
+        await driver.switchTo().alert()
+            .accept();
+
+        // Add a sound
         await clickText('Add Sound');
         const el = await findByXpath("//input[@placeholder='what are you looking for?']");
         await el.sendKeys('chom');
         await clickText('chomp'); // Should close the modal, then click the sounds in the selector
-        await clickText('meow', soundsTabScope);
         await clickText('chomp', soundsTabScope);
-        await clickXpath('//button[@title="Play"]');
-        await clickText('meow', soundsTabScope);
         await clickXpath('//button[@title="Play"]');
 
         await clickText('Louder');


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/858

### Proposed Changes

_Describe what this Pull Request does_

Use the vm editing target directly to handle loading a sound into the sound editor. There is some kind of state synchrony problem between the editing targets as they exist in the VM vs. the redux store. This is a quick fix for that. I've filed another issue to deal with actually finding the root of that problem.

### Test Coverage

_Please show how you have added tests to cover your changes_

Add an integration test that I confirmed used to fail (deleting the only sound). 
