### PR TITLE
Proposed fix for Issue 1212

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -251,8 +251,15 @@ class Blocks extends React.Component {
         this.setState({prompt: null});
     }
     handleCustomProceduresClose (data) {
+
         this.props.onRequestCloseCustomProcedures(data);
-        this.workspace.refreshToolboxSelection_();
+        const ws = this.workspace;
+        ws.refreshToolboxSelection_();
+        const tb = ws.toolbox_;
+        const cat = tb.categoryMenu_.categories_;
+        const idx = cat.length - 1;
+        const name = cat[idx].name_;
+        ws.toolbox_.scrollToCategoryByName(name); // 'My Blocks'
     }
     render () {
         /* eslint-disable no-unused-vars */


### PR DESCRIPTION
### Resolves
https://github.com/LLK/scratch-gui/issues/1212

### Proposed Changes

Scrolls to 'My Blocks' section after creating new block

Because potential conflict with localization in the future,
I select the last name in the toolbox category list.
Hopefully, 'My Blocks' will always remain the last item.
Otherwise, we could simply call scrollToCategoryByName('My Blocks')?

### Reason for Changes
Resolve issue posted.

### Test Coverage

Manually tested on local build and test server using 'npm start'
Two test cases:
1 - Create new block after clicking on 'My Block' category
2 - Create new block after clicking on higher category ('Operators') and then scrolling down and clicking 'Make a Block'
