### PR TITLE
Disable the 'collapse' option in the blocks workspace

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -326,7 +326,8 @@ Blocks.propTypes = {
             fieldShadow: PropTypes.string,
             dragShadowOpacity: PropTypes.number
         }),
-        comments: PropTypes.bool
+        comments: PropTypes.bool,
+        collapse: PropTypes.bool
     }),
     toolboxXML: PropTypes.string,
     updateToolboxState: PropTypes.func,
@@ -356,7 +357,8 @@ Blocks.defaultOptions = {
         fieldShadow: 'rgba(255, 255, 255, 0.3)',
         dragShadowOpacity: 0.6
     },
-    comments: false
+    comments: false,
+    collapse: false
 };
 
 Blocks.defaultProps = {

--- a/src/containers/custom-procedures.jsx
+++ b/src/containers/custom-procedures.jsx
@@ -108,7 +108,8 @@ CustomProcedures.propTypes = {
             wheel: PropTypes.bool,
             startScale: PropTypes.number
         }),
-        comments: PropTypes.bool
+        comments: PropTypes.bool,
+        collapse: PropTypes.bool
     })
 };
 
@@ -119,6 +120,7 @@ CustomProcedures.defaultOptions = {
         startScale: 0.9
     },
     comments: false,
+    collapse: false,
     scrollbars: true
 };
 


### PR DESCRIPTION
### Resolves

GH-1082

### Proposed Changes

- Adds a new `PropType` definition and default option for `collapse: false` to both the `blocks` and `custom-procedures` containers.

### Reason for Changes

- Removes the "collapse" option from context menus in the blocks workspace which is not a feature that would like to support for Scratch 3.0, but is not worth removing from `scratch-blocks`.
