### PR TITLE
Store sample rate/count for recorded sounds

### DIFF
--- a/src/containers/record-modal.jsx
+++ b/src/containers/record-modal.jsx
@@ -77,8 +77,7 @@ class RecordModal extends React.Component {
                     format: '',
                     dataFormat: 'wav',
                     rate: this.state.sampleRate,
-                    sampleCount: clippedSamples.length,
-                    name: `recording ${this.props.vm.editingTarget.sprite.sounds.length}`
+                    sampleCount: clippedSamples.length
                 };
 
                 // Load the encoded .wav into the storage cache and get resulting
@@ -92,6 +91,9 @@ class RecordModal extends React.Component {
 
                 // update vmSound object with md5 property
                 vmSound.md5 = `${md5}.${vmSound.dataFormat}`;
+                // The VM will update the sound name to a fresh name
+                // if the following is already taken
+                vmSound.name = 'recording 1';
 
                 this.props.vm.addSound(vmSound).then(() => {
                     this.props.onClose();

--- a/src/containers/record-modal.jsx
+++ b/src/containers/record-modal.jsx
@@ -93,7 +93,7 @@ class RecordModal extends React.Component {
                 vmSound.md5 = `${md5}.${vmSound.dataFormat}`;
                 // The VM will update the sound name to a fresh name
                 // if the following is already taken
-                vmSound.name = 'recording 1';
+                vmSound.name = 'recording1';
 
                 this.props.vm.addSound(vmSound).then(() => {
                     this.props.onClose();

--- a/src/containers/record-modal.jsx
+++ b/src/containers/record-modal.jsx
@@ -76,6 +76,8 @@ class RecordModal extends React.Component {
                 const vmSound = {
                     format: '',
                     dataFormat: 'wav',
+                    rate: this.state.sampleRate,
+                    sampleCount: clippedSamples.length,
                     name: `recording ${this.props.vm.editingTarget.sprite.sounds.length}`
                 };
 


### PR DESCRIPTION
### Resolves

Resolves #1707 
Towards more easily allowing adding metadata to sounds in the sound editor tab.

### Proposed Changes

Changes include:

- Add sample rate and sample count to sound object being added to the vm when a sound is recorded. This data is already provided for library sounds and for sounds imported from sb2 projects, so this change standardizes the availability of these properties across all sounds.

- Update the name property of the sound object to just be 'recording 1'. The VM already assigns fresh names to sounds, costumes, and sprites to remove duplication, so it will handle renaming the sound so that it doesn't overlap with other sound names for the given sprite. This change resolves #1707.

Note: these changes need to go in before the save-load work, so that the sb3 validation can correctly check that all given sounds have the rate and sampleCount properties provided.

### Test Coverage

Existing tests pass.