### PR TITLE
Update to most recent paint editor release

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "scratch-audio": "0.1.0-prerelease.1511362862",
     "scratch-blocks": "0.1.0-prerelease.1513719016",
     "scratch-l10n": "2.0.20171211145754",
-    "scratch-paint": "0.1.0-prerelease.20171219170526",
+    "scratch-paint": "0.1.0-prerelease.20171220165922",
     "scratch-render": "0.1.0-prerelease.1513022270",
     "scratch-storage": "0.3.0",
     "scratch-vm": "0.1.0-prerelease.1513789849-prerelease.1513789862",


### PR DESCRIPTION
Not sure why greenkeeper hasn't picked up this release... Seems to be up-to-date on the other dependencies?