### PR TITLE
Make libraries screen reader accessible.

### DIFF
--- a/src/components/close-button/close-button.jsx
+++ b/src/components/close-button/close-button.jsx
@@ -17,6 +17,7 @@ const CloseButton = props => (
             }
         )}
         role="button"
+        tabIndex="0"
         onClick={props.onClick}
     >
         <img

--- a/src/components/library-item/library-item.jsx
+++ b/src/components/library-item/library-item.jsx
@@ -46,7 +46,7 @@ class LibraryItem extends React.PureComponent {
                 </div>
             </div>
         ) : (
-            <div
+            <Box
                 className={styles.libraryItem}
                 role="button"
                 tabIndex="0"
@@ -64,7 +64,7 @@ class LibraryItem extends React.PureComponent {
                     </Box>
                 </Box>
                 <span className={styles.libraryItemName}>{this.props.name}</span>
-            </div>
+            </Box>
         );
     }
 }

--- a/src/components/library-item/library-item.jsx
+++ b/src/components/library-item/library-item.jsx
@@ -10,10 +10,18 @@ class LibraryItem extends React.PureComponent {
     constructor (props) {
         super(props);
         bindAll(this, [
+            'handleBlur',
             'handleClick',
+            'handleFocus',
             'handleMouseEnter',
             'handleMouseLeave'
         ]);
+    }
+    handleBlur (e) {
+        this.props.onBlur(this.props.id);
+    }
+    handleFocus (e) {
+        this.props.onFocus(this.props.id);
     }
     handleClick (e) {
         this.props.onSelect(this.props.id);
@@ -50,6 +58,8 @@ class LibraryItem extends React.PureComponent {
                 className={styles.libraryItem}
                 role="button"
                 tabIndex="0"
+                onBlur={this.handleBlur}
+                onFocus={this.handleFocus}
                 onClick={this.handleClick}
                 onMouseEnter={this.handleMouseEnter}
                 onMouseLeave={this.handleMouseLeave}
@@ -75,6 +85,8 @@ LibraryItem.propTypes = {
     iconURL: PropTypes.string.isRequired,
     id: PropTypes.number.isRequired,
     name: PropTypes.string.isRequired,
+    onBlur: PropTypes.func,
+    onFocus: PropTypes.func,
     onMouseEnter: PropTypes.func.isRequired,
     onMouseLeave: PropTypes.func.isRequired,
     onSelect: PropTypes.func.isRequired

--- a/src/components/library-item/library-item.jsx
+++ b/src/components/library-item/library-item.jsx
@@ -17,10 +17,10 @@ class LibraryItem extends React.PureComponent {
             'handleMouseLeave'
         ]);
     }
-    handleBlur (e) {
+    handleBlur () {
         this.props.onBlur(this.props.id);
     }
-    handleFocus (e) {
+    handleFocus () {
         this.props.onFocus(this.props.id);
     }
     handleClick (e) {
@@ -59,8 +59,8 @@ class LibraryItem extends React.PureComponent {
                 role="button"
                 tabIndex="0"
                 onBlur={this.handleBlur}
-                onFocus={this.handleFocus}
                 onClick={this.handleClick}
+                onFocus={this.handleFocus}
                 onMouseEnter={this.handleMouseEnter}
                 onMouseLeave={this.handleMouseLeave}
             >

--- a/src/components/library-item/library-item.jsx
+++ b/src/components/library-item/library-item.jsx
@@ -13,6 +13,7 @@ class LibraryItem extends React.PureComponent {
             'handleBlur',
             'handleClick',
             'handleFocus',
+            'handleKeyPress',
             'handleMouseEnter',
             'handleMouseLeave'
         ]);
@@ -26,6 +27,12 @@ class LibraryItem extends React.PureComponent {
     handleClick (e) {
         this.props.onSelect(this.props.id);
         e.preventDefault();
+    }
+    handleKeyPress (e) {
+        if (e.key === ' ' || e.key === 'Enter') {
+            e.preventDefault();
+            this.props.onSelect(this.props.id);
+        }
     }
     handleMouseEnter () {
         this.props.onMouseEnter(this.props.id);
@@ -61,6 +68,7 @@ class LibraryItem extends React.PureComponent {
                 onBlur={this.handleBlur}
                 onClick={this.handleClick}
                 onFocus={this.handleFocus}
+                onKeyPress={this.handleKeyPress}
                 onMouseEnter={this.handleMouseEnter}
                 onMouseLeave={this.handleMouseLeave}
             >

--- a/src/components/library-item/library-item.jsx
+++ b/src/components/library-item/library-item.jsx
@@ -46,8 +46,10 @@ class LibraryItem extends React.PureComponent {
                 </div>
             </div>
         ) : (
-            <Box
+            <div
                 className={styles.libraryItem}
+                role="button"
+                tabIndex="0"
                 onClick={this.handleClick}
                 onMouseEnter={this.handleMouseEnter}
                 onMouseLeave={this.handleMouseLeave}
@@ -62,7 +64,7 @@ class LibraryItem extends React.PureComponent {
                     </Box>
                 </Box>
                 <span className={styles.libraryItemName}>{this.props.name}</span>
-            </Box>
+            </div>
         );
     }
 }

--- a/src/components/library/library.jsx
+++ b/src/components/library/library.jsx
@@ -11,8 +11,10 @@ class LibraryComponent extends React.Component {
     constructor (props) {
         super(props);
         bindAll(this, [
+            'handleBlur',
             'handleFilterChange',
             'handleFilterClear',
+            'handleFocus',
             'handleMouseEnter',
             'handleMouseLeave',
             'handleSelect'
@@ -21,6 +23,14 @@ class LibraryComponent extends React.Component {
             selectedItem: null,
             filterQuery: ''
         };
+    }
+    handleBlur (id) {
+        console.log('library handling blur');
+        this.handleMouseLeave(id);
+    }
+    handleFocus (id) {
+        console.log('library handling focus');
+        this.handleMouseEnter(id);
     }
     handleSelect (id) {
         this.props.onRequestClose();
@@ -65,6 +75,8 @@ class LibraryComponent extends React.Component {
                                 id={index}
                                 key={`item_${index}`}
                                 name={dataItem.name}
+                                onFocus={this.handleFocus}
+                                onBlur={this.handleBlur}
                                 onMouseEnter={this.handleMouseEnter}
                                 onMouseLeave={this.handleMouseLeave}
                                 onSelect={this.handleSelect}

--- a/src/components/library/library.jsx
+++ b/src/components/library/library.jsx
@@ -25,11 +25,9 @@ class LibraryComponent extends React.Component {
         };
     }
     handleBlur (id) {
-        console.log('library handling blur');
         this.handleMouseLeave(id);
     }
     handleFocus (id) {
-        console.log('library handling focus');
         this.handleMouseEnter(id);
     }
     handleSelect (id) {
@@ -75,8 +73,8 @@ class LibraryComponent extends React.Component {
                                 id={index}
                                 key={`item_${index}`}
                                 name={dataItem.name}
-                                onFocus={this.handleFocus}
                                 onBlur={this.handleBlur}
+                                onFocus={this.handleFocus}
                                 onMouseEnter={this.handleMouseEnter}
                                 onMouseLeave={this.handleMouseLeave}
                                 onSelect={this.handleSelect}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import Modal from 'react-modal';
 
 import AppStateHOC from './lib/app-state-hoc.jsx';
 import GUI from './containers/gui.jsx';
@@ -12,5 +13,7 @@ const App = AppStateHOC(ProjectLoaderHOC(GUI));
 const appTarget = document.createElement('div');
 appTarget.className = styles.app;
 document.body.appendChild(appTarget);
+
+Modal.setAppElement(appTarget);
 
 ReactDOM.render(<App />, appTarget);

--- a/test/unit/components/__snapshots__/sprite-selector-item.test.jsx.snap
+++ b/test/unit/components/__snapshots__/sprite-selector-item.test.jsx.snap
@@ -16,6 +16,7 @@ exports[`SpriteSelectorItemComponent matches snapshot when selected 1`] = `
     className=""
     onClick={[Function]}
     role="button"
+    tabIndex="0"
   >
     <img
       className={undefined}


### PR DESCRIPTION
### Resolves
When a user opens a modal, the screen reader is moved out of the web content. When navigating into the  GUI, it reads "In Scratch 3.0 GUI, web content web content is empty". Modal and GUI becomes completely unusable.

### Proposed Changes

- Rather than hide the entire Scratch GUI from the screen reader when the modal is open, hide everything but the modal.  
- Include library items and close button in the tab order
- assign library items the button aria role
- Add an onBlur and onFocus listener to the library items so that one may preview the sound before selecting it, as is done with mouseEnter and mouseLeave.

### Reason for Changes
Someone who is blind or low-vision can now use the screen reader to identify various assets and add them to their projects! It also enables them to navigate out of the modal and back to the rest of the GUI.

### Test Coverage
Tested with VoiceOver screen reader on MacOS
1. Turn on VoiceOver on Mac (command + F5)
For each library... 

Item Selection
1. Navigate to 'Add _____' button to open the library
2. [control + option + rightArrow] or [tab] to move to next item
3. [control + option + rightArrow] or [tab] to move to previous item
4. [control + option + space] to select an item (and you are brought back to the GUI)

Library Exit
1. Navigate to 'Add _____' button to open the library
2. navigate to and select the close button (by tabbing or by moving right/left

Library Search
1. Navigate to 'Add _____' button to open the library
2. type to search
3. tab past close button to hear search results


