### PR TITLE
Force z-index of inputs down below modals

### DIFF
--- a/src/components/blocks/blocks.css
+++ b/src/components/blocks/blocks.css
@@ -27,6 +27,10 @@
     box-sizing: content-box;
 }
 
+:global(.blocklyWidgetDiv) {
+    z-index: 50 !important; /* High enough blockly, but below modals */
+}
+
 /*
     Shrink category font to fit "My Blocks" for now.
     Probably will need different solutions for language support later, so


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Resolves https://github.com/LLK/scratch-gui/issues/1129

### Proposed Changes

_Describe what this Pull Request does_

Force the z-index of blockly inputs down below the modals. The alternative, calling `Blockly.hideChaff`, would be complex to arrange because the modals aren't communicating with the blocks at all right now, and it would be a lot cleaner if we could keep it that way. 

![modal-input](https://user-images.githubusercontent.com/654102/39444418-adadd518-4c85-11e8-8767-bb8ca03b73e3.gif)
![modal-input-fixed](https://user-images.githubusercontent.com/654102/39444422-af5bb60a-4c85-11e8-81a6-2e440cc834de.gif)
