### PR TITLE
Fixing issue #1753

### DIFF
--- a/src/components/sprite-selector-item/sprite-selector-item.css
+++ b/src/components/sprite-selector-item/sprite-selector-item.css
@@ -54,7 +54,7 @@
     position: absolute;
     top: 0.125rem;
     right: 0.125rem;
-    z-index: 1 ;
+    z-index: 1;
 }
 
 .number {

--- a/src/components/sprite-selector-item/sprite-selector-item.css
+++ b/src/components/sprite-selector-item/sprite-selector-item.css
@@ -54,7 +54,7 @@
     position: absolute;
     top: 0.125rem;
     right: 0.125rem;
-    z-index: 2;
+    z-index: 1 ;
 }
 
 .number {


### PR DESCRIPTION
### Resolves

Close buttons should not be over the new sprite menu #1753

### Proposed Changes

Changed CSS `z-index` of the delete button in question. 

### Reason for Changes

Fix issue #1753 
