### PR TITLE
Force 1024x768 window size for automated tests

### DIFF
--- a/test/helpers/selenium-helper.js
+++ b/test/helpers/selenium-helper.js
@@ -37,10 +37,17 @@ class SeleniumHelper {
     }
 
     loadUri (uri) {
+        const WINDOW_WIDTH = 1024;
+        const WINDOW_HEIGHT = 768;
         return this.driver
             .get(`file://${uri}`)
             .then(() => (
                 this.driver.executeScript('window.onbeforeunload = undefined;')
+            ))
+            .then(() => (
+                this.driver.manage()
+                    .window()
+                    .setSize(WINDOW_WIDTH, WINDOW_HEIGHT)
             ));
     }
 


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/984 (hopefully, needs to be tested to confirm, more on that below).
 
### Proposed Changes

_Describe what this Pull Request does_

Set the integration test window size to 1024x768. In reality this leaves us with a window innerWidth/innerHeight of 1024x654 on my computer, but the tests still pass. 

### Test Coverage

_Please show how you have added tests to cover your changes_

Integration tests still pass for me and presumably will still pass on travis. The real test is to see if @ericrosenbaum, @quachtina96 this PR fixes you running integration tests locally. 
