### PR TITLE
Add 99 max undo stack size for sound editor

### DIFF
--- a/src/containers/sound-editor.jsx
+++ b/src/containers/sound-editor.jsx
@@ -9,6 +9,8 @@ import AudioEffects from '../lib/audio/audio-effects.js';
 import SoundEditorComponent from '../components/sound-editor/sound-editor.jsx';
 import AudioBufferPlayer from '../lib/audio/audio-buffer-player.js';
 
+const UNDO_STACK_SIZE = 99;
+
 class SoundEditor extends React.Component {
     constructor (props) {
         super(props);
@@ -62,6 +64,9 @@ class SoundEditor extends React.Component {
     submitNewSamples (samples, sampleRate, skipUndo) {
         if (!skipUndo) {
             this.redoStack = [];
+            if (this.undoStack.length >= UNDO_STACK_SIZE) {
+                this.undoStack.shift(); // Drop the first element off the array
+            }
             this.undoStack.push(this.props.samples.slice(0));
         }
         this.resetState(samples, sampleRate);


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_
Closes https://github.com/LLK/scratch-gui/issues/1093

### Proposed Changes

_Describe what this Pull Request does_

Start dropping old undo snapshots in the sound editor after 99 snapshots.
