### PR TITLE
Remove border to stop backdrop count from looking like an input.

### DIFF
--- a/src/components/stage-selector/stage-selector.css
+++ b/src/components/stage-selector/stage-selector.css
@@ -58,9 +58,6 @@ $header-height: calc($stage-menu-height - 2px);
     padding: 0.3rem 0.75rem;
     font-size: 0.625rem;
     color: $text-primary;
-    background: white;
-    border: 1px solid #eaeaea;
-    border-radius: 0.25rem;
     user-select: none;
 }
 


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/1065

### Proposed Changes

_Describe what this Pull Request does_

> For now, we would like to drop the outline around the indicator to remove this confusion.

![image](https://user-images.githubusercontent.com/654102/34228440-a74b00f4-e59e-11e7-9eb0-29bc7d432f77.png)

