### PR TITLE
Remove duplicate computer beeps

### DIFF
--- a/src/lib/libraries/sounds.json
+++ b/src/lib/libraries/sounds.json
@@ -546,13 +546,6 @@
         "format": "adpcm"
     },
     {
-        "name": "Computer Beep",
-        "md5": "28c76b6bebd04be1383fe9ba4933d263.wav",
-        "sampleCount": 9536,
-        "rate": 11025,
-        "format": ""
-    },
-    {
         "name": "Computer Beeps1",
         "md5": "1da43f6d52d0615da8a250e28100a80d.wav",
         "sampleCount": 19200,


### PR DESCRIPTION
### Resolves

#1355

### Proposed Changes

Removes the duplicate computer beeps sound

### Reason for Changes

You shouldn't have two of the same sounds

### Test Coverage

If you search for "computer beep", there are 3 results, but only 2 different sounds
