### PR TITLE
Remove sprite-specific text from sprite/sound/etc deletion warning

### DIFF
--- a/src/containers/sprite-selector-item.jsx
+++ b/src/containers/sprite-selector-item.jsx
@@ -21,7 +21,7 @@ class SpriteSelectorItem extends React.Component {
     }
     handleDelete () {
         // eslint-disable-next-line no-alert
-        if (window.confirm('Are you sure you want to delete this sprite?')) {
+        if (window.confirm('Are you sure you want to delete this?')) {
             this.props.onDeleteButtonClick(this.props.id);
         }
     }


### PR DESCRIPTION
### Resolves

Fixes #385.

### Proposed Changes

Removes the sprite-specific message from the "delete" prompt that appears when you click on the X of any sprite, sound, costume, or backdrop card in a project.

### Reason for Changes

If anything, this is a hack :) - But it's appropriate. This fixes #385, which is scheduled for the February milestone; it's a very old bug (May of last year) and has been put into and brought out of backlog over the course of its lifespan. The *correct* fix is to make non-sprite elements use an element other than `SpriteSelectorItem`, but this is a *hard* fix. It means creating a general component for "selector items", then making subclasses for each selector item, and changing the GUI to appropriately use these; no quick task.

This is a simple fix and gets rid of the bug quickly. It should also be noted that putting a lot of time into fixing this *correctly* now probably isn't worth it - see @TheBrokenRail's pull request #513, which contained a fair amount of work but was closed to this comment:

> Sorry for the delay. This totally fell off my radar, that's my fault. We appreciate you porting this over to the new modal style, but the delete alerts are temporary for prototyping. **Eventually we will remove the alerts entirely.**

(Emphasis mine.) Since these alerts are eventually going to be removed altogether, there's no real reason to split this into multiple components right now. (Since they'll all behave the same, I suppose a better solution would just be to rename SpriteSelectorItem to SelectorItem; but this is also a fair amount of work to deal with! And not necessary to fix the bug; in fact, it would just contain the change in this PR anyways.)

### Test Coverage

Untested. I didn't try to run this locally, either (I made the change online through GitHub), but this is just a string change, so I can't imagine I broke anything :)