### PR TITLE
Detect wheel event on canvas and post data to VM

### DIFF
--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -30,6 +30,7 @@ class Stage extends React.Component {
             'onMouseDown',
             'onStartDrag',
             'onStopDrag',
+            'onWheel',
             'updateRect',
             'questionListener',
             'setCanvas'
@@ -97,6 +98,7 @@ class Stage extends React.Component {
         document.addEventListener('touchend', this.onMouseUp);
         canvas.addEventListener('mousedown', this.onMouseDown);
         canvas.addEventListener('touchstart', this.onMouseDown);
+        canvas.addEventListener('wheel', this.onWheel);
     }
     detachMouseEvents (canvas) {
         document.removeEventListener('mousemove', this.onMouseMove);
@@ -105,6 +107,7 @@ class Stage extends React.Component {
         document.removeEventListener('touchend', this.onMouseUp);
         canvas.removeEventListener('mousedown', this.onMouseDown);
         canvas.removeEventListener('touchstart', this.onMouseDown);
+        canvas.removeEventListener('wheel', this.onWheel);
     }
     attachRectEvents () {
         window.addEventListener('resize', this.updateRect);
@@ -226,6 +229,13 @@ class Stage extends React.Component {
             this.props.onDeactivateColorPicker(colorString);
             this.setState({colorInfo: null});
         }
+    }
+    onWheel (e) {
+        const data = {
+            deltaX: e.deltaX,
+            deltaY: e.deltaY
+        };
+        this.props.vm.postIOData('mouseWheel', data);
     }
     cancelMouseDownTimeout () {
         if (this.state.mouseDownTimeoutId !== null) {


### PR DESCRIPTION
### Resolves

Fixes LLK/scratch-vm#865. Must be merged after LLK/scratch-vm#920.

### Proposed Changes

This adds the GUI code which posts wheel scroll data to the VM's `mouseWheel` IO (which, in turn, activates relevant "when key pressed" blocks).

### Reason for Changes

For consistency with 2.0 and 1.4.

### Test Coverage

No automated tests (besides what's in the VM PR); manually tested on the projects mentioned in LLK/scratch-vm#920.