### PR TITLE
Fix feedback iframe scrolling for iOS.

### DIFF
--- a/src/components/feedback-form/feedback-form.css
+++ b/src/components/feedback-form/feedback-form.css
@@ -2,6 +2,9 @@
 @import "../../css/units.css";
 @import "../../css/typography.css";
 
+$content-width: 500px;
+$content-height: 450px;
+
 .modal-overlay {
     position: fixed;
     top: 0;
@@ -19,12 +22,18 @@
     padding: 0;
     border-radius: $space;
     user-select: none;
-    width: 500px;
-    height: 450px;
+    width: $content-width;
     color: $text-primary;
     overflow: hidden;
 }
 
 .body {
+    /* Need to repeat dimensions here to allow iframe scrolling for iOS */
+    width: $content-width;
+    height: $content-height;
     background: $ui-pane-gray;
+
+    /* These properties needed to allow iframe scrolling for iOS */
+    overflow-y: scroll;
+    -webkit-overflow-scrolling: touch;
 }


### PR DESCRIPTION
This is a long standing issue with how iOS deals with scrollable
elements within a fixed area. This was a helpful resource
https://davidwalsh.name/scroll-iframes-ios

### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/1239

### Proposed Changes

_Describe what this Pull Request does_

Adds a CSS property to allow for iOS scrolling of embedded iframe.

Tested in the iOS simulator.