### PR TITLE
Fix painted sprite names

### DIFF
--- a/src/lib/libraries/costumes.json
+++ b/src/lib/libraries/costumes.json
@@ -1364,7 +1364,7 @@
         ]
     },
     {
-        "name": "Empty",
+        "name": "Sprite",
         "md5": "cd21514d0531fdffb22204e0ec5ed84a.svg",
         "type": "costume",
         "tags": [],

--- a/src/lib/libraries/sprites.json
+++ b/src/lib/libraries/sprites.json
@@ -2712,7 +2712,7 @@
         }
     },
     {
-        "name": "Empty",
+        "name": "Sprite",
         "md5": "cd21514d0531fdffb22204e0ec5ed84a.svg",
         "type": "sprite",
         "tags": [],
@@ -2722,7 +2722,7 @@
             1
         ],
         "json": {
-            "objName": "Empty",
+            "objName": "Sprite",
             "sounds": [
                 {
                     "soundName": "pop",
@@ -2735,7 +2735,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "empty",
+                    "costumeName": "sprite",
                     "baseLayerID": -1,
                     "baseLayerMD5": "cd21514d0531fdffb22204e0ec5ed84a.svg",
                     "bitmapResolution": 1,


### PR DESCRIPTION
### Resolves

#1731 

### Proposed Changes

Renames the "Empty" sprite to "Sprite"

### Reason for Changes

When you paint a sprite, this sprite is used, so painted sprites are currently titled "Empty"

### Test Coverage

Maybe consider hiding the "Sprite" sprite from the sprite library somehow?
