### PR TITLE
Modify rounding logic in flyout blocks

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -152,8 +152,8 @@ class Blocks extends React.Component {
     onTargetsUpdate () {
         if (this.props.vm.editingTarget) {
             ['glide', 'move', 'set'].forEach(prefix => {
-                this.updateToolboxBlockValue(`${prefix}x`, this.props.vm.editingTarget.x.toFixed(0));
-                this.updateToolboxBlockValue(`${prefix}y`, this.props.vm.editingTarget.y.toFixed(0));
+                this.updateToolboxBlockValue(`${prefix}x`, Math.round(this.props.vm.editingTarget.x).toString());
+                this.updateToolboxBlockValue(`${prefix}y`, Math.round(this.props.vm.editingTarget.y).toString());
             });
         }
     }


### PR DESCRIPTION
### Resolves

[Issue #1048](https://github.com/LLK/scratch-gui/issues/1048)

### Proposed Changes

Revised number rounding logic for default x and y values in motion blocks on the flyout so that when the sprite is at a position such as (x=-0.001, y=216), the blocks display this
![image](https://user-images.githubusercontent.com/29558846/34320566-450d2bf4-e7cb-11e7-8cf4-2a952a1a710a.png)

instead of this.
![image](https://user-images.githubusercontent.com/29558846/34320562-324f6cfc-e7cb-11e7-8028-b7cf89fd1be0.png)

### Reason for Changes

The value "-0" looks ugly and might confuse beginners.

### Test Coverage

None.
