### PR TITLE
Remove some blocks’ menu shadows to make them non-droppable

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "redux-throttle": "0.1.1",
     "rimraf": "^2.6.1",
     "scratch-audio": "0.1.0-prerelease.1515596313",
-    "scratch-blocks": "0.1.0-prerelease.1515707006",
+    "scratch-blocks": "0.1.0-prerelease.1515788457",
     "scratch-l10n": "2.0.20180108132626",
     "scratch-paint": "0.1.0-prerelease.20180110204944",
     "scratch-render": "0.1.0-prerelease.1515699707",

--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -431,11 +431,7 @@ const sensing = function (isStage) {
         </block>
         <block id="answer" type="sensing_answer"/>
         ${blockSeparator}
-        <block type="sensing_keypressed">
-            <value name="KEY_OPTION">
-                <shadow type="sensing_keyoptions"/>
-            </value>
-        </block>
+        <block type="sensing_keypressed"/>
         <block type="sensing_mousedown"/>
         <block type="sensing_mousex"/>
         <block type="sensing_mousey"/>
@@ -451,19 +447,12 @@ const sensing = function (isStage) {
         <block type="sensing_resettimer"/>
         ${blockSeparator}
         <block id="of" type="sensing_of">
-            <value name="PROPERTY">
-                <shadow id="sensing_of_property_menu" type="sensing_of_property_menu"/>
-            </value>
             <value name="OBJECT">
                 <shadow id="sensing_of_object_menu" type="sensing_of_object_menu"/>
             </value>
         </block>
         ${blockSeparator}
-        <block id="current" type="sensing_current">
-            <value name="CURRENTMENU">
-                <shadow id="sensing_currentmenu" type="sensing_currentmenu"/>
-            </value>
-        </block>
+        <block id="current" type="sensing_current"/>
         <block type="sensing_dayssince2000"/>
         ${categorySeparator}
     </category>


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-blocks/issues/1199

Depends on https://github.com/LLK/scratch-blocks/pull/1339

### Proposed Changes

Remove the menu shadows for some blocks to make the input non-droppable (i.e. so that you cannot drag and drop a reporter block onto the input).

### Reason for Changes

See discussion in the issue above. Our focus is preventing confusion for beginners.