### PR TITLE
Center library content

### DIFF
--- a/src/components/library-item/library-item.css
+++ b/src/components/library-item/library-item.css
@@ -6,9 +6,9 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    flex-basis: 160px;
-    max-width: 160px;
-    height: 160px;
+    flex-basis: $library-item-width;
+    width: $library-item-width;
+    height: $library-item-height;
     margin: $space;
     padding: 1rem 1rem 0 1rem;
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
@@ -69,9 +69,9 @@
 }
 
 .featured-item {
-    flex-basis: 300px;
-    max-width: 300px;
-    height: auto;
+    flex-basis: $library-item-width-large;
+    width: $library-item-width-large;
+    height: $library-item-height-large;
     overflow: hidden;
     padding: 0;
 }

--- a/src/components/library/library.css
+++ b/src/components/library/library.css
@@ -1,20 +1,27 @@
 @import "../../css/units.css";
 @import "../../css/colors.css";
 
-.library-scroll-grid {
-    display: grid;
-    /* 10rem wide items + .5 * 2 gap = 11rem */
-    grid-template-columns: repeat(auto-fill, 11rem);
-    grid-gap: .5rem;
-    padding: 1rem; /* .5rem gap * 2 */
-    justify-content: center;
+.library-scroll-area {
+    padding: calc($library-grid-gap * 2);
     background: $ui-secondary;
     overflow-y: auto;
     height: calc(100% - $library-header-height);
 }
 
-.library-scroll-grid.withFilterBar {
+.with-filter-bar {
     height: calc(100% - $library-header-height - $library-filter-bar-height - 2rem);
+}
+
+.library-grid {
+    display: grid;
+    grid-template-rows: repeat(auto-fill, calc($library-item-height + 2 * $library-grid-gap));
+    grid-template-columns: repeat(auto-fill, calc($library-item-width + 2 * $library-grid-gap));
+    justify-content: center;
+}
+
+.featured {
+    grid-template-rows: repeat(auto-fill, calc($library-item-height-large + 2 * $library-grid-gap));
+    grid-template-columns: repeat(auto-fill, calc($library-item-width-large + 2 * $library-grid-gap));
 }
 
 .filter-bar {

--- a/src/components/library/library.css
+++ b/src/components/library/library.css
@@ -2,15 +2,15 @@
 @import "../../css/colors.css";
 
 .library-scroll-grid {
-    display: flex;
-    justify-content: flex-start;
-    align-content: flex-start;
+    display: grid;
+    /* 10rem wide items + .5 * 2 gap = 11rem */
+    grid-template-columns: repeat(auto-fill, 11rem);
+    grid-gap: .5rem;
+    padding: 1rem; /* .5rem gap * 2 */
+    justify-content: center;
     background: $ui-secondary;
-    flex-grow: 1;
-    flex-wrap: wrap;
     overflow-y: auto;
     height: calc(100% - $library-header-height);
-    padding: 0.5rem;
 }
 
 .library-scroll-grid.withFilterBar {

--- a/src/components/library/library.jsx
+++ b/src/components/library/library.jsx
@@ -50,7 +50,7 @@ class LibraryComponent extends React.Component {
     }
     handleSelect (id) {
         this.props.onRequestClose();
-        this.props.onItemSelected(this.getFilteredData()[id]);
+        this.props.onItemSelected(this.props.data[id]);
     }
     handleTagClick (tag) {
         this.setState({
@@ -59,10 +59,10 @@ class LibraryComponent extends React.Component {
         });
     }
     handleMouseEnter (id) {
-        if (this.props.onItemMouseEnter) this.props.onItemMouseEnter(this.getFilteredData()[id]);
+        if (this.props.onItemMouseEnter) this.props.onItemMouseEnter(this.props.data[id]);
     }
     handleMouseLeave (id) {
-        if (this.props.onItemMouseLeave) this.props.onItemMouseLeave(this.getFilteredData()[id]);
+        if (this.props.onItemMouseLeave) this.props.onItemMouseLeave(this.props.data[id]);
     }
     handleFilterChange (event) {
         this.setState({
@@ -75,7 +75,7 @@ class LibraryComponent extends React.Component {
     }
     getFilteredData () {
         // Filters and splits the data based on the `featured` flag
-        return this.props.data.reduce((acc, dataItem) => {
+        return this.props.data.reduce((acc, dataItem, dataId) => {
             const inSet = this.state.selectedTag === 'all' ? (
                 // Filter based on query
                 (dataItem.tags || [])
@@ -97,7 +97,7 @@ class LibraryComponent extends React.Component {
             if (inSet) {
                 // splt by the featured property
                 if (!acc[dataItem.featured]) acc[dataItem.featured] = [];
-                acc[dataItem.featured].push(dataItem);
+                acc[dataItem.featured].push(Object.assign({}, dataItem, {dataId}));
             }
             return acc;
         }, {});
@@ -161,7 +161,7 @@ class LibraryComponent extends React.Component {
                                 })}
                                 key={`grid-featured-${featured}`}
                             >
-                                {filteredData[featured].map((dataItem, index) => {
+                                {filteredData[featured].map(dataItem => {
                                     const scratchURL = dataItem.md5 ?
                                         `https://cdn.assets.scratch.mit.edu/internalapi/asset/${dataItem.md5}/get/` :
                                         dataItem.rawURL;
@@ -171,8 +171,8 @@ class LibraryComponent extends React.Component {
                                             disabled={dataItem.disabled}
                                             featured={dataItem.featured}
                                             iconURL={scratchURL}
-                                            id={index}
-                                            key={`item_${index}`}
+                                            id={dataItem.dataId}
+                                            key={`item_${dataItem.dataId}`}
                                             name={dataItem.name}
                                             onBlur={this.handleBlur}
                                             onFocus={this.handleFocus}

--- a/src/components/library/library.jsx
+++ b/src/components/library/library.jsx
@@ -74,25 +74,36 @@ class LibraryComponent extends React.Component {
         this.setState({filterQuery: ''});
     }
     getFilteredData () {
-        if (this.state.selectedTag === 'all') {
-            if (!this.state.filterQuery) return this.props.data;
-            return this.props.data.filter(dataItem => (
+        // Filters and splits the data based on the `featured` flag
+        return this.props.data.reduce((acc, dataItem) => {
+            const inSet = this.state.selectedTag === 'all' ? (
+                // Filter based on query
                 (dataItem.tags || [])
-                    // Second argument to map sets `this`
+                    // Lowercase all tags. Second argument is to define `this`
                     .map(String.prototype.toLowerCase.call, String.prototype.toLowerCase)
+                    // Make a list containing all the tags and the item's name
                     .concat(dataItem.name.toLowerCase())
-                    .join('\n') // unlikely to partially match newlines
+                    // The \n delimiter is to not match against regular user input
+                    .join('\n')
+                    // Find within a string representing the title and all the tags for the item
                     .indexOf(this.state.filterQuery.toLowerCase()) !== -1
-            ));
-        }
-        return this.props.data.filter(dataItem => (
-            dataItem.tags &&
-            dataItem.tags
-                .map(String.prototype.toLowerCase.call, String.prototype.toLowerCase)
-                .indexOf(this.state.selectedTag) !== -1
-        ));
+            ) : (
+                // A tag is selected, so just filter based on that tag
+                dataItem.tags &&
+                dataItem.tags
+                    .map(String.prototype.toLowerCase.call, String.prototype.toLowerCase)
+                    .indexOf(this.state.selectedTag) !== -1
+            );
+            if (inSet) {
+                // splt by the featured property
+                if (!acc[dataItem.featured]) acc[dataItem.featured] = [];
+                acc[dataItem.featured].push(dataItem);
+            }
+            return acc;
+        }, {});
     }
     render () {
+        const filteredData = this.getFilteredData();
         return (
             <Modal
                 fullScreen
@@ -138,31 +149,42 @@ class LibraryComponent extends React.Component {
                     </div>
                 )}
                 <div
-                    className={classNames(styles.libraryScrollGrid, {
+                    className={classNames(styles.libraryScrollArea, {
                         [styles.withFilterBar]: this.props.filterable || this.props.tags
                     })}
                 >
-                    {this.getFilteredData().map((dataItem, index) => {
-                        const scratchURL = dataItem.md5 ?
-                            `https://cdn.assets.scratch.mit.edu/internalapi/asset/${dataItem.md5}/get/` :
-                            dataItem.rawURL;
-                        return (
-                            <LibraryItem
-                                description={dataItem.description}
-                                disabled={dataItem.disabled}
-                                featured={dataItem.featured}
-                                iconURL={scratchURL}
-                                id={index}
-                                key={`item_${index}`}
-                                name={dataItem.name}
-                                onBlur={this.handleBlur}
-                                onFocus={this.handleFocus}
-                                onMouseEnter={this.handleMouseEnter}
-                                onMouseLeave={this.handleMouseLeave}
-                                onSelect={this.handleSelect}
-                            />
-                        );
-                    })}
+                    {Object.keys(filteredData).map(featured => (
+                        filteredData[featured].length > 0 && (
+                            <div
+                                className={classNames(styles.libraryGrid, {
+                                    [styles.featured]: featured === 'true'
+                                })}
+                                key={`grid-featured-${featured}`}
+                            >
+                                {filteredData[featured].map((dataItem, index) => {
+                                    const scratchURL = dataItem.md5 ?
+                                        `https://cdn.assets.scratch.mit.edu/internalapi/asset/${dataItem.md5}/get/` :
+                                        dataItem.rawURL;
+                                    return (
+                                        <LibraryItem
+                                            description={dataItem.description}
+                                            disabled={dataItem.disabled}
+                                            featured={dataItem.featured}
+                                            iconURL={scratchURL}
+                                            id={index}
+                                            key={`item_${index}`}
+                                            name={dataItem.name}
+                                            onBlur={this.handleBlur}
+                                            onFocus={this.handleFocus}
+                                            onMouseEnter={this.handleMouseEnter}
+                                            onMouseLeave={this.handleMouseLeave}
+                                            onSelect={this.handleSelect}
+                                        />
+                                    );
+                                })}
+                            </div>
+                        )
+                    ))}
                 </div>
             </Modal>
         );

--- a/src/css/units.css
+++ b/src/css/units.css
@@ -8,6 +8,11 @@ $stage-menu-height: 2.75rem;
 
 $library-header-height: 3.125rem;
 $library-filter-bar-height: 2.5rem;
+$library-item-width: 10rem;
+$library-item-height: 10rem;
+$library-item-width-large: 18.75rem;
+$library-item-height-large: 20rem;
+$library-grid-gap: .5rem;
 
 $form-radius: calc($space / 2);
 


### PR DESCRIPTION
Demo: https://rschamp.github.io/scratch-gui/bugfix/center-library-content/

Center library content using CSS grid.

According to https://caniuse.com/#feat=css-grid `display: grid` has the same browser support as Scratch 3.0.

### Resolves

_What Github issue does this resolve (please include link)?_
Resolves #1277

### Proposed Changes

_Describe what this Pull Request does_

This splits the libraries into "featured" and "unfeatured" sections. Theoretically one library could have both sections, but we currently only have one per library. This will need to be tweaked when that happens but is a starting point (unfeatured extensions will need to be the same width as featured extensions, and not be the same dimensions as sprites, costumes, etc.).

### Test Cases
* The sprite, costume, backdrop, sound and extension libraries should appear to be centered with the last row still left justified at any window width
* The above, in our lowest supported browser versions