### PR TITLE
Custom Titles for Variable Modals

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -231,8 +231,10 @@ class Blocks extends React.Component {
     setBlocks (blocks) {
         this.blocks = blocks;
     }
-    handlePromptStart (message, defaultValue, callback) {
-        this.setState({prompt: {callback, message, defaultValue}});
+    handlePromptStart (message, defaultValue, callback, opt_title) {
+        var p = {prompt: {callback, message, defaultValue}};
+        p.prompt.title = opt_title ? opt_title : "New Variable";
+        this.setState(p);
     }
     handlePromptCallback (data) {
         this.state.prompt.callback(data);
@@ -272,7 +274,7 @@ class Blocks extends React.Component {
                     <Prompt
                         label={this.state.prompt.message}
                         placeholder={this.state.prompt.defaultValue}
-                        title="New Variable" // @todo the only prompt is for new variables
+                        title={this.state.prompt.title}
                         onCancel={this.handlePromptClose}
                         onOk={this.handlePromptCallback}
                     />

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -231,9 +231,9 @@ class Blocks extends React.Component {
     setBlocks (blocks) {
         this.blocks = blocks;
     }
-    handlePromptStart (message, defaultValue, callback, opt_title) {
-        var p = {prompt: {callback, message, defaultValue}};
-        p.prompt.title = opt_title ? opt_title : "New Variable";
+    handlePromptStart (message, defaultValue, callback, optTitle) {
+        const p = {prompt: {callback, message, defaultValue}};
+        p.prompt.title = optTitle ? optTitle : 'New Variable';
         this.setState(p);
     }
     handlePromptCallback (data) {


### PR DESCRIPTION
### Resolves

[LLK/scratch-blocks#1272](https://github.com/LLK/scratch-blocks/issues/1272)

### Proposed Changes

Allows custom modal title for new variable/list/broadcast message.

### Reason for Changes

[LLK/scratch-blocks#1272](https://github.com/LLK/scratch-blocks/issues/1272)

### Test Coverage

Existing tests pass.

### Additional Notes

Associated with PR [LLK/scratch-blocks#1321](https://github.com/LLK/scratch-blocks/pull/1321)