### PR TITLE
Fix proptype warnings for asset panel buttons

### DIFF
--- a/src/components/asset-panel/selector.jsx
+++ b/src/components/asset-panel/selector.jsx
@@ -59,9 +59,9 @@ const Selector = props => {
 
 Selector.propTypes = {
     buttons: PropTypes.arrayOf(PropTypes.shape({
-        message: PropTypes.string.isRequired,
+        title: PropTypes.string.isRequired,
         img: PropTypes.string.isRequired,
-        onClick: PropTypes.func.isRequired
+        onClick: PropTypes.func
     })),
     items: PropTypes.arrayOf(PropTypes.shape({
         url: PropTypes.string,


### PR DESCRIPTION
Fix some proptype warnings not cleaned up by https://github.com/LLK/scratch-gui/pull/1596/files