### PR TITLE
Library tweaks

### DIFF
--- a/src/components/filter/filter.css
+++ b/src/components/filter/filter.css
@@ -20,6 +20,10 @@
     margin: 0 .5rem;
 }
 
+.filter:focus-within {
+    box-shadow: 0 0 0 .25rem $motion-transparent;
+}
+
 /*
     Hidden state
 */

--- a/src/components/library/library.css
+++ b/src/components/library/library.css
@@ -20,6 +20,8 @@
     align-items: center;
     height: calc($library-filter-bar-height + 2rem); /* padding */
     background-color: $motion-transparent;
+    padding: 0 1rem;
+    font-size: .875rem;
 }
 
 .filter-bar-item {
@@ -42,6 +44,7 @@
 
 .divider {
     transform: scaleY(1.39);
+    height: $library-filter-bar-height;
 }
 
 .tag-wrapper {

--- a/src/components/modal/modal.css
+++ b/src/components/modal/modal.css
@@ -111,4 +111,5 @@ $sides: 20rem;
 
 .back-button {
     font-weight: normal;
+    padding-left: 0;
 }


### PR DESCRIPTION
These are some late fixes to layout, some of which that came up while fixing the tag clipping on 1024px wide devices.
* Align back icon with the left edge of content
* Add padding to the search bar
* Give the divider height so you can see it
* Add a cool border around the filter bar while focused, but this uses focus-within which has limited support so not all browsers will display this (let's say it's progressive enhancement)