### PR TITLE
Add "More" category for custom procedures

### DIFF
--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -654,6 +654,13 @@ const data = function () {
     `;
 };
 
+const more = function () {
+    return `
+    <category name="More" colour="#FF6680" secondaryColour="#FF4D6A" custom="PROCEDURE">
+    </category>
+    `;
+};
+
 const xmlOpen = '<xml style="display: none">';
 const xmlClose = '</xml>';
 
@@ -675,7 +682,8 @@ const makeToolboxXML = function (isStage, targetId, categoriesXML) {
         control(isStage, targetId), gap,
         sensing(isStage, targetId), gap,
         operators(isStage, targetId), gap,
-        data(isStage, targetId)
+        data(isStage, targetId), gap,
+        more(isStage, targetId)
     ];
 
     if (categoriesXML) {


### PR DESCRIPTION
### Proposed Changes

_Describe what this Pull Request does_

Add the "More" category. It acts like the variable category in that the palette blocks are dynamic and populated in scratch-blocks. This is what it looks like when you have custom procedures already defined:

![image](https://user-images.githubusercontent.com/654102/33082908-f37d41da-ceab-11e7-968a-3fa0b1eada33.png)

Or when you have no custom procedures
![image](https://user-images.githubusercontent.com/654102/33082927-ff81e38c-ceab-11e7-8ec5-af75a33fd51e.png)

But that is all handled by scratch blocks.

---

Since the "Make a block..." button callback is not implemented yet (it alerts "not implemented") we can hold this PR until the other parts of custom procedures are done. Just wanted to get this submitted (low hanging fruit yay).