### PR TITLE
Fix the broken box shadow to make inputs pop more on focus

### DIFF
--- a/src/components/forms/input.css
+++ b/src/components/forms/input.css
@@ -33,7 +33,7 @@
 
 .input-form:focus {
     border-color: #4c97ff;
-    box-shadow: inset 0 0 0 -2px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 0 0 0.2rem $motion-transparent;
 }
 
 .input-small {


### PR DESCRIPTION
@carljbowman it looks like there was an attempt to make the inputs have that popping border, but the syntax of it was all wrong... 

I updated it and now it shows the light blue border similar to the sprite tiles

![inputs-pop](https://user-images.githubusercontent.com/654102/35929146-cb4243e4-0bfc-11e8-8f05-c417b414c413.gif)
