### PR TITLE
Revert "Sprite library now centered"

### DIFF
--- a/src/components/library/library.css
+++ b/src/components/library/library.css
@@ -5,7 +5,6 @@
     position: absolute;
 
     display: flex;
-    flex-direction: column;
     height: 100%;
     width: 100%;
 
@@ -20,8 +19,13 @@
 }
 
 .library-scroll-grid {
-    display: grid;
-    justify-content: center;
-    grid-template-columns: repeat(auto-fill, 160px);
+    display: flex;
+    justify-content: flex-start;
+    align-content: flex-start;
     background: $ui-pane-gray;
+    flex-grow: 1;
+    flex-wrap: wrap;
+    overflow-y: auto;
+    height: calc(100% - $library-header-height);
+    padding: 0.5rem;
 }


### PR DESCRIPTION
Reverts LLK/scratch-gui#1297

@thisandagain unfortunately this PR broke several things with the libraries (left is develop, right is reverted)

1. The background of the library when you search for something used to be full height:

![image](https://user-images.githubusercontent.com/654102/35705118-8cb16b6e-076f-11e8-9e90-6722dea56d60.png)

2. The extension library used to look... right

![image](https://user-images.githubusercontent.com/654102/35705130-9767aac8-076f-11e8-9dac-8ba93b5dd470.png)

