### PR TITLE
Play the restored sound after undo/redo in the sound editor

### DIFF
--- a/src/containers/sound-editor.jsx
+++ b/src/containers/sound-editor.jsx
@@ -124,6 +124,7 @@ class SoundEditor extends React.Component {
         const samples = this.undoStack.pop();
         if (samples) {
             this.submitNewSamples(samples, this.props.sampleRate, true);
+            this.handlePlay();
         }
     }
     handleRedo () {
@@ -131,6 +132,7 @@ class SoundEditor extends React.Component {
         if (samples) {
             this.undoStack.push(this.props.samples.slice(0));
             this.submitNewSamples(samples, this.props.sampleRate, true);
+            this.handlePlay();
         }
     }
     render () {

--- a/test/unit/containers/sound-editor.test.jsx
+++ b/test/unit/containers/sound-editor.test.jsx
@@ -224,7 +224,7 @@ describe('Sound Editor Container', () => {
         expect(mockAudioEffects.instance.process).toHaveBeenCalled();
     });
 
-    test('undo/redo functionality', () => {
+    test('undo/redo stack state', () => {
         const wrapper = mountWithIntl(
             <SoundEditor
                 soundIndex={soundIndex}
@@ -269,5 +269,35 @@ describe('Sound Editor Container', () => {
         wrapper.update();
         component = wrapper.find(SoundEditorComponent);
         expect(component.prop('canRedo')).toEqual(false);
+    });
+
+    test('undo and redo submit new samples and play the sound', () => {
+        const wrapper = mountWithIntl(
+            <SoundEditor
+                soundIndex={soundIndex}
+                store={store}
+            />
+        );
+        let component = wrapper.find(SoundEditorComponent);
+
+        // Set up an undoable state
+        component.props().onActivateTrim(); // Activate trimming
+        component.props().onActivateTrim(); // Submit new samples by calling again
+        wrapper.update();
+        component = wrapper.find(SoundEditorComponent);
+
+        // Undo should update the sound buffer and play the new samples
+        component.props().onUndo();
+        expect(mockAudioBufferPlayer.instance.play).toHaveBeenCalled();
+        expect(vm.updateSoundBuffer).toHaveBeenCalled();
+
+        // Clear the mocks call history to assert again for redo.
+        vm.updateSoundBuffer.mockClear();
+        mockAudioBufferPlayer.instance.play.mockClear();
+
+        // Undo should update the sound buffer and play the new samples
+        component.props().onRedo();
+        expect(mockAudioBufferPlayer.instance.play).toHaveBeenCalled();
+        expect(vm.updateSoundBuffer).toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/927

### Proposed Changes

_Describe what this Pull Request does_

Play the sound after undo/redo in the sound editor.

### Reason for Changes

_Explain why these changes should be made_

Makes it clear that a change has taken place. See discussion https://github.com/LLK/scratch-gui/issues/927.


### Test Coverage

_Please show how you have added tests to cover your changes_

Added a new test to the sound editor container, making sure that undo/redo updates the sound buffer and plays the sound.