### PR TITLE
Add Google Analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "react-contextmenu": "2.9.1",
     "react-dom": "16.2.0",
     "react-draggable": "3.0.4",
+    "react-ga": "2.4.1",
     "react-intl": "2.4.0",
     "react-intl-redux": "0.6.0",
     "react-modal": "3.1.9",

--- a/src/components/library/library.jsx
+++ b/src/components/library/library.jsx
@@ -2,6 +2,7 @@ import bindAll from 'lodash.bindall';
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import analytics from '../../lib/analytics';
 import LibraryItem from '../library-item/library-item.jsx';
 import ModalComponent from '../modal/modal.jsx';
 
@@ -33,6 +34,11 @@ class LibraryComponent extends React.Component {
     handleSelect (id) {
         this.props.onRequestClose();
         this.props.onItemSelected(this.getFilteredData()[id]);
+        analytics.event({
+            category: 'library',
+            action: 'Select Item',
+            value: id
+        });
     }
     handleMouseEnter (id) {
         if (this.props.onItemMouseEnter) this.props.onItemMouseEnter(this.getFilteredData()[id]);

--- a/src/components/library/library.jsx
+++ b/src/components/library/library.jsx
@@ -2,7 +2,6 @@ import bindAll from 'lodash.bindall';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import analytics from '../../lib/analytics';
 import LibraryItem from '../library-item/library-item.jsx';
 import ModalComponent from '../modal/modal.jsx';
 
@@ -34,11 +33,6 @@ class LibraryComponent extends React.Component {
     handleSelect (id) {
         this.props.onRequestClose();
         this.props.onItemSelected(this.getFilteredData()[id]);
-        analytics.event({
-            category: 'library',
-            action: 'Select Item',
-            value: id
-        });
     }
     handleMouseEnter (id) {
         if (this.props.onItemMouseEnter) this.props.onItemMouseEnter(this.getFilteredData()[id]);

--- a/src/containers/backdrop-library.jsx
+++ b/src/containers/backdrop-library.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import VM from 'scratch-vm';
 
+import analytics from '../lib/analytics';
 import backdropLibraryContent from '../lib/libraries/backdrops.json';
 import LibraryComponent from '../components/library/library.jsx';
 
@@ -26,6 +27,11 @@ class BackdropLibrary extends React.Component {
             if (this.props.onNewBackdrop) {
                 this.props.onNewBackdrop();
             }
+        });
+        analytics.event({
+            category: 'library',
+            action: 'Select Backdrop',
+            label: item.name
         });
     }
     render () {

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -6,6 +6,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import VMScratchBlocks from '../lib/blocks';
 import VM from 'scratch-vm';
+
+import analytics from '../lib/analytics';
 import Prompt from './prompt.jsx';
 import BlocksComponent from '../components/blocks/blocks.jsx';
 import ExtensionLibrary from './extension-library.jsx';
@@ -74,6 +76,8 @@ class Blocks extends React.Component {
 
         this.attachVM();
         this.props.vm.setLocale(this.props.locale, this.props.messages);
+
+        analytics.pageview('/editors/blocks');
     }
     shouldComponentUpdate (nextProps, nextState) {
         return (

--- a/src/containers/controls.jsx
+++ b/src/containers/controls.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import VM from 'scratch-vm';
 
+import analytics from '../lib/analytics';
 import ControlsComponent from '../components/controls/controls.jsx';
 
 class Controls extends React.Component {
@@ -40,11 +41,19 @@ class Controls extends React.Component {
             this.props.vm.setTurboMode(!this.state.turbo);
         } else {
             this.props.vm.greenFlag();
+            analytics.event({
+                category: 'general',
+                action: 'Green Flag'
+            });
         }
     }
     handleStopAllClick (e) {
         e.preventDefault();
         this.props.vm.stopAll();
+        analytics.event({
+            category: 'general',
+            action: 'Stop Button'
+        });
     }
     render () {
         const {

--- a/src/containers/costume-library.jsx
+++ b/src/containers/costume-library.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import VM from 'scratch-vm';
 
+import analytics from '../lib/analytics';
 import costumeLibraryContent from '../lib/libraries/costumes.json';
 import LibraryComponent from '../components/library/library.jsx';
 
@@ -24,6 +25,11 @@ class CostumeLibrary extends React.PureComponent {
         };
         this.props.vm.addCostume(item.md5, vmCostume).then(() => {
             this.props.onNewCostume();
+        });
+        analytics.event({
+            category: 'library',
+            action: 'Select Costume',
+            label: item.name
         });
     }
     render () {

--- a/src/containers/extension-library.jsx
+++ b/src/containers/extension-library.jsx
@@ -5,6 +5,7 @@ import VM from 'scratch-vm';
 
 import extensionLibraryContent from '../lib/libraries/extensions/index';
 
+import analytics from '../lib/analytics';
 import LibraryComponent from '../components/library/library.jsx';
 import extensionIcon from '../components/sprite-selector/icon--sprite.svg';
 
@@ -30,6 +31,11 @@ class ExtensionLibrary extends React.PureComponent {
                 });
             }
         }
+        analytics.event({
+            category: 'library',
+            action: 'Select Extension',
+            label: item.name
+        });
     }
     render () {
         const extensionLibraryThumbnailData = extensionLibraryContent.map(extension => ({

--- a/src/containers/paint-editor-wrapper.jsx
+++ b/src/containers/paint-editor-wrapper.jsx
@@ -2,8 +2,9 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import bindAll from 'lodash.bindall';
 import VM from 'scratch-vm';
-
 import PaintEditor from 'scratch-paint';
+
+import analytics from '../lib/analytics';
 
 import {connect} from 'react-redux';
 
@@ -14,6 +15,9 @@ class PaintEditorWrapper extends React.Component {
             'handleUpdateName',
             'handleUpdateSvg'
         ]);
+    }
+    componentDidMount () {
+        analytics.pageview('/editors/paint');
     }
     handleUpdateName (name) {
         this.props.vm.renameCostume(this.props.selectedCostumeIndex, name);

--- a/src/containers/sound-editor.jsx
+++ b/src/containers/sound-editor.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 
 import {connect} from 'react-redux';
 
+import analytics from '../lib/analytics';
 import {computeChunkedRMS} from '../lib/audio/audio-util.js';
 import AudioEffects from '../lib/audio/audio-effects.js';
 import SoundEditorComponent from '../components/sound-editor/sound-editor.jsx';
@@ -40,6 +41,7 @@ class SoundEditor extends React.Component {
     }
     componentDidMount () {
         this.audioBufferPlayer = new AudioBufferPlayer(this.props.samples, this.props.sampleRate);
+        analytics.pageview('/editors/sound');
     }
     componentWillReceiveProps (newProps) {
         if (newProps.soundId !== this.props.soundId) { // A different sound has been selected

--- a/src/containers/sound-library.jsx
+++ b/src/containers/sound-library.jsx
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import VM from 'scratch-vm';
 import AudioEngine from 'scratch-audio';
+
+import analytics from '../lib/analytics';
 import LibraryComponent from '../components/library/library.jsx';
 
 import soundIcon from '../components/asset-panel/icon--sound.svg';
@@ -57,6 +59,11 @@ class SoundLibrary extends React.PureComponent {
         };
         this.props.vm.addSound(vmSound).then(() => {
             this.props.onNewSound();
+        });
+        analytics.event({
+            category: 'library',
+            action: 'Select Sound',
+            label: soundItem.name
         });
     }
     render () {

--- a/src/containers/sprite-library.jsx
+++ b/src/containers/sprite-library.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import VM from 'scratch-vm';
 
+import analytics from '../lib/analytics';
 import spriteLibraryContent from '../lib/libraries/sprites.json';
 
 import LibraryComponent from '../components/library/library.jsx';
@@ -29,6 +30,11 @@ class SpriteLibrary extends React.PureComponent {
     }
     handleItemSelect (item) {
         this.props.vm.addSprite2(JSON.stringify(item.json));
+        analytics.event({
+            category: 'library',
+            action: 'Select Sprite',
+            label: item.name
+        });
     }
     handleMouseEnter (item) {
         this.stopRotatingCostumes();

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import Modal from 'react-modal';
 
+import analytics from './lib/analytics';
 import AppStateHOC from './lib/app-state-hoc.jsx';
 import GUI from './containers/gui.jsx';
 import ProjectLoaderHOC from './lib/project-loader-hoc.jsx';
@@ -12,6 +13,9 @@ if (process.env.NODE_ENV === 'production' && typeof window === 'object') {
     // Warn before navigating away
     window.onbeforeunload = () => true;
 }
+
+// Register "base" page view
+analytics.pageview('/');
 
 const App = AppStateHOC(ProjectLoaderHOC(GUI));
 

--- a/src/lib/analytics.js
+++ b/src/lib/analytics.js
@@ -3,7 +3,7 @@ import GoogleAnalytics from 'react-ga';
 GoogleAnalytics.initialize('UA-30688952-5', {
     debug: (process.env.NODE_ENV !== 'production'),
     titleCase: true,
-    sampleRate: 100,
+    sampleRate: (process.env.NODE_ENV === 'production') ? 100 : 0,
     forceSSL: true
 });
 

--- a/src/lib/analytics.js
+++ b/src/lib/analytics.js
@@ -1,0 +1,10 @@
+import GoogleAnalytics from 'react-ga';
+
+GoogleAnalytics.initialize('UA-30688952-5', {
+    debug: (process.env.NODE_ENV !== 'production'),
+    titleCase: true,
+    sampleRate: 100,
+    forceSSL: true
+});
+
+export default GoogleAnalytics;

--- a/src/lib/project-loader-hoc.jsx
+++ b/src/lib/project-loader-hoc.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import analytics from './analytics';
 import log from './log';
 import storage from './storage';
 
@@ -44,6 +45,15 @@ const ProjectLoaderHOC = function (WrappedComponent) {
             if (projectId !== this.state.projectId) {
                 if (projectId.length < 1) projectId = 0;
                 this.setState({projectId: projectId});
+
+                if (projectId !== 0) {
+                    analytics.event({
+                        category: 'project',
+                        action: 'Load Project',
+                        value: projectId,
+                        nonInteraction: true
+                    });
+                }
             }
         }
         render () {

--- a/src/reducers/modals.js
+++ b/src/reducers/modals.js
@@ -1,3 +1,5 @@
+import analytics from '../lib/analytics';
+
 const OPEN_MODAL = 'scratch-gui/modals/OPEN_MODAL';
 const CLOSE_MODAL = 'scratch-gui/modals/CLOSE_MODAL';
 
@@ -50,27 +52,35 @@ const closeModal = function (modal) {
     };
 };
 const openBackdropLibrary = function () {
+    analytics.pageview('/libraries/backdrops');
     return openModal(MODAL_BACKDROP_LIBRARY);
 };
 const openCostumeLibrary = function () {
+    analytics.pageview('/libraries/costumes');
     return openModal(MODAL_COSTUME_LIBRARY);
 };
 const openExtensionLibrary = function () {
+    analytics.pageview('/libraries/extensions');
     return openModal(MODAL_EXTENSION_LIBRARY);
 };
 const openFeedbackForm = function () {
+    analytics.pageview('/modals/feedback');
     return openModal(MODAL_FEEDBACK_FORM);
 };
 const openSoundLibrary = function () {
+    analytics.pageview('/libraries/sounds');
     return openModal(MODAL_SOUND_LIBRARY);
 };
 const openSpriteLibrary = function () {
+    analytics.pageview('/libraries/sprites');
     return openModal(MODAL_SPRITE_LIBRARY);
 };
 const openSoundRecorder = function () {
+    analytics.pageview('/modals/microphone');
     return openModal(MODAL_SOUND_RECORDER);
 };
 const openPreviewInfo = function () {
+    analytics.pageview('/modals/preview');
     return openModal(MODAL_PREVIEW_INFO);
 };
 const closeBackdropLibrary = function () {

--- a/test/unit/containers/sound-editor.test.jsx
+++ b/test/unit/containers/sound-editor.test.jsx
@@ -7,6 +7,7 @@ import mockAudioEffects from '../../__mocks__/audio-effects.js';
 import SoundEditor from '../../../src/containers/sound-editor';
 import SoundEditorComponent from '../../../src/components/sound-editor/sound-editor';
 
+jest.mock('react-ga');
 jest.mock('../../../src/lib/audio/audio-buffer-player', () => mockAudioBufferPlayer);
 jest.mock('../../../src/lib/audio/audio-effects', () => mockAudioEffects);
 

--- a/test/unit/util/project-loader-hoc.test.jsx
+++ b/test/unit/util/project-loader-hoc.test.jsx
@@ -3,6 +3,8 @@ import ProjectLoaderHOC from '../../../src/lib/project-loader-hoc.jsx';
 import storage from '../../../src/lib/storage';
 import {mount} from 'enzyme';
 
+jest.mock('react-ga');
+
 describe('ProjectLoaderHOC', () => {
     test('when there is no project data, it renders null', () => {
         const Component = ({projectData}) => <div>{projectData}</div>;


### PR DESCRIPTION
### Resolves
Resolves GH-1036

### Proposed Changes
Add basic telemetry for the preview release that provides us with anonymous usage information. The full scope of `pageview`s and `event`s are listed in detail within GH-1036.

### Reason for Changes
In order to understand usage patterns and the effectiveness of some of our new features / design changes, we will need some basic telemetry that provides us with insight into how the preview release is being used. This is much more minimal that what we have today for Scratch 2.0, but should be helpful nonetheless.