### PR TITLE
Custom procedure enter

### DIFF
--- a/src/components/custom-procedures/custom-procedures.jsx
+++ b/src/components/custom-procedures/custom-procedures.jsx
@@ -14,8 +14,8 @@ const CustomProcedures = props => (
     <Modal
         className={styles.modalContent}
         contentLabel="Make a Block"
-        onRequestClose={props.onCancel}
         onKeyPress={props.onKeyPress}
+        onRequestClose={props.onCancel}
     >
         <Box
             className={styles.workspace}

--- a/src/components/custom-procedures/custom-procedures.jsx
+++ b/src/components/custom-procedures/custom-procedures.jsx
@@ -15,7 +15,7 @@ const CustomProcedures = props => (
         className={styles.modalContent}
         contentLabel="Make a Block"
         onRequestClose={props.onCancel}
-        onKeyPress={porps.onKeyPress}
+        onKeyPress={props.onKeyPress}
     >
         <Box
             className={styles.workspace}
@@ -138,8 +138,8 @@ CustomProcedures.propTypes = {
     onAddLabel: PropTypes.func.isRequired,
     onAddTextNumber: PropTypes.func.isRequired,
     onCancel: PropTypes.func.isRequired,
-    onOk: PropTypes.func.isRequired,
     onKeyPress: PropTypes.func.isRequired,
+    onOk: PropTypes.func.isRequired,
     onToggleWarp: PropTypes.func.isRequired,
     warp: PropTypes.bool.isRequired
 };

--- a/src/components/custom-procedures/custom-procedures.jsx
+++ b/src/components/custom-procedures/custom-procedures.jsx
@@ -15,6 +15,7 @@ const CustomProcedures = props => (
         className={styles.modalContent}
         contentLabel="Make a Block"
         onRequestClose={props.onCancel}
+        onKeyPress={porps.onKeyPress}
     >
         <Box
             className={styles.workspace}
@@ -138,6 +139,7 @@ CustomProcedures.propTypes = {
     onAddTextNumber: PropTypes.func.isRequired,
     onCancel: PropTypes.func.isRequired,
     onOk: PropTypes.func.isRequired,
+    onKeyPress: PropTypes.func.isRequired,
     onToggleWarp: PropTypes.func.isRequired,
     warp: PropTypes.bool.isRequired
 };

--- a/src/containers/custom-procedures.jsx
+++ b/src/containers/custom-procedures.jsx
@@ -113,7 +113,7 @@ class CustomProcedures extends React.Component {
                 onAddLabel={this.handleAddLabel}
                 onAddTextNumber={this.handleAddTextNumber}
                 onCancel={this.handleCancel}
-                onKeyPress={this.handleOk}
+                onKeyPress={this.handleKeyPress}
                 onOk={this.handleOk}
                 onToggleWarp={this.handleToggleWarp}
             />

--- a/src/containers/custom-procedures.jsx
+++ b/src/containers/custom-procedures.jsx
@@ -113,6 +113,7 @@ class CustomProcedures extends React.Component {
                 onAddLabel={this.handleAddLabel}
                 onAddTextNumber={this.handleAddTextNumber}
                 onCancel={this.handleCancel}
+                onKeyPress={this.handleOk}
                 onOk={this.handleOk}
                 onToggleWarp={this.handleToggleWarp}
             />

--- a/src/containers/custom-procedures.jsx
+++ b/src/containers/custom-procedures.jsx
@@ -15,8 +15,8 @@ class CustomProcedures extends React.Component {
             'handleAddTextNumber',
             'handleToggleWarp',
             'handleCancel',
-            'handleOk',
             'handleKeyPress',
+            'handleOk',
             'setBlocks'
         ]);
         this.state = {
@@ -75,12 +75,12 @@ class CustomProcedures extends React.Component {
     handleCancel () {
         this.props.onRequestClose();
     }
+    handleKeyPress (event) {
+        if (event.key === 'Enter') this.handleOk();
+    }
     handleOk () {
         const newMutation = this.mutationRoot ? this.mutationRoot.mutationToDom() : null;
         this.props.onRequestClose(newMutation);
-    }
-    handleKeyPress (event) {
-        if (event.key === 'Enter') this.handleOk();
     }
     handleAddLabel () {
         if (this.mutationRoot) {

--- a/src/containers/custom-procedures.jsx
+++ b/src/containers/custom-procedures.jsx
@@ -16,6 +16,7 @@ class CustomProcedures extends React.Component {
             'handleToggleWarp',
             'handleCancel',
             'handleOk',
+            'handleKeyPress',
             'setBlocks'
         ]);
         this.state = {
@@ -77,6 +78,9 @@ class CustomProcedures extends React.Component {
     handleOk () {
         const newMutation = this.mutationRoot ? this.mutationRoot.mutationToDom() : null;
         this.props.onRequestClose(newMutation);
+    }
+    handleKeyPress (event) {
+        if (event.key === 'Enter') this.handleOk();
     }
     handleAddLabel () {
         if (this.mutationRoot) {


### PR DESCRIPTION
### Resolves

#1649

### Proposed Changes

Adds an onKeyPress event to custom procedure modal, and runs the onOK handler if the key pressed is Enter. Basically, it makes pressing enter in the modal submits the new procedure.

### Reason for Changes

> @kchadha  said "Pressing key on the keyboard after using the custom procedure modal seems to result in a no-op. This is not consistent with the behavior of the variable/list/broadcast message modals."