### PR TITLE
Hook up save load buttons to file/edit options in menu bar

### DIFF
--- a/src/components/load-button/load-button.jsx
+++ b/src/components/load-button/load-button.jsx
@@ -14,25 +14,20 @@ const LoadButtonComponent = ({
     ...props
 }) => (
     <span {...props}>
-        <ComingSoonTooltip
-            place="bottom"
-            tooltipId="load-button"
+        <div
+            className={props.className}
+            onClick={onClick}
         >
-            <ButtonComponent
-                disabled
-                onClick={onClick}
-            >
-                {title}
-            </ButtonComponent>
-            <input
-                disabled
-                accept=".sb2,.sb3"
-                className={styles.fileInput}
-                ref={inputRef}
-                type="file"
-                onChange={onChange}
-            />
-        </ComingSoonTooltip>
+            {title}
+        </div>
+        <input
+            disabled
+            accept=".sb2,.sb3"
+            className={styles.fileInput}
+            ref={inputRef}
+            type="file"
+            onChange={onChange}
+        />
     </span>
 );
 
@@ -44,6 +39,6 @@ LoadButtonComponent.propTypes = {
     title: PropTypes.string
 };
 LoadButtonComponent.defaultProps = {
-    title: 'Load'
+    title: 'Edit'
 };
 export default LoadButtonComponent;

--- a/src/components/load-button/load-button.jsx
+++ b/src/components/load-button/load-button.jsx
@@ -1,9 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import ButtonComponent from '../button/button.jsx';
-import {ComingSoonTooltip} from '../coming-soon/coming-soon.jsx';
-
 import styles from './load-button.css';
 
 const LoadButtonComponent = ({

--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -8,6 +8,8 @@ import Box from '../box/box.jsx';
 import Button from '../button/button.jsx';
 import {ComingSoonTooltip} from '../coming-soon/coming-soon.jsx';
 import LanguageSelector from '../../containers/language-selector.jsx';
+import SaveButton from '../../containers/save-button.jsx';
+import LoadButton from '../../containers/load-button.jsx';
 
 import {openFeedbackForm} from '../../reducers/modals';
 
@@ -53,7 +55,7 @@ const MenuBar = props => (
                         tooltipClassName={styles.comingSoonTooltip}
                         tooltipId="file-menu"
                     >
-                        <div className={classNames(styles.fileMenu)}>File</div>
+                        <SaveButton className={classNames(styles.fileMenu)} />
                     </ComingSoonTooltip>
                 </div>
                 <div className={classNames(styles.menuItem)}>
@@ -63,7 +65,7 @@ const MenuBar = props => (
                         tooltipClassName={styles.comingSoonTooltip}
                         tooltipId="edit-menu"
                     >
-                        <div className={classNames(styles.editMenu)}>Edit</div>
+                        <LoadButton className={classNames(styles.editMenu)} />
                     </ComingSoonTooltip>
                 </div>
             </div>

--- a/src/containers/save-button.jsx
+++ b/src/containers/save-button.jsx
@@ -34,24 +34,18 @@ class SaveButton extends React.Component {
             document.body.removeChild(saveLink);
         });
     }
+    // TODO add back `onClick={this.handleClick}` when enabling button
     render () {
         const {
             vm, // eslint-disable-line no-unused-vars
             ...props
         } = this.props;
         return (
-            <ComingSoonTooltip
-                place="bottom"
-                tooltipId="save-button"
+            <div
+                {...props}
             >
-                <ButtonComponent
-                    disabled
-                    onClick={this.handleClick}
-                    {...props}
-                >
-                    Save
-                </ButtonComponent>
-            </ComingSoonTooltip>
+                File
+            </div>
         );
     }
 }

--- a/src/containers/save-button.jsx
+++ b/src/containers/save-button.jsx
@@ -3,10 +3,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
 
-import ButtonComponent from '../components/button/button.jsx';
-import {ComingSoonTooltip} from '../components/coming-soon/coming-soon.jsx';
-
-
 class SaveButton extends React.Component {
     constructor (props) {
         super(props);


### PR DESCRIPTION
Everything stays disabled and still has tooltips.

### Proposed Changes

Hook up save/load functionality to the file/edit options in the menu bar as a temporary solution while we wait for dropdown menus.

### Reason for Changes

Unblocks save/load progress.

### Test Coverage

Existing tests pass.