### PR TITLE
Remove tooltip from Try It button. (Fixes #1260)

### DIFF
--- a/src/components/preview-modal/preview-modal.jsx
+++ b/src/components/preview-modal/preview-modal.jsx
@@ -54,7 +54,6 @@ const PreviewModal = ({intl, ...props}) => (
                 </button>
                 <button
                     className={styles.okButton}
-                    title="tryit"
                     onClick={props.onTryIt}
                 >
                     <FormattedMessage


### PR DESCRIPTION
### Resolves

#1260 

### Proposed Changes

The "Try It" button had the "tryit" title assigned to it and the other button didn't, this was causing the tooltip to show up. This PR removes the title.

### Reason For Changes 
Requested in #1260 

### Test Coverage
After setting the repository up in an environment, I tested it and the tooltip seems to be gone now.  