### PR TITLE
Hold scroll position on switching sprites

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -95,9 +95,11 @@ class Blocks extends React.Component {
         }
 
         if (prevProps.toolboxXML !== this.props.toolboxXML) {
-            const selectedCategoryName = this.workspace.toolbox_.getSelectedItem().name_;
+            const categoryName = this.workspace.toolbox_.getSelectedCategoryName();
+            const offset = this.workspace.toolbox_.getCategoryScrollOffset();
             this.workspace.updateToolbox(this.props.toolboxXML);
-            this.workspace.toolbox_.setSelectedCategoryByName(selectedCategoryName);
+            const currentCategoryPos = this.workspace.toolbox_.getCategoryPositionByName(categoryName);
+            this.workspace.toolbox_.setFlyoutScrollPos(currentCategoryPos + offset);
         }
         if (this.props.isVisible === prevProps.isVisible) {
             return;


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-blocks/issues/1406

Depends on a blocks PR: https://github.com/LLK/scratch-blocks/pull/1407

### Proposed Changes

When switching sprites, record the name of currently selected blocks category, and the distance by which the flyout is offset from the top of that category. After updating the toolbox, set the scroll position of the flyout to that offset relative relative to the top of the category.

### Reason for Changes

The goal is to keep the scroll position of the blocks menu (aka the flyout) stable when you switch sprites. Generally, it should only move when you drag it or change categories. Up to now, after switching sprites, it would scroll to the top of the current category. This change prevents any scrolling on switching sprites in most cases*.

Note that the the offset can be negative, and this still works- for example if you select "my blocks," the flyout scrolls to the bottom, but that category is not at the top of the scroll pane. In this case, after switching, the selected category highlighted on the left updates to reflect the category at the top of the scroll pane (not very noticeable, but maybe this is a bug).

* The exceptions where the flyout does jump are caused by situations where we are in the middle of a category whose length changes by a large amount (e.g. the motion category, which has no blocks in the stage, or where sprites have different numbers of local variables). In those cases, setting the position to the offset from the top of the same category can put us into a different category. For example, if you scroll so the topmost block visible is "change y by 10", then switch between sprites, it holds still, but if you now switch to the stage, we end up lower down, in the middle of the sounds category (which is the same offset from the top of the motion category). So maybe we should add some logic that skips using the offset if it would put us below the bottom of the category. 
