### PR TITLE
Use unique ids for the toolbox elements that change per sprite

### DIFF
--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -189,7 +189,7 @@ const looks = function (isStage, targetId) {
             </block>
             <block type="looks_nextbackdrop"/>
         ` : `
-            <block type="looks_switchcostumeto">
+            <block id="${targetId}_switchcostumeto" type="looks_switchcostumeto">
                 <value name="COSTUME">
                     <shadow type="looks_costume"/>
                 </value>
@@ -259,15 +259,15 @@ const looks = function (isStage, targetId) {
     `;
 };
 
-const sound = function () {
+const sound = function (isStage, targetId) {
     return `
     <category name="Sound" colour="#D65CD6" secondaryColour="#BD42BD">
-        <block type="sound_play">
+        <block id="${targetId}_sound_play" type="sound_play">
             <value name="SOUND_MENU">
                 <shadow type="sound_sounds_menu"/>
             </value>
         </block>
-        <block type="sound_playuntildone">
+        <block id="${targetId}_sound_playuntildone" type="sound_playuntildone">
             <value name="SOUND_MENU">
                 <shadow type="sound_sounds_menu"/>
             </value>


### PR DESCRIPTION
### Proposed Changes
https://github.com/LLK/scratch-blocks/pull/1442#issuecomment-381216217
In order to use the "reuse toolbox blocks" scratch-blocks patch, we need to make sure blocks that have shadows that will change based on sprite id are updated.
