### PR TITLE
Fix toolbox xml for broadcast messages

### DIFF
--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -332,14 +332,8 @@ const events = function () {
         <block type="event_whenbroadcastreceived">
         </block>
         <block type="event_broadcast">
-            <value name="BROADCAST_OPTION">
-                <shadow type="event_broadcast_menu"/>
-            </value>
         </block>
         <block type="event_broadcastandwait">
-            <value name="BROADCAST_OPTION">
-                <shadow type="event_broadcast_menu"/>
-            </value>
         </block>
         ${categorySeparator}
     </category>


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes the warnings coming from loading the toolbox because the spec for broadcast blocks changed. 

Before there were console warnings, now there are none.