### PR TITLE
Fix deleting in sprite selector item event bubbling

### DIFF
--- a/src/containers/sound-tab.jsx
+++ b/src/containers/sound-tab.jsx
@@ -51,6 +51,9 @@ class SoundTab extends React.Component {
 
     handleDeleteSound (soundIndex) {
         this.props.vm.deleteSound(soundIndex);
+        if (soundIndex >= this.state.selectedSoundIndex) {
+            this.setState({selectedSoundIndex: Math.max(0, soundIndex - 1)});
+        }
     }
 
     handleNewSound () {

--- a/src/containers/sprite-selector-item.jsx
+++ b/src/containers/sprite-selector-item.jsx
@@ -19,7 +19,8 @@ class SpriteSelectorItem extends React.Component {
         e.preventDefault();
         this.props.onClick(this.props.id);
     }
-    handleDelete () {
+    handleDelete (e) {
+        e.stopPropagation(); // To prevent from bubbling back to handleClick
         // @todo add i18n here
         // eslint-disable-next-line no-alert
         if (window.confirm('Are you sure you want to delete this?')) {


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/1486

### Proposed Changes

_Describe what this Pull Request does_

Prevent the sprite selector item context menu click from bubbling to the selector item click. 

### Reason for Changes

_Explain why these changes should be made_
it was deleting a costume, then the event bubbled which tried to select the costume, throwing an error.

