### PR TITLE
Fix only sprite failure

### DIFF
--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -67,7 +67,11 @@ export default function (vm) {
 
     const cloneMenu = function () {
         if (vm.editingTarget && vm.editingTarget.isStage) {
-            return spriteMenu();
+            const menu = spriteMenu();
+            if (menu.length === 0) {
+                return [['', '']]; // Empty menu matches Scratch 2 behavior
+            }
+            return menu;
         }
         return [['myself', '_myself_']].concat(spriteMenu());
     };

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -163,4 +163,18 @@ describe('costumes, sounds and variables', () => {
         const logs = await getLogs(errorWhitelist);
         await expect(logs).toEqual([]);
     });
+
+    test('Deleting only sprite does not crash', async () => {
+        const spriteTileContext = '*[starts-with(@class,"react-contextmenu-wrapper")]';
+        await loadUri(uri);
+        await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for scroll animation
+        await rightClickText('Sprite1', spriteTileContext);
+        await clickText('delete', spriteTileContext);
+        await driver.switchTo().alert()
+            .accept();
+        // Confirm that the stage has been switched to
+        await findByText('Stage selected: no motion blocks');
+        const logs = await getLogs(errorWhitelist);
+        await expect(logs).toEqual([]);
+    });
 });


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes the problem where deleting the only sprite exploded the page. It was caused by the recent change to how the clone menu was populating. 

@ericrosenbaum I am guessing this was another big source of problems with using the GUI.

![sadface](https://user-images.githubusercontent.com/654102/33450563-2fa5a866-d5da-11e7-99e2-245d8be06b87.gif)
