### PR TITLE
Remove "More options" in New Message dialog

### DIFF
--- a/src/components/prompt/prompt.css
+++ b/src/components/prompt/prompt.css
@@ -58,6 +58,10 @@
     margin: 0 0 1rem;
 }
 
+.hide-more-options {
+    display: none;
+}
+
 .more-options-accordion {
     width: 60%;
     margin: 0 auto;

--- a/src/components/prompt/prompt.jsx
+++ b/src/components/prompt/prompt.jsx
@@ -37,7 +37,7 @@ const PromptComponent = props => (
                     onKeyPress={props.onKeyPress}
                 />
             </Box>
-            <Box className={styles.moreOptions}>
+            <Box className={props.showMoreOptions ? styles.moreOptions : styles.hideMoreOptions}>
                 <ComingSoonTooltip
                     className={styles.moreOptionsAccordion}
                     place="right"
@@ -79,6 +79,7 @@ PromptComponent.propTypes = {
     onKeyPress: PropTypes.func.isRequired,
     onOk: PropTypes.func.isRequired,
     placeholder: PropTypes.string,
+    showMoreOptions: PropTypes.bool.isRequired,
     title: PropTypes.string.isRequired
 };
 

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -238,6 +238,7 @@ class Blocks extends React.Component {
     handlePromptStart (message, defaultValue, callback, optTitle) {
         const p = {prompt: {callback, message, defaultValue}};
         p.prompt.title = optTitle ? optTitle : 'New Variable';
+        p.prompt.showMoreOptions = optTitle !== 'New Message';
         this.setState(p);
     }
     handlePromptCallback (data) {
@@ -278,6 +279,7 @@ class Blocks extends React.Component {
                     <Prompt
                         label={this.state.prompt.message}
                         placeholder={this.state.prompt.defaultValue}
+                        showMoreOptions={this.state.prompt.showMoreOptions}
                         title={this.state.prompt.title}
                         onCancel={this.handlePromptClose}
                         onOk={this.handlePromptCallback}

--- a/src/containers/prompt.jsx
+++ b/src/containers/prompt.jsx
@@ -33,6 +33,7 @@ class Prompt extends React.Component {
             <PromptComponent
                 label={this.props.label}
                 placeholder={this.props.placeholder}
+                showMoreOptions={this.props.showMoreOptions}
                 title={this.props.title}
                 onCancel={this.handleCancel}
                 onChange={this.handleChange}
@@ -48,6 +49,7 @@ Prompt.propTypes = {
     onCancel: PropTypes.func.isRequired,
     onOk: PropTypes.func.isRequired,
     placeholder: PropTypes.string,
+    showMoreOptions: PropTypes.bool.isRequired,
     title: PropTypes.string.isRequired
 };
 


### PR DESCRIPTION
### Resolves
#1262

### Proposed Changes
Removes the  "More options" in New Message dialog

### Reason for Changes
Becuase it looks better without it and the issue asked for this change.

### Test Coverage
FF 57.0.4 on 10.13.1. This is the result:
![image](https://user-images.githubusercontent.com/6998018/35174842-bc5d9240-fd68-11e7-97a1-ae70d5d4d7f1.png)

