### PR TITLE
Enable sprite rotation keyboard control and standardize tabbing.

### DIFF
--- a/src/components/sprite-info/sprite-info.css
+++ b/src/components/sprite-info/sprite-info.css
@@ -93,3 +93,8 @@
     user-select: none;
     outline: none;
 }
+
+.rotation-select:focus {
+    border-color: #4c97ff;
+    box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
+}

--- a/src/components/sprite-info/sprite-info.jsx
+++ b/src/components/sprite-info/sprite-info.jsx
@@ -171,6 +171,7 @@ class SpriteInfo extends React.Component {
                                 className={classNames(styles.selectForm, styles.rotationSelect)}
                                 disabled={this.props.disabled}
                                 value={this.props.rotationStyle}
+                                tabIndex="7"
                                 onChange={this.props.onChangeRotationStyle}
                             >
                                 {ROTATION_STYLES.map(style => (

--- a/src/components/sprite-info/sprite-info.jsx
+++ b/src/components/sprite-info/sprite-info.jsx
@@ -42,7 +42,7 @@ class SpriteInfo extends React.Component {
                             <BufferedInput
                                 disabled={this.props.disabled}
                                 placeholder="Name"
-                                tabIndex="1"
+                                tabIndex="0"
                                 type="text"
                                 value={this.props.disabled ? '' : this.props.name}
                                 onSubmit={this.props.onChangeName}
@@ -65,7 +65,7 @@ class SpriteInfo extends React.Component {
                                 small
                                 disabled={this.props.disabled}
                                 placeholder="x"
-                                tabIndex="2"
+                                tabIndex="0"
                                 type="text"
                                 value={this.props.disabled ? '' : this.props.x}
                                 onSubmit={this.props.onChangeX}
@@ -88,7 +88,7 @@ class SpriteInfo extends React.Component {
                                 small
                                 disabled={this.props.disabled}
                                 placeholder="y"
-                                tabIndex="3"
+                                tabIndex="0"
                                 type="text"
                                 value={this.props.disabled ? '' : this.props.y}
                                 onSubmit={this.props.onChangeY}
@@ -116,7 +116,7 @@ class SpriteInfo extends React.Component {
                                         [styles.isDisabled]: this.props.disabled
                                     }
                                 )}
-                                tabIndex="4"
+                                tabIndex="0"
                                 onClick={this.props.onClickVisible}
                                 onKeyPress={this.props.onPressVisible}
                             >
@@ -135,7 +135,7 @@ class SpriteInfo extends React.Component {
                                         [styles.isDisabled]: this.props.disabled
                                     }
                                 )}
-                                tabIndex="5"
+                                tabIndex="0"
                                 onClick={this.props.onClickNotVisible}
                                 onKeyPress={this.props.onPressNotVisible}
                             >
@@ -155,7 +155,7 @@ class SpriteInfo extends React.Component {
                                 small
                                 disabled={this.props.disabled}
                                 label="Direction"
-                                tabIndex="6"
+                                tabIndex="0"
                                 type="text"
                                 value={this.props.disabled ? '' : this.props.direction}
                                 onSubmit={this.props.onChangeDirection}
@@ -170,8 +170,8 @@ class SpriteInfo extends React.Component {
                             <select
                                 className={classNames(styles.selectForm, styles.rotationSelect)}
                                 disabled={this.props.disabled}
+                                tabIndex="0"
                                 value={this.props.rotationStyle}
-                                tabIndex="7"
                                 onChange={this.props.onChangeRotationStyle}
                             >
                                 {ROTATION_STYLES.map(style => (


### PR DESCRIPTION
### Resolves
Unable to tab over the Sprite Rotation dropdown in Sprite Info, and the tab order jumps directly down to Sprite Info when it's standard to tab through elements top to bottom, left to right.

### Proposed Changes
Include the rotation dropdown in the tab order.
Show focus on the rotation dropdown.
![image](https://user-images.githubusercontent.com/10423718/33493152-2f4a3c5c-d68d-11e7-8e80-fe322b598b9a.png)
Use tab index 0.

### Reason for Changes
Improve keyboard control accessibility.
