### PR TITLE
Fix errors when dragging in player mode

### DIFF
--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -297,6 +297,7 @@ class Stage extends React.Component {
         if (drawableId === null) return;
         const drawableData = this.renderer.extractDrawable(drawableId, x, y);
         const targetId = this.props.vm.getTargetIdForDrawableId(drawableId);
+        if (targetId === null) return;
 
         // Only start drags on non-draggable targets in editor drag mode
         if (!this.props.useEditorDragStyle) {
@@ -304,7 +305,6 @@ class Stage extends React.Component {
             if (!target.draggable) return;
         }
 
-        if (targetId === null) return;
         this.props.vm.startDrag(targetId);
         this.setState({
             isDragging: true,


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_
Fixes https://github.com/LLK/scratch-gui/issues/1931
### Proposed Changes

_Describe what this Pull Request does_

Fix early return to be before draggability checking. Looks like just a typo in the original code.

Tested by making the editor fullscreen and trying to drag the stage, seeing no errors.


### Browser Coverage

n/a not browser specific.