### PR TITLE
Make remaining text translatable, and prevent future regressions

### DIFF
--- a/src/.eslintrc.js
+++ b/src/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
         'import/no-mutable-exports': 'error',
         'import/no-commonjs': 'error',
         'import/no-amd': 'error',
-        'import/no-nodejs-modules': 'error'
+        'import/no-nodejs-modules': 'error',
+        'react/jsx-no-literals': 'error'
     }
 };

--- a/src/components/browser-modal/browser-modal.jsx
+++ b/src/components/browser-modal/browser-modal.jsx
@@ -43,18 +43,34 @@ const BrowserModal = ({intl, ...props}) => (
                     className={styles.backButton}
                     onClick={props.onBack}
                 >
-                    Back
+                    <FormattedMessage
+                        defaultMessage="Back"
+                        description="Button to go back in unsupported browser modal"
+                        id="gui.unsupportedBrowser.back"
+                    />
                 </button>
 
             </Box>
             <div className={styles.faqLinkText}>
-                To learn more, go to the {' '}
-                <a
-                    className={styles.faqLink}
-                    href="//scratch.mit.edu/preview-faq"
-                >
-                    preview FAQ
-                </a>.
+                <FormattedMessage
+                    defaultMessage="To learn more, go to the {previewFaqLink}."
+                    description="Invitation to try 3.0 preview"
+                    id="gui.unsupportedBrowser.previewfaq"
+                    values={{
+                        previewFaqLink: (
+                            <a
+                                className={styles.faqLink}
+                                href="//scratch.mit.edu/preview-faq"
+                            >
+                                <FormattedMessage
+                                    defaultMessage="Preview FAQ"
+                                    description="link to Scratch 3.0 preview FAQ page"
+                                    id="gui.unsupportedBrowser.previewfaqlink"
+                                />
+                            </a>
+                        )
+                    }}
+                />
             </div>
         </Box>
     </ReactModal>

--- a/src/components/crash-message/crash-message.jsx
+++ b/src/components/crash-message/crash-message.jsx
@@ -1,3 +1,9 @@
+/* eslint-disable react/jsx-no-literals */
+/*
+    @todo Rule is disabled because this component is rendered outside the
+    intl provider right now so cannot be translated.
+*/
+
 import PropTypes from 'prop-types';
 import React from 'react';
 import Box from '../box/box.jsx';

--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -123,20 +123,43 @@ const MenuBar = props => (
                     })}
                     onMouseUp={props.onClickFile}
                 >
-                    <div className={classNames(styles.fileMenu)}>File</div>
+                    <div className={classNames(styles.fileMenu)}>
+                        <FormattedMessage
+                            defaultMessage="File"
+                            description="Text for file dropdown menu"
+                            id="gui.menuBar.file"
+                        />
+                    </div>
                     <MenuBarMenu
                         open={props.fileMenuOpen}
                         onRequestClose={props.onRequestCloseFile}
                     >
                         <MenuItemTooltip id="new">
-                            <MenuItem>New</MenuItem>
+                            <MenuItem>
+                                <FormattedMessage
+                                    defaultMessage="New"
+                                    description="Menu bar item for creating a new project"
+                                    id="gui.menuBar.new"
+                                />
+                            </MenuItem>
                         </MenuItemTooltip>
                         <MenuSection>
                             <MenuItemTooltip id="save">
-                                <MenuItem>Save now</MenuItem>
+                                <MenuItem>
+                                    <FormattedMessage
+                                        defaultMessage="Save now"
+                                        description="Menu bar item for saving now"
+                                        id="gui.menuBar.saveNow"
+                                    />
+                                </MenuItem>
                             </MenuItemTooltip>
                             <MenuItemTooltip id="copy">
-                                <MenuItem>Save as a copy</MenuItem>
+                                <MenuItem>
+                                    <FormattedMessage
+                                        defaultMessage="Save as a copy"
+                                        description="Menu bar item for saving as a copy"
+                                        id="gui.menuBar.saveAsCopy"
+                                    /></MenuItem>
                             </MenuItemTooltip>
                         </MenuSection>
                         <MenuSection>
@@ -145,7 +168,11 @@ const MenuBar = props => (
                                     onClick={loadProject}
                                     {...loadProps}
                                 >
-                                    Upload from your computer
+                                    <FormattedMessage
+                                        defaultMessage="Upload from your computer"
+                                        description="Menu bar item for uploading a project from your computer"
+                                        id="gui.menuBar.uploadFromComputer"
+                                    />
                                     {renderFileInput()}
                                 </MenuItem>
                             )}</ProjectLoader>
@@ -154,7 +181,11 @@ const MenuBar = props => (
                                     onClick={saveProject}
                                     {...saveProps}
                                 >
-                                    Download to your computer
+                                    <FormattedMessage
+                                        defaultMessage="Download to your computer"
+                                        description="Menu bar item for downloading a project"
+                                        id="gui.menuBar.downloadToComputer"
+                                    />
                                 </MenuItem>
                             )}</ProjectSaver>
                         </MenuSection>
@@ -166,20 +197,44 @@ const MenuBar = props => (
                     })}
                     onMouseUp={props.onClickEdit}
                 >
