### PR TITLE
Add 'empty' sprite and costume

### DIFF
--- a/src/lib/libraries/costumes.json
+++ b/src/lib/libraries/costumes.json
@@ -782,13 +782,13 @@
     },
     {
         "name": "Empty",
-        "md5": "d36f6603ec293d2c2198d3ea05109fe0.png",
+        "md5": "cd21514d0531fdffb22204e0ec5ed84a.svg",
         "type": "costume",
         "tags": [],
         "info": [
             0,
             0,
-            2
+            1
         ]
     },
     {

--- a/src/lib/libraries/costumes.json
+++ b/src/lib/libraries/costumes.json
@@ -781,6 +781,17 @@
         ]
     },
     {
+        "name": "Empty",
+        "md5": "d36f6603ec293d2c2198d3ea05109fe0.png",
+        "type": "costume",
+        "tags": [],
+        "info": [
+            0,
+            0,
+            2
+        ]
+    },
+    {
         "name": "Fish1",
         "md5": "df78f8195f72372846d96dc70cb0ad95.svg",
         "type": "costume",

--- a/src/lib/libraries/sprites.json
+++ b/src/lib/libraries/sprites.json
@@ -1733,7 +1733,7 @@
     },
     {
         "name": "Empty",
-        "md5": "d36f6603ec293d2c2198d3ea05109fe0.png",
+        "md5": "cd21514d0531fdffb22204e0ec5ed84a.svg",
         "type": "sprite",
         "tags": [],
         "info": [
@@ -1757,8 +1757,8 @@
                 {
                     "costumeName": "empty",
                     "baseLayerID": 0,
-                    "baseLayerMD5": "d36f6603ec293d2c2198d3ea05109fe0.png",
-                    "bitmapResolution": 2,
+                    "baseLayerMD5": "cd21514d0531fdffb22204e0ec5ed84a.svg",
+                    "bitmapResolution": 1,
                     "rotationCenterX": 0,
                     "rotationCenterY": 0
                 }

--- a/src/lib/libraries/sprites.json
+++ b/src/lib/libraries/sprites.json
@@ -1732,6 +1732,50 @@
         }
     },
     {
+        "name": "Empty",
+        "md5": "d36f6603ec293d2c2198d3ea05109fe0.png",
+        "type": "sprite",
+        "tags": [],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Empty",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "empty",
+                    "baseLayerID": 0,
+                    "baseLayerMD5": "d36f6603ec293d2c2198d3ea05109fe0.png",
+                    "bitmapResolution": 2,
+                    "rotationCenterX": 0,
+                    "rotationCenterY": 0
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 36,
+            "scratchY": 28,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "indexInLibrary": 68,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
         "name": "Fish1",
         "md5": "df78f8195f72372846d96dc70cb0ad95.svg",
         "type": "sprite",


### PR DESCRIPTION
### Proposed Changes

- Adds "Empty" sprite and costume

### Reason for Changes

 - Temporarily resolves issue for workshops by introducing an "Empty" sprite and costume library option