### PR TITLE
Support new scratch-blocks API for translating custom proc mutations

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "redux-throttle": "0.1.1",
     "rimraf": "^2.6.1",
     "scratch-audio": "0.1.0-prerelease.1516198804",
-    "scratch-blocks": "0.1.0-prerelease.1524163302",
+    "scratch-blocks": "0.1.0-prerelease.1524267558",
     "scratch-l10n": "2.0.20180108132626",
     "scratch-paint": "0.2.0-prerelease.20180410152401",
     "scratch-render": "0.1.0-prerelease.1523453612",

--- a/src/containers/custom-procedures.jsx
+++ b/src/containers/custom-procedures.jsx
@@ -75,7 +75,7 @@ class CustomProcedures extends React.Component {
         this.props.onRequestClose();
     }
     handleOk () {
-        const newMutation = this.mutationRoot ? this.mutationRoot.mutationToDom() : null;
+        const newMutation = this.mutationRoot ? this.mutationRoot.mutationToDom(true) : null;
         this.props.onRequestClose(newMutation);
     }
     handleAddLabel () {


### PR DESCRIPTION
### Proposed Changes

Update gui to handle change to scratch-blocks API.

### Reason for Changes

Compatibility with scratch-blocks dependency.

### Test Coverage

Existing tests pass. Manually tested. Without this change (but with the scratch-blocks update) editing a custom procedure definition with a caller out on the workspace with obscured shadows gets shadows removed when revealed again.