### PR TITLE
Update scratch-paint dependency because greenkeeper does not want to

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "scratch-audio": "0.1.0-prerelease.1516198804",
     "scratch-blocks": "0.1.0-prerelease.1517268276",
     "scratch-l10n": "2.0.20180108132626",
-    "scratch-paint": "0.1.0-prerelease.20180124235741",
+    "scratch-paint": "0.1.0-prerelease.20180130210131",
     "scratch-render": "0.1.0-prerelease.1516837442",
     "scratch-storage": "0.4.0",
     "scratch-vm": "0.1.0-prerelease.1517344159-prerelease.1517344174",


### PR DESCRIPTION
@fsih I'm not sure why greenkeeper didn't do this. Let's keep an eye on it going forward to see if we can figure out when it does/does not update.