### PR TITLE
Always report mouse-up to VM and send flag indicating end of drag

### DIFF
--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -188,16 +188,15 @@ class Stage extends React.Component {
         });
         if (this.state.isDragging) {
             this.onStopDrag();
-        } else {
-            const data = {
-                isDown: false,
-                x: x - this.rect.left,
-                y: y - this.rect.top,
-                canvasWidth: this.rect.width,
-                canvasHeight: this.rect.height
-            };
-            this.props.vm.postIOData('mouse', data);
         }
+        const data = {
+            isDown: false,
+            x: x - this.rect.left,
+            y: y - this.rect.top,
+            canvasWidth: this.rect.width,
+            canvasHeight: this.rect.height
+        };
+        this.props.vm.postIOData('mouse', data);
     }
     onMouseDown (e) {
         this.updateRect();

--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -186,9 +186,6 @@ class Stage extends React.Component {
             mouseDown: false,
             mouseDownPosition: null
         });
-        if (this.state.isDragging) {
-            this.onStopDrag();
-        }
         const data = {
             isDown: false,
             x: x - this.rect.left,
@@ -196,6 +193,10 @@ class Stage extends React.Component {
             canvasWidth: this.rect.width,
             canvasHeight: this.rect.height
         };
+        if (this.state.isDragging) {
+            this.onStopDrag();
+            data.wasDragged = true;
+        }
         this.props.vm.postIOData('mouse', data);
     }
     onMouseDown (e) {

--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -191,11 +191,11 @@ class Stage extends React.Component {
             x: x - this.rect.left,
             y: y - this.rect.top,
             canvasWidth: this.rect.width,
-            canvasHeight: this.rect.height
+            canvasHeight: this.rect.height,
+            wasDragged: this.state.isDragging
         };
         if (this.state.isDragging) {
             this.onStopDrag();
-            data.wasDragged = true;
         }
         this.props.vm.postIOData('mouse', data);
     }


### PR DESCRIPTION
### Resolves

Resolves LLK/scratch-vm#940

### Proposed Changes

Reports mouse-up data to VM even in the case of ending a drag. Also sends VM flag indicating whether this mouse-up was the end of a drag (which the VM should then use so that the `when this sprite clicked` block doesn't get activated on a drag: LLK/scratch-vm#957).

### Reason for Changes

Compatibility bugfix.

### Test Coverage

Existing tests pass.

#### Note: This PR depends on LLK/scratch-vm#957