### PR TITLE
Update travis to publish dist and build

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,16 @@
+# Mac OS
+.DS_Store
+
+# NPM
+/node_modules
+npm-*
+
+# Testing
+/.nyc_output
+/coverage
+
+# Build
+/.opt-in
+
+# generated translation files
+/translations

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,14 @@ addons:
     chrome: stable
 node_js:
 - 8
+env:
+  - NODE_ENV=production
 cache:
   directories:
   - node_modules
 install:
-- npm install
-- npm update
+- npm --production=false install
+- npm --production=false update
 before_deploy:
 - npm --no-git-tag-version version 0.1.0-prerelease.$(date +%Y%m%d%H%M%S)
 - git config --global user.email $(git log --pretty=format:"%ae" -n1)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -69,8 +69,88 @@ const base = {
     ] : [])
 };
 
-module.exports = (
-    process.env.NODE_ENV === 'production' ?
+module.exports = [
+    // to run editor examples
+    defaultsDeep({}, base, {
+        entry: {
+            lib: ['react', 'react-dom'],
+            gui: './src/playground/index.jsx',
+            blocksonly: './src/playground/blocks-only.jsx',
+            compatibilitytesting: './src/playground/compatibility-testing.jsx',
+            player: './src/playground/player.jsx'
+        },
+        output: {
+            path: path.resolve(__dirname, 'build'),
+            filename: '[name].js'
+        },
+        externals: {
+            React: 'react',
+            ReactDOM: 'react-dom'
+        },
+        module: {
+            rules: base.module.rules.concat([
+                {
+                    test: /\.(svg|png|wav)$/,
+                    loader: 'file-loader',
+                    options: {
+                        outputPath: 'static/assets/'
+                    }
+                }
+            ])
+        },
+        plugins: base.plugins.concat([
+            new webpack.DefinePlugin({
+                'process.env.NODE_ENV': '"' + process.env.NODE_ENV + '"',
+                'process.env.DEBUG': Boolean(process.env.DEBUG)
+            }),
+            new webpack.optimize.CommonsChunkPlugin({
+                name: 'lib',
+                filename: 'lib.min.js'
+            }),
+            new HtmlWebpackPlugin({
+                chunks: ['lib', 'gui'],
+                template: 'src/playground/index.ejs',
+                title: 'Scratch 3.0 GUI'
+            }),
+            new HtmlWebpackPlugin({
+                chunks: ['lib', 'blocksonly'],
+                template: 'src/playground/index.ejs',
+                filename: 'blocks-only.html',
+                title: 'Scratch 3.0 GUI: Blocks Only Example'
+            }),
+            new HtmlWebpackPlugin({
+                chunks: ['lib', 'compatibilitytesting'],
+                template: 'src/playground/index.ejs',
+                filename: 'compatibility-testing.html',
+                title: 'Scratch 3.0 GUI: Compatibility Testing'
+            }),
+            new HtmlWebpackPlugin({
+                chunks: ['lib', 'player'],
+                template: 'src/playground/index.ejs',
+                filename: 'player.html',
+                title: 'Scratch 3.0 GUI: Player Example'
+            }),
+            new CopyWebpackPlugin([{
+                from: 'static',
+                to: 'static'
+            }]),
+            new CopyWebpackPlugin([{
+                from: 'node_modules/scratch-blocks/media',
+                to: 'static/blocks-media'
+            }]),
+            new CopyWebpackPlugin([{
+                from: 'extensions/**',
+                to: 'static',
+                context: 'src/examples'
+            }]),
+            new CopyWebpackPlugin([{
+                from: 'extension-worker.{js,js.map}',
+                context: 'node_modules/scratch-vm/dist/web'
+            }])
+        ])
+    })
+].concat(
+    process.env.NODE_ENV === 'production' ? (
         // export as library
         defaultsDeep({}, base, {
             target: 'web',
@@ -107,84 +187,5 @@ module.exports = (
                     context: 'node_modules/scratch-vm/dist/web'
                 }])
             ])
-        }) :
-        // to run editor examples
-        defaultsDeep({}, base, {
-            entry: {
-                lib: ['react', 'react-dom'],
-                gui: './src/playground/index.jsx',
-                blocksonly: './src/playground/blocks-only.jsx',
-                compatibilitytesting: './src/playground/compatibility-testing.jsx',
-                player: './src/playground/player.jsx'
-            },
-            output: {
-                path: path.resolve(__dirname, 'build'),
-                filename: '[name].js'
-            },
-            externals: {
-                React: 'react',
-                ReactDOM: 'react-dom'
-            },
-            module: {
-                rules: base.module.rules.concat([
-                    {
-                        test: /\.(svg|png|wav)$/,
-                        loader: 'file-loader',
-                        options: {
-                            outputPath: 'static/assets/'
-                        }
-                    }
-                ])
-            },
-            plugins: base.plugins.concat([
-                new webpack.DefinePlugin({
-                    'process.env.NODE_ENV': '"' + process.env.NODE_ENV + '"',
-                    'process.env.DEBUG': Boolean(process.env.DEBUG)
-                }),
-                new webpack.optimize.CommonsChunkPlugin({
-                    name: 'lib',
-                    filename: 'lib.min.js'
-                }),
-                new HtmlWebpackPlugin({
-                    chunks: ['lib', 'gui'],
-                    template: 'src/playground/index.ejs',
-                    title: 'Scratch 3.0 GUI'
-                }),
-                new HtmlWebpackPlugin({
-                    chunks: ['lib', 'blocksonly'],
-                    template: 'src/playground/index.ejs',
-                    filename: 'blocks-only.html',
-                    title: 'Scratch 3.0 GUI: Blocks Only Example'
-                }),
-                new HtmlWebpackPlugin({
-                    chunks: ['lib', 'compatibilitytesting'],
-                    template: 'src/playground/index.ejs',
-                    filename: 'compatibility-testing.html',
-                    title: 'Scratch 3.0 GUI: Compatibility Testing'
-                }),
-                new HtmlWebpackPlugin({
-                    chunks: ['lib', 'player'],
-                    template: 'src/playground/index.ejs',
-                    filename: 'player.html',
-                    title: 'Scratch 3.0 GUI: Player Example'
-                }),
-                new CopyWebpackPlugin([{
-                    from: 'static',
-                    to: 'static'
-                }]),
-                new CopyWebpackPlugin([{
-                    from: 'node_modules/scratch-blocks/media',
-                    to: 'static/blocks-media'
-                }]),
-                new CopyWebpackPlugin([{
-                    from: 'extensions/**',
-                    to: 'static',
-                    context: 'src/examples'
-                }]),
-                new CopyWebpackPlugin([{
-                    from: 'extension-worker.{js,js.map}',
-                    context: 'node_modules/scratch-vm/dist/web'
-                }])
-            ])
-        })
+        })) : []
 );


### PR DESCRIPTION
### Resolves

Dependency of https://github.com/LLK/scratch-www/issues/1773

### Proposed Changes

1. Update webpack so that `./dist` is an addition to the default build when `NODE_ENV=production`
2. Adds .npmignore so that `./dist` and `./build` get published.
3. Set NODE_ENV to production in travis

### Reason for Changes

Build directory is needed for the normal integration tests to run, and the dist directory is needed to for importing to www.

### Test Coverage

Normal integration tests run
