### PR TITLE
Update libraries re: feedback from smoke test

### DIFF
--- a/src/lib/libraries/costumes.json
+++ b/src/lib/libraries/costumes.json
@@ -1914,17 +1914,6 @@
         ]
     },
     {
-        "name": "Jez-a",
-        "md5": "9de23c4a7a7fbb67136b539241346854.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            67,
-            95,
-            1
-        ]
-    },
-    {
         "name": "Jez-b",
         "md5": "f1e74f3c02333e9e2068e8baf4e77aa0.svg",
         "type": "costume",
@@ -2053,6 +2042,17 @@
         "info": [
             72,
             68,
+            1
+        ]
+    },
+    {
+        "name": "Kiran-a",
+        "md5": "9de23c4a7a7fbb67136b539241346854.svg",
+        "type": "costume",
+        "tags": [],
+        "info": [
+            67,
+            95,
             1
         ]
     },

--- a/src/lib/libraries/costumes.json
+++ b/src/lib/libraries/costumes.json
@@ -1255,12 +1255,12 @@
     },
     {
         "name": "Drum-snare-b",
-        "md5": "b72e49aa2547f69edb9d9d0760d5e633.svg",
+        "md5": "f6d2f2a6e1055dab6262336625ddf652.svg",
         "type": "costume",
         "tags": [],
         "info": [
-            40,
-            69,
+            36,
+            66,
             1
         ]
     },
