### PR TITLE
Post keyboard event.key

### DIFF
--- a/src/lib/vm-listener-hoc.jsx
+++ b/src/lib/vm-listener-hoc.jsx
@@ -50,6 +50,7 @@ const vmListenerHOC = function (WrappedComponent) {
 
             this.props.vm.postIOData('keyboard', {
                 keyCode: e.keyCode,
+                key: e.key,
                 isDown: true
             });
         }
@@ -58,6 +59,7 @@ const vmListenerHOC = function (WrappedComponent) {
             // even those that have switched to other targets.
             this.props.vm.postIOData('keyboard', {
                 keyCode: e.keyCode,
+                key: e.key,
                 isDown: false
             });
 


### PR DESCRIPTION
### Resolves

Support for https://github.com/LLK/scratch-vm/issues/980
Required for a VM PR (coming up)

### Proposed Changes

When a key is pressed, post the event's key property, which is a string, in addition to the keyCode.

### Reason for Changes

This key property seems to be the best way to receive unicode characters as keys:
https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key