### PR TITLE
Don't prevent default on keyboard events

### DIFF
--- a/src/lib/vm-listener-hoc.jsx
+++ b/src/lib/vm-listener-hoc.jsx
@@ -52,11 +52,6 @@ const vmListenerHOC = function (WrappedComponent) {
                 keyCode: e.keyCode,
                 isDown: true
             });
-
-            // Don't stop browser keyboard shortcuts
-            if (e.metaKey || e.altKey || e.ctrlKey) return;
-
-            e.preventDefault();
         }
         handleKeyUp (e) {
             // Always capture up events,


### PR DESCRIPTION
vm-listener-hoc's prevent default on keyboard events prevents the text tool in the paint editor from working.