### PR TITLE
Add more information to error boundary messages

### DIFF
--- a/src/containers/error-boundary.jsx
+++ b/src/containers/error-boundary.jsx
@@ -17,7 +17,7 @@ class ErrorBoundary extends React.Component {
     componentDidCatch (error, info) {
         // Display fallback UI
         this.setState({hasError: true});
-        log.error(`Unhandled Error: ${error}, info: ${info}`);
+        log.error(`Unhandled Error: ${error}\n${error.stack}\nComponent stack: ${info.componentStack}`);
         analytics.event({
             category: 'error',
             action: 'Fatal Error',

--- a/src/containers/error-boundary.jsx
+++ b/src/containers/error-boundary.jsx
@@ -17,7 +17,7 @@ class ErrorBoundary extends React.Component {
     componentDidCatch (error, info) {
         // Display fallback UI
         this.setState({hasError: true});
-        log.error(`Unhandled Error: ${error}\n${error.stack}\nComponent stack: ${info.componentStack}`);
+        log.error(`Unhandled Error: ${error.stack}\nComponent stack: ${info.componentStack}`);
         analytics.event({
             category: 'error',
             action: 'Fatal Error',


### PR DESCRIPTION
### Proposed Changes

_Describe what this Pull Request does_
Add more stack info to the error messages emitted by the error boundary.  Retains the error message (it's the first line of `error.stack`).

### Reason for Changes

_Explain why these changes should be made_
While working on the menubar, I couldn't find the source of an error. I imagine this will help others in the future.
