### PR TITLE
Performance audit of react/redux state

### DIFF
--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -33,6 +33,10 @@ const messages = defineMessages({
     }
 });
 
+// Cache this value to only retreive it once the first time.
+// Assume that it doesn't change for a session.
+let isRendererSupported = null;
+
 const GUIComponent = props => {
     const {
         activeTabIndex,
@@ -66,7 +70,9 @@ const GUIComponent = props => {
         tabSelected: classNames(tabStyles.reactTabsTabSelected, styles.isSelected)
     };
 
-    const isRendererSupported = Renderer.isSupported();
+    if (isRendererSupported === null) {
+        isRendererSupported = Renderer.isSupported();
+    }
 
     return (
         <Box

--- a/src/containers/costume-tab.jsx
+++ b/src/containers/costume-tab.jsx
@@ -218,7 +218,6 @@ class CostumeTab extends React.Component {
             >
                 {target.costumes ?
                     <PaintEditorWrapper
-                        {...props}
                         selectedCostumeIndex={this.state.selectedCostumeIndex}
                     /> :
                     null

--- a/src/containers/load-button.jsx
+++ b/src/containers/load-button.jsx
@@ -14,6 +14,9 @@ class LoadButton extends React.Component {
             'handleClick'
         ]);
     }
+    shouldComponentUpdate () {
+        return false;
+    }
     handleChange (e) {
         const reader = new FileReader();
         reader.onload = () => this.props.loadProject(reader.result);

--- a/src/containers/load-button.jsx
+++ b/src/containers/load-button.jsx
@@ -14,12 +14,9 @@ class LoadButton extends React.Component {
             'handleClick'
         ]);
     }
-    shouldComponentUpdate () {
-        return false;
-    }
     handleChange (e) {
         const reader = new FileReader();
-        reader.onload = () => this.props.loadProject(reader.result);
+        reader.onload = () => this.props.vm.fromJSON(reader.result);
         reader.readAsText(e.target.files[0]);
     }
     handleClick () {
@@ -30,7 +27,7 @@ class LoadButton extends React.Component {
     }
     render () {
         const {
-            loadProject, // eslint-disable-line no-unused-vars
+            vm, // eslint-disable-line no-unused-vars
             ...props
         } = this.props;
         return (
@@ -45,11 +42,13 @@ class LoadButton extends React.Component {
 }
 
 LoadButton.propTypes = {
-    loadProject: PropTypes.func.isRequired
+    vm: PropTypes.shape({
+        fromJSON: PropTypes.func
+    })
 };
 
 const mapStateToProps = state => ({
-    loadProject: state.vm.fromJSON.bind(state.vm)
+    vm: state.vm
 });
 
 export default connect(

--- a/src/containers/paint-editor-wrapper.jsx
+++ b/src/containers/paint-editor-wrapper.jsx
@@ -59,7 +59,8 @@ const mapStateToProps = (state, {selectedCostumeIndex}) => {
         name: costume && costume.name,
         rotationCenterX: costume && costume.rotationCenterX,
         rotationCenterY: costume && costume.rotationCenterY,
-        svgId: editingTarget && `${editingTarget}${costume.skinId}`
+        svgId: editingTarget && `${editingTarget}${costume.skinId}`,
+        vm: state.vm
     };
 };
 

--- a/src/containers/save-button.jsx
+++ b/src/containers/save-button.jsx
@@ -14,11 +14,8 @@ class SaveButton extends React.Component {
             'handleClick'
         ]);
     }
-    shouldComponentUpdate () {
-        return false;
-    }
     handleClick () {
-        const json = this.props.saveProjectSb3();
+        const json = this.props.vm.saveProjectSb3();
 
         // Download project data into a file - create link element,
         // simulate click on it, and then remove it.
@@ -39,7 +36,7 @@ class SaveButton extends React.Component {
     }
     render () {
         const {
-            saveProjectSb3, // eslint-disable-line no-unused-vars
+            vm, // eslint-disable-line no-unused-vars
             ...props
         } = this.props;
         return (
@@ -60,11 +57,12 @@ class SaveButton extends React.Component {
 }
 
 SaveButton.propTypes = {
-    saveProjectSb3: PropTypes.func.isRequired
-};
+    vm: PropTypes.shape({
+        saveProjectSb3: PropTypes.func
+    })};
 
 const mapStateToProps = state => ({
-    saveProjectSb3: state.vm.saveProjectSb3.bind(state.vm)
+    vm: state.vm
 });
 
 export default connect(

--- a/src/containers/save-button.jsx
+++ b/src/containers/save-button.jsx
@@ -14,6 +14,9 @@ class SaveButton extends React.Component {
             'handleClick'
         ]);
     }
+    shouldComponentUpdate () {
+        return false;
+    }
     handleClick () {
         const json = this.props.saveProjectSb3();
 

--- a/src/containers/sound-editor.jsx
+++ b/src/containers/sound-editor.jsx
@@ -89,7 +89,7 @@ class SoundEditor extends React.Component {
         }
 
         this.resetState(samples, sampleRate);
-        this.props.onUpdateSoundBuffer(
+        this.props.vm.updateSoundBuffer(
             this.props.soundIndex,
             this.audioBufferPlayer.buffer,
             wavBuffer ? new Uint8Array(wavBuffer) : new Uint8Array());
@@ -112,7 +112,7 @@ class SoundEditor extends React.Component {
         this.setState({playhead});
     }
     handleChangeName (name) {
-        this.props.onRenameSound(this.props.soundIndex, name);
+        this.props.vm.renameSound(this.props.soundIndex, name);
     }
     handleActivateTrim () {
         if (this.state.trimStart === null && this.state.trimEnd === null) {
@@ -200,12 +200,14 @@ class SoundEditor extends React.Component {
 
 SoundEditor.propTypes = {
     name: PropTypes.string.isRequired,
-    onRenameSound: PropTypes.func.isRequired,
-    onUpdateSoundBuffer: PropTypes.func.isRequired,
     sampleRate: PropTypes.number,
     samples: PropTypes.instanceOf(Float32Array),
     soundId: PropTypes.string,
-    soundIndex: PropTypes.number
+    soundIndex: PropTypes.number,
+    vm: PropTypes.shape({
+        updateSoundBuffer: PropTypes.func,
+        renameSound: PropTypes.func
+    })
 };
 
 const mapStateToProps = (state, {soundIndex}) => {
@@ -219,8 +221,7 @@ const mapStateToProps = (state, {soundIndex}) => {
         sampleRate: audioBuffer.sampleRate,
         samples: audioBuffer.getChannelData(0),
         name: sound.name,
-        onRenameSound: state.vm.renameSound.bind(state.vm),
-        onUpdateSoundBuffer: state.vm.updateSoundBuffer.bind(state.vm)
+        vm: state.vm
     };
 };
 


### PR DESCRIPTION
This PR is a few small tweaks to the way that certain components consume state that actually add up to a pretty large benefit. The largest thing is to make sure that the props only contain the things you actually need (costume editor change) and to not use `.bind()` when creating props, because it will always cause a re-render. Here are some example flame graphs:

Here is an example while dragging a sprite with the sound editor open

<img width="1176" alt="screen shot 2018-02-26 at 3 40 24 pm" src="https://user-images.githubusercontent.com/654102/36699385-6cde6d5a-1b1a-11e8-9aa1-267c346d9b1a.png">

And after fixing the binds
<img width="935" alt="screen shot 2018-02-26 at 3 39 24 pm" src="https://user-images.githubusercontent.com/654102/36699401-7a4849e8-1b1a-11e8-96d9-ca98899f2c22.png">

I used the react devtools extension, particularly the "highlight on update" checkbox, to show which components were re-rendering (this is like a version of the chrome "paint flashing" tool, but showing react renders not just (after-reconciliation) dom updates).

There is one "bonus" thing here which is to cache the result of the renderers isSupported method, which takes about 30ms every time to run on my machine, which is run whenever you switch editor tabs.