### PR TITLE
Fix issue 1212

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -252,7 +252,10 @@ class Blocks extends React.Component {
     }
     handleCustomProceduresClose (data) {
         this.props.onRequestCloseCustomProcedures(data);
-        this.workspace.refreshToolboxSelection_();
+        const ws = this.workspace;
+        ws.refreshToolboxSelection_();
+        // @todo ensure this does not break on localization
+        ws.toolbox_.scrollToCategoryByName('My Blocks');
     }
     render () {
         /* eslint-disable no-unused-vars */


### PR DESCRIPTION
### Resolves
Fixes https://github.com/LLK/scratch-gui/issues/1212

### Proposed Changes
- Call scrollToCategoryByName('My Blocks') after custom block is created
- Cannot assume custom blocks section will be last category
- May pose issue during localization efforts

### Reason for Changes
Fix issue posted

### Test Coverage
Manually tested on local build and test server using 'npm start'
Two test cases:
1 - Create new block after clicking on 'My Block' category
2 - Create new block after clicking on higher category ('Operators') and then scrolling down and clicking 'Make a Block'
3 - Add extensions 'Music' and 'Pen'  to Toolbox categories then repeat  cases 1 and 2

