### PR TITLE
Revert "Update scratch-vm"

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "scratch-paint": "0.2.0-prerelease.20180423143518",
     "scratch-render": "0.1.0-prerelease.1523453612",
     "scratch-storage": "0.4.0",
-    "scratch-vm": "0.1.0-prerelease.1524520946",
+    "scratch-vm": "0.1.0-prerelease.1524254811",
     "selenium-webdriver": "3.6.0",
     "startaudiocontext": "1.2.1",
     "style-loader": "^0.20.0",


### PR DESCRIPTION
Reverts LLK/scratch-gui#1861, which broke adding new costumes and backdrops from the paint editor.

/cc @ericrosenbaum FYI