### PR TITLE
Fix handleExtensionAdded when no targets present

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -221,11 +221,18 @@ class Blocks extends React.Component {
         }
     }
     handleExtensionAdded (blocksInfo) {
-        this.ScratchBlocks.defineBlocksWithJsonArray(blocksInfo.map(blockInfo => blockInfo.json));
-        const dynamicBlocksXML = this.props.vm.runtime.getBlocksXML();
-        const target = this.props.vm.editingTarget;
-        const toolboxXML = makeToolboxXML(target.isStage, target.id, dynamicBlocksXML);
-        this.props.updateToolboxState(toolboxXML);
+        // select JSON from each block info object then reject the pseudo-blocks which don't have JSON, like separators
+        // this actually defines blocks and MUST run regardless of the UI state
+        this.ScratchBlocks.defineBlocksWithJsonArray(blocksInfo.map(blockInfo => blockInfo.json).filter(x => x));
+
+        // update the toolbox view: this can be skipped if we're not looking at a target, etc.
+        const runtime = this.props.vm.runtime;
+        const target = runtime.getEditingTarget() || runtime.getTargetForStage();
+        if (target) {
+            const dynamicBlocksXML = runtime.getBlocksXML();
+            const toolboxXML = makeToolboxXML(target.isStage, target.id, dynamicBlocksXML);
+            this.props.updateToolboxState(toolboxXML);
+        }
     }
     handleBlocksInfoUpdate (blocksInfo) {
         // @todo Later we should replace this to avoid all the warnings from redefining blocks.


### PR DESCRIPTION
### Resolves

This resolves issues encountered while converting control blocks into an extension.

### Proposed Changes

If an extension is loaded at project-load time, there won't be any targets. In that case, `handleExtensionAdded` now skips target-specific steps.

This change also adds a filter for JSON block info to support upcoming block separators, which have XML but no JSON.
