### PR TITLE
Add editor drag mode for popping sprites of stage.

### DIFF
--- a/src/components/stage/stage.css
+++ b/src/components/stage/stage.css
@@ -14,6 +14,9 @@
 
     /* @todo: This is for overriding the value being set somewhere. Where is it being set? */
     background-color: transparent;
+
+    /* Allow custom touch handling to prevent scrolling on Edge */
+    touch-action: none;
 }
 
 .with-color-picker {

--- a/src/components/stage/stage.css
+++ b/src/components/stage/stage.css
@@ -8,6 +8,10 @@
     */
     display: block;
 
+    /* Attach border radius directly to canvas to prevent needing overflow:hidden; */
+    border-radius: $space;
+    border: 1px solid $ui-black-transparent;
+
     /* @todo: This is for overriding the value being set somewhere. Where is it being set? */
     background-color: transparent;
 }
@@ -30,10 +34,6 @@
 
 .stage-wrapper {
     position: relative;
-    border-radius: $space;
-    border: 1px solid $ui-black-transparent;
-    /* Keep the canvas inside the border radius */
-    overflow: hidden;
 }
 
 .stage-wrapper-overlay {
@@ -78,3 +78,11 @@
     pointer-events: none;
     overflow: hidden;
 }
+
+.dragging-sprite {
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 1000; /* Above everything so it is draggable into other panes */
+    filter: drop-shadow(5px 5px 5px $ui-black-transparent);
+ }

--- a/src/components/stage/stage.jsx
+++ b/src/components/stage/stage.jsx
@@ -12,6 +12,7 @@ import styles from './stage.css';
 const StageComponent = props => {
     const {
         canvasRef,
+        dragRef,
         height,
         isColorPicking,
         isFullScreen,
@@ -24,7 +25,7 @@ const StageComponent = props => {
     } = props;
 
     const stageSize = getStageSize(isFullScreen, height, width);
-    
+
     return (
         <div>
             <Box
@@ -71,6 +72,12 @@ const StageComponent = props => {
                         </div>
                     </div>
                 )}
+                <canvas
+                    className={styles.draggingSprite}
+                    height={0}
+                    ref={dragRef}
+                    width={0}
+                />
             </Box>
             {isColorPicking ? (
                 <Box
@@ -84,6 +91,7 @@ const StageComponent = props => {
 StageComponent.propTypes = {
     canvasRef: PropTypes.func,
     colorInfo: Loupe.propTypes.colorInfo,
+    dragRef: PropTypes.func,
     height: PropTypes.number,
     isColorPicking: PropTypes.bool,
     isFullScreen: PropTypes.bool.isRequired,
@@ -94,6 +102,7 @@ StageComponent.propTypes = {
 };
 StageComponent.defaultProps = {
     canvasRef: () => {},
+    dragRef: () => {},
     width: 480,
     height: 360
 };

--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -356,6 +356,7 @@ class Stage extends React.Component {
         const {
             vm, // eslint-disable-line no-unused-vars
             onActivateColorPicker, // eslint-disable-line no-unused-vars
+            useEditorDragStyle, // eslint-disable-line no-unused-vars
             ...props
         } = this.props;
         return (

--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -278,9 +278,11 @@ class Stage extends React.Component {
         // can use translation to move to mouse position smoothly.
         this.dragCanvas.style.left = `${-x}px`;
         this.dragCanvas.style.top = `${-y}px`;
+        this.dragCanvas.style.display = 'block';
     }
     clearDragCanvas () {
         this.dragCanvas.width = this.dragCanvas.height = 0;
+        this.dragCanvas.style.display = 'none';
     }
     positionDragCanvas (mouseX, mouseY) {
         // mouseX/Y are relative to stage top/left, and dragCanvas is already


### PR DESCRIPTION
Also integrate the "ignore draggability, always drag" behavior of editor
mode.

Right now, editor drag mode is hooked up to the "isFullscreen" flag,
since it is the closest thing we have to player mode now.

### Resolves

_What Github issue does this resolve (please include link)?_

Resolves https://github.com/LLK/scratch-render/issues/128, implemented in the GUI because (a) we needed the sprite drag out of the stage for the backpack and (b) the shadow is trivial in the GUI (`filter: drop-shadow`) but would be complex in the renderer.

Resolves https://github.com/LLK/scratch-gui/issues/1653

Doesn't create a "player" mode, but introduces a flag that can be used when making player mode, so related to https://github.com/LLK/scratch-gui/issues/1687

### Proposed Changes

_Describe what this Pull Request does_

Adds a flag to the stage `useEditorDragStyle`, that when enabled changes the drag behavior in the following ways:
- Make the sprite not visible in the renderer while dragging.
- Use the renderer `extractDrawable` function to render the sprite on its own canvas, managed by the GUI.
- Adds a drop shadow to the sprite canvas. 
- Changes the CSS to allow dragging outside the stage. 
- Hooks up the `isFullscreen` flag to also determine whether to use editor drag style (`useEditorDragStyle = !isFullScreen`)
- When not using editor drag style, check targets for draggability before starting a drag on them.

### Test Coverage

_Please show how you have added tests to cover your changes_

@BryceLTaylor when we test this, there are a few things we should make sure to do:
- Make sure not-draggable sprites can be dragged in the editor,  but cannot be dragged when you make it fullscreen (matching scratch2 behavior)
- Sprites can be dragged all around!
- Sprite XY position is still fenced even when dragging (i.e. the x/y inputs should not go way outside stage bounds, and the sprite should pop back to the fenced position when you drop the sprite).
- It should work on touch devices just as well. 

![drag-outside](https://user-images.githubusercontent.com/654102/38687005-acb75f94-3e43-11e8-912e-613766667a32.gif)

/cc @cwillisf you might want to take a look at the way I'm actually using the data from `extractDrawable`. One hiccup was that to draw image data I needed to create a `Uint8ClampedArray`, the imagedata constructor cannot be used with `Uint8Array` directly. But I used the constructor that reads from the underlying buffer, so it doesn't do a copy and isn't slow. But if you have a different idea about this let me know. 
