### PR TITLE
Update scratch paint version number manually

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "scratch-audio": "0.1.0-prerelease.1513803406",
     "scratch-blocks": "0.1.0-prerelease.1514558744",
     "scratch-l10n": "2.0.20171211145754",
-    "scratch-paint": "0.1.0-prerelease.20171220165922",
+    "scratch-paint": "0.1.0-prerelease.20180103203117",
     "scratch-render": "0.1.0-prerelease.1513807417",
     "scratch-storage": "0.3.0",
     "scratch-vm": "0.1.0-prerelease.1514561281-prerelease.1514561294",


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_
Fixes https://github.com/LLK/scratch-gui/issues/1161

### Proposed Changes

_Describe what this Pull Request does_

Update to the most recent scratch paint manually. Not sure why greenkeeper didn't pick this up?
