### PR TITLE
Focus on the last input when opening custom block modal

### DIFF
--- a/src/containers/custom-procedures.jsx
+++ b/src/containers/custom-procedures.jsx
@@ -65,8 +65,11 @@ class CustomProcedures extends React.Component {
         this.mutationRoot.domToMutation(this.props.mutator);
         this.mutationRoot.initSvg();
         this.mutationRoot.render();
-
         this.setState({warp: this.mutationRoot.getWarp()});
+        // Allow the initial events to run to position this block, then focus.
+        setTimeout(() => {
+            this.mutationRoot.focusLastEditor_();
+        });
     }
     handleCancel () {
         this.props.onRequestClose();


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/1024

### Proposed Changes

_Describe what this Pull Request does_

Auto focus last input when opening custom procedure modal.

![last-editor-focus](https://user-images.githubusercontent.com/654102/34274366-3e1b3a18-e666-11e7-813e-773a96b3496b.gif)
