### PR TITLE
chore(package): update scratch-blocks to version 0.1.0-prerelease.152…

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "redux-throttle": "0.1.1",
     "rimraf": "^2.6.1",
     "scratch-audio": "0.1.0-prerelease.1523977528",
-    "scratch-blocks": "0.1.0-prerelease.1524267558",
+    "scratch-blocks": "0.1.0-prerelease.1524774938",
     "scratch-l10n": "2.0.20180108132626",
     "scratch-paint": "0.2.0-prerelease.20180426161647",
     "scratch-render": "0.1.0-prerelease.20180425181730",

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -132,13 +132,6 @@ export default function (vm) {
         this.jsonInit(json);
     };
 
-    ScratchBlocks.Blocks.sensing_videoonmenutwo.init = function () {
-        const json = jsonForMenuBlock('VIDEOONMENU2', spriteMenu, sensingColors, [
-            ['stage', 'STAGE']
-        ]);
-        this.jsonInit(json);
-    };
-
     ScratchBlocks.Blocks.sensing_distancetomenu.init = function () {
         const json = jsonForMenuBlock('DISTANCETOMENU', spriteMenu, sensingColors, [
             ['mouse-pointer', '_mouse_']


### PR DESCRIPTION
…4774938

Closes #1877

Brings in the changes that prepare the blocks to be translated. 

Needed an additional commit that removes an old menu definition that was removed from scratch-blocks, which was causing a crash.