### PR TITLE
Revert localization of crash message.

### DIFF
--- a/src/components/crash-message/crash-message.jsx
+++ b/src/components/crash-message/crash-message.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import Box from '../box/box.jsx';
-import {FormattedMessage} from 'react-intl';
 
 import styles from './crash-message.css';
 import reloadIcon from './reload.svg';
@@ -14,20 +13,13 @@ const CrashMessage = props => (
                 src={reloadIcon}
             />
             <h2>
-                <FormattedMessage
-                    defaultMessage="Oops! Something went wrong."
-                    description="Unhandled error title"
-                    id="gui.crashMessage.title"
-                />
+                Oops! Something went wrong.
             </h2>
             <p>
-                { /* eslint-disable max-len */ }
-                <FormattedMessage
-                    defaultMessage="We are so sorry, but it looks like Scratch has crashed. This bug has been automatically reported to the Scratch Team. Please refresh your page to try again."
-                    description="Unhandled error description"
-                    id="gui.crashMessage.description"
-                />
-                { /* eslint-enable max-len */ }
+                We are so sorry, but it looks like Scratch has crashed. This bug has been
+                automatically reported to the Scratch Team. Please refresh your page to try
+                again.
+
             </p>
             <button
                 className={styles.reloadButton}


### PR DESCRIPTION
Back out a change which is not allowing the "crash" message to be seen.

/cc @chrisgarrity It doesn't work without an intl provider, which is mounted inside the error boundary.
