### PR TITLE
Protect against showing costume tab for target that does not exist.

### DIFF
--- a/src/lib/vm-listener-hoc.jsx
+++ b/src/lib/vm-listener-hoc.jsx
@@ -98,8 +98,7 @@ const vmListenerHOC = function (WrappedComponent) {
     });
     const mapDispatchToProps = dispatch => ({
         onTargetsUpdate: data => {
-            dispatch(updateEditingTarget(data.editingTarget));
-            dispatch(updateTargets(data.targetList));
+            dispatch(updateTargets(data.targetList, data.editingTarget));
         },
         onMonitorsUpdate: monitorList => {
             dispatch(updateMonitors(monitorList));

--- a/src/lib/vm-listener-hoc.jsx
+++ b/src/lib/vm-listener-hoc.jsx
@@ -5,7 +5,7 @@ import VM from 'scratch-vm';
 
 import {connect} from 'react-redux';
 
-import {updateEditingTarget, updateTargets} from '../reducers/targets';
+import {updateTargets} from '../reducers/targets';
 import {updateBlockDrag} from '../reducers/block-drag';
 import {updateMonitors} from '../reducers/monitors';
 

--- a/src/reducers/targets.js
+++ b/src/reducers/targets.js
@@ -1,4 +1,3 @@
-const UPDATE_EDITING_TARGET = 'scratch-gui/targets/UPDATE_EDITING_TARGET';
 const UPDATE_TARGET_LIST = 'scratch-gui/targets/UPDATE_TARGET_LIST';
 
 const initialState = {
@@ -21,27 +20,18 @@ const reducer = function (state, action) {
                     {}
                 ),
             stage: action.targets
-                .filter(target => target.isStage)[0] || {}
+                .filter(target => target.isStage)[0] || {},
+            editingTarget: action.editingTarget
         });
-    case UPDATE_EDITING_TARGET:
-        return Object.assign({}, state, {editingTarget: action.target});
     default:
         return state;
     }
 };
-const updateTargets = function (targetList) {
+const updateTargets = function (targetList, editingTarget) {
     return {
         type: UPDATE_TARGET_LIST,
         targets: targetList,
-        meta: {
-            throttle: 30
-        }
-    };
-};
-const updateEditingTarget = function (editingTarget) {
-    return {
-        type: UPDATE_EDITING_TARGET,
-        target: editingTarget,
+        editingTarget: editingTarget,
         meta: {
             throttle: 30
         }
@@ -49,6 +39,5 @@ const updateEditingTarget = function (editingTarget) {
 };
 export {
     reducer as default,
-    updateTargets,
-    updateEditingTarget
+    updateTargets
 };


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/1632

### Proposed Changes

_Describe what this Pull Request does_

Make sure not to render the costume tab if the data indicates a sprite is selected that is not in the targets list. 

### Reason for Changes

_Explain why these changes should be made_

I decided to make this defensive change instead of changing the reducer API because I want that to involve a more holistic refactor after discussing with @rschamp 


@fsih can you try this branch out, you should be able to find it (after travis builds) here:
paulkaplan.me/scratch-gui/fix-costume-crash or by pulling this locally.