### PR TITLE
Temporarily hide WeDo extension

### DIFF
--- a/src/lib/libraries/extensions/index.js
+++ b/src/lib/libraries/extensions/index.js
@@ -16,12 +16,5 @@ export default [
         iconURL: penImage,
         description: 'Draw with your sprites.',
         featured: true
-    },
-    {
-        name: 'Lego WeDo 2.0',
-        extensionURL: 'wedo2',
-        iconURL: wedoImage,
-        description: 'Build with motors and sensors.',
-        featured: true
     }
 ];

--- a/src/lib/libraries/extensions/index.js
+++ b/src/lib/libraries/extensions/index.js
@@ -1,6 +1,5 @@
 import musicImage from './music.png';
 import penImage from './pen.png';
-import wedoImage from './wedo.png';
 
 export default [
     {


### PR DESCRIPTION
### Proposed Changes

We're temporarily hiding this extension (until after the preview release- it will come back!).

### Reason for Changes

The extension system is missing a few features (connection status indicator, non-droppable inputs, stop button events) and the WeDo extension itself has some unfixed bugs (error on running blocks when not connected, failure to reconnect on disconnect, crash on excessively rapid commands, can't set motor direction while running). 