### PR TITLE
Include editing target in x of x menu

### DIFF
--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -126,9 +126,16 @@ export default function (vm) {
     };
 
     ScratchBlocks.Blocks.sensing_of_object_menu.init = function () {
-        const json = jsonForMenuBlock('OBJECT', spriteMenu, sensingColors, [
+        const start = [
             ['Stage', '_stage_']
-        ]);
+        ];
+        if (vm.editingTarget) {
+            start.splice(0, 0,
+                [vm.editingTarget.sprite.name, vm.editingTarget.sprite.name]
+            );
+        }
+
+        const json = jsonForMenuBlock('OBJECT', spriteMenu, sensingColors, start);
         this.jsonInit(json);
     };
 


### PR DESCRIPTION
### Resolves

Fixes https://github.com/LLK/scratch-gui/issues/1207

### Proposed Changes

Include the current target in the list of sprites that can be selected in the () of () reporter.
This appends the current target to the start of the list to match Scratch 2.0.
