### PR TITLE
Update make-toolbox-xml.js

### DIFF
--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -234,9 +234,6 @@ const looks = function (isStage, targetId) {
         </block>
         <block type="looks_cleargraphiceffects"/>
         ${blockSeparator}
-        <block type="looks_show"/>
-        <block type="looks_hide"/>
-        ${blockSeparator}
         ${isStage ? '' : `
             <block type="looks_gotofrontback"/>
             <block type="looks_goforwardbackwardlayers">
@@ -247,6 +244,8 @@ const looks = function (isStage, targetId) {
                 </value>
             </block>
             ${blockSeparator}
+        <block type="looks_show"/>
+        <block type="looks_hide"/>
         `}
         ${isStage ? `
             <block id="backdropnumbername" type="looks_backdropnumbername"/>

--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -235,6 +235,9 @@ const looks = function (isStage, targetId) {
         <block type="looks_cleargraphiceffects"/>
         ${blockSeparator}
         ${isStage ? '' : `
+            <block type="looks_show"/>
+            <block type="looks_hide"/>
+        ${blockSeparator}
             <block type="looks_gotofrontback"/>
             <block type="looks_goforwardbackwardlayers">
                 <value name="NUM">
@@ -243,9 +246,6 @@ const looks = function (isStage, targetId) {
                     </shadow>
                 </value>
             </block>
-            ${blockSeparator}
-        <block type="looks_show"/>
-        <block type="looks_hide"/>
         `}
         ${isStage ? `
             <block id="backdropnumbername" type="looks_backdropnumbername"/>


### PR DESCRIPTION
### Resolves

#1494 

### Proposed Changes

Removes show and hide from stage toolbox.

### Reason for Changes

You can't show or hide the stage (and the blocks don't work anyway)
