### PR TITLE
Add constraint on min height for large stage

### DIFF
--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -144,16 +144,21 @@ const GUIComponent = props => {
                         </Box>
                         <Box className={styles.stageWrapper}>
                             {/* eslint-disable arrow-body-style */}
-                            <MediaQuery minWidth={layout.fullSizeMinWidth}>{isFullSize => {
-                                return isRendererSupported ? (
-                                    <Stage
-                                        height={isFullSize ? layout.fullStageHeight : layout.smallerStageHeight}
-                                        shrink={0}
-                                        vm={vm}
-                                        width={isFullSize ? layout.fullStageWidth : layout.smallerStageWidth}
-                                    />
-                                ) : null;
-                            }}</MediaQuery>
+                            <MediaQuery
+                                minHeight={layout.fullSizeMinHeight}
+                                minWidth={layout.fullSizeMinWidth}
+                            >
+                                {isFullSize => {
+                                    return isRendererSupported ? (
+                                        <Stage
+                                            height={isFullSize ? layout.fullStageHeight : layout.smallerStageHeight}
+                                            shrink={0}
+                                            vm={vm}
+                                            width={isFullSize ? layout.fullStageWidth : layout.smallerStageWidth}
+                                        />
+                                    ) : null;
+                                }}
+                            </MediaQuery>
                             {/* eslint-enable arrow-body-style */}
                         </Box>
                         <Box className={styles.targetWrapper}>

--- a/src/components/sprite-info/sprite-info.jsx
+++ b/src/components/sprite-info/sprite-info.jsx
@@ -51,7 +51,10 @@ class SpriteInfo extends React.Component {
                     </div>
 
                     <div className={styles.group}>
-                        <MediaQuery minWidth={layout.fullSizeMinWidth}>
+                        <MediaQuery
+                            minHeight={layout.fullSizeMinHeight}
+                            minWidth={layout.fullSizeMinWidth}
+                        >
                             <div className={styles.iconWrapper}>
                                 <img
                                     aria-hidden="true"
@@ -74,7 +77,10 @@ class SpriteInfo extends React.Component {
                     </div>
 
                     <div className={styles.group}>
-                        <MediaQuery minWidth={layout.fullSizeMinWidth}>
+                        <MediaQuery
+                            minHeight={layout.fullSizeMinHeight}
+                            minWidth={layout.fullSizeMinWidth}
+                        >
                             <div className={styles.iconWrapper}>
                                 <img
                                     aria-hidden="true"
@@ -99,7 +105,10 @@ class SpriteInfo extends React.Component {
 
                 <div className={classNames(styles.row, styles.rowSecondary)}>
                     <div className={styles.group}>
-                        <MediaQuery minWidth={layout.fullSizeMinWidth}>
+                        <MediaQuery
+                            minHeight={layout.fullSizeMinHeight}
+                            minWidth={layout.fullSizeMinWidth}
+                        >
                             <Label
                                 secondary
                                 text="Show"

--- a/src/lib/layout-constants.js
+++ b/src/lib/layout-constants.js
@@ -4,5 +4,6 @@ export default {
     smallerStageWidth: 480 * 0.85,
     smallerStageHeight: 360 * 0.85,
     fullSizeMinWidth: 1096,
+    fullSizeMinHeight: 821, // Adding 7% to 768.
     fullSizePaintMinWidth: 1250
 };


### PR DESCRIPTION
### Proposed Changes

Take screen height into account when deciding on stage size (full/small), instead of just screen width. 

Not sure if that's the right solution - let me know if you have other ideas. Also not sure what the min size should be - in this case I took a little over 768px, which is the same as the width (1096, as a little over 1024) - would love your opinion. 

### Reason for Changes

Should help with #1403 - after discussing with @rschamp and @ericrosenbaum, we think that maybe the reason you can't see enough of the sprite area is because the screen width is bigger than the min supported size for the big stage, but their height isn't (For example, 11in chromebook with a screen resolution of 1366x768)

It doesn't solve the issue with the missing scroll bar, but should at least make the stage smaller which will make it less problematic. 

### Test Coverage

Can add a test if we decide it's a good solution :) 
