### PR TITLE
Attempt to make project load test in examples.test less flaky

### DIFF
--- a/test/integration/examples.test.js
+++ b/test/integration/examples.test.js
@@ -29,6 +29,7 @@ describe('player example', () => {
     test('Load a project by ID', async () => {
         const projectId = '96708228';
         await loadUri(`${uri}#${projectId}`);
+        await clickXpath('//button[@title="tryit"]');
         await new Promise(resolve => setTimeout(resolve, 2000));
         await clickXpath('//img[@title="Go"]');
         await new Promise(resolve => setTimeout(resolve, 2000));
@@ -52,6 +53,7 @@ describe('blocks example', () => {
     test('Load a project by ID', async () => {
         const projectId = '96708228';
         await loadUri(`${uri}#${projectId}`);
+        await clickXpath('//button[@title="tryit"]');
         await new Promise(resolve => setTimeout(resolve, 2000));
         await clickXpath('//img[@title="Go"]');
         await new Promise(resolve => setTimeout(resolve, 2000));


### PR DESCRIPTION
Try to make the examples integration test less flaky by making it match exactly the test in project-loading.test.js that it's a copy of. (Although examples.test.js often works for me locally and project-loading.test.js often flakes on Travis)
