### PR TITLE
Localize extension blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "rimraf": "^2.6.1",
     "scratch-audio": "latest",
     "scratch-blocks": "latest",
-    "scratch-l10n": "^2.0.0",
+    "scratch-l10n": "latest",
     "scratch-paint": "latest",
     "scratch-render": "latest",
     "scratch-storage": "^0.3.0",

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -59,6 +59,7 @@ class Blocks extends React.Component {
     componentDidMount () {
         this.ScratchBlocks.FieldColourSlider.activateEyedropper_ = this.props.onActivateColorPicker;
         this.ScratchBlocks.Procedures.externalProcedureDefCallback = this.props.onActivateCustomProcedures;
+        this.props.vm.setLocale(this.props.locale, this.props.messages);
 
         const workspaceConfig = defaultsDeep({},
             Blocks.defaultOptions,
@@ -79,10 +80,15 @@ class Blocks extends React.Component {
             this.props.isVisible !== nextProps.isVisible ||
             this.props.toolboxXML !== nextProps.toolboxXML ||
             this.props.extensionLibraryVisible !== nextProps.extensionLibraryVisible ||
-            this.props.customProceduresVisible !== nextProps.customProceduresVisible
+            this.props.customProceduresVisible !== nextProps.customProceduresVisible ||
+            this.props.locale !== nextProps.locale
         );
     }
     componentDidUpdate (prevProps) {
+        if (prevProps.locale !== this.props.locale) {
+            this.props.vm.setLocale(this.props.locale, this.props.messages);
+        }
+
         if (prevProps.toolboxXML !== this.props.toolboxXML) {
             const selectedCategoryName = this.workspace.toolbox_.getSelectedItem().name_;
             this.workspace.updateToolbox(this.props.toolboxXML);
@@ -288,6 +294,8 @@ Blocks.propTypes = {
     customProceduresVisible: PropTypes.bool,
     extensionLibraryVisible: PropTypes.bool,
     isVisible: PropTypes.bool,
+    locale: PropTypes.string,
+    messages: PropTypes.objectOf(PropTypes.string),
     onActivateColorPicker: PropTypes.func,
     onActivateCustomProcedures: PropTypes.func,
     onRequestCloseCustomProcedures: PropTypes.func,
@@ -351,6 +359,8 @@ Blocks.defaultProps = {
 
 const mapStateToProps = state => ({
     extensionLibraryVisible: state.modals.extensionLibrary,
+    locale: state.intl.locale,
+    messages: state.intl.messages,
     toolboxXML: state.toolbox.toolboxXML,
     customProceduresVisible: state.customProcedures.active
 });

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -60,7 +60,6 @@ class Blocks extends React.Component {
     componentDidMount () {
         this.ScratchBlocks.FieldColourSlider.activateEyedropper_ = this.props.onActivateColorPicker;
         this.ScratchBlocks.Procedures.externalProcedureDefCallback = this.props.onActivateCustomProcedures;
-        this.props.vm.setLocale(this.props.locale, this.props.messages);
 
         const workspaceConfig = defaultsDeep({},
             Blocks.defaultOptions,

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -223,11 +223,8 @@ class Blocks extends React.Component {
         this.props.updateToolboxState(toolboxXML);
     }
     handleBlocksInfoUpdate (blocksInfo) {
-        this.ScratchBlocks.defineBlocksWithJsonArray(blocksInfo.map(blockInfo => blockInfo.json));
-        const dynamicBlocksXML = this.props.vm.runtime.getBlocksXML();
-        const target = this.props.vm.editingTarget;
-        const toolboxXML = makeToolboxXML(target.isStage, target.id, dynamicBlocksXML);
-        this.props.updateToolboxState(toolboxXML);
+        // @todo Later we should replace this to avoid all the warnings from redefining blocks.
+        this.handleExtensionAdded(blocksInfo);
     }
     handleCategorySelected (categoryName) {
         this.workspace.toolbox_.setSelectedCategoryByName(categoryName);

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -43,6 +43,7 @@ class Blocks extends React.Component {
             'onBlockGlowOn',
             'onBlockGlowOff',
             'handleExtensionAdded',
+            'handleBlocksInfoUpdate',
             'onTargetsUpdate',
             'onVisualReport',
             'onWorkspaceUpdate',
@@ -73,6 +74,7 @@ class Blocks extends React.Component {
         addFunctionListener(this.workspace, 'zoom', this.onWorkspaceMetricsChange);
 
         this.attachVM();
+        this.props.vm.setLocale(this.props.locale, this.props.messages);
     }
     shouldComponentUpdate (nextProps, nextState) {
         return (
@@ -126,6 +128,7 @@ class Blocks extends React.Component {
         this.props.vm.addListener('workspaceUpdate', this.onWorkspaceUpdate);
         this.props.vm.addListener('targetsUpdate', this.onTargetsUpdate);
         this.props.vm.addListener('EXTENSION_ADDED', this.handleExtensionAdded);
+        this.props.vm.addListener('BLOCKSINFO_UPDATE', this.handleBlocksInfoUpdate);
     }
     detachVM () {
         this.props.vm.removeListener('SCRIPT_GLOW_ON', this.onScriptGlowOn);
@@ -136,6 +139,7 @@ class Blocks extends React.Component {
         this.props.vm.removeListener('workspaceUpdate', this.onWorkspaceUpdate);
         this.props.vm.removeListener('targetsUpdate', this.onTargetsUpdate);
         this.props.vm.removeListener('EXTENSION_ADDED', this.handleExtensionAdded);
+        this.props.vm.removeListener('BLOCKSINFO_UPDATE', this.handleBlocksInfoUpdate);
     }
     updateToolboxBlockValue (id, value) {
         const block = this.workspace
@@ -212,6 +216,13 @@ class Blocks extends React.Component {
         }
     }
     handleExtensionAdded (blocksInfo) {
+        this.ScratchBlocks.defineBlocksWithJsonArray(blocksInfo.map(blockInfo => blockInfo.json));
+        const dynamicBlocksXML = this.props.vm.runtime.getBlocksXML();
+        const target = this.props.vm.editingTarget;
+        const toolboxXML = makeToolboxXML(target.isStage, target.id, dynamicBlocksXML);
+        this.props.updateToolboxState(toolboxXML);
+    }
+    handleBlocksInfoUpdate (blocksInfo) {
         this.ScratchBlocks.defineBlocksWithJsonArray(blocksInfo.map(blockInfo => blockInfo.json));
         const dynamicBlocksXML = this.props.vm.runtime.getBlocksXML();
         const target = this.props.vm.editingTarget;

--- a/src/reducers/intl.js
+++ b/src/reducers/intl.js
@@ -6,8 +6,9 @@ import defaultsDeep from 'lodash.defaultsdeep';
 import localeData from 'scratch-l10n';
 import guiMessages from 'scratch-l10n/locales/gui-msgs';
 import paintMessages from 'scratch-l10n/locales/paint-msgs';
+import penMessages from 'scratch-l10n/locales/pen-msgs';
 
-const combinedMessages = defaultsDeep({}, guiMessages.messages, paintMessages.messages);
+const combinedMessages = defaultsDeep({}, guiMessages.messages, paintMessages.messages, penMessages.messages);
 
 Object.keys(localeData).forEach(locale => {
     // TODO: will need to handle locales not in the default intl - see www/custom-locales

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -219,4 +219,24 @@ describe('costumes, sounds and variables', () => {
         const logs = await getLogs(errorWhitelist);
         await expect(logs).toEqual([]);
     });
+
+    test('Localization', async () => {
+        await loadUri(uri);
+        await clickText('Blocks');
+        await clickText('Extensions');
+        await clickText('Pen', modalScope); // Modal closes
+        await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for scroll animation
+        await clickText('English');
+        await clickText('Deutsch');
+        await new Promise(resolve => setTimeout(resolve, 1000)); // wait for blocks refresh
+        await clickText('Pen', blocksTabScope); // will need to be updated when 'Pen' is translated
+
+        // Make sure "Add Sprite" has changed to "Figur hinzufügen"
+        await findByText('Figur hinzufügen');
+        // Find the stamp block in German
+        await findByText('Abdruck', blocksTabScope);
+
+        const logs = await getLogs(errorWhitelist);
+        await expect(logs).toEqual([]);
+    })
 });

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -229,12 +229,12 @@ describe('costumes, sounds and variables', () => {
         await clickText('English');
         await clickText('Deutsch');
         await new Promise(resolve => setTimeout(resolve, 1000)); // wait for blocks refresh
-        await clickText('Pen', blocksTabScope); // will need to be updated when 'Pen' is translated
+        await clickText('Pen'); // will need to be updated when 'Pen' is translated
 
         // Make sure "Add Sprite" has changed to "Figur hinzufügen"
         await findByText('Figur hinzufügen');
         // Find the stamp block in German
-        await findByText('Abdruck', blocksTabScope);
+        await findByText('Abdruck');
 
         const logs = await getLogs(errorWhitelist);
         await expect(logs).toEqual([]);

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -238,5 +238,5 @@ describe('costumes, sounds and variables', () => {
 
         const logs = await getLogs(errorWhitelist);
         await expect(logs).toEqual([]);
-    })
+    });
 });


### PR DESCRIPTION
Initial version of extension localization.

- pen translations are imported by default, we may want to consider whether the translations should be imported dynamically when the extension is added.
- blocks.jsx container is calling setLocale on the VM when the locale changes. Would this actually be better in the intl reducer?
- handleBlocksInfoUpdate is currently a duplicate of adding an extension, but it gets lots of warnings about overwriting the definition of blocks from blockly.js. Do we want to change the handler to remove the blocks before redefining them, or just remove the warning in scratch-blocks? [Update, left a todo comment to deal with scratch-blocks warnings, and simply call handleExtensionAdded]

The setLocale in componentDidUpdate never actually gets called because blocks always get remounted when the locale changes (see #555 )
