### PR TITLE
Limit toolbox updates to when we tell it to update

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -74,7 +74,9 @@ class Blocks extends React.Component {
         // entire toolbox every time we reset the workspace.  We call updateToolbox as a part of
         // componentDidUpdate so the toolbox will still correctly be updated
         this.setToolboxRefreshEnabled = this.workspace.setToolboxRefreshEnabled.bind(this.workspace);
-        this.workspace.setToolboxRefreshEnabled = () => this.setToolboxRefreshEnabled(false);
+        this.workspace.setToolboxRefreshEnabled = () => {
+            this.setToolboxRefreshEnabled(false);
+        };
 
         // @todo change this when blockly supports UI events
         addFunctionListener(this.workspace, 'translate', this.onWorkspaceMetricsChange);
@@ -107,6 +109,11 @@ class Blocks extends React.Component {
             clearTimeout(this.toolboxUpdateTimeout);
             this.toolboxUpdateTimeout = setTimeout(() => {
                 this.workspace.updateToolbox(this.props.toolboxXML);
+                // In order to catch any changes that mutate the toolbox during "normal runtime"
+                // (variable changes/etc), re-enable toolbox refresh.
+                // Using the setter function will rerender the entire toolbox which we just rendered.
+                this.workspace.toolboxRefreshEnabled_ = true;
+
                 const currentCategoryPos = this.workspace.toolbox_.getCategoryPositionByName(categoryName);
                 this.workspace.toolbox_.setFlyoutScrollPos(currentCategoryPos + offset);
             }, 0);

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -218,19 +218,15 @@ class Blocks extends React.Component {
         // Remove and reattach the workspace listener (but allow flyout events)
         this.workspace.removeChangeListener(this.props.vm.blockListener);
         const dom = this.ScratchBlocks.Xml.textToDom(data.xml);
-        // @todo This line rerenders toolbox, and the change in the toolbox XML also rerenders the toolbox.
-        // We should only rerender the toolbox once. See https://github.com/LLK/scratch-gui/issues/901
         this.ScratchBlocks.Xml.clearWorkspaceAndLoadFromXml(dom, this.workspace);
         this.workspace.addChangeListener(this.props.vm.blockListener);
 
         if (this.props.vm.editingTarget && this.state.workspaceMetrics[this.props.vm.editingTarget.id]) {
-            setTimeout(() => {
-                const {scrollX, scrollY, scale} = this.state.workspaceMetrics[this.props.vm.editingTarget.id];
-                this.workspace.scrollX = scrollX;
-                this.workspace.scrollY = scrollY;
-                this.workspace.scale = scale;
-                this.workspace.resize();
-            }, 0);
+            const {scrollX, scrollY, scale} = this.state.workspaceMetrics[this.props.vm.editingTarget.id];
+            this.workspace.scrollX = scrollX;
+            this.workspace.scrollY = scrollY;
+            this.workspace.scale = scale;
+            this.workspace.resize();
         }
     }
     handleExtensionAdded (blocksInfo) {

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -104,8 +104,8 @@ class Blocks extends React.Component {
             const categoryName = this.workspace.toolbox_.getSelectedCategoryName();
             const offset = this.workspace.toolbox_.getCategoryScrollOffset();
             // rather than update the toolbox "sync" -- update it in the next frame
-            clearTimeout(this.toolboxUpdate);
-            this.toolboxUpdate = setTimeout(() => {
+            clearTimeout(this.toolboxUpdateTimeout);
+            this.toolboxUpdateTimeout = setTimeout(() => {
                 this.workspace.updateToolbox(this.props.toolboxXML);
                 const currentCategoryPos = this.workspace.toolbox_.getCategoryPositionByName(categoryName);
                 this.workspace.toolbox_.setFlyoutScrollPos(currentCategoryPos + offset);
@@ -127,7 +127,7 @@ class Blocks extends React.Component {
     componentWillUnmount () {
         this.detachVM();
         this.workspace.dispose();
-        clearTimeout(this.toolboxUpdate);
+        clearTimeout(this.toolboxUpdateTimeout);
     }
     attachVM () {
         this.workspace.addChangeListener(this.props.vm.blockListener);

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -70,9 +70,9 @@ class Blocks extends React.Component {
         );
         this.workspace = this.ScratchBlocks.inject(this.blocks, workspaceConfig);
 
-        // we actually never want the workspace to enable "refresh toolbox" - this basically re-renders the entire toolbox
-        // every time we reset the workspace.  We call updateToolbox as a part of componentDidUpdate so the toolbox will
-        // still correctly be updated
+        // we actually never want the workspace to enable "refresh toolbox" - this basically re-renders the
+        // entire toolbox every time we reset the workspace.  We call updateToolbox as a part of
+        // componentDidUpdate so the toolbox will still correctly be updated
         this.setToolboxRefreshEnabled = this.workspace.setToolboxRefreshEnabled.bind(this.workspace);
         this.workspace.setToolboxRefreshEnabled = () => this.setToolboxRefreshEnabled(false);
 


### PR DESCRIPTION
### Resolves

#901

### Proposed Changes

* Force the `toolboxRefreshEnabled` flag on the workspace to always be false (regardless of what `Blockly.Xml.domToWorkspace` says)

* Defer the toolbox update a frame to allow the click handler to return earlier

### Reason for Changes

* Removes approximately 400ms from the click event handler.
* Defers 200ms of it to the "next frame" so it still feels a bit jumpy, but since nothing really changes much you don't notice it.
