### PR TITLE
Clean up monitor dropdown strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "redux-throttle": "0.1.1",
     "rimraf": "^2.6.1",
     "scratch-audio": "0.1.0-prerelease.1513803406",
-    "scratch-blocks": "0.1.0-prerelease.1515121920",
+    "scratch-blocks": "0.1.0-prerelease.1515601869",
     "scratch-l10n": "2.0.20180108132626",
     "scratch-paint": "0.1.0-prerelease.20180103203117",
     "scratch-render": "0.1.0-prerelease.1513807417",

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -126,9 +126,16 @@ export default function (vm) {
     };
 
     ScratchBlocks.Blocks.sensing_of_object_menu.init = function () {
-        const json = jsonForMenuBlock('OBJECT', spriteMenu, sensingColors, [
+        const start = [
             ['Stage', '_stage_']
-        ]);
+        ];
+        if (vm.editingTarget) {
+            start.splice(0, 0,
+                [vm.editingTarget.sprite.name, vm.editingTarget.sprite.name]
+            );
+        }
+
+        const json = jsonForMenuBlock('OBJECT', spriteMenu, sensingColors, start);
         this.jsonInit(json);
     };
 

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -126,16 +126,9 @@ export default function (vm) {
     };
 
     ScratchBlocks.Blocks.sensing_of_object_menu.init = function () {
-        const start = [
+        const json = jsonForMenuBlock('OBJECT', spriteMenu, sensingColors, [
             ['Stage', '_stage_']
-        ];
-        if (vm.editingTarget) {
-            start.splice(0, 0,
-                [vm.editingTarget.sprite.name, vm.editingTarget.sprite.name]
-            );
-        }
-
-        const json = jsonForMenuBlock('OBJECT', spriteMenu, sensingColors, start);
+        ]);
         this.jsonInit(json);
     };
 

--- a/src/lib/opcode-labels.js
+++ b/src/lib/opcode-labels.js
@@ -58,11 +58,23 @@ const opcodeMap = {
     },
     sensing_of: {
         category: 'sensing',
-        labelFn: params => `${params.PROPERTY} of ${params.OBJECT}`
+        labelFn: params => {
+            let object = params.OBJECT;
+            if (params.OBJECT === '_stage_') {
+                object = 'Stage';
+            }
+            return `${params.PROPERTY} of ${object}`;
+        }
     },
     sensing_current: {
         category: 'sensing',
-        labelFn: params => params.CURRENTMENU.toLowerCase()
+        labelFn: params => {
+            let currentMenu = params.CURRENTMENU.toLowerCase();
+            if (currentMenu === 'dayofweek') {
+                currentMenu = 'day of week';
+            }
+            return currentMenu;
+        }
     },
     sensing_timer: {
         category: 'sensing',

--- a/src/lib/opcode-labels.js
+++ b/src/lib/opcode-labels.js
@@ -56,16 +56,6 @@ const opcodeMap = {
         category: 'sensing',
         label: 'loudness'
     },
-    sensing_of: {
-        category: 'sensing',
-        labelFn: params => {
-            let object = params.OBJECT;
-            if (params.OBJECT === '_stage_') {
-                object = 'Stage';
-            }
-            return `${params.PROPERTY} of ${object}`;
-        }
-    },
     sensing_current: {
         category: 'sensing',
         labelFn: params => {


### PR DESCRIPTION
### Resolves
Fixes https://github.com/LLK/scratch-gui/issues/1211

### Proposed Changes
Clean up the param strings that are shown as monitor labels
Remove sensing of, which is no longer monitored after https://github.com/LLK/scratch-blocks/pull/1337 goes in.
Convert 'dayofweek' to 'day of week'
  