### PR TITLE
Add drag mode block to make toolbox XML

### DIFF
--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -440,6 +440,11 @@ const sensing = function (isStage) {
         <block type="sensing_mousedown"/>
         <block type="sensing_mousex"/>
         <block type="sensing_mousey"/>
+        ${isStage ? '' : `
+            ${blockSeparator}
+            '<block type="sensing_setdragmode" id="sensing_setdragmode"></block>'+
+            ${blockSeparator}
+        `}
         ${blockSeparator}
         <block id="loudness" type="sensing_loudness"/>
         ${blockSeparator}


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

GUI part of https://github.com/LLK/scratch-vm/issues/553

Depends on https://github.com/LLK/scratch-blocks/pull/1325

### Proposed Changes

_Describe what this Pull Request does_
Adds new drag mode block to the toolbox. 

![image](https://user-images.githubusercontent.com/654102/34418096-1f47ac52-ebca-11e7-9ae1-c282d84f0b45.png)


@thisandagain I assume this block shouldn't be there for the stage, but let me know if that isn't right. 