### PR TITLE
Costume index state

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "redux": "3.7.2",
     "redux-mock-store": "^1.2.3",
     "redux-throttle": "0.1.1",
+    "redux-thunk": "^2.2.0",
     "rimraf": "^2.6.1",
     "scratch-audio": "0.1.0-prerelease.1516198804",
     "scratch-blocks": "0.1.0-prerelease.1520519504",

--- a/src/containers/backdrop-library.jsx
+++ b/src/containers/backdrop-library.jsx
@@ -23,11 +23,7 @@ class BackdropLibrary extends React.Component {
             bitmapResolution: item.info.length > 2 ? item.info[2] : 1,
             skinId: null
         };
-        this.props.vm.addBackdrop(item.md5, vmBackdrop).then(() => {
-            if (this.props.onNewBackdrop) {
-                this.props.onNewBackdrop();
-            }
-        });
+        this.props.vm.addBackdrop(item.md5, vmBackdrop);
         analytics.event({
             category: 'library',
             action: 'Select Backdrop',
@@ -47,7 +43,6 @@ class BackdropLibrary extends React.Component {
 }
 
 BackdropLibrary.propTypes = {
-    onNewBackdrop: PropTypes.func.isRequired,
     onRequestClose: PropTypes.func,
     vm: PropTypes.instanceOf(VM).isRequired
 };

--- a/src/containers/costume-library.jsx
+++ b/src/containers/costume-library.jsx
@@ -23,9 +23,7 @@ class CostumeLibrary extends React.PureComponent {
             bitmapResolution: item.info.length > 2 ? item.info[2] : 1,
             skinId: null
         };
-        this.props.vm.addCostume(item.md5, vmCostume).then(() => {
-            this.props.onNewCostume();
-        });
+        this.props.vm.addCostume(item.md5, vmCostume);
         analytics.event({
             category: 'library',
             action: 'Select Costume',
@@ -45,7 +43,6 @@ class CostumeLibrary extends React.PureComponent {
 }
 
 CostumeLibrary.propTypes = {
-    onNewCostume: PropTypes.func.isRequired,
     onRequestClose: PropTypes.func,
     vm: PropTypes.instanceOf(VM).isRequired
 };

--- a/src/containers/costume-tab.jsx
+++ b/src/containers/costume-tab.jsx
@@ -232,9 +232,7 @@ class CostumeTab extends React.Component {
                 onItemClick={this.handleSelectCostume}
             >
                 {target.costumes ?
-                    <PaintEditorWrapper
-                        selectedCostumeIndex={this.props.editingCostumeIndex}
-                    /> :
+                    <PaintEditorWrapper /> :
                     null
                 }
                 {costumeLibraryVisible ? (

--- a/src/containers/costume-tab.jsx
+++ b/src/containers/costume-tab.jsx
@@ -69,7 +69,6 @@ class CostumeTab extends React.Component {
             'handleSelectCostume',
             'handleDeleteCostume',
             'handleDuplicateCostume',
-            'handleNewCostume',
             'handleNewBlankCostume',
             'handleSurpriseCostume',
             'handleSurpriseBackdrop'
@@ -94,14 +93,7 @@ class CostumeTab extends React.Component {
         this.props.vm.deleteCostume(costumeIndex);
     }
     handleDuplicateCostume (costumeIndex) {
-        this.props.vm.duplicateCostume(costumeIndex).then(() => {
-            this.props.setEditingCostumeIndex(costumeIndex + 1);
-        });
-    }
-    handleNewCostume () {
-        if (!this.props.vm.editingTarget) return;
-        const costumes = this.props.vm.editingTarget.getCostumes() || [];
-        this.props.setEditingCostumeIndex(Math.max(costumes.length - 1, 0));
+        this.props.vm.duplicateCostume(costumeIndex);
     }
     handleNewBlankCostume () {
         const emptyItem = costumeLibraryContent.find(item => (
@@ -116,9 +108,7 @@ class CostumeTab extends React.Component {
             skinId: null
         };
 
-        this.props.vm.addCostume(emptyItem.md5, vmCostume).then(() => {
-            this.handleNewCostume();
-        });
+        this.props.vm.addCostume(emptyItem.md5, vmCostume);
     }
     handleSurpriseCostume () {
         const item = costumeLibraryContent[Math.floor(Math.random() * costumeLibraryContent.length)];
@@ -129,9 +119,7 @@ class CostumeTab extends React.Component {
             bitmapResolution: item.info.length > 2 ? item.info[2] : 1,
             skinId: null
         };
-        this.props.vm.addCostume(item.md5, vmCostume).then(() => {
-            this.handleNewCostume();
-        });
+        this.props.vm.addCostume(item.md5, vmCostume);
     }
     handleSurpriseBackdrop () {
         const item = backdropLibraryContent[Math.floor(Math.random() * backdropLibraryContent.length)];
@@ -142,9 +130,7 @@ class CostumeTab extends React.Component {
             bitmapResolution: item.info.length > 2 ? item.info[2] : 1,
             skinId: null
         };
-        this.props.vm.addCostume(item.md5, vmCostume).then(() => {
-            this.handleNewCostume();
-        });
+        this.props.vm.addCostume(item.md5, vmCostume);
     }
     render () {
         // For paint wrapper
@@ -217,14 +203,12 @@ class CostumeTab extends React.Component {
                 {costumeLibraryVisible ? (
                     <CostumeLibrary
                         vm={vm}
-                        onNewCostume={this.handleNewCostume}
                         onRequestClose={onRequestCloseCostumeLibrary}
                     />
                 ) : null}
                 {backdropLibraryVisible ? (
                     <BackdropLibrary
                         vm={vm}
-                        onNewBackdrop={this.handleNewCostume}
                         onRequestClose={onRequestCloseBackdropLibrary}
                     />
                 ) : null}

--- a/src/containers/costume-tab.jsx
+++ b/src/containers/costume-tab.jsx
@@ -27,6 +27,8 @@ import surpriseIcon from '../components/action-menu/icon--surprise.svg';
 import costumeLibraryContent from '../lib/libraries/costumes.json';
 import backdropLibraryContent from '../lib/libraries/backdrops.json';
 
+import {setEditingCostumeIndex} from '../reducers/editing-costume-index';
+
 const messages = defineMessages({
     addLibraryBackdropMsg: {
         defaultMessage: 'Backdrop Library',
@@ -72,16 +74,16 @@ class CostumeTab extends React.Component {
             'handleSurpriseCostume',
             'handleSurpriseBackdrop'
         ]);
+    }
+    componentWillMount () {
         const {
             editingTarget,
             sprites,
             stage
-        } = props;
+        } = this.props;
         const target = editingTarget && sprites[editingTarget] ? sprites[editingTarget] : stage;
-        if (target && target.currentCostume) {
-            this.state = {selectedCostumeIndex: target.currentCostume};
-        } else {
-            this.state = {selectedCostumeIndex: 0};
+        if (target && !isNaN(target.currentCostume)) {
+            this.props.setEditingCostumeIndex(target.currentCostume);
         }
     }
     componentWillReceiveProps (nextProps) {
@@ -95,30 +97,32 @@ class CostumeTab extends React.Component {
         if (!target || !target.costumes) {
             return;
         }
-
         // If switching editing targets, update the costume index
         if (this.props.editingTarget !== editingTarget) {
-            this.setState({selectedCostumeIndex: target.currentCostume});
-        } else if (this.state.selectedCostumeIndex > target.costumes.length - 1) {
-            this.setState({selectedCostumeIndex: target.costumes.length - 1});
+            console.log(this.props);
+            console.log(nextProps);
         }
+        //     this.props.setEditingCostumeIndex(target.currentCostume);
+        // } else if (this.props.editingCostumeIndex > target.costumes.length - 1) {
+        //     this.props.setEditingCostumeIndex(target.costumes.length - 1);
+        // }
     }
     handleSelectCostume (costumeIndex) {
         this.props.vm.editingTarget.setCostume(costumeIndex);
-        this.setState({selectedCostumeIndex: costumeIndex});
+        this.props.setEditingCostumeIndex(costumeIndex);
     }
     handleDeleteCostume (costumeIndex) {
         this.props.vm.deleteCostume(costumeIndex);
     }
     handleDuplicateCostume (costumeIndex) {
         this.props.vm.duplicateCostume(costumeIndex).then(() => {
-            this.setState({selectedCostumeIndex: costumeIndex + 1});
+            this.props.setEditingCostumeIndex(costumeIndex + 1);
         });
     }
     handleNewCostume () {
         if (!this.props.vm.editingTarget) return;
         const costumes = this.props.vm.editingTarget.getCostumes() || [];
-        this.setState({selectedCostumeIndex: Math.max(costumes.length - 1, 0)});
+        this.props.setEditingCostumeIndex(Math.max(costumes.length - 1, 0));
     }
     handleNewBlankCostume () {
         const emptyItem = costumeLibraryContent.find(item => (
@@ -222,14 +226,14 @@ class CostumeTab extends React.Component {
                     }
                 ]}
                 items={target.costumes || []}
-                selectedItemIndex={this.state.selectedCostumeIndex}
+                selectedItemIndex={this.props.editingCostumeIndex}
                 onDeleteClick={target.costumes.length > 1 ? this.handleDeleteCostume : null}
                 onDuplicateClick={this.handleDuplicateCostume}
                 onItemClick={this.handleSelectCostume}
             >
                 {target.costumes ?
                     <PaintEditorWrapper
-                        selectedCostumeIndex={this.state.selectedCostumeIndex}
+                        selectedCostumeIndex={this.props.editingCostumeIndex}
                     /> :
                     null
                 }
@@ -255,12 +259,14 @@ class CostumeTab extends React.Component {
 CostumeTab.propTypes = {
     backdropLibraryVisible: PropTypes.bool,
     costumeLibraryVisible: PropTypes.bool,
+    editingCostumeIndex: PropTypes.number.isRequired,
     editingTarget: PropTypes.string,
     intl: intlShape,
     onNewLibraryBackdropClick: PropTypes.func.isRequired,
     onNewLibraryCostumeClick: PropTypes.func.isRequired,
     onRequestCloseBackdropLibrary: PropTypes.func.isRequired,
     onRequestCloseCostumeLibrary: PropTypes.func.isRequired,
+    setEditingCostumeIndex: PropTypes.func.isRequired,
     sprites: PropTypes.shape({
         id: PropTypes.shape({
             costumes: PropTypes.arrayOf(PropTypes.shape({
@@ -280,6 +286,7 @@ CostumeTab.propTypes = {
 
 const mapStateToProps = state => ({
     editingTarget: state.targets.editingTarget,
+    editingCostumeIndex: state.editingCostumeIndex,
     sprites: state.targets.sprites,
     stage: state.targets.stage,
     costumeLibraryVisible: state.modals.costumeLibrary,
@@ -300,6 +307,9 @@ const mapDispatchToProps = dispatch => ({
     },
     onRequestCloseCostumeLibrary: () => {
         dispatch(closeCostumeLibrary());
+    },
+    setEditingCostumeIndex: index => {
+        dispatch(setEditingCostumeIndex(index));
     }
 });
 

--- a/src/containers/costume-tab.jsx
+++ b/src/containers/costume-tab.jsx
@@ -86,27 +86,6 @@ class CostumeTab extends React.Component {
             this.props.setEditingCostumeIndex(target.currentCostume);
         }
     }
-    componentWillReceiveProps (nextProps) {
-        const {
-            editingTarget,
-            sprites,
-            stage
-        } = nextProps;
-
-        const target = editingTarget && sprites[editingTarget] ? sprites[editingTarget] : stage;
-        if (!target || !target.costumes) {
-            return;
-        }
-        // If switching editing targets, update the costume index
-        if (this.props.editingTarget !== editingTarget) {
-            console.log(this.props);
-            console.log(nextProps);
-        }
-        //     this.props.setEditingCostumeIndex(target.currentCostume);
-        // } else if (this.props.editingCostumeIndex > target.costumes.length - 1) {
-        //     this.props.setEditingCostumeIndex(target.costumes.length - 1);
-        // }
-    }
     handleSelectCostume (costumeIndex) {
         this.props.vm.editingTarget.setCostume(costumeIndex);
         this.props.setEditingCostumeIndex(costumeIndex);

--- a/src/containers/paint-editor-wrapper.jsx
+++ b/src/containers/paint-editor-wrapper.jsx
@@ -26,11 +26,11 @@ class PaintEditorWrapper extends React.Component {
         this.props.vm.updateSvg(this.props.editingCostumeIndex, svg, rotationCenterX, rotationCenterY);
     }
     render () {
+        if (!this.props.svgId) return null;
         const {
             editingCostumeIndex, // eslint-disable-line no-unused-vars
             ...props
         } = this.props;
-        if (!this.props.svgId) return null;
         return (
             <PaintEditor
                 {...props}

--- a/src/containers/paint-editor-wrapper.jsx
+++ b/src/containers/paint-editor-wrapper.jsx
@@ -20,17 +20,21 @@ class PaintEditorWrapper extends React.Component {
         analytics.pageview('/editors/paint');
     }
     handleUpdateName (name) {
-        this.props.vm.renameCostume(this.props.selectedCostumeIndex, name);
+        this.props.vm.renameCostume(this.props.editingCostumeIndex, name);
     }
     handleUpdateSvg (svg, rotationCenterX, rotationCenterY) {
-        this.props.vm.updateSvg(this.props.selectedCostumeIndex, svg, rotationCenterX, rotationCenterY);
+        this.props.vm.updateSvg(this.props.editingCostumeIndex, svg, rotationCenterX, rotationCenterY);
     }
     render () {
+        const {
+            editingCostumeIndex, // eslint-disable-line no-unused-vars
+            ...props
+        } = this.props;
         if (!this.props.svgId) return null;
         return (
             <PaintEditor
-                {...this.props}
-                svg={this.props.vm.getCostumeSvg(this.props.selectedCostumeIndex)}
+                {...props}
+                svg={this.props.vm.getCostumeSvg(this.props.editingCostumeIndex)}
                 onUpdateName={this.handleUpdateName}
                 onUpdateSvg={this.handleUpdateSvg}
             />
@@ -39,23 +43,25 @@ class PaintEditorWrapper extends React.Component {
 }
 
 PaintEditorWrapper.propTypes = {
+    editingCostumeIndex: PropTypes.number,
     name: PropTypes.string,
     rotationCenterX: PropTypes.number,
     rotationCenterY: PropTypes.number,
-    selectedCostumeIndex: PropTypes.number.isRequired,
     svgId: PropTypes.string,
     vm: PropTypes.instanceOf(VM)
 };
 
-const mapStateToProps = (state, {selectedCostumeIndex}) => {
+const mapStateToProps = state => {
     const {
         editingTarget,
         sprites,
         stage
     } = state.targets;
+    const editingCostumeIndex = state.editingCostumeIndex;
     const target = editingTarget && sprites[editingTarget] ? sprites[editingTarget] : stage;
-    const costume = target && target.costumes[selectedCostumeIndex];
+    const costume = target && target.costumes[editingCostumeIndex];
     return {
+        editingCostumeIndex: editingCostumeIndex,
         name: costume && costume.name,
         rotationCenterX: costume && costume.rotationCenterX,
         rotationCenterY: costume && costume.rotationCenterY,

--- a/src/lib/app-state-hoc.jsx
+++ b/src/lib/app-state-hoc.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {Provider} from 'react-redux';
 import {createStore, applyMiddleware, compose} from 'redux';
 import throttle from 'redux-throttle';
+import thunk from 'redux-thunk';
 
 import {intlInitialState, IntlProvider} from '../reducers/intl.js';
 import reducer from '../reducers/gui';
@@ -9,7 +10,8 @@ import reducer from '../reducers/gui';
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 const enhancer = composeEnhancers(
     applyMiddleware(
-        throttle(300, {leading: true, trailing: true})
+        throttle(300, {leading: true, trailing: true}),
+        thunk
     )
 );
 const store = createStore(reducer, intlInitialState, enhancer);

--- a/src/lib/vm-listener-hoc.jsx
+++ b/src/lib/vm-listener-hoc.jsx
@@ -5,7 +5,7 @@ import VM from 'scratch-vm';
 
 import {connect} from 'react-redux';
 
-import {updateEditingTarget, updateTargets} from '../reducers/targets';
+import {updateTargets} from '../reducers/targets';
 import {updateBlockDrag} from '../reducers/block-drag';
 import {updateMonitors} from '../reducers/monitors';
 
@@ -105,7 +105,6 @@ const vmListenerHOC = function (WrappedComponent) {
     });
     const mapDispatchToProps = dispatch => ({
         onTargetsUpdate: data => {
-            dispatch(updateEditingTarget(data.editingTarget, data.targetList));
             dispatch(updateTargets(data.editingTarget, data.targetList));
         },
         onMonitorsUpdate: monitorList => {

--- a/src/lib/vm-listener-hoc.jsx
+++ b/src/lib/vm-listener-hoc.jsx
@@ -105,8 +105,8 @@ const vmListenerHOC = function (WrappedComponent) {
     });
     const mapDispatchToProps = dispatch => ({
         onTargetsUpdate: data => {
-            dispatch(updateEditingTarget(data.editingTarget));
-            dispatch(updateTargets(data.targetList));
+            dispatch(updateEditingTarget(data.editingTarget, data.targetList));
+            dispatch(updateTargets(data.editingTarget, data.targetList));
         },
         onMonitorsUpdate: monitorList => {
             dispatch(updateMonitors(monitorList));

--- a/src/reducers/editing-costume-index.js
+++ b/src/reducers/editing-costume-index.js
@@ -1,0 +1,28 @@
+// Controls the index of the editing target's costume shown in the paint editor.
+// This doesn't always match the current costume of the editing target, as the costume
+// should switch under you in the paint editor if the project is running in the back
+const SET_EDITING_COSTUME_INDEX = 'scratch-gui/costume-tab/SET_EDITING_COSTUME_INDEX';
+
+const initialState = 0;
+
+const reducer = function (state, action) {
+    if (typeof state === 'undefined') state = initialState;
+    switch (action.type) {
+    case SET_EDITING_COSTUME_INDEX:
+        return action.index;
+    default:
+        return state;
+    }
+};
+
+const setEditingCostumeIndex = function (index) {
+    return {
+        type: SET_EDITING_COSTUME_INDEX,
+        index: index
+    };
+};
+
+export {
+    reducer as default,
+    setEditingCostumeIndex
+};

--- a/src/reducers/editing-costume-index.js
+++ b/src/reducers/editing-costume-index.js
@@ -1,6 +1,6 @@
 // Controls the index of the editing target's costume shown in the paint editor.
 // This doesn't always match the current costume of the editing target, as the costume
-// should switch under you in the paint editor if the project is running in the back
+// shouldn't switch under you in the paint editor if the project is running in the background
 import {UPDATE_TARGET_LIST} from './targets';
 
 const SET_EDITING_COSTUME_INDEX = 'scratch-gui/costume-tab/SET_EDITING_COSTUME_INDEX';
@@ -12,6 +12,8 @@ const reducer = function (state, action) {
     switch (action.type) {
     case SET_EDITING_COSTUME_INDEX:
         return action.index;
+    // Changing the editing target or the number of costumes should trigger a costume
+    // change in the paint editor
     case UPDATE_TARGET_LIST:
         return action.editingCostume;
     default:

--- a/src/reducers/editing-costume-index.js
+++ b/src/reducers/editing-costume-index.js
@@ -1,6 +1,8 @@
 // Controls the index of the editing target's costume shown in the paint editor.
 // This doesn't always match the current costume of the editing target, as the costume
 // should switch under you in the paint editor if the project is running in the back
+import {UPDATE_TARGET_LIST} from './targets';
+
 const SET_EDITING_COSTUME_INDEX = 'scratch-gui/costume-tab/SET_EDITING_COSTUME_INDEX';
 
 const initialState = 0;
@@ -10,6 +12,8 @@ const reducer = function (state, action) {
     switch (action.type) {
     case SET_EDITING_COSTUME_INDEX:
         return action.index;
+    case UPDATE_TARGET_LIST:
+        return action.editingCostume;
     default:
         return state;
     }

--- a/src/reducers/gui.js
+++ b/src/reducers/gui.js
@@ -3,6 +3,7 @@ import colorPickerReducer from './color-picker';
 import customProceduresReducer from './custom-procedures';
 import blockDragReducer from './block-drag';
 import editorTabReducer from './editor-tab';
+import editingCostumeIndexReducer from './editing-costume-index';
 import hoveredTargetReducer from './hovered-target';
 import intlReducer from './intl';
 import modalReducer from './modals';
@@ -18,6 +19,7 @@ export default combineReducers({
     blockDrag: blockDragReducer,
     colorPicker: colorPickerReducer,
     customProcedures: customProceduresReducer,
+    editingCostumeIndex: editingCostumeIndexReducer,
     editorTab: editorTabReducer,
     hoveredTarget: hoveredTargetReducer,
     intl: intlReducer,

--- a/src/reducers/targets.js
+++ b/src/reducers/targets.js
@@ -27,7 +27,7 @@ const reducer = function (state, action) {
         return state;
     }
 };
-const updateTargets_ = function (targetList, editingTarget, editingCostume) {
+const updateTargetsAction_ = function (targetList, editingTarget, editingCostume) {
     return {
         type: UPDATE_TARGET_LIST,
         targets: targetList,
@@ -43,7 +43,7 @@ const updateTargets = function (editingTarget, targetList) {
         const state = getState();
         let editingCostume = state.editingCostumeIndex ? state.editingCostumeIndex : 0;
         if (!editingTarget || !targetList || !state.targets || !state.targets.sprites) {
-            dispatch(updateTargets_(targetList, editingTarget, editingCostume));
+            dispatch(updateTargetsAction_(targetList, editingTarget, editingCostume));
             return Promise.resolve();
         }
 
@@ -73,7 +73,7 @@ const updateTargets = function (editingTarget, targetList) {
                 break;
             }
         }
-        dispatch(updateTargets_(targetList, editingTarget, editingCostume));
+        dispatch(updateTargetsAction_(targetList, editingTarget, editingCostume));
         return Promise.resolve();
     };
 };

--- a/src/reducers/targets.js
+++ b/src/reducers/targets.js
@@ -38,6 +38,15 @@ const updateTargetsAction_ = function (targetList, editingTarget, editingCostume
         }
     };
 };
+/**
+ * Updates state.targets and state.editingTarget. Also updates state.editingCostume,
+ * the costume that is active in the paint editor, to match the editing sprite's active
+ * costume if the editing target changes or if costumes have been added or removed.
+ * @param {string} editingTarget Id of the active editing target
+ * @param {Array<Target>} targetList List of all sprite objects in the project
+ * @return {function} function which returns an action that updates the state's targets,
+ *     editingTarget, and editingCostume together.
+ */
 const updateTargets = function (editingTarget, targetList) {
     return function (dispatch, getState) {
         const state = getState();
@@ -66,7 +75,7 @@ const updateTargets = function (editingTarget, targetList) {
         for (const target of targetList) {
             if (target.id === editingTarget) {
                 const newCostumes = target.costumeCount;
-                if (newCostumes < oldCostumes ||
+                if (newCostumes !== oldCostumes ||
                         state.targets.editingTarget !== editingTarget) {
                     editingCostume = target.currentCostume;
                 }

--- a/src/reducers/targets.js
+++ b/src/reducers/targets.js
@@ -1,3 +1,5 @@
+import {setEditingCostumeIndex} from './editing-costume-index';
+
 const UPDATE_EDITING_TARGET = 'scratch-gui/targets/UPDATE_EDITING_TARGET';
 const UPDATE_TARGET_LIST = 'scratch-gui/targets/UPDATE_TARGET_LIST';
 
@@ -29,7 +31,7 @@ const reducer = function (state, action) {
         return state;
     }
 };
-const updateTargets = function (targetList) {
+const updateTargets_ = function (targetList) {
     return {
         type: UPDATE_TARGET_LIST,
         targets: targetList,
@@ -38,13 +40,75 @@ const updateTargets = function (targetList) {
         }
     };
 };
-const updateEditingTarget = function (editingTarget) {
+const updateTargets = function (editingTarget, targetList) {
+    return function (dispatch, getState) {
+        const state = getState();
+        if (!editingTarget || !targetList || !state.targets || !state.targets.sprites) {
+            dispatch(updateTargets_(targetList));
+            return Promise.resolve();
+        }
+
+        // Detect if a costume has been deleted from the editing target.
+        // If so, update the editing costume index to the target's current costume.
+        let oldCostumes = 0;
+        if (state.targets.stage.id === editingTarget) {
+            oldCostumes = state.targets.stage.costumeCount;
+        } else {
+            for (const sprite in state.targets.sprites) {
+                if (state.targets.sprites.hasOwnProperty(sprite) &&
+                        sprite === editingTarget) {
+                    oldCostumes = state.targets.sprites[sprite].costumeCount;
+                    break;
+                }
+            }
+        }
+        for (const target of targetList) {
+            if (target.id === editingTarget) {
+                const newCostumes = target.costumeCount;
+                if (newCostumes < oldCostumes) {
+                    dispatch(setEditingCostumeIndex(target.currentCostume));
+                }
+                break;
+            }
+        }
+        dispatch(updateTargets_(targetList));
+        return Promise.resolve();
+    };
+};
+const updateEditingTarget_ = function (editingTarget) {
     return {
         type: UPDATE_EDITING_TARGET,
         target: editingTarget,
         meta: {
             throttle: 30
         }
+    };
+};
+/* Updates editing target and editing costume index */
+const updateEditingTarget = function (editingTarget, targetList) {
+    return function (dispatch, getState) {
+        // No change
+        if (getState().targets.editingTarget === editingTarget) {
+            return Promise.resolve();
+        }
+
+        // Changing the editing target to null
+        if (!editingTarget || !targetList) {
+            dispatch(updateEditingTarget_(editingTarget));
+            return Promise.resolve();
+        }
+
+        // When the editing target is changed, also update the editing costume index
+        let index = 0;
+        for (const target of targetList) {
+            if (target.id === editingTarget) {
+                index = target.currentCostume;
+                break;
+            }
+        }
+        dispatch(updateEditingTarget_(editingTarget));
+        dispatch(setEditingCostumeIndex(index));
+        return Promise.resolve();
     };
 };
 export {


### PR DESCRIPTION
Moves the selected costume index from internal state in costume-tab to redux state. This is in preparation for fixing https://github.com/LLK/scratch-gui/issues/1475

In order to have this work correctly, I needed to make updateEditingTarget, updateTargets, and setEditingCostumeIndex happen together atomically. This way, if a costume is deleted or the target sprite changes, the editing costume index and costume deletion happen together, instead of e.g. the costume index moving up first, then the data about the costume being deleted catching up later, which would confuse the paint editor.

I used thunk so that I could access the current state when determining what the action should do. (This is because our target state is sent all at once, instead of individual actions for each change, which means that in order to tell if a deletion has occurred, I need to compare the state against the previous state)