### PR TITLE
Fixing monitor prop type warning for scalar variable monitors.

### DIFF
--- a/src/components/monitor/monitor.jsx
+++ b/src/components/monitor/monitor.jsx
@@ -42,7 +42,9 @@ MonitorComponent.propTypes = {
     componentRef: PropTypes.func.isRequired,
     label: PropTypes.string.isRequired,
     onDragEnd: PropTypes.func.isRequired,
-    value: PropTypes.string.isRequired
+    value: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number])
 };
 
 MonitorComponent.defaultProps = {


### PR DESCRIPTION
### Resolves

Partial fix for #1298 

### Proposed Changes

Proptype validator for monitor prop type now asserts that the monitor value can be a string or a number.

#### Additional Notes

I couldn't seem to remove the second warning mentioned in #1298 about OrderedMap, but @fsih mentioned that that warning has been around for a while...

### Reason for Changes

#1298

### Test Coverage

Existing tests pass.
