### PR TITLE
Exit full-screen mode by hitting escape key

### DIFF
--- a/src/components/stage-header/stage-header.jsx
+++ b/src/components/stage-header/stage-header.jsx
@@ -42,6 +42,7 @@ const messages = defineMessages({
 const StageHeaderComponent = function (props) {
     const {
         isFullScreen,
+        onKeyPress,
         onSetStageLarge,
         onSetStageFull,
         onSetStageUnFull,
@@ -58,6 +59,7 @@ const StageHeaderComponent = function (props) {
                     <Button
                         className={styles.stageButton}
                         onClick={onSetStageUnFull}
+                        onKeyPress={onKeyPress}
                     >
                         <img
                             alt={props.intl.formatMessage(messages.unFullStageSizeMessage)}
@@ -138,6 +140,7 @@ const StageHeaderComponent = function (props) {
 StageHeaderComponent.propTypes = {
     intl: intlShape,
     isFullScreen: PropTypes.bool.isRequired,
+    onKeyPress: PropTypes.func.isRequired,
     onSetStageFull: PropTypes.func.isRequired,
     onSetStageLarge: PropTypes.func.isRequired,
     onSetStageUnFull: PropTypes.func.isRequired,

--- a/src/containers/stage-header.jsx
+++ b/src/containers/stage-header.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import bindAll from 'lodash.bindall';
 import VM from 'scratch-vm';
 import {setStageSize, setFullScreen, STAGE_SIZES} from '../reducers/stage-size';
 
@@ -9,6 +10,23 @@ import StageHeaderComponent from '../components/stage-header/stage-header.jsx';
 
 // eslint-disable-next-line react/prefer-stateless-function
 class StageHeader extends React.Component {
+    constructor (props) {
+        super(props);
+        bindAll(this, [
+            'handleKeyPress'
+        ]);
+    }
+    componentDidMount () {
+        document.addEventListener('keydown', this.handleKeyPress);
+    }
+    componentWillUnmount () {
+        document.removeEventListener('keydown', this.handleKeyPress);
+    }
+    handleKeyPress (event) {
+        if (event.key === 'Escape' && this.props.isFullScreen) {
+            this.props.onSetStageUnFull(false);
+        }
+    }
     render () {
         const {
             ...props
@@ -16,12 +34,15 @@ class StageHeader extends React.Component {
         return (
             <StageHeaderComponent
                 {...props}
+                onKeyPress={this.handleKeyPress}
             />
         );
     }
 }
 
 StageHeader.propTypes = {
+    isFullScreen: PropTypes.bool.isRequired,
+    onSetStageUnFull: PropTypes.func.isRequired,
     stageSize: PropTypes.oneOf(Object.keys(STAGE_SIZES)),
     vm: PropTypes.instanceOf(VM).isRequired
 };


### PR DESCRIPTION
### Resolves

LLK/scratch-gui#1171

### Proposed Changes

The stage-header now listens for the 'escape' key press. If in full-screen mode, it exits this mode.

### Reason for Changes

Requested by user  @kyleplo.

### Test Coverage

No additional testing added.
