### PR TITLE
Style costume canvases so that the size is respected in Edge

### DIFF
--- a/src/components/costume-canvas/costume-canvas.jsx
+++ b/src/components/costume-canvas/costume-canvas.jsx
@@ -107,6 +107,10 @@ class CostumeCanvas extends React.Component {
                 className={this.props.className}
                 height={this.props.height}
                 width={this.props.width}
+                style={{
+                    width: this.props.width + 'px',
+                    height: this.props.height + 'px'
+                }}
                 ref={c => (this.canvas = c)} // eslint-disable-line react/jsx-sort-props
             />
         );


### PR DESCRIPTION
### Resolves
Fixes https://github.com/LLK/scratch-gui/issues/214

### Proposed Changes
Add a style to costume canvases to set the width and height. Canvas width and height aren't respected by Edge.