### PR TITLE
Add more browsers to the unsupported list

### DIFF
--- a/src/components/browser-modal/browser-modal.jsx
+++ b/src/components/browser-modal/browser-modal.jsx
@@ -9,7 +9,7 @@ import styles from './browser-modal.css';
 const messages = defineMessages({
     label: {
         id: 'gui.unsupportedBrowser.label',
-        defaultMessage: 'Internet Explorer is not supported',
+        defaultMessage: 'Browser is not supported',
         description: ''
     }
 });
@@ -31,7 +31,7 @@ const BrowserModal = ({intl, ...props}) => (
             <p>
                 { /* eslint-disable max-len */ }
                 <FormattedMessage
-                    defaultMessage="We're very sorry, but Scratch 3.0 does not support Internet Explorer. We recommend trying a newer browser such as Google Chrome, Mozilla Firefox, or Microsoft Edge."
+                    defaultMessage="We're very sorry, but Scratch 3.0 does not support Internet Explorer, Opera or Silk. We recommend trying a newer browser such as Google Chrome, Mozilla Firefox, or Microsoft Edge."
                     description="Unsupported browser description"
                     id="gui.unsupportedBrowser.description"
                 />

--- a/src/containers/error-boundary.jsx
+++ b/src/containers/error-boundary.jsx
@@ -35,7 +35,12 @@ class ErrorBoundary extends React.Component {
 
     render () {
         if (this.state.hasError) {
-            if (platform.name === 'IE') {
+            // don't use array.includes because that's something that causes IE to crash.
+            if (
+                platform.name === 'IE' ||
+                platform.name === 'Opera' ||
+                platform.name === 'Opera Mini' ||
+                platform.name === 'Silk') {
                 return <BrowserModalComponent onBack={this.handleBack} />;
             }
             return <CrashMessageComponent onReload={this.handleReload} />;

--- a/src/containers/preview-modal.jsx
+++ b/src/containers/preview-modal.jsx
@@ -36,10 +36,7 @@ class PreviewModal extends React.Component {
         this.props.onViewProject();
     }
     supportedBrowser () {
-        if (platform.name === 'IE') {
-            return false;
-        }
-        return true;
+        return !['IE', 'Opera', 'Opera Mini', 'Silk', 'Vivaldi'].includes(platform.name);
     }
     render () {
         return (this.supportedBrowser() ?


### PR DESCRIPTION
Added:
- Opera (including Opera Mini)
- Silk

Not Added:
- Vivialdi - appears to be ‘Chrome’ in `platform.name`

### Resolves

Resolves #1460 

### Test Coverage

I downloaded Opera (and Vivaldi) and checked that Opera gets the unsupported browser modal.

Testing: 
- [ ] Opera
  - [ ] Windows
  - [ ] OSX
- [ ] Opera Mini
  - [ ] ?
- [ ] Silk
  - [ ] FireOS


