### PR TITLE
Update to 2.8.0 manually because of greenkeeper test error.

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "enzyme-adapter-react-16": "1.1.0",
     "eslint": "^4.7.1",
     "eslint-config-scratch": "^5.0.0",
-    "eslint-plugin-import": "^2.7.0",
+    "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-react": "^7.5.1",
     "file-loader": "1.1.6",
     "get-float-time-domain-data": "0.1.0",


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/795

### Proposed Changes

_Describe what this Pull Request does_

Update the dependency manually. It looks like it tried to update at a moment when develop wasn't building (before we pinned all the other repo deps). Trying again, if it passes will merge. 