### PR TITLE
Allow new sprite to propagate before selecting costume tab

### DIFF
--- a/src/containers/target-pane.jsx
+++ b/src/containers/target-pane.jsx
@@ -74,7 +74,9 @@ class TargetPane extends React.Component {
         const emptyItem = spriteLibraryContent.find(item => item.name === 'Empty');
         if (emptyItem) {
             this.props.vm.addSprite2(JSON.stringify(emptyItem.json)).then(() => {
-                this.props.onActivateTab(COSTUMES_TAB_INDEX);
+                setTimeout(() => { // Wait for targets update to propagate before tab switching
+                    this.props.onActivateTab(COSTUMES_TAB_INDEX);
+                });
             });
         }
     }


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

https://github.com/LLK/scratch-gui/issues/1611

Activating the costume tab before the new sprite has been loaded and events emitted causes the editor to crash