### PR TITLE
Try using sentry to make bug finding more effective

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -4,6 +4,14 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title><%= htmlWebpackPlugin.options.title %></title>
+
+    <!-- Sentry error logging to help with finding bugs -->
+    <script src="https://cdn.ravenjs.com/3.20.1/raven.min.js" crossorigin="anonymous"></script>
+    <script>
+        Raven.config('https://dcc4ed76876b411c99997f4ad5ab78a5@sentry.io/253297').install();
+    </script>
+    <!-- /Sentry -->
+
   </head>
   <body>
   </body>


### PR DESCRIPTION
This is a small experiment to use Sentry to record uncaught errors from using scratch-gui. I don't expect that we will keep this in for a long time, but I've been trying it and it gives a lot of useful context. 