### PR TITLE
Make it so that the user cannot select tabs

### DIFF
--- a/src/components/gui/gui.css
+++ b/src/components/gui/gui.css
@@ -69,11 +69,6 @@
     justify-content: center;
     align-items: center;
 
-    -webkit-touch-callout: none;
-    -webkit-user-select: none;
-    -khtml-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
     user-select: none;
 }
 

--- a/src/components/gui/gui.css
+++ b/src/components/gui/gui.css
@@ -68,6 +68,13 @@
     display: flex;
     justify-content: center;
     align-items: center;
+
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
 }
 
 .tab.is-selected {


### PR DESCRIPTION
### Resolves
#1015

### Proposed Changes
Remove the ability to select the tab button text

### Reason for Changes
The text selection can easily be trigged by accident and it doesn't look good