### PR TITLE
Update scratch-audio to the latest version 🚀 

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "redux-mock-store": "^1.2.3",
     "redux-throttle": "0.1.1",
     "rimraf": "^2.6.1",
-    "scratch-audio": "0.1.0-prerelease.1515596313",
+    "scratch-audio": "0.1.0-prerelease.1516198804",
     "scratch-blocks": "0.1.0-prerelease.1515788457",
     "scratch-l10n": "2.0.20180108132626",
     "scratch-paint": "0.1.0-prerelease.20180110204944",


### PR DESCRIPTION
I just released a new version of scratch-audio because Travis is being slow. Now I'm making this PR because Greenkeeper is also slow. Try and keep up guys.