### PR TITLE
fix not now to redirect to scratch.mit.edu

### DIFF
--- a/src/containers/preview-modal.jsx
+++ b/src/containers/preview-modal.jsx
@@ -28,7 +28,7 @@ class PreviewModal extends React.Component {
         this.props.onTryIt();
     }
     handleCancel () {
-        window.history.back();
+        window.location.replace('https://scratch.mit.edu');
     }
     supportedBrowser () {
         if (platform.name === 'IE') {

--- a/test/integration/project-loading.test.js
+++ b/test/integration/project-loading.test.js
@@ -2,6 +2,7 @@ import path from 'path';
 import SeleniumHelper from '../helpers/selenium-helper';
 
 const {
+    clickText,
     clickXpath,
     getDriver,
     getLogs,
@@ -11,6 +12,15 @@ const {
 const uri = path.resolve(__dirname, '../../build/index.html');
 
 let driver;
+
+describe('Loading scratch gui', () => {
+    test('The "Not Now" button sends you to scratch', async () => {
+        await loadUri(uri);
+        await clickText('Not Now');
+        const currentUrl = await driver.getCurrentUrl();
+        await expect(currentUrl).toEqual('https://scratch.mit.edu/');
+    });
+});
 
 describe('Loading projects by ID', () => {
     beforeAll(() => {

--- a/test/integration/project-loading.test.js
+++ b/test/integration/project-loading.test.js
@@ -14,15 +14,6 @@ const uri = path.resolve(__dirname, '../../build/index.html');
 let driver;
 
 describe('Loading scratch gui', () => {
-    test('The "Not Now" button sends you to scratch', async () => {
-        await loadUri(uri);
-        await clickText('Not Now');
-        const currentUrl = await driver.getCurrentUrl();
-        await expect(currentUrl).toEqual('https://scratch.mit.edu/');
-    });
-});
-
-describe('Loading projects by ID', () => {
     beforeAll(() => {
         driver = getDriver();
     });
@@ -31,40 +22,50 @@ describe('Loading projects by ID', () => {
         await driver.quit();
     });
 
-    test('Load a project by ID', async () => {
-        const projectId = '96708228';
-        await loadUri(`${uri}#${projectId}`);
-        await clickXpath('//button[@title="tryit"]');
-        await new Promise(resolve => setTimeout(resolve, 2000));
-        await clickXpath('//img[@title="Go"]');
-        await new Promise(resolve => setTimeout(resolve, 2000));
-        await clickXpath('//img[@title="Stop"]');
-        const logs = await getLogs();
-        await expect(logs).toEqual([]);
+    test('The "Not Now" button sends you to scratch', async () => {
+        await loadUri(uri);
+        await clickText('Not Now');
+        const currentUrl = await driver.getCurrentUrl();
+        await expect(currentUrl).toEqual('https://scratch.mit.edu/');
     });
 
-    test('Load a project by ID (fullscreen)', async () => {
-        const prevSize = driver.manage()
-            .window()
-            .getSize();
-        await new Promise(resolve => setTimeout(resolve, 2000));
-        driver.manage()
-            .window()
-            .setSize(1920, 1080);
-        const projectId = '96708228';
-        await loadUri(`${uri}#${projectId}`);
-        await clickXpath('//button[@title="tryit"]');
-        await new Promise(resolve => setTimeout(resolve, 2000));
-        await clickXpath('//img[@title="Full Screen Control"]');
-        await clickXpath('//img[@title="Go"]');
-        await new Promise(resolve => setTimeout(resolve, 2000));
-        await clickXpath('//img[@title="Stop"]');
-        prevSize.then(value => {
+    describe('Loading projects by ID', () => {
+
+        test('Load a project by ID', async () => {
+            const projectId = '96708228';
+            await loadUri(`${uri}#${projectId}`);
+            await clickXpath('//button[@title="tryit"]');
+            await new Promise(resolve => setTimeout(resolve, 2000));
+            await clickXpath('//img[@title="Go"]');
+            await new Promise(resolve => setTimeout(resolve, 2000));
+            await clickXpath('//img[@title="Stop"]');
+            const logs = await getLogs();
+            await expect(logs).toEqual([]);
+        });
+
+        test('Load a project by ID (fullscreen)', async () => {
+            const prevSize = driver.manage()
+                .window()
+                .getSize();
+            await new Promise(resolve => setTimeout(resolve, 2000));
             driver.manage()
                 .window()
-                .setSize(value.width, value.height);
+                .setSize(1920, 1080);
+            const projectId = '96708228';
+            await loadUri(`${uri}#${projectId}`);
+            await clickXpath('//button[@title="tryit"]');
+            await new Promise(resolve => setTimeout(resolve, 2000));
+            await clickXpath('//img[@title="Full Screen Control"]');
+            await clickXpath('//img[@title="Go"]');
+            await new Promise(resolve => setTimeout(resolve, 2000));
+            await clickXpath('//img[@title="Stop"]');
+            prevSize.then(value => {
+                driver.manage()
+                    .window()
+                    .setSize(value.width, value.height);
+            });
+            const logs = await getLogs();
+            await expect(logs).toEqual([]);
         });
-        const logs = await getLogs();
-        await expect(logs).toEqual([]);
     });
 });


### PR DESCRIPTION
### Resolves

Resolves #1359

### Proposed Changes

When the user clicks the `Not Now` button, it will direct them to `scratch.mit.edu` instead of sending them back.

If this should instead be an `href` instead of a button that redirects, I could give that try?

### Reason for Changes

Requested in #1359 

### Test Coverage

I'm not sure how to write a test for this one, but if there's a way, I would love to learn and implement it.
