### PR TITLE
Constrain selected sound index to the list of available sounds.

### DIFF
--- a/src/containers/sound-editor.jsx
+++ b/src/containers/sound-editor.jsx
@@ -190,8 +190,11 @@ SoundEditor.propTypes = {
 };
 
 const mapStateToProps = (state, {soundIndex}) => {
-    const sound = state.vm.editingTarget.sprite.sounds[soundIndex];
-    const audioBuffer = state.vm.getSoundBuffer(soundIndex);
+    const sprite = state.vm.editingTarget.sprite;
+    // Make sure the sound index doesn't go out of range.
+    const index = soundIndex < sprite.sounds.length ? soundIndex : sprite.sounds.length - 1;
+    const sound = state.vm.editingTarget.sprite.sounds[index];
+    const audioBuffer = state.vm.getSoundBuffer(index);
     return {
         soundId: sound.soundId,
         sampleRate: audioBuffer.sampleRate,

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -272,4 +272,28 @@ describe('costumes, sounds and variables', () => {
         const logs = await getLogs(errorWhitelist);
         await expect(logs).toEqual([]);
     });
+
+    // Regression test for gui issue #1320
+    test('Switching sprites with different numbers of sounds', async () => {
+        await loadUri(uri);
+        await clickXpath('//button[@title="tryit"]');
+
+        // Add a sound so this sprite has 2 sounds.
+        await clickText('Sounds');
+        await clickText('Add Sound');
+        await clickText('A Bass'); // Closes the modal
+
+        // Now add a sprite with only one sound.
+        await clickText('Add Sprite');
+        await clickText('Abby'); // Doing this used to crash the editor.
+
+        await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for error
+
+        // Make sure the 'Oops' screen is not visible
+        const content = await driver.getPageSource();
+        expect(content.indexOf('Oops')).toEqual(-1);
+
+        const logs = await getLogs(errorWhitelist);
+        await expect(logs).toEqual([]);
+    });
 });


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/1320

### Proposed Changes

_Describe what this Pull Request does_

Make sure that the "selected sound index" is within the range of available sounds.

### Reason for Changes

_Explain why these changes should be made_

When switching sprites, the selected sound index is supposed to reset to zero. This is done in the `componentWillReceiveProps`. However the setState there is async. The sound tab can be rendered before that setState, so you can get to a place where the selected sound index is outside the range of available sprites. 

### Test Coverage

_Please show how you have added tests to cover your changes_

Added a regression integration test to make sure it works.