### PR TITLE
Fix extensions disappearing when switching sprites

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -175,7 +175,9 @@ class Blocks extends React.Component {
         // When we change sprites, update the toolbox to have the new sprite's blocks
         if (this.props.vm.editingTarget) {
             const target = this.props.vm.editingTarget;
-            this.props.updateToolboxState(makeToolboxXML(target.isStage, target.id));
+            const dynamicBlocksXML = this.props.vm.runtime.getBlocksXML();
+            const toolboxXML = makeToolboxXML(target.isStage, target.id, dynamicBlocksXML);
+            this.props.updateToolboxState(toolboxXML);
         }
 
         if (this.props.vm.editingTarget && !this.state.workspaceMetrics[this.props.vm.editingTarget.id]) {

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -156,6 +156,9 @@ describe('costumes, sounds and variables', () => {
         await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for scroll animation
         await clickText('stamp', blocksTabScope); // Would fail if didn't scroll back
 
+        // Make sure switching sprites doesn't clear extensions
+        await clickText('Backdrops'); // Switch to the backdrop
+        await findByText('Pen', blocksTabScope); // Pen extension should still be loaded
 
         const logs = await getLogs(errorWhitelist);
         await expect(logs).toEqual([]);


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/937

### Proposed Changes

_Describe what this Pull Request does_

### Reason for Changes

_Explain why these changes should be made_

Missed this when reviewing the PR for custom target palettes. We forgot to include the dynamic extension toolbox XML from the VM when changing targets. 

### Test Coverage

_Please show how you have added tests to cover your changes_

I added a step to the integration test that loads extensions to switch sprites and confirm that the pen category is still loaded.
