### PR TITLE
Fix integration tests failing due to Chrome update?

### DIFF
--- a/test/integration/project-loading.test.js
+++ b/test/integration/project-loading.test.js
@@ -66,6 +66,9 @@ describe('Loading scratch gui', () => {
         });
 
         test('Load a project by ID directly through url', async () => {
+            await driver.quit(); // Reset driver to test hitting # url directly
+            driver = getDriver();
+
             const projectId = '96708228';
             await loadUri(`${uri}#${projectId}`);
             await clickXpath('//button[@title="tryit"]');
@@ -78,6 +81,9 @@ describe('Loading scratch gui', () => {
         });
 
         test('Load a project by ID (fullscreen)', async () => {
+            await driver.quit(); // Reset driver to test hitting # url directly
+            driver = getDriver();
+
             const prevSize = driver.manage()
                 .window()
                 .getSize();


### PR DESCRIPTION
Quit and restart driver to hit # URL because hashchange behavior changed
and pages no longer reload if you hit the same hash URL twice

If it passes on travis, it works!