### PR TITLE
Move backdrop library back to costumes tab

### DIFF
--- a/src/components/stage-selector/stage-selector.jsx
+++ b/src/components/stage-selector/stage-selector.jsx
@@ -94,12 +94,12 @@ const StageSelector = props => {
                     }, {
                         title: intl.formatMessage(messages.addBackdropFromSurprise),
                         img: surpriseIcon,
-                        onClick: onSurpriseBackdropClick // TODO NEED REAL FUNCTION
+                        onClick: onSurpriseBackdropClick
 
                     }, {
                         title: intl.formatMessage(messages.addBackdropFromPaint),
                         img: paintIcon,
-                        onClick: onEmptyBackdropClick // TODO NEED REAL FUNCTION
+                        onClick: onEmptyBackdropClick
                     }
                 ]}
                 title={intl.formatMessage(messages.addBackdropFromLibrary)}

--- a/src/components/target-pane/target-pane.jsx
+++ b/src/components/target-pane/target-pane.jsx
@@ -4,7 +4,6 @@ import React from 'react';
 import VM from 'scratch-vm';
 
 import SpriteLibrary from '../../containers/sprite-library.jsx';
-import BackdropLibrary from '../../containers/backdrop-library.jsx';
 import SpriteSelectorComponent from '../sprite-selector/sprite-selector.jsx';
 import StageSelector from '../../containers/stage-selector.jsx';
 
