### PR TITLE
Conditionally use "when stage clicked" vs "when this sprite clicked"

### DIFF
--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -310,13 +310,17 @@ const sound = function () {
     `;
 };
 
-const events = function () {
+const events = function (isStage) {
     return `
     <category name="Events" colour="#FFD500" secondaryColour="#CC9900">
         <block type="event_whenflagclicked"/>
         <block type="event_whenkeypressed">
         </block>
-        <block type="event_whenthisspriteclicked"/>
+        ${isStage ? `
+            <block type="event_whenstageclicked"/>
+        ` : `
+            <block type="event_whenthisspriteclicked"/>
+        `}
         <block type="event_whenbackdropswitchesto">
         </block>
         ${blockSeparator}


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Final piece to resolve https://github.com/LLK/scratch-blocks/issues/634

Depends on https://github.com/LLK/scratch-blocks/pull/1412 and https://github.com/LLK/scratch-vm/pull/992
