### PR TITLE
Remove enableExtensions prop

### DIFF
--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -37,7 +37,6 @@ const GUIComponent = props => {
     const {
         basePath,
         children,
-        enableExtensions,
         intl,
         feedbackFormVisible,
         vm,
@@ -109,9 +108,7 @@ const GUIComponent = props => {
                                 </Box>
                                 <Box className={styles.extensionButtonContainer}>
                                     <button
-                                        className={classNames(styles.extensionButton, {
-                                            [styles.hidden]: !enableExtensions
-                                        })}
+                                        className={styles.extensionButton}
                                         title={intl.formatMessage(messages.addExtension)}
                                         onClick={onExtensionButtonClick}
                                     >
@@ -164,7 +161,6 @@ const GUIComponent = props => {
 GUIComponent.propTypes = {
     basePath: PropTypes.string,
     children: PropTypes.node,
-    enableExtensions: PropTypes.bool,
     feedbackFormVisible: PropTypes.bool,
     intl: intlShape.isRequired,
     onExtensionButtonClick: PropTypes.func,

--- a/src/containers/gui.jsx
+++ b/src/containers/gui.jsx
@@ -46,7 +46,6 @@ class GUI extends React.Component {
         } = this.props;
         return (
             <GUIComponent
-                enableExtensions={window.location.search.includes('extensions')}
                 tabIndex={this.state.tabIndex}
                 vm={vm}
                 onTabSelect={this.handleTabSelect}


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-gui/issues/1151

### Proposed Changes

Remove the enableExtensions prop.

### Reason for Changes

This prop was used to hide the "add extension" button during a prototyping phase. We do not plan to use it, and it was confusing because it no longer worked.