### PR TITLE
Fix firefox display and functionality issues with sound edit

### DIFF
--- a/src/components/asset-panel/asset-panel.css
+++ b/src/components/asset-panel/asset-panel.css
@@ -12,7 +12,8 @@
 }
 
 .detail-area {
+    display: flex;
     flex-grow: 1;
-    flex-shrink: 0;
+    flex-shrink: 1;
     border-left: 1px solid $ui-pane-border;
 }

--- a/src/components/sound-editor/sound-editor.css
+++ b/src/components/sound-editor/sound-editor.css
@@ -4,6 +4,7 @@
 .editor-container {
     display: flex;
     flex-direction: column;
+    flex-grow: 1;
     padding: calc(2 * $space);
 }
 

--- a/src/containers/sound-editor.jsx
+++ b/src/containers/sound-editor.jsx
@@ -15,6 +15,7 @@ class SoundEditor extends React.Component {
     constructor (props) {
         super(props);
         bindAll(this, [
+            'copyCurrentSamples',
             'handleStoppedPlaying',
             'handleChangeName',
             'handlePlay',
@@ -67,7 +68,7 @@ class SoundEditor extends React.Component {
             if (this.undoStack.length >= UNDO_STACK_SIZE) {
                 this.undoStack.shift(); // Drop the first element off the array
             }
-            this.undoStack.push(this.props.samples.slice(0));
+            this.undoStack.push(this.copyCurrentSamples());
         }
         this.resetState(samples, sampleRate);
         this.props.onUpdateSoundBuffer(
@@ -115,6 +116,10 @@ class SoundEditor extends React.Component {
     effectFactory (name) {
         return () => this.handleEffect(name);
     }
+    copyCurrentSamples () {
+        // Cannot reliably use props.samples because it gets detached by Firefox
+        return this.audioBufferPlayer.buffer.getChannelData(0);
+    }
     handleEffect (name) {
         const effects = new AudioEffects(this.audioBufferPlayer.buffer, name);
         effects.process(({renderedBuffer}) => {
@@ -125,7 +130,7 @@ class SoundEditor extends React.Component {
         });
     }
     handleUndo () {
-        this.redoStack.push(this.props.samples.slice(0));
+        this.redoStack.push(this.copyCurrentSamples());
         const samples = this.undoStack.pop();
         if (samples) {
             this.submitNewSamples(samples, this.props.sampleRate, true);
@@ -135,7 +140,7 @@ class SoundEditor extends React.Component {
     handleRedo () {
         const samples = this.redoStack.pop();
         if (samples) {
-            this.undoStack.push(this.props.samples.slice(0));
+            this.undoStack.push(this.copyCurrentSamples());
             this.submitNewSamples(samples, this.props.sampleRate, true);
             this.handlePlay();
         }

--- a/src/containers/sound-editor.jsx
+++ b/src/containers/sound-editor.jsx
@@ -100,10 +100,11 @@ class SoundEditor extends React.Component {
         if (this.state.trimStart === null && this.state.trimEnd === null) {
             this.setState({trimEnd: 0.95, trimStart: 0.05});
         } else {
-            const sampleCount = this.props.samples.length;
+            const samples = this.copyCurrentSamples();
+            const sampleCount = samples.length;
             const startIndex = Math.floor(this.state.trimStart * sampleCount);
             const endIndex = Math.floor(this.state.trimEnd * sampleCount);
-            const clippedSamples = this.props.samples.slice(startIndex, endIndex);
+            const clippedSamples = samples.slice(startIndex, endIndex);
             this.submitNewSamples(clippedSamples, this.props.sampleRate);
         }
     }

--- a/test/__mocks__/audio-buffer-player.js
+++ b/test/__mocks__/audio-buffer-player.js
@@ -2,6 +2,9 @@ export default class MockAudioBufferPlayer {
     constructor (samples, sampleRate) {
         this.samples = samples;
         this.sampleRate = sampleRate;
+        this.buffer = {
+            getChannelData: jest.fn(() => samples)
+        };
         this.play = jest.fn((trimStart, trimEnd, onUpdate) => {
             this.onUpdate = onUpdate;
         });


### PR DESCRIPTION
Fixes the overflowing display of the waveform editor on firefox
Fixes https://github.com/LLK/scratch-gui/issues/990 sound editor not working on firefox.

broken

![image](https://user-images.githubusercontent.com/654102/34678438-2980d276-f461-11e7-9d7f-7ddf368c3a12.png)

fixed

![image](https://user-images.githubusercontent.com/654102/34678442-2ba1e0a4-f461-11e7-8230-5e0a3425d7af.png)

 
And the detached array buffer issue was fixed by retrieving a fresh copy of the samples. 