### PR TITLE
Added small separation between tabs and content

### DIFF
--- a/src/components/gui/gui.css
+++ b/src/components/gui/gui.css
@@ -74,7 +74,7 @@
     z-index: 1;
     color: #40B9F5;
     background-color: #FFFFFF;
-    border-bottom: white 1px solid;
+    border-bottom: $ui-background-blue 1px solid;
 }
 
 .tabs {


### PR DESCRIPTION
I changed the color of the bottom of the tab when selected from white
to the background color of the block chooser.
The main reason for the change was that the white bottom on the tabs
did not blend well with the boundary between gray/blue and white when
selected.  It has been changed so that there is a line that is lighter
than the regular border color which signifies that the tab is selected
and gives it separation from the white content but doesn’t separate the
content too far from the tab as a darker color would do.