### PR TITLE
Cache Renderer.isSupported because it takes 30ms every time and breaks if called too often

### DIFF
--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -34,6 +34,10 @@ const messages = defineMessages({
     }
 });
 
+// Cache this value to only retreive it once the first time.
+// Assume that it doesn't change for a session.
+let isRendererSupported = null;
+
 const GUIComponent = props => {
     const {
         activeTabIndex,
@@ -69,7 +73,9 @@ const GUIComponent = props => {
         tabSelected: classNames(tabStyles.reactTabsTabSelected, styles.isSelected)
     };
 
-    const isRendererSupported = Renderer.isSupported();
+    if (isRendererSupported === null) {
+        isRendererSupported = Renderer.isSupported();
+    }
 
     return (
         <Box


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-render/issues/243

### Proposed Changes

_Describe what this Pull Request does_

Cache Renderer.isSupported because it takes 30ms every time and breaks if called too often


---
This was separated from the performance PR so that it could be merged as a quick fix because share-the-love causes webgl contexts to be created en-masse