### PR TITLE
Broadcast Inputs

### DIFF
--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -332,8 +332,14 @@ const events = function () {
         <block type="event_whenbroadcastreceived">
         </block>
         <block type="event_broadcast">
+            <value name="BROADCAST_INPUT">
+                <shadow type="event_broadcast_menu"></shadow>
+            </value>
         </block>
         <block type="event_broadcastandwait">
+            <value name="BROADCAST_INPUT">
+              <shadow type="event_broadcast_menu"></shadow>
+            </value>
         </block>
         ${categorySeparator}
     </category>


### PR DESCRIPTION
### Resolves

Pluggable inputs for broadcast blocks.

### Proposed Changes

Accomodates pluggable input functionality for broadcast blocks.

Depends on these PRs and **should not get merged in until these are also ready to be merged**:
[LLK/scratch-blocks#1302](https://github.com/LLK/scratch-blocks/pull/1302)
[LLK/scratch-vm#860](https://github.com/LLK/scratch-vm/pull/860)


### Reason for Changes

To make pluggable inputs work correctly. Compatibility with SB2.

### Test Coverage

Existing tests pass.

### Additional Notes
These three PRs can be tested together [here](https://llk.github.io/scratch-gui/broadcast-input/).