### PR TITLE
Sprite library now centered

### DIFF
--- a/src/components/library/library.css
+++ b/src/components/library/library.css
@@ -20,7 +20,7 @@
 
 .library-scroll-grid {
     display: flex;
-    justify-content: flex-start;
+    justify-content: center;
     align-content: flex-start;
     background: $ui-pane-gray;
     flex-grow: 1;

--- a/src/components/library/library.css
+++ b/src/components/library/library.css
@@ -5,6 +5,7 @@
     position: absolute;
 
     display: flex;
+    flex-direction: column;
     height: 100%;
     width: 100%;
 
@@ -19,13 +20,8 @@
 }
 
 .library-scroll-grid {
-    display: flex;
+    display: grid;
     justify-content: center;
-    align-content: flex-start;
+    grid-template-columns: repeat(auto-fill, 160px);
     background: $ui-pane-gray;
-    flex-grow: 1;
-    flex-wrap: wrap;
-    overflow-y: auto;
-    height: calc(100% - $library-header-height);
-    padding: 0.5rem;
 }


### PR DESCRIPTION
### Resolves
#1277

### Proposed Changes
Changed the library style sheet to center each row on the sprite library.

### Reason for Changes
Center the grid on the sprite library.

### Test Coverage
Ran on Firefox 57.0.1 on Mac OS 10.13.1 and checked sprites were centered.