### PR TITLE
Upload a sound file

### DIFF
--- a/src/components/action-menu/action-menu.css
+++ b/src/components/action-menu/action-menu.css
@@ -80,6 +80,10 @@ $more-button-size: 2.25rem;
     z-index: 10; /* @todo justify */
 }
 
+.file-input {
+    display: none;
+}
+
 .expanded .more-buttons {
     max-height: 1000px; /* Arbitrary, needs to be a value in order for animation to run */
 }

--- a/src/components/action-menu/action-menu.jsx
+++ b/src/components/action-menu/action-menu.jsx
@@ -140,7 +140,7 @@ class ActionMenu extends React.Component {
                             fileInput, accept: fileAccept, fileChange, fileInputRef}) => {
                             const isComingSoon = !handleClick;
                             const hasFileInput = fileInput;
-                            const tooltipId = `tooltip-${Math.random()}`;
+                            const tooltipId = title;
                             return (
                                 <div key={tooltipId}>
                                     <button

--- a/src/components/action-menu/action-menu.jsx
+++ b/src/components/action-menu/action-menu.jsx
@@ -191,10 +191,9 @@ ActionMenu.propTypes = {
         img: PropTypes.string,
         title: PropTypes.node.isRequired,
         onClick: PropTypes.func, // Optional, "coming soon" if no callback provided
-        fileInput: PropTypes.string, // Optional, only for file and camera upload
-        accept: PropTypes.string, // Optional, only for file and camera upload
-        fileChange: PropTypes.func, // Optional, only for file and camera upload
-        fileInputRef: PropTypes.func
+        fileAccept: PropTypes.string, // Optional, only for file upload
+        fileChange: PropTypes.func, // Optional, only for file upload
+        fileInput: PropTypes.func // Optional, only for file upload
     })),
     onClick: PropTypes.func.isRequired,
     title: PropTypes.node.isRequired

