### PR TITLE
Player mode

### DIFF
--- a/src/components/green-flag/green-flag.css
+++ b/src/components/green-flag/green-flag.css
@@ -1,7 +1,7 @@
 @import "../../css/colors.css";
 
 .green-flag {
-    box-sizing: content-box;
+    box-sizing: content-box !important;
     width: 1.25rem;
     height: 1.25rem;
     padding: 0.375rem;

--- a/src/components/green-flag/green-flag.css
+++ b/src/components/green-flag/green-flag.css
@@ -1,9 +1,8 @@
 @import "../../css/colors.css";
 
 .green-flag {
-    box-sizing: content-box !important;
-    width: 1.25rem;
-    height: 1.25rem;
+    width: 2rem;
+    height: 2rem;
     padding: 0.375rem;
     border-radius: 0.25rem;
     user-select: none;
@@ -13,10 +12,7 @@
 }
 
 .green-flag:hover {
-    /* Scale flag image by 1.2, but keep background static */
-    width: 1.5rem;
-    height: 1.5rem;
-    padding: 0.25rem;
+    transform: scale(1.2);
 }
 
 .green-flag.is-active {

--- a/src/components/gui/gui.css
+++ b/src/components/gui/gui.css
@@ -10,6 +10,10 @@
     background-color: $ui-primary;
 }
 
+.body-wrapper * {
+    box-sizing: border-box;
+}
+
 .flex-wrapper {
     display: flex;
 
@@ -57,6 +61,7 @@
 .tab {
     flex-grow: 1;
     height: 80%;
+    margin-bottom: 0;
     margin-left: -0.5rem;
 
     border-radius: 1rem 1rem 0 0;
@@ -162,14 +167,6 @@
 
     /* Fix the max width to max stage size (defined in layout_constants.js) + gutter size */
     max-width: calc(480px + calc($space * 2));
-}
-
-.stage-wrapper {
-    padding-left: $space;
-    padding-right: $space;
-
-    /* Hides negative space between edge of rounded corners + container, when selected */
-    user-select: none;
 }
 
 .target-wrapper {

--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -50,8 +50,8 @@ const GUIComponent = props => {
         costumesTabVisible,
         importInfoVisible,
         intl,
+        isPlayerOnly,
         loading,
-        mode,
         onExtensionButtonClick,
         onActivateCostumesTab,
         onActivateSoundsTab,
@@ -80,7 +80,7 @@ const GUIComponent = props => {
         isRendererSupported = Renderer.isSupported();
     }
 
-    return mode === 'player' ? (
+    return isPlayerOnly ? (
         <StageWrapper
             isRendererSupported={isRendererSupported}
             vm={vm}
@@ -226,8 +226,8 @@ GUIComponent.propTypes = {
     costumesTabVisible: PropTypes.bool,
     importInfoVisible: PropTypes.bool,
     intl: intlShape.isRequired,
+    isPlayerOnly: PropTypes.bool,
     loading: PropTypes.bool,
-    mode: PropTypes.string,
     onActivateCostumesTab: PropTypes.func,
     onActivateSoundsTab: PropTypes.func,
     onActivateTab: PropTypes.func,

--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {defineMessages, FormattedMessage, injectIntl, intlShape} from 'react-intl';
 import {Tab, Tabs, TabList, TabPanel} from 'react-tabs';
-import MediaQuery from 'react-responsive';
 import tabStyles from 'react-tabs/style/react-tabs.css';
 import VM from 'scratch-vm';
 import Renderer from 'scratch-render';
@@ -12,8 +11,7 @@ import Blocks from '../../containers/blocks.jsx';
 import CostumeTab from '../../containers/costume-tab.jsx';
 import TargetPane from '../../containers/target-pane.jsx';
 import SoundTab from '../../containers/sound-tab.jsx';
-import StageHeader from '../../containers/stage-header.jsx';
-import Stage from '../../containers/stage.jsx';
+import StageWrapper from '../../containers/stage-wrapper.jsx';
 import Loader from '../loader/loader.jsx';
 import Box from '../box/box.jsx';
 import MenuBar from '../menu-bar/menu-bar.jsx';
@@ -24,7 +22,6 @@ import WebGlModal from '../../containers/webgl-modal.jsx';
 import TipsLibrary from '../../containers/tips-library.jsx';
 import Cards from '../../containers/cards.jsx';
 
-import layout from '../../lib/layout-constants.js';
 import styles from './gui.css';
 import addExtensionIcon from './icon--extensions.svg';
 import codeIcon from './icon--code.svg';
@@ -54,6 +51,7 @@ const GUIComponent = props => {
         importInfoVisible,
         intl,
         loading,
+        mode,
         onExtensionButtonClick,
         onActivateCostumesTab,
         onActivateSoundsTab,
@@ -66,11 +64,7 @@ const GUIComponent = props => {
         ...componentProps
     } = props;
     if (children) {
-        return (
-            <Box {...componentProps}>
-                {children}
-            </Box>
-        );
+        return <Box {...componentProps}>{children}</Box>;
     }
 
     const tabClassNames = {
@@ -85,7 +79,13 @@ const GUIComponent = props => {
     if (isRendererSupported === null) {
         isRendererSupported = Renderer.isSupported();
     }
-    return (
+
+    return mode === 'player' ? (
+        <StageWrapper
+            isRendererSupported={isRendererSupported}
+            vm={vm}
+        />
+    ) : (
         <Box
             className={styles.pageWrapper}
             {...componentProps}
@@ -204,27 +204,12 @@ const GUIComponent = props => {
                     </Box>
 
                     <Box className={styles.stageAndTargetWrapper}>
-                        <Box className={styles.stageMenuWrapper}>
-                            <StageHeader vm={vm} />
-                        </Box>
-                        <Box className={styles.stageWrapper}>
-                            {/* eslint-disable arrow-body-style */}
-                            <MediaQuery minWidth={layout.fullSizeMinWidth}>{isFullSize => {
-                                return isRendererSupported ? (
-                                    <Stage
-                                        height={isFullSize ? layout.fullStageHeight : layout.smallerStageHeight}
-                                        shrink={0}
-                                        vm={vm}
-                                        width={isFullSize ? layout.fullStageWidth : layout.smallerStageWidth}
-                                    />
-                                ) : null;
-                            }}</MediaQuery>
-                            {/* eslint-enable arrow-body-style */}
-                        </Box>
+                        <StageWrapper
+                            isRendererSupported={isRendererSupported}
+                            vm={vm}
+                        />
                         <Box className={styles.targetWrapper}>
-                            <TargetPane
-                                vm={vm}
-                            />
+                            <TargetPane vm={vm} />
                         </Box>
                     </Box>
                 </Box>
@@ -242,6 +227,7 @@ GUIComponent.propTypes = {
     importInfoVisible: PropTypes.bool,
     intl: intlShape.isRequired,
     loading: PropTypes.bool,
+    mode: PropTypes.string,
     onActivateCostumesTab: PropTypes.func,
     onActivateSoundsTab: PropTypes.func,
     onActivateTab: PropTypes.func,

--- a/src/components/sprite-info/sprite-info.css
+++ b/src/components/sprite-info/sprite-info.css
@@ -31,9 +31,8 @@
 
 .icon-wrapper {
     display: inline-block;
-    box-sizing: content-box !important;
-    width: 1rem;
-    height: 1rem;
+    width: calc(2rem + 2px);
+    height: calc(2rem + 2px);
     padding: 0.5rem;
     outline: none;
     user-select: none;

--- a/src/components/sprite-info/sprite-info.css
+++ b/src/components/sprite-info/sprite-info.css
@@ -31,7 +31,7 @@
 
 .icon-wrapper {
     display: inline-block;
-    box-sizing: content-box;
+    box-sizing: content-box !important;
     width: 1rem;
     height: 1rem;
     padding: 0.5rem;

--- a/src/components/stage-header/stage-header.css
+++ b/src/components/stage-header/stage-header.css
@@ -22,7 +22,6 @@
     align-items: center;
     height: $stage-menu-height;
     padding: $space;
-    box-sizing: border-box;
 }
 
 .stage-size-row {
@@ -38,9 +37,8 @@
     display: block;
     border: 1px solid $ui-black-transparent;
     border-radius: .25rem;
-    box-sizing: content-box !important;
-    width: 1.25rem;
-    height: 1.25rem;
+    width: calc(2rem + 2px);
+    height: calc(2rem + 2px);
     background: $ui-white;
     padding: 0.375rem;
     user-select: none;

--- a/src/components/stage-header/stage-header.css
+++ b/src/components/stage-header/stage-header.css
@@ -22,6 +22,7 @@
     align-items: center;
     height: $stage-menu-height;
     padding: $space;
+    box-sizing: border-box;
 }
 
 .stage-size-row {
@@ -37,7 +38,7 @@
     display: block;
     border: 1px solid $ui-black-transparent;
     border-radius: .25rem;
-    box-sizing: content-box;
+    box-sizing: content-box !important;
     width: 1.25rem;
     height: 1.25rem;
     background: $ui-white;

--- a/src/components/stage-header/stage-header.jsx
+++ b/src/components/stage-header/stage-header.jsx
@@ -9,7 +9,6 @@ import Button from '../button/button.jsx';
 import {ComingSoonTooltip} from '../coming-soon/coming-soon.jsx';
 import Controls from '../../containers/controls.jsx';
 import {getStageSize} from '../../lib/screen-utils.js';
-import {MODES} from '../../reducers/mode';
 
 import fullScreenIcon from './icon--fullscreen.svg';
 import largeStageIcon from './icon--large-stage.svg';
@@ -49,7 +48,7 @@ const messages = defineMessages({
 const StageHeaderComponent = function (props) {
     const {
         isFullScreen,
-        mode,
+        isPlayerOnly,
         onKeyPress,
         onSetStageLarge,
         onSetStageFull,
@@ -86,7 +85,9 @@ const StageHeaderComponent = function (props) {
         );
     } else {
         const stageControls =
-            mode === 'editor' ? (
+            isPlayerOnly ? (
+                []
+            ) : (
                 <div className={styles.stageSizeToggleGroup}>
                     <ComingSoonTooltip
                         place="left"
@@ -124,8 +125,6 @@ const StageHeaderComponent = function (props) {
                         </Button>
                     </div>
                 </div>
-            ) : (
-                []
             );
         header = (
             <Box className={styles.stageHeaderWrapper}>
@@ -159,7 +158,7 @@ const StageHeaderComponent = function (props) {
 StageHeaderComponent.propTypes = {
     intl: intlShape,
     isFullScreen: PropTypes.bool.isRequired,
-    mode: PropTypes.oneOf(Object.keys(MODES)),
+    isPlayerOnly: PropTypes.bool.isRequired,
     onKeyPress: PropTypes.func.isRequired,
     onSetStageFull: PropTypes.func.isRequired,
     onSetStageLarge: PropTypes.func.isRequired,

--- a/src/components/stage-header/stage-header.jsx
+++ b/src/components/stage-header/stage-header.jsx
@@ -9,6 +9,7 @@ import Button from '../button/button.jsx';
 import {ComingSoonTooltip} from '../coming-soon/coming-soon.jsx';
 import Controls from '../../containers/controls.jsx';
 import {getStageSize} from '../../lib/screen-utils.js';
+import {MODES} from '../../reducers/mode';
 
 import fullScreenIcon from './icon--fullscreen.svg';
 import largeStageIcon from './icon--large-stage.svg';
@@ -48,6 +49,7 @@ const messages = defineMessages({
 const StageHeaderComponent = function (props) {
     const {
         isFullScreen,
+        mode,
         onKeyPress,
         onSetStageLarge,
         onSetStageFull,
@@ -83,51 +85,54 @@ const StageHeaderComponent = function (props) {
             </Box>
         );
     } else {
+        const stageControls =
+            mode === 'editor' ? (
+                <div className={styles.stageSizeToggleGroup}>
+                    <ComingSoonTooltip
+                        place="left"
+                        tooltipId="small-stage-button"
+                    >
+                        <div
+                            disabled
+                            className={classNames(
+                                styles.stageButton,
+                                styles.stageButtonLeft,
+                                styles.stageButtonDisabled
+                            )}
+                            role="button"
+                        >
+                            <img
+                                disabled
+                                alt={props.intl.formatMessage(messages.smallStageSizeMessage)}
+                                className={styles.stageButtonIcon}
+                                draggable={false}
+                                src={smallStageIcon}
+                            />
+                        </div>
+                    </ComingSoonTooltip>
+                    <div>
+                        <Button
+                            className={classNames(styles.stageButton, styles.stageButtonRight)}
+                            onClick={onSetStageLarge}
+                        >
+                            <img
+                                alt={props.intl.formatMessage(messages.largeStageSizeMessage)}
+                                className={styles.stageButtonIcon}
+                                draggable={false}
+                                src={largeStageIcon}
+                            />
+                        </Button>
+                    </div>
+                </div>
+            ) : (
+                []
+            );
         header = (
             <Box className={styles.stageHeaderWrapper}>
                 <Box className={styles.stageMenuWrapper}>
                     <Controls vm={vm} />
                     <div className={styles.stageSizeRow}>
-                        <div className={styles.stageSizeToggleGroup}>
-                            <ComingSoonTooltip
-                                place="left"
-                                tooltipId="small-stage-button"
-                            >
-                                <div
-                                    disabled
-                                    className={classNames(
-                                        styles.stageButton,
-                                        styles.stageButtonLeft,
-                                        styles.stageButtonDisabled
-                                    )}
-                                    role="button"
-                                >
-                                    <img
-                                        disabled
-                                        alt={props.intl.formatMessage(messages.smallStageSizeMessage)}
-                                        className={styles.stageButtonIcon}
-                                        draggable={false}
-                                        src={smallStageIcon}
-                                    />
-                                </div>
-                            </ComingSoonTooltip>
-                            <div>
-                                <Button
-                                    className={classNames(
-                                        styles.stageButton,
-                                        styles.stageButtonRight
-                                    )}
-                                    onClick={onSetStageLarge}
-                                >
-                                    <img
-                                        alt={props.intl.formatMessage(messages.largeStageSizeMessage)}
-                                        className={styles.stageButtonIcon}
-                                        draggable={false}
-                                        src={largeStageIcon}
-                                    />
-                                </Button>
-                            </div>
-                        </div>
+                        {stageControls}
                         <div>
                             <Button
                                 className={styles.stageButton}
@@ -154,6 +159,7 @@ const StageHeaderComponent = function (props) {
 StageHeaderComponent.propTypes = {
     intl: intlShape,
     isFullScreen: PropTypes.bool.isRequired,
+    mode: PropTypes.oneOf(Object.keys(MODES)),
     onKeyPress: PropTypes.func.isRequired,
     onSetStageFull: PropTypes.func.isRequired,
     onSetStageLarge: PropTypes.func.isRequired,

--- a/src/components/stage-wrapper/stage-wrapper.css
+++ b/src/components/stage-wrapper/stage-wrapper.css
@@ -1,0 +1,14 @@
+@import "../../css/units.css";
+@import "../../css/colors.css";
+
+.stage-wrapper {
+    box-sizing: border-box;
+}
+
+.stage-canvas-wrapper {
+    padding-left: $space;
+    padding-right: $space;
+
+    /* Hides negative space between edge of rounded corners + container, when selected */
+    user-select: none;
+}

--- a/src/components/stage-wrapper/stage-wrapper.jsx
+++ b/src/components/stage-wrapper/stage-wrapper.jsx
@@ -1,0 +1,47 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import MediaQuery from 'react-responsive';
+import VM from 'scratch-vm';
+
+import Box from '../box/box.jsx';
+import layout from '../../lib/layout-constants.js';
+import StageHeader from '../../containers/stage-header.jsx';
+import Stage from '../../containers/stage.jsx';
+
+import styles from './stage-wrapper.css';
+
+const StageWrapperComponent = function (props) {
+    const {
+        isRendererSupported,
+        vm
+    } = props;
+
+    return (
+        <Box className={styles.stageWrapper}>
+            <Box className={styles.stageMenuWrapper}>
+                <StageHeader vm={vm} />
+            </Box>
+            <Box className={styles.stageCanvasWrapper}>
+                {/* eslint-disable arrow-body-style */}
+                <MediaQuery minWidth={layout.fullSizeMinWidth}>{isFullSize => {
+                    return isRendererSupported ? (
+                        <Stage
+                            height={isFullSize ? layout.fullStageHeight : layout.smallerStageHeight}
+                            shrink={0}
+                            vm={vm}
+                            width={isFullSize ? layout.fullStageWidth : layout.smallerStageWidth}
+                        />
+                    ) : null;
+                }}</MediaQuery>
+                {/* eslint-enable arrow-body-style */}
+            </Box>
+        </Box>
+    );
+};
+
+StageWrapperComponent.propTypes = {
+    isRendererSupported: PropTypes.bool.isRequired,
+    vm: PropTypes.instanceOf(VM).isRequired
+};
+
+export default StageWrapperComponent;

--- a/src/components/stop-all/stop-all.css
+++ b/src/components/stop-all/stop-all.css
@@ -1,5 +1,5 @@
 .stop-all {
-    box-sizing: content-box;
+    box-sizing: content-box !important;
     width: 1.25rem;
     height: 1.25rem;
     padding: 0.375rem;
@@ -14,7 +14,10 @@
 }
 
 .stop-all:hover {
-    transform: scale(1.2);
+    /* Scale stop image by 1.2, but keep background static */
+    width: 1.5rem;
+    height: 1.5rem;
+    padding: 0.25rem;
 }
 
 .stop-all.is-active {

--- a/src/components/stop-all/stop-all.css
+++ b/src/components/stop-all/stop-all.css
@@ -1,7 +1,6 @@
 .stop-all {
-    box-sizing: content-box !important;
-    width: 1.25rem;
-    height: 1.25rem;
+    width: 2rem;
+    height: 2rem;
     padding: 0.375rem;
     border-radius: 0.25rem;
     user-select: none;
@@ -14,10 +13,7 @@
 }
 
 .stop-all:hover {
-    /* Scale stop image by 1.2, but keep background static */
-    width: 1.5rem;
-    height: 1.5rem;
-    padding: 0.25rem;
+    transform: scale(1.2);
 }
 
 .stop-all.is-active {

--- a/src/containers/gui.jsx
+++ b/src/containers/gui.jsx
@@ -101,6 +101,7 @@ const mapStateToProps = state => ({
     cardsVisible: state.cards.visible,
     costumesTabVisible: state.editorTab.activeTabIndex === COSTUMES_TAB_INDEX,
     importInfoVisible: state.modals.importInfo,
+    mode: state.guiMode.mode,
     loadingStateVisible: state.modals.loadingProject,
     previewInfoVisible: state.modals.previewInfo,
     targetIsStage: state.targets.stage && state.targets.stage.id === state.targets.editingTarget,

--- a/src/containers/gui.jsx
+++ b/src/containers/gui.jsx
@@ -101,7 +101,6 @@ const mapStateToProps = state => ({
     cardsVisible: state.cards.visible,
     costumesTabVisible: state.editorTab.activeTabIndex === COSTUMES_TAB_INDEX,
     importInfoVisible: state.modals.importInfo,
-    mode: state.guiMode.mode,
     loadingStateVisible: state.modals.loadingProject,
     previewInfoVisible: state.modals.previewInfo,
     targetIsStage: state.targets.stage && state.targets.stage.id === state.targets.editingTarget,

--- a/src/containers/stage-header.jsx
+++ b/src/containers/stage-header.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import bindAll from 'lodash.bindall';
 import VM from 'scratch-vm';
 import {setStageSize, setFullScreen, STAGE_SIZES} from '../reducers/stage-size';
+import {MODES} from '../reducers/mode';
 
 import {connect} from 'react-redux';
 
@@ -42,12 +43,14 @@ class StageHeader extends React.Component {
 
 StageHeader.propTypes = {
     isFullScreen: PropTypes.bool.isRequired,
+    mode: PropTypes.oneOf(Object.keys(MODES)),
     onSetStageUnFull: PropTypes.func.isRequired,
     stageSize: PropTypes.oneOf(Object.keys(STAGE_SIZES)),
     vm: PropTypes.instanceOf(VM).isRequired
 };
 
 const mapStateToProps = state => ({
+    mode: state.guiMode.mode,
     stageSize: state.stageSize.stageSize,
     isFullScreen: state.stageSize.isFullScreen
 });

--- a/src/containers/stage-header.jsx
+++ b/src/containers/stage-header.jsx
@@ -2,8 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import bindAll from 'lodash.bindall';
 import VM from 'scratch-vm';
-import {setStageSize, setFullScreen, STAGE_SIZES} from '../reducers/stage-size';
-import {MODES} from '../reducers/mode';
+import {setStageSize, STAGE_SIZES} from '../reducers/stage-size';
+import {setFullScreen} from '../reducers/mode';
 
 import {connect} from 'react-redux';
 
@@ -42,17 +42,17 @@ class StageHeader extends React.Component {
 }
 
 StageHeader.propTypes = {
-    isFullScreen: PropTypes.bool.isRequired,
-    mode: PropTypes.oneOf(Object.keys(MODES)),
+    isFullScreen: PropTypes.bool,
+    isPlayerOnly: PropTypes.bool,
     onSetStageUnFull: PropTypes.func.isRequired,
     stageSize: PropTypes.oneOf(Object.keys(STAGE_SIZES)),
     vm: PropTypes.instanceOf(VM).isRequired
 };
 
 const mapStateToProps = state => ({
-    mode: state.guiMode.mode,
     stageSize: state.stageSize.stageSize,
-    isFullScreen: state.stageSize.isFullScreen
+    isFullScreen: state.mode.isFullScreen,
+    isPlayerOnly: state.mode.isPlayerOnly
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/containers/stage-wrapper.jsx
+++ b/src/containers/stage-wrapper.jsx
@@ -1,0 +1,13 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import VM from 'scratch-vm';
+import StageWrapperComponent from '../components/stage-wrapper/stage-wrapper.jsx';
+
+const StageWrapper = props => <StageWrapperComponent {...props} />;
+
+StageWrapper.propTypes = {
+    isRendererSupported: PropTypes.bool.isRequired,
+    vm: PropTypes.instanceOf(VM).isRequired
+};
+
+export default StageWrapper;

--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -395,8 +395,8 @@ Stage.defaultProps = {
 const mapStateToProps = state => ({
     isColorPicking: state.colorPicker.active,
     isFullScreen: state.stageSize.isFullScreen,
-    // Do not use editor drag style in fullscreen mode.
-    useEditorDragStyle: !state.stageSize.isFullScreen
+    // Do not use editor drag style in fullscreen or player mode.
+    useEditorDragStyle: !(state.stageSize.isFullScreen || state.guiMode.mode === 'player')
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -394,9 +394,9 @@ Stage.defaultProps = {
 
 const mapStateToProps = state => ({
     isColorPicking: state.colorPicker.active,
-    isFullScreen: state.stageSize.isFullScreen,
+    isFullScreen: state.mode.isFullScreen,
     // Do not use editor drag style in fullscreen or player mode.
-    useEditorDragStyle: !(state.stageSize.isFullScreen || state.guiMode.mode === 'player')
+    useEditorDragStyle: !(state.mode.isFullScreen || state.mode.isPlayerOnly)
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/lib/app-state-hoc.jsx
+++ b/src/lib/app-state-hoc.jsx
@@ -7,7 +7,7 @@ import throttle from 'redux-throttle';
 import {intlShape} from 'react-intl';
 import {IntlProvider, updateIntl} from 'react-intl-redux';
 import {intlInitialState} from '../reducers/intl.js';
-import {initialState as modeInitialState, MODES} from '../reducers/mode.js';
+import {initialState as modeInitialState} from '../reducers/mode.js';
 import reducer from '../reducers/gui';
 
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
@@ -40,9 +40,10 @@ const AppStateHOC = function (WrappedComponent) {
             } else {
                 intl = intlInitialState;
             }
-            if (props.mode) {
+            if (props.isPlayerOnly || props.isFullScreen) {
                 mode = {
-                    mode: props.mode
+                    isFullScreen: props.isFullScreen || false,
+                    isPlayerOnly: props.isPlayerOnly || false
                 };
             } else {
                 mode = modeInitialState;
@@ -52,7 +53,7 @@ const AppStateHOC = function (WrappedComponent) {
                 reducer,
                 {
                     intl: intl,
-                    guiMode: mode
+                    mode: mode
                 },
                 enhancer);
         }
@@ -74,7 +75,8 @@ const AppStateHOC = function (WrappedComponent) {
     }
     AppStateWrapper.propTypes = {
         intl: intlShape,
-        mode: PropTypes.oneOf(Object.keys(MODES))
+        isFullScreen: PropTypes.bool,
+        isPlayerOnly: PropTypes.bool
     };
     return AppStateWrapper;
 };

--- a/src/lib/app-state-hoc.jsx
+++ b/src/lib/app-state-hoc.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import {Provider} from 'react-redux';
 import {createStore, applyMiddleware, compose} from 'redux';
 import throttle from 'redux-throttle';
@@ -6,6 +7,7 @@ import throttle from 'redux-throttle';
 import {intlShape} from 'react-intl';
 import {IntlProvider, updateIntl} from 'react-intl-redux';
 import {intlInitialState} from '../reducers/intl.js';
+import {initialState as modeInitialState, MODES} from '../reducers/mode.js';
 import reducer from '../reducers/gui';
 
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
@@ -26,6 +28,7 @@ const AppStateHOC = function (WrappedComponent) {
         constructor (props) {
             super(props);
             let intl = {};
+            let mode = {};
             if (props.intl) {
                 intl = {
                     intl: {
@@ -37,8 +40,21 @@ const AppStateHOC = function (WrappedComponent) {
             } else {
                 intl = intlInitialState;
             }
+            if (props.mode) {
+                mode = {
+                    mode: props.mode
+                };
+            } else {
+                mode = modeInitialState;
+            }
 
-            this.store = createStore(reducer, intl, enhancer);
+            this.store = createStore(
+                reducer,
+                {
+                    intl: intl,
+                    guiMode: mode
+                },
+                enhancer);
         }
         componentDidUpdate (prevProps) {
             if (prevProps.intl !== this.props.intl) updateIntl(this.props.intl);
@@ -57,7 +73,8 @@ const AppStateHOC = function (WrappedComponent) {
 
     }
     AppStateWrapper.propTypes = {
-        intl: intlShape
+        intl: intlShape,
+        mode: PropTypes.oneOf(Object.keys(MODES))
     };
     return AppStateWrapper;
 };

--- a/src/lib/app-state-hoc.jsx
+++ b/src/lib/app-state-hoc.jsx
@@ -7,7 +7,7 @@ import throttle from 'redux-throttle';
 import {intlShape} from 'react-intl';
 import {IntlProvider, updateIntl} from 'react-intl-redux';
 import {intlInitialState} from '../reducers/intl.js';
-import {initialState as modeInitialState} from '../reducers/mode.js';
+import {initialState as modeInitialState, setPlayer} from '../reducers/mode.js';
 import reducer from '../reducers/gui';
 
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
@@ -31,14 +31,12 @@ const AppStateHOC = function (WrappedComponent) {
             let mode = {};
             if (props.intl) {
                 intl = {
-                    intl: {
-                        defaultLocale: 'en',
-                        locale: props.intl.locale,
-                        messages: props.intl.messages
-                    }
+                    defaultLocale: 'en',
+                    locale: props.intl.locale,
+                    messages: props.intl.messages
                 };
             } else {
-                intl = intlInitialState;
+                intl = intlInitialState.intl;
             }
             if (props.isPlayerOnly || props.isFullScreen) {
                 mode = {
@@ -58,7 +56,12 @@ const AppStateHOC = function (WrappedComponent) {
                 enhancer);
         }
         componentDidUpdate (prevProps) {
-            if (prevProps.intl !== this.props.intl) updateIntl(this.props.intl);
+            if (prevProps.intl !== this.props.intl) {
+                this.store.dispatch(updateIntl(this.props.intl));
+            }
+            if (prevProps.isPlayerOnly !== this.props.isPlayerOnly) {
+                this.store.dispatch(setPlayer(this.props.isPlayerOnly));
+            }
         }
         render () {
             return (
@@ -68,10 +71,7 @@ const AppStateHOC = function (WrappedComponent) {
                     </IntlProvider>
                 </Provider>
             );
-
         }
-
-
     }
     AppStateWrapper.propTypes = {
         intl: intlShape,

--- a/src/lib/app-state-hoc.jsx
+++ b/src/lib/app-state-hoc.jsx
@@ -7,7 +7,7 @@ import throttle from 'redux-throttle';
 import {intlShape} from 'react-intl';
 import {IntlProvider, updateIntl} from 'react-intl-redux';
 import {intlInitialState} from '../reducers/intl.js';
-import {initialState as modeInitialState, setPlayer} from '../reducers/mode.js';
+import {initialState as modeInitialState, setPlayer, setFullScreen} from '../reducers/mode.js';
 import reducer from '../reducers/gui';
 
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
@@ -61,6 +61,9 @@ const AppStateHOC = function (WrappedComponent) {
             }
             if (prevProps.isPlayerOnly !== this.props.isPlayerOnly) {
                 this.store.dispatch(setPlayer(this.props.isPlayerOnly));
+            }
+            if (prevProps.isFullScreen !== this.props.isFullScreen) {
+                this.store.dispatch(setFullScreen(this.props.isFullScreen));
             }
         }
         render () {

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -2,7 +2,7 @@ import ScratchStorage from 'scratch-storage';
 
 import defaultProjectAssets from './default-project';
 
-const PROJECT_SERVER = 'https://cdn.projects.scratch.mit.edu';
+const PROJECT_SERVER = 'https://projects.scratch.mit.edu';
 const ASSET_SERVER = 'https://cdn.assets.scratch.mit.edu';
 
 /**

--- a/src/playground/player.css
+++ b/src/playground/player.css
@@ -1,3 +1,7 @@
 .stage-only {
-    width: 500px;
+    width: calc(480px + 1rem);
+}
+
+.stage-only * {
+    box-sizing: border-box;
 }

--- a/src/playground/player.css
+++ b/src/playground/player.css
@@ -1,4 +1,3 @@
-body {
-    padding: 0;
-    margin: 0;
+.stage-only {
+    width: 500px;
 }

--- a/src/playground/player.jsx
+++ b/src/playground/player.jsx
@@ -14,8 +14,8 @@ import styles from './player.css';
 const Player = () => (
     <Box className={styles.stageOnly}>
         <GUI
+            isPlayerOnly
             isFullScreen={false}
-            mode="player"
         />
     </Box>
 );

--- a/src/playground/player.jsx
+++ b/src/playground/player.jsx
@@ -1,74 +1,26 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {connect} from 'react-redux';
 
-import Controls from '../containers/controls.jsx';
-import Stage from '../containers/stage.jsx';
 import Box from '../components/box/box.jsx';
 import GUI from '../containers/gui.jsx';
-import ProjectLoaderHOC from '../lib/project-loader-hoc.jsx';
+import ErrorBoundaryHOC from './error-boundary-hoc.jsx';
 
-import './player.css';
-
-const mapStateToProps = state => ({vm: state.vm});
-
-const VMStage = connect(mapStateToProps)(Stage);
-const VMControls = connect(mapStateToProps)(Controls);
-
-class Player extends React.Component {
-    constructor (props) {
-        super(props);
-        this.handleResize = this.handleResize.bind(this);
-        this.state = this.getWindowSize();
-    }
-    componentDidMount () {
-        window.addEventListener('resize', this.handleResize);
-    }
-    componentWillUnmount () {
-        window.removeEventListener('resize', this.handleResize);
-    }
-    getWindowSize () {
-        return {
-            width: window.innerWidth,
-            height: window.innerHeight
-        };
-    }
-    handleResize () {
-        this.setState(this.getWindowSize());
-    }
-    render () {
-        let height = this.state.height - 40;
-        let width = height + (height / 3);
-        if (width > this.state.width) {
-            width = this.state.width;
-            height = width * .75;
-        }
-        return (
-            <GUI
-                {...this.props}
-                style={{
-                    margin: '0 auto'
-                }}
-                width={width}
-            >
-                <Box height={40}>
-                    <VMControls
-                        style={{
-                            marginRight: 10,
-                            height: 40
-                        }}
-                    />
-                </Box>
-                <VMStage
-                    height={height}
-                    width={width}
-                />
-            </GUI>
-        );
-    }
+if (process.env.NODE_ENV === 'production' && typeof window === 'object') {
+    // Warn before navigating away
+    window.onbeforeunload = () => true;
 }
 
-const App = ProjectLoaderHOC(Player);
+import styles from './player.css';
+const Player = () => (
+    <Box className={styles.stageOnly}>
+        <GUI
+            isFullScreen={false}
+            mode="player"
+        />
+    </Box>
+);
+
+const App = ErrorBoundaryHOC(Player);
 
 const appTarget = document.createElement('div');
 document.body.appendChild(appTarget);

--- a/src/reducers/gui.js
+++ b/src/reducers/gui.js
@@ -23,7 +23,7 @@ export default combineReducers({
     colorPicker: colorPickerReducer,
     customProcedures: customProceduresReducer,
     editorTab: editorTabReducer,
-    guiMode: modeReducer,
+    mode: modeReducer,
     hoveredTarget: hoveredTargetReducer,
     intl: intlReducer,
     stageSize: stageSizeReducer,

--- a/src/reducers/gui.js
+++ b/src/reducers/gui.js
@@ -8,6 +8,7 @@ import hoveredTargetReducer from './hovered-target';
 import intlReducer from './intl';
 import menuReducer from './menus';
 import modalReducer from './modals';
+import modeReducer from './mode';
 import monitorReducer from './monitors';
 import monitorLayoutReducer from './monitor-layout';
 import targetReducer from './targets';
@@ -22,6 +23,7 @@ export default combineReducers({
     colorPicker: colorPickerReducer,
     customProcedures: customProceduresReducer,
     editorTab: editorTabReducer,
+    guiMode: modeReducer,
     hoveredTarget: hoveredTargetReducer,
     intl: intlReducer,
     stageSize: stageSizeReducer,

--- a/src/reducers/mode.js
+++ b/src/reducers/mode.js
@@ -1,0 +1,36 @@
+const SET_MODE = 'scratch-gui/mode/SET_MODE';
+
+const initialState = {
+    mode: 'editor'
+};
+
+const MODES = {
+    editor: 'editor',
+    player: 'player'
+};
+
+const reducer = function (state, action) {
+    if (typeof state === 'undefined') state = initialState;
+    switch (action.type) {
+    case SET_MODE:
+        return {
+            mode: action.mode
+        };
+    default:
+        return state;
+    }
+};
+
+const setMode = function (mode) {
+    return {
+        type: SET_MODE,
+        mode: mode
+    };
+};
+
+export {
+    reducer as default,
+    initialState,
+    setMode,
+    MODES
+};

--- a/src/reducers/mode.js
+++ b/src/reducers/mode.js
@@ -1,36 +1,45 @@
-const SET_MODE = 'scratch-gui/mode/SET_MODE';
+const SET_FULL_SCREEN = 'scratch-gui/mode/SET_FULL_SCREEN';
+const SET_PLAYER = 'scratch-gui/mode/SET_PLAYER';
 
 const initialState = {
-    mode: 'editor'
-};
-
-const MODES = {
-    editor: 'editor',
-    player: 'player'
+    isFullScreen: false,
+    isPlayerOnly: false
 };
 
 const reducer = function (state, action) {
     if (typeof state === 'undefined') state = initialState;
     switch (action.type) {
-    case SET_MODE:
+    case SET_FULL_SCREEN:
         return {
-            mode: action.mode
+            isFullScreen: action.isFullScreen,
+            isPlayerOnly: state.isPlayerOnly
+        };
+    case SET_PLAYER:
+        return {
+            isFullScreen: state.isFullScreen,
+            isPlayerOnly: action.isPlayerOnly
         };
     default:
         return state;
     }
 };
 
-const setMode = function (mode) {
+const setFullScreen = function (isFullScreen) {
     return {
-        type: SET_MODE,
-        mode: mode
+        type: SET_FULL_SCREEN,
+        isFullScreen: isFullScreen
+    };
+};
+const setPlayer = function (isPlayerOnly) {
+    return {
+        type: SET_PLAYER,
+        isPlayerOnly: isPlayerOnly
     };
 };
 
 export {
     reducer as default,
     initialState,
-    setMode,
-    MODES
+    setFullScreen,
+    setPlayer
 };

--- a/src/reducers/stage-size.js
+++ b/src/reducers/stage-size.js
@@ -1,8 +1,6 @@
 const SET_STAGE_SIZE = 'scratch-gui/StageSize/SET_STAGE_SIZE';
-const SET_FULL_SCREEN = 'scratch-gui/StageSize/SET_FULL_SCREEN';
 
 const initialState = {
-    isFullScreen: false,
     stageSize: 'large'
 };
 
@@ -17,13 +15,7 @@ const reducer = function (state, action) {
     switch (action.type) {
     case SET_STAGE_SIZE:
         return {
-            isFullScreen: state.isFullScreen,
             stageSize: action.stageSize
-        };
-    case SET_FULL_SCREEN:
-        return {
-            isFullScreen: action.isFullScreen,
-            stageSize: state.stageSize
         };
     default:
         return state;
@@ -37,19 +29,8 @@ const setStageSize = function (stageSize) {
     };
 };
 
-// `isFullScreen` is a separate value because "stage size" does not
-// actually apply to full screen mode, so they are treated as separate
-// values to be assessed.
-const setFullScreen = function (isFullScreen) {
-    return {
-        type: SET_FULL_SCREEN,
-        isFullScreen: isFullScreen
-    };
-};
-
 export {
     reducer as default,
     setStageSize,
-    setFullScreen,
     STAGE_SIZES
 };


### PR DESCRIPTION
Adds player-only mode to GUI.

### Resolves

Fixes #1687

### Proposed Changes
Add isPlayerOnly property on GUI. Move isFullScreen into mode reducer with isPlayerOnly.

Full screen needs to be a separate prop so that GUI knows what to show when exiting full-screen (either player-only or full editor).

Set `box-sizing: border-box` for all of gui-body. Required the update to width and height on some elements that were still content-box sized.

### Reason for Changes

Player mode for www

### Test Coverage

Current tests run, player playground example uses `player` mode, so player integration test checks player.

To check manually:
- [ ] sprites are not draggable in player mode
- [ ] stage is the default size when not in full screen mode.
- [ ] clicking the full screen button toggles full-screen.
- [ ] green flag, stop, stage-size, and full-screen buttons all look the right size in editor and player.