### PR TITLE
Check for the selected sound before rendering the editor

### DIFF
--- a/src/containers/sound-tab.jsx
+++ b/src/containers/sound-tab.jsx
@@ -104,7 +104,7 @@ class SoundTab extends React.Component {
                 onDeleteClick={this.handleDeleteSound}
                 onItemClick={this.handleSelectSound}
             >
-                {sprite.sounds && sprite.sounds.length > 0 ? (
+                {sprite.sounds && sprite.sounds[this.state.selectedSoundIndex] ? (
                     <SoundEditor soundIndex={this.state.selectedSoundIndex} />
                 ) : null}
                 {this.props.soundRecorderVisible ? (


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/1013

### Proposed Changes

_Describe what this Pull Request does_

Check for the selected sound before rendering the sound editor. 


### Reason for Changes

_Explain why these changes should be made_

The fix from https://github.com/LLK/scratch-gui/issues/858 was not complete.

### Test Coverage

_Please show how you have added tests to cover your changes_

Crash no longer occurs 
