### PR TITLE
Use special method for downloading blobs in Edge

### DIFF
--- a/src/containers/project-saver.jsx
+++ b/src/containers/project-saver.jsx
@@ -29,15 +29,21 @@ class ProjectSaver extends React.Component {
         document.body.appendChild(saveLink);
 
         this.props.vm.saveProjectSb3().then(content => {
-            const url = window.URL.createObjectURL(content);
-
-            saveLink.href = url;
-
             // TODO user-friendly project name
             // File name: project-DATE-TIME
             const date = new Date();
             const timestamp = `${date.toLocaleDateString()}-${date.toLocaleTimeString()}`;
-            saveLink.download = `untitled-project-${timestamp}.sb3`;
+            const filename = `untitled-project-${timestamp}.sb3`;
+
+            // Use special ms version if available to get it working on Edge.
+            if (navigator.msSaveOrOpenBlob) {
+                navigator.msSaveOrOpenBlob(content, filename);
+                return;
+            }
+
+            const url = window.URL.createObjectURL(content);
+            saveLink.href = url;
+            saveLink.download = filename;
             saveLink.click();
             window.URL.revokeObjectURL(url);
             document.body.removeChild(saveLink);


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/1897

### Proposed Changes

_Describe what this Pull Request does_

Use the method available to Edge for downloading files, namely `msSaveOrOpenBlob`

### Reason for Changes

_Explain why these changes should be made_

Because Edge has to be special like that :( 

### Test Coverage

_Please show how you have added tests to cover your changes_

Tested by downloading files on Edge

Can test with this demo http://paulkaplan.me/scratch-gui/fix-edge-downloading/