### PR TITLE
Make sensing "key pressed" block input droppable

### DIFF
--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -431,7 +431,11 @@ const sensing = function (isStage) {
         </block>
         <block id="answer" type="sensing_answer"/>
         ${blockSeparator}
-        <block type="sensing_keypressed"/>
+        <block type="sensing_keypressed">
+            <value name="KEY_OPTION">
+                <shadow type="sensing_keyoptions"/>
+            </value>
+        </block>
         <block type="sensing_mousedown"/>
         <block type="sensing_mousex"/>
         <block type="sensing_mousey"/>


### PR DESCRIPTION
### Resolves

Fixes LLK/scratch-blocks#1370. Must be merged after LLK/scratch-blocks#1371.

(I haven't done many pull requests which span across multiple repositories before. I'm not sure if I'll need to update `scratch-blocks` in the package.json in this PR?)

### Proposed Changes

Reverts part of #1223 to make the "key pressed" sensing block input droppable.

### Reason for Changes

To implement a help wanted feature request; to make the "key pressed" block more powerful. (See discussion in LLK/scratch-blocks#1370.)

### Test Coverage

Manually tested locally. VM functionality tested as well ("set my variable to space, say (key (my variable) pressed?)").