### PR TITLE
Asset menu follow ups

### DIFF
--- a/src/components/action-menu/action-menu.jsx
+++ b/src/components/action-menu/action-menu.jsx
@@ -21,6 +21,16 @@ class ActionMenu extends React.Component {
             forceHide: false
         };
     }
+    shouldComponentUpdate (newProps, newState) {
+        // This check prevents re-rendering while the project is updating.
+        // @todo check only the state and the title because it is enough to know
+        //  if anything substantial has changed
+        // This is needed because of the sloppy way the props are passed as a new object,
+        //  which should be refactored.
+        return newState.isOpen !== this.state.isOpen ||
+            newState.forceHide !== this.state.forceHide ||
+            newProps.title !== this.props.title;
+    }
     handleClosePopover () {
         this.closeTimeoutId = setTimeout(() => {
             this.setState({isOpen: false});

--- a/src/components/asset-panel/selector.css
+++ b/src/components/asset-panel/selector.css
@@ -35,6 +35,7 @@ $fade-out-distance: 100px;
     background: linear-gradient(rgba(232,237,241, 0),rgba(232,237,241, 1));
     height: $fade-out-distance;
     width: 100%;
+    pointer-events: none;
 }
 
 .new-buttons > button + button {

--- a/src/containers/stage-selector.jsx
+++ b/src/containers/stage-selector.jsx
@@ -54,6 +54,7 @@ class StageSelector extends React.Component {
             /* eslint-disable no-unused-vars */
             assetId,
             id,
+            onActivateTab,
             onSelect,
             /* eslint-enable no-unused-vars */
             ...componentProps

--- a/src/containers/target-pane.jsx
+++ b/src/containers/target-pane.jsx
@@ -72,9 +72,13 @@ class TargetPane extends React.Component {
         }
     }
     render () {
+        const {
+            onActivateTab, // eslint-disable-line no-unused-vars
+            ...componentProps
+        } = this.props;
         return (
             <TargetPaneComponent
-                {...this.props}
+                {...componentProps}
                 onChangeSpriteDirection={this.handleChangeSpriteDirection}
                 onChangeSpriteName={this.handleChangeSpriteName}
                 onChangeSpriteSize={this.handleChangeSpriteSize}


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/1501
Fixes https://github.com/LLK/scratch-gui/issues/1505
Fixes https://github.com/LLK/scratch-gui/issues/1504
Fixes https://github.com/LLK/scratch-gui/issues/1499
and fixes a few proptype warnings that get logged in development

### Proposed Changes

_Describe what this Pull Request does_

- Adds a shouldComponentUpdate that prevents re-rendering constantly. The reason for the re-rendering is a not-so-great use of react props that aren't simple values (using arrays/objects). Refactoring will be needed for a more thorough fix. fixing is a really good introduction/exercise on how react/redux works.
- Adds a pointer-events: none to prevent the fade-out pseudo element in the costume tab from blocking clicks.
- Various prop cleanup.  
- Fix asset menus on touch by binding a touchstart to prevent the main button click if the menu isn't open and another touchstart to the document to catch touches outside, making the menu close. 

@ericrosenbaum I'm not 100% sure the "staying open" problem is fixed by this, because it is tough to reproduce, but maybe give it a try?