### PR TITLE
Reorder menu options so random position is above mouse-pointer

### DIFF
--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -110,16 +110,16 @@ export default function (vm) {
 
     ScratchBlocks.Blocks.motion_goto_menu.init = function () {
         const json = jsonForMenuBlock('TO', spriteMenu, motionColors, [
-            ['mouse-pointer', '_mouse_'],
-            ['random position', '_random_']
+            ['random position', '_random_'],
+            ['mouse-pointer', '_mouse_']
         ]);
         this.jsonInit(json);
     };
 
     ScratchBlocks.Blocks.motion_glideto_menu.init = function () {
         const json = jsonForMenuBlock('TO', spriteMenu, motionColors, [
-            ['mouse-pointer', '_mouse_'],
-            ['random position', '_random_']
+            ['random position', '_random_'],
+            ['mouse-pointer', '_mouse_']
         ]);
         this.jsonInit(json);
     };


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/1009

### Proposed Changes

_Describe what this Pull Request does_

Reorders the menus so that the random is above mouse pointer.

### Reason for Changes

_Explain why these changes should be made_

Want to make randomness easier to get to, more fun!