### PR TITLE
chore(package): update copy-webpack-plugin to version 4.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "buffer-loader": "0.0.1",
     "chromedriver": "2.33.1",
     "classnames": "2.2.5",
-    "copy-webpack-plugin": "^4.2.3",
+    "copy-webpack-plugin": "^4.3.0",
     "css-loader": "^0.28.7",
     "enzyme": "^3.1.0",
     "enzyme-adapter-react-16": "1.1.0",


### PR DESCRIPTION
copy-webpack-plugin 4.2.2 was published with no dist. Ensure we skip over this version.

Closes #941 