### PR TITLE
Show "Backdrops" instead of "Costumes" in tab text if stage is selected.

### DIFF
--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -57,6 +57,7 @@ const GUIComponent = props => {
         onActivateSoundsTab,
         onActivateTab,
         previewInfoVisible,
+        targetIsStage,
         soundsTabVisible,
         tipsLibraryVisible,
         vm,
@@ -134,11 +135,19 @@ const GUIComponent = props => {
                                         draggable={false}
                                         src={costumesIcon}
                                     />
-                                    <FormattedMessage
-                                        defaultMessage="Costumes"
-                                        description="Button to get to the costumes panel"
-                                        id="gui.gui.costumesTab"
-                                    />
+                                    {targetIsStage ? (
+                                        <FormattedMessage
+                                            defaultMessage="Backdrops"
+                                            description="Button to get to the backdrops panel"
+                                            id="gui.gui.backdropsTab"
+                                        />
+                                    ) : (
+                                        <FormattedMessage
+                                            defaultMessage="Costumes"
+                                            description="Button to get to the costumes panel"
+                                            id="gui.gui.costumesTab"
+                                        />
+                                    )}
                                 </Tab>
                                 <Tab
                                     className={tabClassNames.tab}
@@ -234,6 +243,7 @@ GUIComponent.propTypes = {
     onTabSelect: PropTypes.func,
     previewInfoVisible: PropTypes.bool,
     soundsTabVisible: PropTypes.bool,
+    targetIsStage: PropTypes.bool,
     tipsLibraryVisible: PropTypes.bool,
     vm: PropTypes.instanceOf(VM).isRequired
 };

--- a/src/containers/gui.jsx
+++ b/src/containers/gui.jsx
@@ -101,6 +101,7 @@ const mapStateToProps = state => ({
     costumesTabVisible: state.editorTab.activeTabIndex === COSTUMES_TAB_INDEX,
     loadingStateVisible: state.modals.loadingProject,
     previewInfoVisible: state.modals.previewInfo,
+    targetIsStage: state.targets.stage && state.targets.stage.id === state.targets.editingTarget,
     soundsTabVisible: state.editorTab.activeTabIndex === SOUNDS_TAB_INDEX,
     tipsLibraryVisible: state.modals.tipsLibrary
 });


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/267

### Proposed Changes

_Describe what this Pull Request does_

Show "Backdrops" for the costumes tab if the editing target is the stage.

### Reason for Changes

_Explain why these changes should be made_

Scratch 2

### Test Coverage

_Please show how you have added tests to cover your changes_

![costumes-tab-text](https://user-images.githubusercontent.com/654102/39444756-caff3908-4c86-11e8-9274-d4f71ed5f57f.gif)

