### PR TITLE
Support IE just enough to show unsupported modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,5 +115,8 @@
       "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/test/__mocks__/fileMock.js",
       "\\.(css|less)$": "<rootDir>/test/__mocks__/styleMock.js"
     }
+  },
+  "dependencies": {
+    "babel-polyfill": "6.26.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "css-loader": "^0.28.7",
     "enzyme": "^3.1.0",
     "enzyme-adapter-react-16": "1.1.0",
+    "es6-object-assign": "1.1.0",
     "eslint": "^4.7.1",
     "eslint-config-scratch": "^5.0.0",
     "eslint-plugin-import": "^2.8.0",
@@ -115,8 +116,5 @@
       "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/test/__mocks__/fileMock.js",
       "\\.(css|less)$": "<rootDir>/test/__mocks__/styleMock.js"
     }
-  },
-  "dependencies": {
-    "babel-polyfill": "6.26.0"
   }
 }

--- a/src/containers/error-boundary.jsx
+++ b/src/containers/error-boundary.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import platform from 'platform';
+import BrowserModalComponent from '../components/browser-modal/browser-modal.jsx';
 import WebGlModalComponent from '../components/webgl-modal/webgl-modal.jsx';
 import log from '../lib/log.js';
 
@@ -25,7 +26,7 @@ class ErrorBoundary extends React.Component {
     render () {
         if (this.state.hasError) {
             if (platform.name === 'IE') {
-                return <h1>Sorry Internet Explorer is not supported.</h1>;
+                return <BrowserModalComponent onBack={this.handleBack} />;
             }
             if (window.WebGLRenderingContext) {
                 const canvas = document.createElement('canvas');

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,3 +1,4 @@
+import 'babel-polyfill';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Modal from 'react-modal';

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,4 +1,4 @@
-import 'babel-polyfill';
+import 'es6-object-assign/auto';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Modal from 'react-modal';

--- a/src/lib/audio/shared-audio-context.js
+++ b/src/lib/audio/shared-audio-context.js
@@ -1,8 +1,12 @@
 import StartAudioContext from 'startaudiocontext';
+import platform from 'platform';
 
-const AUDIO_CONTEXT = new (window.AudioContext || window.webkitAudioContext)();
+let AUDIO_CONTEXT;
+if (platform.name !== 'IE') {
+    AUDIO_CONTEXT = new (window.AudioContext || window.webkitAudioContext)();
 
-StartAudioContext(AUDIO_CONTEXT);
+    StartAudioContext(AUDIO_CONTEXT);
+}
 
 /**
  * Wrap browser AudioContext because we shouldn't create more than one


### PR DESCRIPTION
- Add object-assign polyfill to handle missing features in IE.
- Prevent audio library from trying to create an Audio Context is the browser is IE, as that fails during load. (This prevents the `SCRIPT445: Object doesn't support this action` error) 

Catch any other errors during render, and render Browser unsupported modal instead.

Fixes #982 

/cc @ericrosenbaum @rschamp 
  