### PR TITLE
Fix numerous draggable images in the GUI

### DIFF
--- a/src/components/asset-button/asset-button.jsx
+++ b/src/components/asset-button/asset-button.jsx
@@ -16,6 +16,7 @@ const AssetButton = ({
     >
         <img
             className={styles.icon}
+            draggable={false}
             src={img}
         />
     </button>

--- a/src/components/green-flag/green-flag.jsx
+++ b/src/components/green-flag/green-flag.jsx
@@ -22,6 +22,7 @@ const GreenFlagComponent = function (props) {
                     [styles.isActive]: active
                 }
             )}
+            draggable={false}
             src={greenFlagIcon}
             title={title}
             onClick={onClick}

--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -117,6 +117,7 @@ const GUIComponent = props => {
                                     >
                                         <img
                                             className={styles.extensionButtonIcon}
+                                            draggable={false}
                                             src={addExtensionIcon}
                                         />
                                     </button>

--- a/src/components/icon-button/icon-button.jsx
+++ b/src/components/icon-button/icon-button.jsx
@@ -16,6 +16,7 @@ const IconButton = ({
     >
         <img
             className={styles.icon}
+            draggable={false}
             src={img}
         />
         <div className={styles.title}>

--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -28,6 +28,7 @@ const MenuBar = props => (
                 <img
                     alt="Scratch"
                     className={styles.scratchLogo}
+                    draggable={false}
                     src={scratchLogo}
                 />
             </div>
@@ -42,6 +43,7 @@ const MenuBar = props => (
             >
                 <img
                     className={styles.feedbackButtonIcon}
+                    draggable={false}
                     src={feedbackIcon}
                 />
                 <span className={styles.feedbackText}>

--- a/src/components/record-modal/playback-step.jsx
+++ b/src/components/record-modal/playback-step.jsx
@@ -42,7 +42,10 @@ const PlaybackStep = props => (
                 className={styles.mainButton}
                 onClick={props.playing ? props.onStopPlaying : props.onPlay}
             >
-                <img src={props.playing ? stopIcon : playIcon} />
+                <img
+                    draggable={false}
+                    src={props.playing ? stopIcon : playIcon}
+                />
                 <div className={styles.helpText}>
                     <span className={styles.playingText}>
                         {props.playing ? 'Stop' : 'Play'}
@@ -55,7 +58,10 @@ const PlaybackStep = props => (
                 className={styles.cancelButton}
                 onClick={props.onBack}
             >
-                <img src={backIcon} /> Re-record
+                <img
+                    draggable={false}
+                    src={backIcon}
+                /> Re-record
             </button>
             <button
                 className={styles.okButton}

--- a/src/components/record-modal/recording-step.jsx
+++ b/src/components/record-modal/recording-step.jsx
@@ -40,7 +40,10 @@ const RecordingStep = props => (
                 onClick={props.recording ? props.onStopRecording : props.onRecord}
             >
                 {props.recording ? (
-                    <img src={stopIcon} />
+                    <img
+                        draggable={false}
+                        src={stopIcon}
+                    />
                 ) : (
                     <svg
                         className={styles.recordButton}

--- a/src/components/sound-editor/sound-editor.jsx
+++ b/src/components/sound-editor/sound-editor.jsx
@@ -121,7 +121,10 @@ const SoundEditor = props => (
                         title={props.intl.formatMessage(messages.undo)}
                         onClick={props.onUndo}
                     >
-                        <img src={undoIcon} />
+                        <img
+                            draggable={false}
+                            src={undoIcon}
+                        />
                     </button>
                     <button
                         className={styles.button}
@@ -129,7 +132,10 @@ const SoundEditor = props => (
                         title={props.intl.formatMessage(messages.redo)}
                         onClick={props.onRedo}
                     >
-                        <img src={redoIcon} />
+                        <img
+                            draggable={false}
+                            src={redoIcon}
+                        />
                     </button>
                 </div>
             </div>
@@ -170,7 +176,10 @@ const SoundEditor = props => (
                         title={props.intl.formatMessage(messages.stop)}
                         onClick={props.onStop}
                     >
-                        <img src={stopIcon} />
+                        <img
+                            draggable={false}
+                            src={stopIcon}
+                        />
                     </button>
                 ) : (
                     <button
@@ -178,7 +187,10 @@ const SoundEditor = props => (
                         title={props.intl.formatMessage(messages.play)}
                         onClick={props.onPlay}
                     >
-                        <img src={playIcon} />
+                        <img
+                            draggable={false}
+                            src={playIcon}
+                        />
                     </button>
                 )}
             </div>

--- a/src/components/stage-header/stage-header.jsx
+++ b/src/components/stage-header/stage-header.jsx
@@ -69,6 +69,7 @@ const StageHeaderComponent = function (props) {
                         <img
                             alt={props.intl.formatMessage(messages.unFullStageSizeMessage)}
                             className={styles.stageButtonIcon}
+                            draggable={false}
                             src={unFullScreenIcon}
                             title="Full Screen Control"
                         />
@@ -100,6 +101,7 @@ const StageHeaderComponent = function (props) {
                                         disabled
                                         alt={props.intl.formatMessage(messages.smallStageSizeMessage)}
                                         className={styles.stageButtonIcon}
+                                        draggable={false}
                                         src={smallStageIcon}
                                     />
                                 </div>
@@ -115,6 +117,7 @@ const StageHeaderComponent = function (props) {
                                     <img
                                         alt={props.intl.formatMessage(messages.largeStageSizeMessage)}
                                         className={styles.stageButtonIcon}
+                                        draggable={false}
                                         src={largeStageIcon}
                                     />
                                 </Button>
@@ -128,6 +131,7 @@ const StageHeaderComponent = function (props) {
                                 <img
                                     alt={props.intl.formatMessage(messages.fullStageSizeMessage)}
                                     className={styles.stageButtonIcon}
+                                    draggable={false}
                                     src={fullScreenIcon}
                                     title="Full Screen Control"
                                 />

--- a/src/components/stop-all/stop-all.jsx
+++ b/src/components/stop-all/stop-all.jsx
@@ -22,6 +22,7 @@ const StopAllComponent = function (props) {
                     [styles.isActive]: active
                 }
             )}
+            draggable={false}
             src={stopAllIcon}
             title={title}
             onClick={onClick}

--- a/test/unit/components/__snapshots__/icon-button.test.jsx.snap
+++ b/test/unit/components/__snapshots__/icon-button.test.jsx.snap
@@ -8,6 +8,7 @@ exports[`IconButtonComponent matches snapshot 1`] = `
 >
   <img
     className={undefined}
+    draggable={false}
     src="imgSrc"
   />
   <div

--- a/test/unit/components/__snapshots__/sound-editor.test.jsx.snap
+++ b/test/unit/components/__snapshots__/sound-editor.test.jsx.snap
@@ -39,6 +39,7 @@ exports[`Sound Editor Component matches snapshot 1`] = `
           title="Undo"
         >
           <img
+            draggable={false}
             src="test-file-stub"
           />
         </button>
@@ -49,6 +50,7 @@ exports[`Sound Editor Component matches snapshot 1`] = `
           title="Redo"
         >
           <img
+            draggable={false}
             src="test-file-stub"
           />
         </button>
@@ -61,6 +63,7 @@ exports[`Sound Editor Component matches snapshot 1`] = `
     >
       <img
         className={undefined}
+        draggable={false}
         src="test-file-stub"
       />
       <div
@@ -342,6 +345,7 @@ exports[`Sound Editor Component matches snapshot 1`] = `
         title="Stop"
       >
         <img
+          draggable={false}
           src="test-file-stub"
         />
       </button>
@@ -353,6 +357,7 @@ exports[`Sound Editor Component matches snapshot 1`] = `
     >
       <img
         className={undefined}
+        draggable={false}
         src="test-file-stub"
       />
       <div
@@ -370,6 +375,7 @@ exports[`Sound Editor Component matches snapshot 1`] = `
     >
       <img
         className={undefined}
+        draggable={false}
         src="test-file-stub"
       />
       <div
@@ -387,6 +393,7 @@ exports[`Sound Editor Component matches snapshot 1`] = `
     >
       <img
         className={undefined}
+        draggable={false}
         src="test-file-stub"
       />
       <div
@@ -404,6 +411,7 @@ exports[`Sound Editor Component matches snapshot 1`] = `
     >
       <img
         className={undefined}
+        draggable={false}
         src="test-file-stub"
       />
       <div
@@ -421,6 +429,7 @@ exports[`Sound Editor Component matches snapshot 1`] = `
     >
       <img
         className={undefined}
+        draggable={false}
         src="test-file-stub"
       />
       <div
@@ -438,6 +447,7 @@ exports[`Sound Editor Component matches snapshot 1`] = `
     >
       <img
         className={undefined}
+        draggable={false}
         src="test-file-stub"
       />
       <div
@@ -455,6 +465,7 @@ exports[`Sound Editor Component matches snapshot 1`] = `
     >
       <img
         className={undefined}
+        draggable={false}
         src="test-file-stub"
       />
       <div

--- a/test/unit/containers/__snapshots__/green-flag.test.jsx.snap
+++ b/test/unit/containers/__snapshots__/green-flag.test.jsx.snap
@@ -3,6 +3,7 @@
 exports[`GreenFlag Container renders active state 1`] = `
 <img
   className="undefined"
+  draggable={false}
   onClick={[Function]}
   src="test-file-stub"
   title="Go"
@@ -12,6 +13,7 @@ exports[`GreenFlag Container renders active state 1`] = `
 exports[`GreenFlag Container renders inactive state 1`] = `
 <img
   className=""
+  draggable={false}
   onClick={[Function]}
   src="test-file-stub"
   title="Go"


### PR DESCRIPTION
Images are draggable by default, but when used within buttons or as
clickable elements, they should not be draggable because starting a drag
accidentally prevents the click event.

### Resolves

_What Github issue does this resolve (please include link)?_

Resolves https://github.com/LLK/scratch-gui/issues/1430
(GUI part only, will submit separate PR for scratch-paint).

### Proposed Changes

_Describe what this Pull Request does_

use the `draggable={false}` attribute on images that are used as clickable elements

### Reason for Changes

_Explain why these changes should be made_


Images are draggable by default, but when used within buttons or as
clickable elements, they should not be draggable because starting a drag
accidentally prevents the click event.

### Test Coverage

_Please show how you have added tests to cover your changes_

![no-drag-images](https://user-images.githubusercontent.com/654102/36032774-0fd31c00-0d7d-11e8-8eb4-0780d78dc9c9.gif)

Note a couple things about this gif:
1. Didn't show the paint editor because that is a separate PR to scratch-paint.
2. Intentionally dragged all the way off the button to show nothing was being dragged. If you drag and stay within the bounds of the clickable area and release, it triggers a click, like a normal button, which is good. Just didn't show that in the gif.
