### PR TITLE
Use style sizing to fix issues with Edge + flex + canvas.

### DIFF
--- a/src/components/costume-canvas/costume-canvas.jsx
+++ b/src/components/costume-canvas/costume-canvas.jsx
@@ -105,12 +105,12 @@ class CostumeCanvas extends React.Component {
         return (
             <canvas
                 className={this.props.className}
-                height={this.props.height * window.devicePixelRatio}
+                height={this.props.height * (window.devicePixelRatio || 1)}
                 style={{
                     height: `${this.props.height}px`,
                     width: `${this.props.width}px`
                 }}
-                width={this.props.width * window.devicePixelRatio}
+                width={this.props.width * (window.devicePixelRatio || 1)}
                 ref={c => (this.canvas = c)} // eslint-disable-line react/jsx-sort-props
             />
         );

--- a/src/components/costume-canvas/costume-canvas.jsx
+++ b/src/components/costume-canvas/costume-canvas.jsx
@@ -105,8 +105,12 @@ class CostumeCanvas extends React.Component {
         return (
             <canvas
                 className={this.props.className}
-                height={this.props.height}
-                width={this.props.width}
+                height={this.props.height * window.devicePixelRatio}
+                style={{
+                    height: `${this.props.height}px`,
+                    width: `${this.props.width}px`
+                }}
+                width={this.props.width * window.devicePixelRatio}
                 ref={c => (this.canvas = c)} // eslint-disable-line react/jsx-sort-props
             />
         );

--- a/test/unit/components/__snapshots__/sprite-selector-item.test.jsx.snap
+++ b/test/unit/components/__snapshots__/sprite-selector-item.test.jsx.snap
@@ -26,6 +26,12 @@ exports[`SpriteSelectorItemComponent matches snapshot when selected 1`] = `
   <canvas
     className={undefined}
     height={32}
+    style={
+      Object {
+        "height": "32px",
+        "width": "32px",
+      }
+    }
     width={32}
   />
   <div


### PR DESCRIPTION
Additionally render the canvas at a multiplier of the device pixel
ratio, so we get hidpi images for supported screens. The fixed CSS
sizing allows us to do that.

The problem was that on Edge, flexbox apparently can grow canvas
elements, whereas on Chrome/FF the canvas width/height is respected. No
problem, we can set the width/height in CSS to fix it, which
conveniently allows us to also fix the low-res-on-retina-screens problem
at the same time.

Before on Edge
![image](https://user-images.githubusercontent.com/654102/34835523-101990c0-f6c3-11e7-8cbb-81f0738d950f.png)

After on Edge
![image](https://user-images.githubusercontent.com/654102/34835530-13150e94-f6c3-11e7-8993-cdd59dc6853c.png)


@cwillisf this may interfere with some of the work you are doing with the SVG rendering stuff. If so, feel free to defer this until that is done. But it is just a couple line change, so it should be easy to reconcile with whatever you are working on. But let me know if it causes any issues. 