### PR TITLE
Renderer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "scratch-paint": "0.1.0-prerelease.20180112204058",
     "scratch-render": "0.1.0-prerelease.1516202017",
     "scratch-storage": "0.3.0",
+    "scratch-svg-renderer": "0.1.0-prerelease.20180118224509",
     "scratch-vm": "0.1.0-prerelease.1516201958-prerelease.1516201973",
     "selenium-webdriver": "3.5.0",
     "startaudiocontext": "1.2.1",


### PR DESCRIPTION
Add the dependency on svg renderer to GUI. scratch-render will get the svg render code from GUI. Eventually, other parts of GUI will use the svg-renderer code.