### PR TITLE
Make the loader message update every 5 seconds

### DIFF
--- a/src/components/loader/loader.css
+++ b/src/components/loader/loader.css
@@ -29,18 +29,17 @@
     margin-top: -4px;
 }
 
-.topBlock {
+.top-block {
     animation: top-slide-in 1.5s ease infinite;
 }
 
-.middleBlock {
+.middle-block {
     animation: middle-slide-in 1.5s ease infinite;
 }
 
-.bottomBlock {
+.bottom-block {
     animation: bottom-slide-in 1.5s ease infinite;
 }
-
 
 @keyframes top-slide-in {
   0% {
@@ -86,4 +85,18 @@
     transform: translateY(0px);
     opacity: 1;
   }
+}
+
+.message-container-outer {
+    height: 30px;
+    overflow: hidden;
+}
+
+.message-container-inner {
+    transition: transform 0.5s;
+}
+
+.message {
+    height: 20px;
+    margin: 5px 0;
 }

--- a/src/components/loader/loader.jsx
+++ b/src/components/loader/loader.jsx
@@ -5,140 +5,171 @@ import styles from './loader.css';
 import topBlock from './top-block.svg';
 import middleBlock from './middle-block.svg';
 import bottomBlock from './bottom-block.svg';
-
-const LoaderComponent = () => {
-    const messages = [
-        {
-            message: (
-                <FormattedMessage
-                    defaultMessage="Creating blocks …"
-                    description="One of the loading messages"
-                    id="gui.loader.message1"
-                />
-            ),
-            weight: 50
-        },
-        {
-            message: (
-                <FormattedMessage
-                    defaultMessage="Loading sprites …"
-                    description="One of the loading messages"
-                    id="gui.loader.message2"
-                />
-            ),
-            weight: 50
-        },
-        {
-            message: (
-                <FormattedMessage
-                    defaultMessage="Loading sounds …"
-                    description="One of the loading messages"
-                    id="gui.loader.message3"
-                />
-            ),
-            weight: 50
-        },
-        {
-            message: (
-                <FormattedMessage
-                    defaultMessage="Loading extensions …"
-                    description="One of the loading messages"
-                    id="gui.loader.message4"
-                />
-            ),
-            weight: 50
-        },
-        {
-            message: (
-                <FormattedMessage
-                    defaultMessage="Creating blocks …"
-                    description="One of the loading messages"
-                    id="gui.loader.message1"
-                />
-            ),
-            weight: 20
-        },
-        {
-            message: (
-                <FormattedMessage
-                    defaultMessage="Herding cats …"
-                    description="One of the loading messages"
-                    id="gui.loader.message5"
-                />
-            ),
-            weight: 1
-        },
-        {
-            message: (
-                <FormattedMessage
-                    defaultMessage="Transmitting nanos …"
-                    description="One of the loading messages"
-                    id="gui.loader.message6"
-                />
-            ),
-            weight: 1
-        },
-        {
-            message: (
-                <FormattedMessage
-                    defaultMessage="Inflating gobos …"
-                    description="One of the loading messages"
-                    id="gui.loader.message7"
-                />
-            ),
-            weight: 1
-        },
-        {
-            message: (
-                <FormattedMessage
-                    defaultMessage="Preparing emojiis …"
-                    description="One of the loading messages"
-                    id="gui.loader.message8"
-                />
-            ),
-            weight: 1
-        }
-    ];
-
-    let message;
-    const sum = messages.reduce((acc, m) => acc + m.weight, 0);
-    let rand = sum * Math.random();
-    for (let i = 0; i < messages.length; i++) {
-        rand -= messages[i].weight;
-        if (rand <= 0) {
-            message = messages[i].message;
-            break;
-        }
+const messages = [
+    {
+        message: (
+            <FormattedMessage
+                defaultMessage="Creating blocks …"
+                description="One of the loading messages"
+                id="gui.loader.message1"
+            />
+        ),
+        weight: 50
+    },
+    {
+        message: (
+            <FormattedMessage
+                defaultMessage="Loading sprites …"
+                description="One of the loading messages"
+                id="gui.loader.message2"
+            />
+        ),
+        weight: 50
+    },
+    {
+        message: (
+            <FormattedMessage
+                defaultMessage="Loading sounds …"
+                description="One of the loading messages"
+                id="gui.loader.message3"
+            />
+        ),
+        weight: 50
+    },
+    {
+        message: (
+            <FormattedMessage
+                defaultMessage="Loading extensions …"
+                description="One of the loading messages"
+                id="gui.loader.message4"
+            />
+        ),
+        weight: 50
+    },
+    {
+        message: (
+            <FormattedMessage
+                defaultMessage="Creating blocks …"
+                description="One of the loading messages"
+                id="gui.loader.message1"
+            />
+        ),
+        weight: 20
+    },
+    {
+        message: (
+            <FormattedMessage
+                defaultMessage="Herding cats …"
+                description="One of the loading messages"
+                id="gui.loader.message5"
+            />
+        ),
+        weight: 1
+    },
+    {
+        message: (
+            <FormattedMessage
+                defaultMessage="Transmitting nanos …"
+                description="One of the loading messages"
+                id="gui.loader.message6"
+            />
+        ),
+        weight: 1
+    },
+    {
+        message: (
+            <FormattedMessage
+                defaultMessage="Inflating gobos …"
+                description="One of the loading messages"
+                id="gui.loader.message7"
+            />
+        ),
+        weight: 1
+    },
+    {
+        message: (
+            <FormattedMessage
+                defaultMessage="Preparing emojiis …"
+                description="One of the loading messages"
+                id="gui.loader.message8"
+            />
+        ),
+        weight: 1
     }
+];
 
-    return (
-        <div className={styles.background}>
-            <div className={styles.container}>
-                <div className={styles.blockAnimation}>
-                    <img
-                        className={styles.topBlock}
-                        src={topBlock}
-                    />
-                    <img
-                        className={styles.middleBlock}
-                        src={middleBlock}
-                    />
-                    <img
-                        className={styles.bottomBlock}
-                        src={bottomBlock}
-                    />
+class LoaderComponent extends React.Component {
+    constructor (props) {
+        super(props);
+        this.state = {
+            messageNumber: 0
+        };
+    }
+    componentDidMount () {
+        this.chooseRandomMessage();
+
+        // Start an interval to choose a new message every 5 seconds
+        this.intervalId = setInterval(() => {
+            this.chooseRandomMessage();
+        }, 5000);
+    }
+    componentWillUnmount () {
+        clearInterval(this.intervalId);
+    }
+    chooseRandomMessage () {
+        let messageNumber;
+        const sum = messages.reduce((acc, m) => acc + m.weight, 0);
+        let rand = sum * Math.random();
+        for (let i = 0; i < messages.length; i++) {
+            rand -= messages[i].weight;
+            if (rand <= 0) {
+                messageNumber = i;
+                break;
+            }
+        }
+        this.setState({messageNumber});
+    }
+    render () {
+        return (
+            <div className={styles.background}>
+                <div className={styles.container}>
+                    <div className={styles.blockAnimation}>
+                        <img
+                            className={styles.topBlock}
+                            src={topBlock}
+                        />
+                        <img
+                            className={styles.middleBlock}
+                            src={middleBlock}
+                        />
+                        <img
+                            className={styles.bottomBlock}
+                            src={bottomBlock}
+                        />
+                    </div>
+                    <h1 className={styles.title}>
+                        <FormattedMessage
+                            defaultMessage="Loading Project"
+                            description="Main loading message"
+                            id="gui.loader.headline"
+                        />
+                    </h1>
+                    <div className={styles.messageContainerOuter}>
+                        <div
+                            className={styles.messageContainerInner}
+                            style={{transform: `translate(0, -${this.state.messageNumber * 25}px)`}}
+                        >
+                            {messages.map(m => (
+                                <div className={styles.message}>
+                                    {m.message}
+                                </div>
+                            ))}
+                        </div>
+                    </div>
                 </div>
-                <h1 className={styles.title}>
-                    <FormattedMessage
-                        defaultMessage="Loading Project"
-                        description="Main loading message"
-                        id="gui.loader.headline"
-                    />
-                </h1>
-                <p>{message}</p>
             </div>
-        </div>
-    );
-};
+        );
+    }
+}
 
 export default LoaderComponent;

--- a/src/components/loader/loader.jsx
+++ b/src/components/loader/loader.jsx
@@ -159,8 +159,11 @@ class LoaderComponent extends React.Component {
                             className={styles.messageContainerInner}
                             style={{transform: `translate(0, -${this.state.messageNumber * 25}px)`}}
                         >
-                            {messages.map(m => (
-                                <div className={styles.message}>
+                            {messages.map((m, i) => (
+                                <div
+                                    className={styles.message}
+                                    key={i}
+                                >
                                     {m.message}
                                 </div>
                             ))}

--- a/src/components/loader/loader.jsx
+++ b/src/components/loader/loader.jsx
@@ -89,7 +89,7 @@ const messages = [
     {
         message: (
             <FormattedMessage
-                defaultMessage="Preparing emojiis …"
+                defaultMessage="Preparing emojis …"
                 description="One of the loading messages"
                 id="gui.loader.message8"
             />


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Resolvers https://github.com/LLK/scratch-gui/issues/1552

### Proposed Changes

_Describe what this Pull Request does_

Rotate the loading messages every 5 seconds to make sure people know it is still going!

### Reason for Changes

_Explain why these changes should be made_

From @thisandagain 
> While loading projects, displaying a single message (e.g. "Loading sprites ...", "Loading costumes ...", etc.) can lead to the perception that the editor has "hung" and gotten stuck. My instinct is that this is reinforced by the behavior of the current Scratch 2.0 loading screen which shows a progress bar.
> My recommendation would be for us to rotate through messages every few seconds to better reinforce that the 3.0 editor is "doing something".


![loading-messages](https://user-images.githubusercontent.com/654102/37711017-d2df85bc-2ce5-11e8-8886-ade1db586a1e.gif)

