### PR TITLE
Lower long and double click timing to 400ms to match scratch 2

### DIFF
--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -201,7 +201,7 @@ class Stage extends React.Component {
                 mouseDownPosition: mousePosition,
                 mouseDownTimeoutId: setTimeout(
                     this.onStartDrag.bind(this, mousePosition[0], mousePosition[1]),
-                    500
+                    400
                 )
             });
         }


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Part of resolving https://github.com/LLK/scratch-gui/issues/1408

### Proposed Changes

_Describe what this Pull Request does_

In scratch 2, it is 400ms, in scratch 3 it was 500ms. 

### Reason for Changes

_Explain why these changes should be made_

To make the behavior feel more similar to scratch 2.

### Test Coverage

_Please show how you have added tests to cover your changes_

n/a

/cc @morantsur 
