### PR TITLE
Fix reload button on error page 

### DIFF
--- a/src/containers/error-boundary.jsx
+++ b/src/containers/error-boundary.jsx
@@ -30,7 +30,7 @@ class ErrorBoundary extends React.Component {
     }
 
     handleReload () {
-        window.location.replace(window.location.origin);
+        window.location.replace(window.location.origin + window.location.pathname);
     }
 
     render () {


### PR DESCRIPTION
### Resolves

Resolves #1609 

### Proposed Changes

Fix reload button on the "Oops" error page so that it goes to the correct url (including the pathname).
