### PR TITLE
Remove toString call in the project-loader.

### DIFF
--- a/src/lib/project-loader-hoc.jsx
+++ b/src/lib/project-loader-hoc.jsx
@@ -31,7 +31,7 @@ const ProjectLoaderHOC = function (WrappedComponent) {
                     storage
                         .load(storage.AssetType.Project, this.state.projectId, storage.DataFormat.JSON)
                         .then(projectAsset => projectAsset && this.setState({
-                            projectData: projectAsset.data.toString(),
+                            projectData: projectAsset.data,
                             fetchingProject: false
                         }))
                         .catch(err => log.error(err));


### PR DESCRIPTION
### Proposed Changes

No longer need to convert the data from the loaded project to a string. This was also causing an error in the issue mentioned below.

### Reason for Changes

Resolves part of #1722 (namely the second project mentioned in that issue). Also for ergonomics; the toString call is no longer necessary now that vm/parser can load .sb2 files.

### Test Coverage

Existing tests pass.