-                    <div className={classNames(styles.editMenu)}>Edit</div>
+                    <div className={classNames(styles.editMenu)}>
+                        <FormattedMessage
+                            defaultMessage="Edit"
+                            description="Text for edit dropdown menu"
+                            id="gui.menuBar.edit"
+                        />
+                    </div>
                     <MenuBarMenu
                         open={props.editMenuOpen}
                         onRequestClose={props.onRequestCloseEdit}
                     >
                         <MenuItemTooltip id="undo">
-                            <MenuItem>Undo</MenuItem>
+                            <MenuItem>
+                                <FormattedMessage
+                                    defaultMessage="Undo"
+                                    description="Menu bar item for undoing"
+                                    id="gui.menuBar.undo"
+                                />
+                            </MenuItem>
                         </MenuItemTooltip>
                         <MenuItemTooltip id="redo">
-                            <MenuItem>Redo</MenuItem>
+                            <MenuItem>
+                                <FormattedMessage
+                                    defaultMessage="Redo"
+                                    description="Menu bar item for redoing"
+                                    id="gui.menuBar.redo"
+                                />
+                            </MenuItem>
                         </MenuItemTooltip>
                         <MenuSection>
                             <MenuItemTooltip id="turbo">
-                                <MenuItem>Turbo mode</MenuItem>
+                                <MenuItem>
+                                    <FormattedMessage
+                                        defaultMessage="Turbo mode"
+                                        description="Menu bar item for toggling turbo mode"
+                                        id="gui.menuBar.turboMode"
+                                    />
+                                </MenuItem>
                             </MenuItemTooltip>
                         </MenuSection>
                     </MenuBarMenu>
@@ -262,7 +317,9 @@ const MenuBar = props => (
                         className={styles.profileIcon}
                         src={profileIcon}
                     />
-                    <span>scratch-cat</span>
+                    <span>
+                        {'scratch-cat' /* @todo username */}
+                    </span>
                     <img
                         className={styles.dropdownCaretIcon}
                         src={dropdownCaret}

--- a/src/components/prompt/prompt.jsx
+++ b/src/components/prompt/prompt.jsx
@@ -59,13 +59,21 @@ const PromptComponent = props => (
                     className={styles.cancelButton}
                     onClick={props.onCancel}
                 >
-                    Cancel
+                    <FormattedMessage
+                        defaultMessage="Cancel"
+                        description="Button in prompt for cancelling the dialog"
+                        id="gui.prompt.cancel"
+                    />
                 </button>
                 <button
                     className={styles.okButton}
                     onClick={props.onOk}
                 >
-                    OK
+                    <FormattedMessage
+                        defaultMessage="OK"
+                        description="Button in prompt for confirming the dialog"
+                        id="gui.prompt.ok"
+                    />
                 </button>
             </Box>
         </Box>

--- a/src/components/question/question.jsx
+++ b/src/components/question/question.jsx
@@ -28,7 +28,7 @@ const QuestionComponent = props => {
                         className={styles.questionSubmitButton}
                         onClick={onClick}
                     >
-                        ✔︎
+                        {'✔︎' /* @todo should this be an image? */}
                     </button>
                 </div>
             </div>

--- a/src/components/record-modal/playback-step.jsx
+++ b/src/components/record-modal/playback-step.jsx
@@ -31,6 +31,11 @@ const messages = defineMessages({
         defaultMessage: 'Save',
         description: 'Loading/Save button in recording playback',
         id: 'gui.playbackStep.saveMsg'
+    },
+    reRecordMsg: {
+        defaultMessage: 'Re-record',
+        description: 'Button to re-record sound in recording playback',
+        id: 'gui.playbackStep.reRecordMsg'
     }
 });
 
@@ -88,7 +93,8 @@ const PlaybackStep = props => (
                 <img
                     draggable={false}
                     src={backIcon}
-                /> Re-record
+                />
+                {props.intl.formatMessage(messages.reRecordMsg)}
             </button>
             <button
                 className={styles.okButton}

--- a/src/components/stage-selector/stage-selector.jsx
+++ b/src/components/stage-selector/stage-selector.jsx
@@ -60,7 +60,13 @@ const StageSelector = props => {
             {...componentProps}
         >
             <div className={styles.header}>
-                <div className={styles.headerTitle}>Stage</div>
+                <div className={styles.headerTitle}>
+                    <FormattedMessage
+                        defaultMessage="Stage"
+                        description="Label for the stage in the stage selector"
+                        id="gui.stageSelector.stage"
+                    />
+                </div>
             </div>
             {url ? (
                 <CostumeCanvas

--- a/test/helpers/selenium-helper.js
+++ b/test/helpers/selenium-helper.js
@@ -87,7 +87,7 @@ class SeleniumHelper {
     }
 
     clickButton (text) {
-        return this.clickXpath(`//button[contains(text(), '${text}')]`);
+        return this.clickXpath(`//button//*[contains(text(), '${text}')]`);
     }
 
     getLogs (whitelist) {


### PR DESCRIPTION
This moves all the remaining text in JSX to translatable `FormatMessage` components and adds the `react/jsx-no-literals` rule to the gui's eslintrc to prevent new untranslated strings from being introduced.

One thing to note about the `jsx-no-literals` rule is that you can still do `{'hello'}`. There is a mode to enforce not doing this, but I found turning it on that it gave a lot of "false positives" with respect to what we want, because there are a fair number of non-translation-related strings in the code. But this mode caught most of what I think we care about.

/cc @rschamp @chrisgarrity 