### PR TITLE
Revert breaking change version update

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "react-dom": "16.1.1",
     "react-draggable": "3.0.3",
     "react-intl": "2.4.0",
-    "react-intl-redux": "0.7.0",
+    "react-intl-redux": "0.6.0",
     "react-modal": "3.1.2",
     "react-redux": "5.0.6",
     "react-responsive": "4.0.0",


### PR DESCRIPTION
react-intl-redux is introducing breaking changes in minor version updates since they’re pre version 1.0

For now I just want to revert the change. Later I'l figure out what we need to do to handle the change (or maybe decide we don't want to depend on this package)