### PR TITLE
Account for filter bar in library grid height

### DIFF
--- a/src/components/library/library.css
+++ b/src/components/library/library.css
@@ -13,6 +13,10 @@
     padding: 0.5rem;
 }
 
+.library-scroll-grid.withFilterBar {
+    height: calc(100% - $library-header-height - $library-filter-bar-height - 2rem);
+}
+
 .filter-bar {
     display: flex;
     flex-direction: row;

--- a/src/components/library/library.jsx
+++ b/src/components/library/library.jsx
@@ -128,7 +128,11 @@ class LibraryComponent extends React.Component {
                         }
                     </div>
                 )}
-                <div className={styles.libraryScrollGrid}>
+                <div
+                    className={classNames(styles.libraryScrollGrid, {
+                        [styles.withFilterBar]: this.props.filterable || this.props.tags
+                    })}
+                >
                     {this.getFilteredData().map((dataItem, index) => {
                         const scratchURL = dataItem.md5 ?
                             `https://cdn.assets.scratch.mit.edu/internalapi/asset/${dataItem.md5}/get/` :


### PR DESCRIPTION
This prevents the fullscreen modal from being scrollable by removing extra height from the 

Try scrolling on the header of the sprite library. You shouldn't be able to scroll this.

Demo: https://rschamp.github.io/scratch-gui/bugfix/library-header-height/