### PR TITLE
Fix duplicate birthday sound clips

### DIFF
--- a/src/lib/libraries/sounds.json
+++ b/src/lib/libraries/sounds.json
@@ -197,20 +197,6 @@
     },
     {
         "name": "Birthday",
-        "md5": "e8df0951694293fe17850260b4d12734.wav",
-        "sampleCount": 167040,
-        "rate": 22050,
-        "format": ""
-    },
-    {
-        "name": "Birthday Bells",
-        "md5": "89691587a169d935a58c48c3d4e78534.wav",
-        "sampleCount": 161408,
-        "rate": 22050,
-        "format": ""
-    },
-    {
-        "name": "Birthday Song",
         "md5": "89691587a169d935a58c48c3d4e78534.wav",
         "sampleCount": 161408,
         "rate": 22050,


### PR DESCRIPTION
### Resolves

Fixes #1180.

### Proposed Changes

Removes "Birthday" and "Birthday Song"; renames "Birthday Bells" to "Birthday".

### Reason for Changes

To fix #1180. Rest in peace, [Birthday](https://cdn.assets.scratch.mit.edu/internalapi/asset/e8df0951694293fe17850260b4d12734.wav/get/)! 🍰

### Test Coverage

Automated tests aren't applicable; tested manually locally.