### PR TITLE
Revert to pre-bitmap paint editor for deploying

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "scratch-audio": "0.1.0-prerelease.1523977528",
     "scratch-blocks": "0.1.0-prerelease.1524774938",
     "scratch-l10n": "2.0.20180108132626",
-    "scratch-paint": "0.2.0-prerelease.20180426204040",
+    "scratch-paint": "0.2.0-prerelease.20180410152401",
     "scratch-render": "0.1.0-prerelease.20180425181730",
     "scratch-svg-renderer": "0.1.0-prerelease.20180423193917",
     "scratch-storage": "0.4.0",


### PR DESCRIPTION
Looks like bitmap paint editor is still having issues that are causing crashes, so excluding it from todays deploy.