### PR TITLE
Use variable type information in variable prompts to show/hide 'more options'

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -235,10 +235,11 @@ class Blocks extends React.Component {
     setBlocks (blocks) {
         this.blocks = blocks;
     }
-    handlePromptStart (message, defaultValue, callback, optTitle) {
+    handlePromptStart (message, defaultValue, callback, optTitle, optVarType) {
         const p = {prompt: {callback, message, defaultValue}};
         p.prompt.title = optTitle ? optTitle : 'New Variable';
-        p.prompt.showMoreOptions = optTitle !== 'New Message';
+        p.prompt.showMoreOptions =
+            optVarType !== this.ScratchBlocks.BROADCAST_MESSAGE_VARIABLE_TYPE;
         this.setState(p);
     }
     handlePromptCallback (data) {

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -237,7 +237,8 @@ class Blocks extends React.Component {
     }
     handlePromptStart (message, defaultValue, callback, optTitle, optVarType) {
         const p = {prompt: {callback, message, defaultValue}};
-        p.prompt.title = optTitle ? optTitle : 'New Variable';
+        p.prompt.title = optTitle ? optTitle :
+            this.ScratchBlocks.VARIABLE_MODAL_TITLE;
         p.prompt.showMoreOptions =
             optVarType !== this.ScratchBlocks.BROADCAST_MESSAGE_VARIABLE_TYPE;
         this.setState(p);


### PR DESCRIPTION
### Resolves

Resolves #1361.

Depends on https://github.com/LLK/scratch-blocks/pull/1366

### Proposed Changes

Uses the variable type provided by the scratch blocks to show/hide 'more options' in the different variable prompts. Also uses the ScratchBlocks constant for the default modal title instead of a hard-coded string literal.

### Reason for Changes

#1361.

### Test Coverage

Existing tests pass.