### PR TITLE
Make sound editor buttons unselectable

### DIFF
--- a/src/components/sound-editor/sound-editor.css
+++ b/src/components/sound-editor/sound-editor.css
@@ -58,6 +58,7 @@ $border-radius: 0.25rem;
     cursor: pointer;
     font-size: 0.85rem;
     transition: 0.2s;
+    user-select: none;
 }
 
 .button > img {
@@ -76,6 +77,7 @@ $border-radius: 0.25rem;
     border: 1px solid $ui-black-transparent;
     cursor: pointer;
     padding: 0.75rem;
+    user-select: none;
 }
 
 .round-button > img {
@@ -91,6 +93,7 @@ $border-radius: 0.25rem;
     color: $text-primary;
     font-size: 0.625rem;
     margin-left: 1rem;
+    user-select: none;
 }
 
 .trim-button > img {
@@ -108,6 +111,7 @@ $border-radius: 0.25rem;
     flex-basis: 60px;
     color: $text-primary;
     font-size: 0.625rem;
+    user-select: none;
 }
 
 .effect-button + .effect-button {


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes an issue @carljbowman noticed where you can select the text on sound editor buttons

![selectable-sounds](https://user-images.githubusercontent.com/654102/39431105-b3141eea-4c5d-11e8-89a0-58276d1c85ae.gif)

### Proposed Changes

_Describe what this Pull Request does_

Like elsewhere in the UI, if you can click it, you shouldn't be able to select the text on it.

### Reason for Changes

_Explain why these changes should be made_

It is easy to get confused/lost when click/dragging on buttons (happens a lot) and all the sudden the UI turns blue.

### Test Coverage

_Please show how you have added tests to cover your changes_


![unselectable-sounds](https://user-images.githubusercontent.com/654102/39431108-b5b0bf3c-4c5d-11e8-8865-9fad96d21a4c.gif)

