### PR TITLE
Fix spelling of backdrop

### DIFF
--- a/src/lib/libraries/backdrops.json
+++ b/src/lib/libraries/backdrops.json
@@ -77,7 +77,7 @@
         ]
     },
     {
-        "name": "Jurrasic",
+        "name": "Jurassic",
         "md5": "73fd0531a1aaca5dff2d1c67202ff5bd.svg",
         "type": "backdrop",
         "tags": [],


### PR DESCRIPTION
### Resolves
Fixes #1302 

### Proposed Changes

This corrects a spelling error of the word "jurassic".

### Reason for Changes

Correct spelling.

### Test Coverage

N/A - Just a quick spelling fix [dictionary.com for Jurassic](http://www.dictionary.com/browse/jurassic) :smile_cat: 