### PR TITLE
Update graphics effects blocks to use scratch2 default values.

### DIFF
--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -208,14 +208,14 @@ const looks = function (isStage, targetId) {
         <block type="looks_changeeffectby">
             <value name="CHANGE">
                 <shadow type="math_number">
-                    <field name="NUM">10</field>
+                    <field name="NUM">25</field>
                 </shadow>
             </value>
         </block>
         <block type="looks_seteffectto">
             <value name="VALUE">
                 <shadow type="math_number">
-                    <field name="NUM">10</field>
+                    <field name="NUM">0</field>
                 </shadow>
             </value>
         </block>


### PR DESCRIPTION
Fixes https://github.com/LLK/scratch-gui/issues/1103

### Resolves

_What Github issue does this resolve (please include link)?_
Closes https://github.com/LLK/scratch-gui/issues/1103

![image](https://user-images.githubusercontent.com/654102/34263092-5218cf50-e63c-11e7-9806-ebe98214b916.png)


Sorry @thisandagain stole it!