### PR TITLE
Try to keep new custom procedure inputs in view

### DIFF
--- a/src/containers/custom-procedures.jsx
+++ b/src/containers/custom-procedures.jsx
@@ -49,8 +49,13 @@ class CustomProcedures extends React.Component {
             // Keep the block centered on the workspace
             const metrics = this.workspace.getMetrics();
             const {x, y} = this.mutationRoot.getRelativeToSurfaceXY();
-            const dx = (metrics.viewWidth / 2) - (this.mutationRoot.width / 2) - x;
             const dy = (metrics.viewHeight / 2) - (this.mutationRoot.height / 2) - y;
+            let dx = (metrics.viewWidth / 2) - (this.mutationRoot.width / 2) - x;
+            // If the procedure declaration is wider than the view width,
+            // keep the right-hand side of the procedure in view.
+            if (this.mutationRoot.width > metrics.viewWidth) {
+                dx = metrics.viewWidth - this.mutationRoot.width - x;
+            }
             this.mutationRoot.moveBy(dx, dy);
         });
         this.mutationRoot.domToMutation(this.props.mutator);


### PR DESCRIPTION
Currently the custom procedure block is just centered in the view.

![no-keep-in-view](https://user-images.githubusercontent.com/654102/33631668-3b00f302-d9d9-11e7-99f0-a39025385a64.gif)

Instead, try to center the custom procedures block but make sure the right side doesn't fall off the edge.

![keep-in-view](https://user-images.githubusercontent.com/654102/33631717-63a7283a-d9d9-11e7-89c9-562a8e93458c.gif)
