### PR TITLE
Switch to the correct costume number when switching sprites

### DIFF
--- a/src/containers/costume-tab.jsx
+++ b/src/containers/costume-tab.jsx
@@ -90,7 +90,14 @@ class CostumeTab extends React.Component {
         } = nextProps;
 
         const target = editingTarget && sprites[editingTarget] ? sprites[editingTarget] : stage;
-        if (target && target.costumes && this.state.selectedCostumeIndex > target.costumes.length - 1) {
+        if (!target || !target.costumes) {
+            return;
+        }
+
+        // If switching editing targets, update the costume index
+        if (this.props.editingTarget !== editingTarget) {
+            this.setState({selectedCostumeIndex: target.currentCostume});
+        } else if (this.state.selectedCostumeIndex > target.costumes.length - 1) {
             this.setState({selectedCostumeIndex: target.costumes.length - 1});
         }
     }

--- a/src/containers/sound-tab.jsx
+++ b/src/containers/sound-tab.jsx
@@ -46,8 +46,14 @@ class SoundTab extends React.Component {
         } = nextProps;
 
         const target = editingTarget && sprites[editingTarget] ? sprites[editingTarget] : stage;
+        if (!target || !target.sounds) {
+            return;
+        }
 
-        if (target && target.sounds && this.state.selectedSoundIndex > target.sounds.length - 1) {
+        // If switching editing targets, reset the sound index
+        if (this.props.editingTarget !== editingTarget) {
+            this.setState({selectedSoundIndex: 0});
+        } else if (this.state.selectedSoundIndex > target.sounds.length - 1) {
             this.setState({selectedSoundIndex: Math.max(target.sounds.length - 1, 0)});
         }
     }


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-gui/issues/1502

### Proposed Changes
When switching targets, update the selected costume in the costume tab

### Reason for Changes

Selected costume did not match costume on stage before
