### PR TITLE
Make MINDSTORMS uppercase as per feedback from LEGO

### DIFF
--- a/src/lib/libraries/extensions/index.js
+++ b/src/lib/libraries/extensions/index.js
@@ -54,7 +54,7 @@ export default [
         disabled: true
     },
     {
-        name: 'LEGO Mindstorms EV3',
+        name: 'LEGO MINDSTORMS EV3',
         extensionURL: '',
         iconURL: ev3Image,
         description: 'Build interactive robots and more.',


### PR DESCRIPTION
### Proposed Changes

- Make the word "Mindstorms" uppercase ("MINDSTORMS") as per feedback from LEGO

### Reason for Changes

- Correct branding in extension library