### PR TITLE
Apply a drag threshold to make clicking sprites easier

### DIFF
--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -15,6 +15,7 @@ import {
 } from '../reducers/color-picker';
 
 const colorPickerRadius = 20;
+const dragThreshold = 3; // Same as the block drag threshold
 
 class Stage extends React.Component {
     constructor (props) {
@@ -149,9 +150,13 @@ class Stage extends React.Component {
         this.pickX = mousePosition[0];
         this.pickY = mousePosition[1];
 
-        if (this.state.mouseDownTimeoutId !== null) {
-            this.cancelMouseDownTimeout();
-            if (this.state.mouseDown && !this.state.isDragging) {
+        if (this.state.mouseDown && !this.state.isDragging) {
+            const distanceFromMouseDown = Math.sqrt(
+                Math.pow(mousePosition[0] - this.state.mouseDownPosition[0], 2) +
+                Math.pow(mousePosition[1] - this.state.mouseDownPosition[1], 2)
+            );
+            if (distanceFromMouseDown > dragThreshold) {
+                this.cancelMouseDownTimeout();
                 this.onStartDrag(...this.state.mouseDownPosition);
             }
         }


### PR DESCRIPTION
Use the same drag threshold as from the blocks. It may need to be dialed
in further, but testing will be needed.

### Resolves

_What Github issue does this resolve (please include link)?_

Resolvers https://github.com/LLK/scratch-gui/issues/1408, but may need further refinements to the drag threshold to dial it in.

### Proposed Changes

_Describe what this Pull Request does_

### Reason for Changes

_Explain why these changes should be made_

Use a 3 px drag threshold before starting a drag on sprites. This gives a bit of breathing space for an unintentional movement while the mouse/touchpoint is down.

### Test Coverage

_Please show how you have added tests to cover your changes_

This will require a fair bit of manual testing on different devices / pointers. I'll mark it "needs-qa" so we can make sure to dial it in.