--- a/src/components/action-menu/action-menu.jsx
+++ b/src/components/action-menu/action-menu.jsx
@@ -137,7 +137,7 @@ class ActionMenu extends React.Component {
                 <div className={styles.moreButtonsOuter}>
                     <div className={styles.moreButtons}>
                         {(moreButtons || []).map(({img, title, onClick: handleClick,
-                            fileInput, accept: fileAccept, fileChange, fileInputRef}) => {
+                            fileAccept, fileChange, fileInput}) => {
                             const isComingSoon = !handleClick;
                             const hasFileInput = fileInput;
                             const tooltipId = title;
@@ -161,8 +161,8 @@ class ActionMenu extends React.Component {
                                             <input
                                                 accept={fileAccept}
                                                 className={styles.fileInput}
-                                                ref={fileInputRef}
-                                                type={fileInput}
+                                                ref={fileInput}
+                                                type="file"
                                                 onChange={fileChange}
                                             />) : null}
                                     </button>

--- a/src/components/action-menu/action-menu.jsx
+++ b/src/components/action-menu/action-menu.jsx
@@ -136,8 +136,10 @@ class ActionMenu extends React.Component {
                 />
                 <div className={styles.moreButtonsOuter}>
                     <div className={styles.moreButtons}>
-                        {(moreButtons || []).map(({img, title, onClick: handleClick}) => {
+                        {(moreButtons || []).map(({img, title, onClick: handleClick,
+                            fileInput, accept: fileAccept, fileChange, fileInputRef}) => {
                             const isComingSoon = !handleClick;
+                            const hasFileInput = fileInput;
                             const tooltipId = `tooltip-${Math.random()}`;
                             return (
                                 <div key={tooltipId}>
@@ -148,13 +150,21 @@ class ActionMenu extends React.Component {
                                         })}
                                         data-for={tooltipId}
                                         data-tip={title}
-                                        onClick={this.clickDelayer(handleClick)}
+                                        onClick={hasFileInput ? handleClick : this.clickDelayer(handleClick)}
                                     >
                                         <img
                                             className={styles.moreIcon}
                                             draggable={false}
                                             src={img}
                                         />
+                                        {hasFileInput ? (
+                                            <input
+                                                accept={fileAccept}
+                                                className={styles.fileInput}
+                                                ref={fileInputRef}
+                                                type={fileInput}
+                                                onChange={fileChange}
+                                            />) : null}
                                     </button>
                                     <ReactTooltip
                                         className={classNames(styles.tooltip, {
@@ -180,7 +190,11 @@ ActionMenu.propTypes = {
     moreButtons: PropTypes.arrayOf(PropTypes.shape({
         img: PropTypes.string,
         title: PropTypes.node.isRequired,
-        onClick: PropTypes.func // Optional, "coming soon" if no callback provided
+        onClick: PropTypes.func, // Optional, "coming soon" if no callback provided
+        fileInput: PropTypes.string, // Optional, only for file and camera upload
+        accept: PropTypes.string, // Optional, only for file and camera upload
+        fileChange: PropTypes.func, // Optional, only for file and camera upload
+        fileInputRef: PropTypes.func
     })),
     onClick: PropTypes.func.isRequired,
     title: PropTypes.node.isRequired

--- a/src/containers/sound-tab.jsx
+++ b/src/containers/sound-tab.jsx
@@ -202,10 +202,9 @@ class SoundTab extends React.Component {
                     title: intl.formatMessage(messages.fileUploadSound),
                     img: fileUploadIcon,
                     onClick: this.handleFileUploadClick,
-                    fileInput: 'file',
-                    accept: '.wav, .mp3',
+                    fileAccept: '.wav, .mp3',
                     fileChange: this.handleSoundUpload,
-                    fileInputRef: this.setFileInput
+                    fileInput: this.setFileInput
                 }, {
                     title: intl.formatMessage(messages.surpriseSound),
                     img: surpriseIcon,

--- a/src/containers/sound-tab.jsx
+++ b/src/containers/sound-tab.jsx
@@ -107,14 +107,19 @@ class SoundTab extends React.Component {
 
     handleSoundUpload (e) {
         const thisFileInput = e.target;
+        let thisFile = null;
         const reader = new FileReader();
         reader.onload = () => {
+            // Reset the file input value now that we have everything we need
+            // so that the user can upload the same sound multiple times if
+            // they choose
+            thisFileInput.value = null;
             // Cache the sound in storage
             const soundBuffer = reader.result;
             const storage = this.props.vm.runtime.storage;
-            // TODO only accepting .wav files right now,
-            // but later will have to do something sensible with other types of sounds
-            const soundFormat = storage.DataFormat.WAV;
+
+            const fileType = thisFile.type; // what file type does the browser think this is
+            const soundFormat = fileType === 'audio/mp3' ? storage.DataFormat.MP3 : storage.DataFormat.WAV;
             const md5 = storage.builtinHelper.cache(
                 storage.AssetType.Sound,
                 soundFormat,
@@ -133,13 +138,12 @@ class SoundTab extends React.Component {
             });
         };
         if (thisFileInput.files) {
-            reader.readAsArrayBuffer(thisFileInput.files[0]);
-            thisFileInput.value = null;
+            thisFile = thisFileInput.files[0];
+            reader.readAsArrayBuffer(thisFile);
         }
     }
 
     setFileInput (input) {
-        console.log('setting file input!');
         if (input && !this.fileInput) this.fileInput = input;
     }
 

--- a/src/containers/sound-tab.jsx
+++ b/src/containers/sound-tab.jsx
@@ -144,7 +144,7 @@ class SoundTab extends React.Component {
     }
 
     setFileInput (input) {
-        if (input && !this.fileInput) this.fileInput = input;
+        this.fileInput = input;
     }
 
     render () {


### PR DESCRIPTION
### Resolves

#1776

### Proposed Changes

Adds the ability to upload a sound from a file on disk. Supports both .wav (regular and ADPCM) and .mp3.

**Changes yet to come:** Support for selecting and uploading multiple files at once (this shouldn't be a difficult change, but I wanted to get feedback on these proposed changes first).

#### Related PRs
These changes depend on the following, and should not be merged until these others have been merged in:

LLK/scratch-vm#1060
LLK/scratch-audio#76

### Reason for Changes

#1776

### Test Coverage

Existing tests pass.
