### PR TITLE
Use new renderer methods to check for WebGL.

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "scratch-blocks": "0.1.0-prerelease.1515707006",
     "scratch-l10n": "2.0.20180108132626",
     "scratch-paint": "0.1.0-prerelease.20180110204944",
-    "scratch-render": "0.1.0-prerelease.1515614083",
+    "scratch-render": "0.1.0-prerelease.1515699707",
     "scratch-storage": "0.3.0",
     "scratch-vm": "0.1.0-prerelease.1515691021-prerelease.1515691035",
     "selenium-webdriver": "3.5.0",

--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -6,6 +6,7 @@ import MediaQuery from 'react-responsive';
 import {FormattedMessage} from 'react-intl';
 import tabStyles from 'react-tabs/style/react-tabs.css';
 import VM from 'scratch-vm';
+import Renderer from 'scratch-render';
 
 import Blocks from '../../containers/blocks.jsx';
 import CostumeTab from '../../containers/costume-tab.jsx';
@@ -63,6 +64,8 @@ const GUIComponent = props => {
         tabSelected: classNames(tabStyles.reactTabsTabSelected, styles.isSelected)
     };
 
+    const isRendererSupported = Renderer.isSupported();
+
     return (
         <Box
             className={styles.pageWrapper}
@@ -74,7 +77,9 @@ const GUIComponent = props => {
             {feedbackFormVisible ? (
                 <FeedbackForm />
             ) : null}
-            {(window.WebGLRenderingContext) ? null : (<WebGlModal />)}
+            {isRendererSupported ? null : (
+                <WebGlModal />
+            )}
             <MenuBar />
             <Box className={styles.bodyWrapper}>
                 <Box className={styles.flexWrapper}>
@@ -127,14 +132,18 @@ const GUIComponent = props => {
                             <StageHeader vm={vm} />
                         </Box>
                         <Box className={styles.stageWrapper}>
-                            <MediaQuery minWidth={layout.fullSizeMinWidth}>{isFullSize => (
-                                <Stage
-                                    height={isFullSize ? layout.fullStageHeight : layout.smallerStageHeight}
-                                    shrink={0}
-                                    vm={vm}
-                                    width={isFullSize ? layout.fullStageWidth : layout.smallerStageWidth}
-                                />
-                            )}</MediaQuery>
+                            {/* eslint-disable arrow-body-style */}
+                            <MediaQuery minWidth={layout.fullSizeMinWidth}>{isFullSize => {
+                                return isRendererSupported ? (
+                                    <Stage
+                                        height={isFullSize ? layout.fullStageHeight : layout.smallerStageHeight}
+                                        shrink={0}
+                                        vm={vm}
+                                        width={isFullSize ? layout.fullStageWidth : layout.smallerStageWidth}
+                                    />
+                                ) : null;
+                            }}</MediaQuery>
+                            {/* eslint-enable arrow-body-style */}
                         </Box>
                         <Box className={styles.targetWrapper}>
                             <TargetPane

--- a/src/containers/error-boundary.jsx
+++ b/src/containers/error-boundary.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import platform from 'platform';
 import BrowserModalComponent from '../components/browser-modal/browser-modal.jsx';
-import WebGlModalComponent from '../components/webgl-modal/webgl-modal.jsx';
 import log from '../lib/log.js';
 
 class ErrorBoundary extends React.Component {

--- a/src/containers/error-boundary.jsx
+++ b/src/containers/error-boundary.jsx
@@ -28,14 +28,6 @@ class ErrorBoundary extends React.Component {
             if (platform.name === 'IE') {
                 return <BrowserModalComponent onBack={this.handleBack} />;
             }
-            if (window.WebGLRenderingContext) {
-                const canvas = document.createElement('canvas');
-                if (!canvas.getContext('webgl') && !canvas.getContext('experimental-webgl')) {
-                    return <WebGlModalComponent onBack={this.handleBack} />;
-                }
-            } else {
-                return <WebGlModalComponent onBack={this.handleBack} />;
-            }
             return (
                 <div style={{margin: '2rem'}}>
                     <h1>Oops! Something went wrong.</h1>


### PR DESCRIPTION

### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/1227

### Proposed Changes

_Describe what this Pull Request does_

0. Update renderer in package json to get new checking methods.
1. Use new renderer methods to check for WebGL.
2. Remove the WebGL checks from the error boundary. Instead, just do not
render the stage if it is not supported.

### Reason for Changes

_Explain why these changes should be made_

The renderer can now tell us if it can be supported. Because we put up a fullscreen block if it isn't supported, do not bother trying to render the stage if the renderer is not supported (preventing errors which would lead to the error boundary. ). 

### Test Coverage

_Please show how you have added tests to cover your changes_

Tested locally using an extension to disable WebGL.