### PR TITLE
Do not autofocus filter in libraries.

### DIFF
--- a/src/components/filter/filter.jsx
+++ b/src/components/filter/filter.jsx
@@ -25,7 +25,6 @@ const FilterComponent = props => {
                 src={filterIcon}
             />
             <input
-                autoFocus
                 className={styles.filterInput}
                 placeholder={placeholderText}
                 type="text"


### PR DESCRIPTION
Resolves https://github.com/LLK/scratch-gui/issues/1644 by not autofocusing the filter input when opening modals. 