### PR TITLE
Add number rounding in variable monitors

### DIFF
--- a/src/lib/monitor-adapter.js
+++ b/src/lib/monitor-adapter.js
@@ -37,7 +37,7 @@ export default function ({id, spriteName, index, opcode, params, value, x, y}) {
     if (isUndefined(y)) y = PADDING + (index * (PADDING + MONITOR_HEIGHT));
     
     // If value is a number, round it to six decimal places
-    if (!isNaN(value)) {
+    if (typeof value === "number" || (typeof value === "string" && String(parseFloat(value)) === value)) {
         value = Number(Number(value).toFixed(6));
     }
     

--- a/src/lib/monitor-adapter.js
+++ b/src/lib/monitor-adapter.js
@@ -35,6 +35,11 @@ export default function ({id, spriteName, index, opcode, params, value, x, y}) {
     // @todo e.g. this does not work well when monitors have already been moved
     if (isUndefined(x)) x = PADDING;
     if (isUndefined(y)) y = PADDING + (index * (PADDING + MONITOR_HEIGHT));
-
+    
+    // If value is a number, round it to six decimal places
+    if (!isNaN(value)) {
+        value = Number(Number(value).toFixed(6));
+    }
+    
     return {id, label, category, value, x, y};
 }


### PR DESCRIPTION
### Resolves

[Issue #924](https://github.com/LLK/scratch-gui/issues/924)

### Proposed Changes

Numerical values in a variable monitor now round to six decimal places.

### Reason for Changes

Scratch 2 variable monitors round this way, so Scratch 3 should use the same rounding logic.

### Test Coverage

None.