### PR TITLE
Get GUI working on Edge

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "scratch-blocks": "0.1.0-prerelease.1515601869",
     "scratch-l10n": "2.0.20180108132626",
     "scratch-paint": "0.1.0-prerelease.20180103203117",
-    "scratch-render": "0.1.0-prerelease.1513807417",
+    "scratch-render": "0.1.0-prerelease.1515614083",
     "scratch-storage": "0.3.0",
     "scratch-vm": "0.1.0-prerelease.1515163816-prerelease.1515163829",
     "selenium-webdriver": "3.5.0",

--- a/src/containers/error-boundary.jsx
+++ b/src/containers/error-boundary.jsx
@@ -30,7 +30,7 @@ class ErrorBoundary extends React.Component {
             }
             if (window.WebGLRenderingContext) {
                 const canvas = document.createElement('canvas');
-                if (!canvas.getContext('webgl')) {
+                if (!canvas.getContext('webgl') && !canvas.getContext('experimental-webgl')) {
                     return <WebGlModalComponent onBack={this.handleBack} />;
                 }
             } else {


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes Edge not rendering at all.

Pulls in the fix from scratch-render, and also fixes the webgl check to make sure it doesn't say "webgl not supported" whenever there is an error in Edge.

@chrisgarrity the change to the webgl check is because edge actually uses `experimental-webgl` context. 

/cc @fsih 