### PR TITLE
Fix issue where loading a project while in costume tab yields oops page.

### DIFF
--- a/src/containers/costume-tab.jsx
+++ b/src/containers/costume-tab.jsx
@@ -224,7 +224,8 @@ class CostumeTab extends React.Component {
                 ]}
                 items={costumeData}
                 selectedItemIndex={this.state.selectedCostumeIndex}
-                onDeleteClick={target.costumes.length > 1 ? this.handleDeleteCostume : null}
+                onDeleteClick={target && target.costumes && target.costumes.length > 1 ?
+                    this.handleDeleteCostume : null}
                 onDuplicateClick={this.handleDuplicateCostume}
                 onItemClick={this.handleSelectCostume}
             >


### PR DESCRIPTION
### Resolves

#1795

### Proposed Changes

Loading a project while in the costume tab was yielding a fatal error resulting in the 'Oops' page because we were trying to lookup the length of target.costumes at a time when target.costumes doesn't exist anymore (because loading a new project requires clearing the runtime).
Change the line causing the error to first check if target and target.costumes are not falsey.

### Reason for Changes

#1795

### Test Coverage

Existing tests pass. Also manually tested for the same issue with the sound tab. 