@@ -1288,7 +1288,7 @@
     },
     {
         "name": "Egg-a",
-        "md5": "83016b7ff817f99be4a454600b4a78fc.svg",
+        "md5": "bc723738dfe626c5c3bb90970d985961.svg",
         "type": "costume",
         "tags": [],
         "info": [
@@ -1299,7 +1299,7 @@
     },
     {
         "name": "Egg-b",
-        "md5": "d9a44d151fbd909bdbbcf7877055af6d.svg",
+        "md5": "83016b7ff817f99be4a454600b4a78fc.svg",
         "type": "costume",
         "tags": [],
         "info": [
@@ -1310,7 +1310,7 @@
     },
     {
         "name": "Egg-c",
-        "md5": "c91c7f72b8523b0910a84bce7d99c37b.svg",
+        "md5": "d9a44d151fbd909bdbbcf7877055af6d.svg",
         "type": "costume",
         "tags": [],
         "info": [
@@ -1321,7 +1321,7 @@
     },
     {
         "name": "Egg-d",
-        "md5": "65c15516e62596e1f72e874359fc7254.svg",
+        "md5": "c91c7f72b8523b0910a84bce7d99c37b.svg",
         "type": "costume",
         "tags": [],
         "info": [
@@ -1332,7 +1332,7 @@
     },
     {
         "name": "Egg-e",
-        "md5": "bc723738dfe626c5c3bb90970d985961.svg",
+        "md5": "65c15516e62596e1f72e874359fc7254.svg",
         "type": "costume",
         "tags": [],
         "info": [
@@ -1772,12 +1772,12 @@
     },
     {
         "name": "Hedgehog-e",
-        "md5": "454037f03e7808dc715b69b2b30d8110.svg",
+        "md5": "78a0e3789f6d778e20f9bf3d308a0b19.svg",
         "type": "costume",
         "tags": [],
         "info": [
-            71,
-            56,
+            61,
+            45,
             1
         ]
     },
@@ -2212,7 +2212,7 @@
     },
     {
         "name": "Milk-a",
-        "md5": "82d4c1855fe0d400433c7344fb2af3b5.svg",
+        "md5": "e6a7964bc4ea38c79a5a31d6ddfb5ba9.svg",
         "type": "costume",
         "tags": [],
         "info": [
@@ -2223,6 +2223,17 @@
     },
     {
         "name": "Milk-b",
+        "md5": "82d4c1855fe0d400433c7344fb2af3b5.svg",
+        "type": "costume",
+        "tags": [],
+        "info": [
+            68,
+            71,
+            1
+        ]
+    },
+    {
+        "name": "Milk-c",
         "md5": "50afc991b6fdad4b6547ba98ecf8a6af.svg",
         "type": "costume",
         "tags": [],
@@ -2233,7 +2244,7 @@
         ]
     },
     {
-        "name": "Milk-c",
+        "name": "Milk-d",
         "md5": "8fc7606a176149d225a541a04fa67473.svg",
         "type": "costume",
         "tags": [],
@@ -2244,19 +2255,8 @@
         ]
     },
     {
-        "name": "Milk-d",
-        "md5": "f2373d449b1226c44436dced422c2935.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            68,
-            71,
-            1
-        ]
-    },
-    {
         "name": "Milk-e",
-        "md5": "e6a7964bc4ea38c79a5a31d6ddfb5ba9.svg",
+        "md5": "f2373d449b1226c44436dced422c2935.svg",
         "type": "costume",
         "tags": [],
         "info": [
@@ -3059,50 +3059,6 @@
     },
     {
         "name": "Strawberry-a",
-        "md5": "77dadaa80bc5156f655c2196f57972f7.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            57,
-            58,
-            1
-        ]
-    },
-    {
-        "name": "Strawberry-b",
-        "md5": "19f933b3cf3e8e150753f8fb9bb7a779.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            57,
-            58,
-            1
-        ]
-    },
-    {
-        "name": "Strawberry-c",
-        "md5": "8e8057da8457e6167de36b7d3d28b4bb.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            57,
-            58,
-            1
-        ]
-    },
-    {
-        "name": "Strawberry-d",
-        "md5": "5eb63e64b83f5aa5b75a55329a34efec.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            57,
-            58,
-            1
-        ]
-    },
-    {
-        "name": "Strawberry-e",
         "md5": "734556fb8e14740f2cbc971238b71d47.svg",
         "type": "costume",
         "tags": [],
@@ -3113,8 +3069,52 @@
         ]
     },
     {
+        "name": "Strawberry-b",
+        "md5": "77dadaa80bc5156f655c2196f57972f7.svg",
+        "type": "costume",
+        "tags": [],
+        "info": [
+            57,
+            58,
+            1
+        ]
+    },
+    {
+        "name": "Strawberry-c",
+        "md5": "19f933b3cf3e8e150753f8fb9bb7a779.svg",
+        "type": "costume",
+        "tags": [],
+        "info": [
+            57,
+            58,
+            1
+        ]
+    },
+    {
+        "name": "Strawberry-d",
+        "md5": "8e8057da8457e6167de36b7d3d28b4bb.svg",
+        "type": "costume",
+        "tags": [],
+        "info": [
+            57,
+            58,
+            1
+        ]
+    },
+    {
+        "name": "Strawberry-e",
+        "md5": "5eb63e64b83f5aa5b75a55329a34efec.svg",
+        "type": "costume",
+        "tags": [],
+        "info": [
+            57,
+            58,
+            1
+        ]
+    },
+    {
         "name": "Takeout-a",
-        "md5": "48b19c48e32c98a35836ee40e3a7accf.svg",
+        "md5": "0cfdefe0df1a032b90c8facd9f5dbe1f.svg",
         "type": "costume",
         "tags": [],
         "info": [
@@ -3125,7 +3125,7 @@
     },
     {
         "name": "Takeout-b",
-        "md5": "22d33d87883f8fb26c642eccc9b339f0.svg",
+        "md5": "48b19c48e32c98a35836ee40e3a7accf.svg",
         "type": "costume",
         "tags": [],
         "info": [
@@ -3136,7 +3136,7 @@
     },
     {
         "name": "Takeout-c",
-        "md5": "262f1a3730d669dc9d43b3853e397361.svg",
+        "md5": "22d33d87883f8fb26c642eccc9b339f0.svg",
         "type": "costume",
         "tags": [],
         "info": [
@@ -3147,7 +3147,7 @@
     },
     {
         "name": "Takeout-d",
-        "md5": "528e9df8c3bd173867be4143f8563e87.svg",
+        "md5": "262f1a3730d669dc9d43b3853e397361.svg",
         "type": "costume",
         "tags": [],
         "info": [
@@ -3158,7 +3158,7 @@
     },
     {
         "name": "Takeout-e",
-        "md5": "0cfdefe0df1a032b90c8facd9f5dbe1f.svg",
+        "md5": "528e9df8c3bd173867be4143f8563e87.svg",
         "type": "costume",
         "tags": [],
         "info": [

--- a/src/lib/libraries/sounds.json
+++ b/src/lib/libraries/sounds.json
@@ -455,14 +455,14 @@
         "format": ""
     },
     {
-        "name": "Cough-female",
+        "name": "Cough1",
         "md5": "98ec3e1eeb7893fca519aa52cc1ef3c1.wav",
         "sampleCount": 7516,
         "rate": 11025,
         "format": ""
     },
     {
-        "name": "Cough-male",
+        "name": "Cough2",
         "md5": "467fe8ef3cab475af4b3088fd1261510.wav",
         "sampleCount": 16612,
         "rate": 22050,
@@ -1225,21 +1225,21 @@
         "format": ""
     },
     {
-        "name": "Laugh-female",
+        "name": "Laugh1",
         "md5": "1e8e7fb94103282d02a4bb597248c788.wav",
         "sampleCount": 13547,
         "rate": 11025,
         "format": ""
     },
     {
-        "name": "Laugh-male1",
+        "name": "Laugh2",
         "md5": "8b1e025f38b0635f7e34e9afcace1b5e.wav",
         "sampleCount": 14662,
         "rate": 11025,
         "format": ""
     },
     {
-        "name": "Laugh-male2",
+        "name": "Laugh3",
         "md5": "86dee6fa7cd73095ba17e4d666a27804.wav",
         "sampleCount": 32065,
         "rate": 11025,
@@ -1407,14 +1407,14 @@
         "format": ""
     },
     {
-        "name": "Scream-female",
+        "name": "Scream1",
         "md5": "10420bb2f5a3ab440f3b10fc8ea2b08b.wav",
         "sampleCount": 6628,
         "rate": 11025,
         "format": ""
     },
     {
-        "name": "Scream-male1",
+        "name": "Scream2",
         "md5": "e06e29398d770dae3cd57447439752ef.wav",
         "sampleCount": 17010,
         "rate": 22050,
@@ -1491,14 +1491,14 @@
         "format": "adpcm"
     },
     {
-        "name": "Sneeze-female",
+        "name": "Sneeze1",
         "md5": "31600c613823710b66a74f4dd54c4cdd.wav",
         "sampleCount": 11818,
         "rate": 11025,
         "format": ""
     },
     {
-        "name": "Sneeze-male",
+        "name": "Sneeze2",
         "md5": "42b5a31628083f3089f494f2ba644660.wav",
         "sampleCount": 15218,
         "rate": 22050,

--- a/src/lib/libraries/sprites.json
+++ b/src/lib/libraries/sprites.json
@@ -3915,7 +3915,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "jez-a",
+                    "costumeName": "kiran-a",
                     "baseLayerID": -1,
                     "baseLayerMD5": "9de23c4a7a7fbb67136b539241346854.svg",
                     "bitmapResolution": 1,

--- a/src/lib/libraries/sprites.json
+++ b/src/lib/libraries/sprites.json
@@ -1743,19 +1743,19 @@
                     "rotationCenterY": 54
                 },
                 {
-                    "costumeName": "dinosaur4-c",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "9a4bbc1b104c8112be82c252a6ecfd11.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 59,
-                    "rotationCenterY": 54
-                },
-                {
                     "costumeName": "dinosaur4-b",
                     "baseLayerID": -1,
                     "baseLayerMD5": "a3028e87caeb8338f50b2c6dec9f23d2.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 86,
+                    "rotationCenterY": 54
+                },
+                {
+                    "costumeName": "dinosaur4-c",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "9a4bbc1b104c8112be82c252a6ecfd11.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 59,
                     "rotationCenterY": 54
                 },
                 {
@@ -2512,11 +2512,11 @@
                 },
                 {
                     "costumeName": "drum-snare-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "b72e49aa2547f69edb9d9d0760d5e633.svg",
+                    "baseLayerID": 0,
+                    "baseLayerMD5": "f6d2f2a6e1055dab6262336625ddf652.svg",
                     "bitmapResolution": 1,
-                    "rotationCenterX": 40,
-                    "rotationCenterY": 69
+                    "rotationCenterX": 36,
+                    "rotationCenterY": 66
                 },
                 {
                     "costumeName": "drum-snare-c",
@@ -2527,7 +2527,7 @@
                     "rotationCenterY": 69
                 }
             ],
-            "currentCostumeIndex": 0,
+            "currentCostumeIndex": 1,
             "scratchX": 45,
             "scratchY": -33,
             "scale": 1,
@@ -2585,7 +2585,7 @@
     },
     {
         "name": "Egg",
-        "md5": "83016b7ff817f99be4a454600b4a78fc.svg",
+        "md5": "bc723738dfe626c5c3bb90970d985961.svg",
         "type": "sprite",
         "tags": [],
         "info": [
@@ -2609,7 +2609,7 @@
                 {
                     "costumeName": "egg-a",
                     "baseLayerID": -1,
-                    "baseLayerMD5": "83016b7ff817f99be4a454600b4a78fc.svg",
+                    "baseLayerMD5": "bc723738dfe626c5c3bb90970d985961.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 68,
                     "rotationCenterY": 54
@@ -2617,7 +2617,7 @@
                 {
                     "costumeName": "egg-b",
                     "baseLayerID": -1,
-                    "baseLayerMD5": "d9a44d151fbd909bdbbcf7877055af6d.svg",
+                    "baseLayerMD5": "83016b7ff817f99be4a454600b4a78fc.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 68,
                     "rotationCenterY": 54
@@ -2625,7 +2625,7 @@
                 {
                     "costumeName": "egg-c",
                     "baseLayerID": -1,
-                    "baseLayerMD5": "c91c7f72b8523b0910a84bce7d99c37b.svg",
+                    "baseLayerMD5": "d9a44d151fbd909bdbbcf7877055af6d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 68,
                     "rotationCenterY": 54
@@ -2633,7 +2633,7 @@
                 {
                     "costumeName": "egg-d",
                     "baseLayerID": -1,
-                    "baseLayerMD5": "65c15516e62596e1f72e874359fc7254.svg",
+                    "baseLayerMD5": "c91c7f72b8523b0910a84bce7d99c37b.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 68,
                     "rotationCenterY": 54
@@ -2641,15 +2641,15 @@
                 {
                     "costumeName": "egg-e",
                     "baseLayerID": -1,
-                    "baseLayerMD5": "bc723738dfe626c5c3bb90970d985961.svg",
+                    "baseLayerMD5": "65c15516e62596e1f72e874359fc7254.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 68,
                     "rotationCenterY": 54
                 }
             ],
             "currentCostumeIndex": 0,
-            "scratchX": -99,
-            "scratchY": 77,
+            "scratchX": -95,
+            "scratchY": 60,
             "scale": 1,
             "direction": 90,
             "rotationStyle": "normal",
@@ -3632,11 +3632,11 @@
                 },
                 {
                     "costumeName": "hedgehog-e",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "454037f03e7808dc715b69b2b30d8110.svg",
+                    "baseLayerID": 0,
+                    "baseLayerMD5": "78a0e3789f6d778e20f9bf3d308a0b19.svg",
                     "bitmapResolution": 1,
-                    "rotationCenterX": 71,
-                    "rotationCenterY": 56
+                    "rotationCenterX": 61,
+                    "rotationCenterY": 45
                 }
             ],
             "currentCostumeIndex": 0,
@@ -4553,7 +4553,7 @@
     },
     {
         "name": "Milk",
-        "md5": "82d4c1855fe0d400433c7344fb2af3b5.svg",
+        "md5": "e6a7964bc4ea38c79a5a31d6ddfb5ba9.svg",
         "type": "sprite",
         "tags": [],
         "info": [
@@ -4577,7 +4577,7 @@
                 {
                     "costumeName": "milk-a",
                     "baseLayerID": -1,
-                    "baseLayerMD5": "82d4c1855fe0d400433c7344fb2af3b5.svg",
+                    "baseLayerMD5": "e6a7964bc4ea38c79a5a31d6ddfb5ba9.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 68,
                     "rotationCenterY": 71
@@ -4585,13 +4585,21 @@
                 {
                     "costumeName": "milk-b",
                     "baseLayerID": -1,
+                    "baseLayerMD5": "82d4c1855fe0d400433c7344fb2af3b5.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 68,
+                    "rotationCenterY": 71
+                },
+                {
+                    "costumeName": "milk-c",
+                    "baseLayerID": -1,
                     "baseLayerMD5": "50afc991b6fdad4b6547ba98ecf8a6af.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 47,
                     "rotationCenterY": 44
                 },
                 {
-                    "costumeName": "milk-c",
+                    "costumeName": "milk-d",
                     "baseLayerID": -1,
                     "baseLayerMD5": "8fc7606a176149d225a541a04fa67473.svg",
                     "bitmapResolution": 1,
@@ -4599,25 +4607,17 @@
                     "rotationCenterY": 71
                 },
                 {
-                    "costumeName": "milk-d",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "f2373d449b1226c44436dced422c2935.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 68,
-                    "rotationCenterY": 71
-                },
-                {
                     "costumeName": "milk-e",
                     "baseLayerID": -1,
-                    "baseLayerMD5": "e6a7964bc4ea38c79a5a31d6ddfb5ba9.svg",
+                    "baseLayerMD5": "f2373d449b1226c44436dced422c2935.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 68,
                     "rotationCenterY": 71
                 }
             ],
             "currentCostumeIndex": 0,
-            "scratchX": 22,
-            "scratchY": -64,
+            "scratchX": -2,
+            "scratchY": -85,
             "scale": 1,
             "direction": 90,
             "rotationStyle": "normal",
@@ -6361,7 +6361,7 @@
     },
     {
         "name": "Strawberry",
-        "md5": "77dadaa80bc5156f655c2196f57972f7.svg",
+        "md5": "734556fb8e14740f2cbc971238b71d47.svg",
         "type": "sprite",
         "tags": [],
         "info": [
@@ -6385,7 +6385,7 @@
                 {
                     "costumeName": "strawberry-a",
                     "baseLayerID": -1,
-                    "baseLayerMD5": "77dadaa80bc5156f655c2196f57972f7.svg",
+                    "baseLayerMD5": "734556fb8e14740f2cbc971238b71d47.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 57,
                     "rotationCenterY": 58
@@ -6393,7 +6393,7 @@
                 {
                     "costumeName": "strawberry-b",
                     "baseLayerID": -1,
-                    "baseLayerMD5": "19f933b3cf3e8e150753f8fb9bb7a779.svg",
+                    "baseLayerMD5": "77dadaa80bc5156f655c2196f57972f7.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 57,
                     "rotationCenterY": 58
@@ -6401,7 +6401,7 @@
                 {
                     "costumeName": "strawberry-c",
                     "baseLayerID": -1,
-                    "baseLayerMD5": "8e8057da8457e6167de36b7d3d28b4bb.svg",
+                    "baseLayerMD5": "19f933b3cf3e8e150753f8fb9bb7a779.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 57,
                     "rotationCenterY": 58
@@ -6409,7 +6409,7 @@
                 {
                     "costumeName": "strawberry-d",
                     "baseLayerID": -1,
-                    "baseLayerMD5": "5eb63e64b83f5aa5b75a55329a34efec.svg",
+                    "baseLayerMD5": "8e8057da8457e6167de36b7d3d28b4bb.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 57,
                     "rotationCenterY": 58
@@ -6417,15 +6417,15 @@
                 {
                     "costumeName": "strawberry-e",
                     "baseLayerID": -1,
-                    "baseLayerMD5": "734556fb8e14740f2cbc971238b71d47.svg",
+                    "baseLayerMD5": "5eb63e64b83f5aa5b75a55329a34efec.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 57,
                     "rotationCenterY": 58
                 }
             ],
             "currentCostumeIndex": 0,
-            "scratchX": 141,
-            "scratchY": 104,
+            "scratchX": 138,
+            "scratchY": 91,
             "scale": 1,
             "direction": 90,
             "rotationStyle": "normal",
@@ -6437,7 +6437,7 @@
     },
     {
         "name": "Takeout",
-        "md5": "48b19c48e32c98a35836ee40e3a7accf.svg",
+        "md5": "0cfdefe0df1a032b90c8facd9f5dbe1f.svg",
         "type": "sprite",
         "tags": [],
         "info": [
@@ -6461,7 +6461,7 @@
                 {
                     "costumeName": "takeout-a",
                     "baseLayerID": -1,
-                    "baseLayerMD5": "48b19c48e32c98a35836ee40e3a7accf.svg",
+                    "baseLayerMD5": "0cfdefe0df1a032b90c8facd9f5dbe1f.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 78,
                     "rotationCenterY": 61
@@ -6469,7 +6469,7 @@
                 {
                     "costumeName": "takeout-b",
                     "baseLayerID": -1,
-                    "baseLayerMD5": "22d33d87883f8fb26c642eccc9b339f0.svg",
+                    "baseLayerMD5": "48b19c48e32c98a35836ee40e3a7accf.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 78,
                     "rotationCenterY": 61
@@ -6477,7 +6477,7 @@
                 {
                     "costumeName": "takeout-c",
                     "baseLayerID": -1,
-                    "baseLayerMD5": "262f1a3730d669dc9d43b3853e397361.svg",
+                    "baseLayerMD5": "22d33d87883f8fb26c642eccc9b339f0.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 78,
                     "rotationCenterY": 61
@@ -6485,7 +6485,7 @@
                 {
                     "costumeName": "takeout-d",
                     "baseLayerID": -1,
-                    "baseLayerMD5": "528e9df8c3bd173867be4143f8563e87.svg",
+                    "baseLayerMD5": "262f1a3730d669dc9d43b3853e397361.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 78,
                     "rotationCenterY": 61
@@ -6493,7 +6493,7 @@
                 {
                     "costumeName": "takeout-e",
                     "baseLayerID": -1,
-                    "baseLayerMD5": "0cfdefe0df1a032b90c8facd9f5dbe1f.svg",
+                    "baseLayerMD5": "528e9df8c3bd173867be4143f8563e87.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 78,
                     "rotationCenterY": 61
@@ -6501,7 +6501,7 @@
             ],
             "currentCostumeIndex": 0,
             "scratchX": -5,
-            "scratchY": 84,
+            "scratchY": 65,
             "scale": 1,
             "direction": 90,
             "rotationStyle": "normal",


### PR DESCRIPTION
### Resolves

Resolves GH-1182
Resolves GH-1187
Resolves GH-1188
Resolves GH-1189
Resolves GH-1184

### Proposed Changes

- Removes any remaining gender pronouns from legacy sounds (GH-1184)
- Changes default food costume for "food" theme sprites (GH-1189)
- Changes grouping of `drum-snare-b` costume (GH-1188)
- Removes pillow from sleeping hedgehog sprite (GH-1187)
- Fixes ordering of costumes in `dinosaur4` sprite (GH-1182)