### PR TITLE
Add next/previous backdrop options in backdrop block

### DIFF
--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -44,9 +44,8 @@ export default function (vm) {
 
     const backdropsMenu = function () {
         if (vm.runtime.targets[0] && vm.runtime.targets[0].sprite.costumes.length > 0) {
-            const a = vm.runtime.targets[0].sprite.costumes.map(costume => [costume.name, costume.name]);
-            a.push(['next backdrop', 'next backdrop'], ['previous backdrop', 'previous backdrop']);
-            return a;
+            return vm.runtime.targets[0].sprite.costumes.map(costume => [costume.name, costume.name])
+                .concat(['next backdrop', '_nextBackdrop_'], ['previous backdrop', '_prevBackdrop_']);
         }
         return [['', '']];
     };

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -44,7 +44,7 @@ export default function (vm) {
 
     const backdropsMenu = function () {
         if (vm.runtime.targets[0] && vm.runtime.targets[0].sprite.costumes.length > 0) {
-            var a = vm.runtime.targets[0].sprite.costumes.map(costume => [costume.name, costume.name]);
+            const a = vm.runtime.targets[0].sprite.costumes.map(costume => [costume.name, costume.name]);
             a.push(['next backdrop', 'next backdrop'], ['previous backdrop', 'previous backdrop']);
             return a;
         }

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -45,7 +45,7 @@ export default function (vm) {
     const backdropsMenu = function () {
         if (vm.runtime.targets[0] && vm.runtime.targets[0].sprite.costumes.length > 0) {
             return vm.runtime.targets[0].sprite.costumes.map(costume => [costume.name, costume.name])
-                .concat(['next backdrop', '_nextBackdrop_'], ['previous backdrop', '_prevBackdrop_']);
+                .concat([['next backdrop', '_nextBackdrop_'], ['previous backdrop', '_prevBackdrop_']]);
         }
         return [['', '']];
     };

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -45,7 +45,7 @@ export default function (vm) {
     const backdropsMenu = function () {
         if (vm.runtime.targets[0] && vm.runtime.targets[0].sprite.costumes.length > 0) {
             var a = vm.runtime.targets[0].sprite.costumes.map(costume => [costume.name, costume.name]);
-            a.push(["next backdrop", "next backdrop"], ["previous backdrop", "previous backdrop"]);
+            a.push(['next backdrop', 'next backdrop'], ['previous backdrop', 'previous backdrop']);
             return a;
         }
         return [['', '']];

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -44,7 +44,9 @@ export default function (vm) {
 
     const backdropsMenu = function () {
         if (vm.runtime.targets[0] && vm.runtime.targets[0].sprite.costumes.length > 0) {
-            return vm.runtime.targets[0].sprite.costumes.map(costume => [costume.name, costume.name]);
+            var a = vm.runtime.targets[0].sprite.costumes.map(costume => [costume.name, costume.name]);
+            a.push(["next backdrop", "next backdrop"], ["previous backdrop", "previous backdrop"]);
+            return a;
         }
         return [['', '']];
     };

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -45,7 +45,7 @@ export default function (vm) {
     const backdropsMenu = function () {
         if (vm.runtime.targets[0] && vm.runtime.targets[0].sprite.costumes.length > 0) {
             return vm.runtime.targets[0].sprite.costumes.map(costume => [costume.name, costume.name])
-                .concat([['next backdrop', '_nextBackdrop_'], ['previous backdrop', '_prevBackdrop_']]);
+                .concat([['next backdrop', 'next backdrop'], ['previous backdrop', 'previous backdrop']]);
         }
         return [['', '']];
     };


### PR DESCRIPTION
### Resolves

[Issue #849 in the VM](https://github.com/LLK/scratch-vm/issues/849)

### Proposed Changes

Adds "next backdrop" and "previous backdrop" menu options to the "switch backdrop to [  ]" block.

### Reason for Changes

Consistency with Scratch 2.

### Test Coverage

None.