### PR TITLE
chore(package): update scratch-paint to version 0.2.0-prerelease.2018…

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "scratch-audio": "0.1.0-prerelease.1523977528",
     "scratch-blocks": "0.1.0-prerelease.1524267558",
     "scratch-l10n": "2.0.20180108132626",
-    "scratch-paint": "0.2.0-prerelease.20180426161647",
+    "scratch-paint": "0.2.0-prerelease.20180426225029",
     "scratch-render": "0.1.0-prerelease.20180425181730",
     "scratch-svg-renderer": "0.1.0-prerelease.20180423193917",
     "scratch-storage": "0.4.0",


### PR DESCRIPTION
…0426225029

Closes #1879

This version of scratch-paint brings in bitmap import/export and the bitmap line tool.