### PR TITLE
Use relative path to load extension assets

### DIFF
--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -27,7 +27,7 @@ class Storage extends ScratchStorage {
         );
         this.addWebSource(
             [this.AssetType.Sound],
-            asset => `/static/extension-assets/scratch3_music/${asset.assetId}.${asset.dataFormat}`
+            asset => `static/extension-assets/scratch3_music/${asset.assetId}.${asset.dataFormat}`
         );
         defaultProjectAssets.forEach(asset => this.cache(
             this.AssetType[asset.assetType],


### PR DESCRIPTION
### Resolves

The drum sounds were not loading after we merged https://github.com/LLK/scratch-vm/pull/785

### Proposed Changes

Use a relative path to the static assets directory.

### Reason for Changes

The path used to load the sounds as static assets was working correctly locally, but not in the deployed version. This relative path accounts for the fact that the URL on github.io is different.

### Test Coverage

_Please show how you have added tests to cover your changes_
