### PR TITLE
Fix Firefox sound recording

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "eslint-plugin-react": "^7.5.1",
     "file-loader": "1.1.6",
     "get-float-time-domain-data": "0.1.0",
+    "get-user-media-promise": "1.1.1",
     "gh-pages": "github:rschamp/gh-pages#publish-branch-to-subfolder",
     "html-webpack-plugin": "^2.30.0",
     "immutable": "3.8.1",

--- a/src/lib/audio/audio-recorder.js
+++ b/src/lib/audio/audio-recorder.js
@@ -1,4 +1,5 @@
 import 'get-float-time-domain-data';
+import getUserMedia from 'get-user-media-promise';
 import SharedAudioContext from './shared-audio-context.js';
 import {computeRMS} from './audio-util.js';
 
@@ -22,17 +23,19 @@ class AudioRecorder {
 
     startListening (onStarted, onUpdate, onError) {
         try {
-            navigator.getUserMedia({audio: true}, userMediaStream => {
-                if (!this.disposed) {
-                    this.started = true;
-                    onStarted();
-                    this.attachUserMediaStream(userMediaStream, onUpdate);
-                }
-            }, e => {
-                if (!this.disposed) {
-                    onError(e);
-                }
-            });
+            getUserMedia({audio: true})
+                .then(userMediaStream => {
+                    if (!this.disposed) {
+                        this.started = true;
+                        onStarted();
+                        this.attachUserMediaStream(userMediaStream, onUpdate);
+                    }
+                })
+                .catch(e => {
+                    if (!this.disposed) {
+                        onError(e);
+                    }
+                });
         } catch (e) {
             if (!this.disposed) {
                 onError(e);


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes sound recording in firefox.

### Proposed Changes

_Describe what this Pull Request does_

Use a ponyfill for `getUserMedia` to use the promise based API for many different browsers. Tested on safari (mobile ios11/desktop), edge, chrome and firefox. 

### Reason for Changes

_Explain why these changes should be made_

Firefox doesn't support the old callback method anymore, so use the polyfill to get maximum coverage while using the new API.
