### PR TITLE
Whole border now highlighted blue

### DIFF
--- a/src/components/sprite-info/sprite-info.css
+++ b/src/components/sprite-info/sprite-info.css
@@ -71,6 +71,7 @@
     border-bottom: 1px solid $form-border;
     border-top: 1px solid $form-border;
     border-right: 1px solid $form-border;
+    border-left: 1px solid $form-border;
     border-top-right-radius: $form-radius;
     border-bottom-right-radius: $form-radius;
 }


### PR DESCRIPTION
### Resolves
#1288 

### Proposed Changes
Changed the sprite stlye sheet to add the left hand border for the hide icon. 

### Reason for Changes
So that the icon has a border all the way round.

### Test Coverage
Ran on Firefox 57.0.1 on Mac OS 10.13.1, checked that the border went around the whole icon.
