### PR TITLE
Update looks palette ordering, including "next backdrop" in sprite.

### DIFF
--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -175,9 +175,6 @@ const looks = function (isStage, targetId) {
             </value>
         </block>
         ${blockSeparator}
-        <block type="looks_show"/>
-        <block type="looks_hide"/>
-        ${blockSeparator}
         `}
         ${isStage ? `
             <block type="looks_switchbackdropto">
@@ -203,6 +200,22 @@ const looks = function (isStage, targetId) {
                     <shadow type="looks_backdrops"/>
                 </value>
             </block>
+            <block type="looks_nextbackdrop"/>
+            ${blockSeparator}
+            <block type="looks_changesizeby">
+                <value name="CHANGE">
+                    <shadow type="math_number">
+                        <field name="NUM">10</field>
+                    </shadow>
+                </value>
+            </block>
+            <block type="looks_setsizeto">
+                <value name="SIZE">
+                    <shadow type="math_number">
+                        <field name="NUM">100</field>
+                    </shadow>
+                </value>
+            </block>
         `}
         ${blockSeparator}
         <block type="looks_changeeffectby">
@@ -221,22 +234,10 @@ const looks = function (isStage, targetId) {
         </block>
         <block type="looks_cleargraphiceffects"/>
         ${blockSeparator}
+        <block type="looks_show"/>
+        <block type="looks_hide"/>
+        ${blockSeparator}
         ${isStage ? '' : `
-            <block type="looks_changesizeby">
-                <value name="CHANGE">
-                    <shadow type="math_number">
-                        <field name="NUM">10</field>
-                    </shadow>
-                </value>
-            </block>
-            <block type="looks_setsizeto">
-                <value name="SIZE">
-                    <shadow type="math_number">
-                        <field name="NUM">100</field>
-                    </shadow>
-                </value>
-            </block>
-            ${blockSeparator}
             <block type="looks_gotofront"/>
             <block type="looks_gobacklayers">
                 <value name="NUM">


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/1066

### Proposed Changes

_Describe what this Pull Request does_

For stage

![image](https://user-images.githubusercontent.com/654102/34230115-f54866ba-e5a4-11e7-8850-098b0e8e9d6c.png)


For sprite

![image](https://user-images.githubusercontent.com/654102/34230119-f7551430-e5a4-11e7-8240-42f69c7eb67f.png)