@@ -17,7 +16,6 @@ import styles from './target-pane.css';
  * @returns {React.Component} rendered component
  */
 const TargetPane = ({
-    backdropLibraryVisible,
     editingTarget,
     hoveredTarget,
     spriteLibraryVisible,
@@ -33,7 +31,6 @@ const TargetPane = ({
     onSurpriseSpriteClick,
     onPaintSpriteClick,
     onRequestCloseSpriteLibrary,
-    onRequestCloseBackdropLibrary,
     onSelectSprite,
     raiseSprites,
     stage,
@@ -83,12 +80,6 @@ const TargetPane = ({
                         onRequestClose={onRequestCloseSpriteLibrary}
                     />
                 ) : null}
-                {backdropLibraryVisible ? (
-                    <BackdropLibrary
-                        vm={vm}
-                        onRequestClose={onRequestCloseBackdropLibrary}
-                    />
-                ) : null}
             </div>
         </div>
     </div>
@@ -113,7 +104,6 @@ const spriteShape = PropTypes.shape({
 });
 
 TargetPane.propTypes = {
-    backdropLibraryVisible: PropTypes.bool,
     editingTarget: PropTypes.string,
     extensionLibraryVisible: PropTypes.bool,
     hoveredTarget: PropTypes.shape({
@@ -130,7 +120,6 @@ TargetPane.propTypes = {
     onDuplicateSprite: PropTypes.func,
     onNewSpriteClick: PropTypes.func,
     onPaintSpriteClick: PropTypes.func,
-    onRequestCloseBackdropLibrary: PropTypes.func,
     onRequestCloseExtensionLibrary: PropTypes.func,
     onRequestCloseSpriteLibrary: PropTypes.func,
     onSelectSprite: PropTypes.func,

--- a/src/containers/backdrop-library.jsx
+++ b/src/containers/backdrop-library.jsx
@@ -47,7 +47,7 @@ class BackdropLibrary extends React.Component {
 }
 
 BackdropLibrary.propTypes = {
-    onNewBackdrop: PropTypes.func,
+    onNewBackdrop: PropTypes.func.isRequired,
     onRequestClose: PropTypes.func,
     vm: PropTypes.instanceOf(VM).isRequired
 };

--- a/src/containers/costume-tab.jsx
+++ b/src/containers/costume-tab.jsx
@@ -7,10 +7,12 @@ import VM from 'scratch-vm';
 import AssetPanel from '../components/asset-panel/asset-panel.jsx';
 import PaintEditorWrapper from './paint-editor-wrapper.jsx';
 import CostumeLibrary from './costume-library.jsx';
+import BackdropLibrary from './backdrop-library.jsx';
 import {connect} from 'react-redux';
 
 import {
     closeCostumeLibrary,
+    closeBackdropLibrary,
     openCostumeLibrary,
     openBackdropLibrary
 } from '../reducers/modals';
@@ -160,7 +162,9 @@ class CostumeTab extends React.Component {
             intl,
             onNewLibraryBackdropClick,
             onNewLibraryCostumeClick,
+            backdropLibraryVisible,
             costumeLibraryVisible,
+            onRequestCloseBackdropLibrary,
             onRequestCloseCostumeLibrary,
             ...props
         } = this.props;
@@ -230,6 +234,13 @@ class CostumeTab extends React.Component {
                         onRequestClose={onRequestCloseCostumeLibrary}
                     />
                 ) : null}
+                {backdropLibraryVisible ? (
+                    <BackdropLibrary
+                        vm={vm}
+                        onNewBackdrop={this.handleNewCostume}
+                        onRequestClose={onRequestCloseBackdropLibrary}
+                    />
+                ) : null}
             </AssetPanel>
         );
     }
@@ -277,6 +288,9 @@ const mapDispatchToProps = dispatch => ({
     onNewLibraryCostumeClick: e => {
         e.preventDefault();
         dispatch(openCostumeLibrary());
+    },
+    onRequestCloseBackdropLibrary: () => {
+        dispatch(closeBackdropLibrary());
     },
     onRequestCloseCostumeLibrary: () => {
         dispatch(closeCostumeLibrary());

--- a/src/containers/stage-selector.jsx
+++ b/src/containers/stage-selector.jsx
@@ -83,6 +83,7 @@ const mapStateToProps = (state, {assetId}) => ({
 const mapDispatchToProps = dispatch => ({
     onNewBackdropClick: e => {
         e.preventDefault();
+        dispatch(activateTab(COSTUMES_TAB_INDEX));
         dispatch(openBackdropLibrary());
     },
     onActivateTab: tabIndex => {

--- a/src/containers/stage-selector.jsx
+++ b/src/containers/stage-selector.jsx
@@ -38,7 +38,9 @@ class StageSelector extends React.Component {
     handleSurpriseBackdrop () {
         // @todo should this not add a backdrop you already have?
         const item = backdropLibraryContent[Math.floor(Math.random() * backdropLibraryContent.length)];
-        this.addBackdropFromLibraryItem(item);
+        this.addBackdropFromLibraryItem(item).then(() => {
+            this.props.onActivateTab(COSTUMES_TAB_INDEX);
+        });
     }
     handleEmptyBackdrop () {
         // @todo this is brittle, will need to be refactored for localized libraries

--- a/src/containers/target-pane.jsx
+++ b/src/containers/target-pane.jsx
@@ -5,7 +5,6 @@ import {connect} from 'react-redux';
 
 import {
     openSpriteLibrary,
-    closeBackdropLibrary,
     closeSpriteLibrary
 } from '../reducers/modals';
 
@@ -132,8 +131,7 @@ const mapStateToProps = state => ({
     }, {}),
     stage: state.targets.stage,
     raiseSprites: state.blockDrag,
-    spriteLibraryVisible: state.modals.spriteLibrary,
-    backdropLibraryVisible: state.modals.backdropLibrary
+    spriteLibraryVisible: state.modals.spriteLibrary
 });
 const mapDispatchToProps = dispatch => ({
     onNewSpriteClick: e => {
@@ -142,9 +140,6 @@ const mapDispatchToProps = dispatch => ({
     },
     onRequestCloseSpriteLibrary: () => {
         dispatch(closeSpriteLibrary());
-    },
-    onRequestCloseBackdropLibrary: () => {
-        dispatch(closeBackdropLibrary());
     },
     onActivateTab: tabIndex => {
         dispatch(activateTab(tabIndex));

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -9,7 +9,7 @@
     <!-- Sentry error logging to help with finding bugs -->
     <script src="https://cdn.ravenjs.com/3.22.1/raven.min.js" crossorigin="anonymous"></script>
     <script>
-        Raven.config('https://42b7d13da8ad4d68b13e57c5e54f9a23@sentry.io/273218').install();
+        // Raven.config('https://42b7d13da8ad4d68b13e57c5e54f9a23@sentry.io/273218').install();
     </script>
     <!-- /Sentry -->
 

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -9,7 +9,7 @@
     <!-- Sentry error logging to help with finding bugs -->
     <script src="https://cdn.ravenjs.com/3.22.1/raven.min.js" crossorigin="anonymous"></script>
     <script>
-        // Raven.config('https://42b7d13da8ad4d68b13e57c5e54f9a23@sentry.io/273218').install();
+        Raven.config('https://42b7d13da8ad4d68b13e57c5e54f9a23@sentry.io/273218').install();
     </script>
     <!-- /Sentry -->
 


### PR DESCRIPTION
Move the backdrop library back in to costume-tab. This fixes https://github.com/LLK/scratch-gui/issues/1475 for all but adding a surprise or paint backdrop from the info pane (Fixes adding a backdrop from library from the costume tab, adding a surprise/paint backdrop from the costume tab, and adding a backdrop from library from the info pane)

Fixing surprise backdrop from the info pane is more complex so I plan to make another PR.