### PR TITLE
Add an integration test for bitmap vector conversion

### DIFF
--- a/test/integration/costumes.test.js
+++ b/test/integration/costumes.test.js
@@ -64,4 +64,28 @@ describe('Working with costumes', () => {
         const logs = await getLogs();
         await expect(logs).toEqual([]);
     });
+
+    test('Converting bitmap/vector in paint editor', async () => {
+        await loadUri(uri);
+        await clickXpath('//button[@title="tryit"]');
+        await clickText('Costumes');
+
+        // Convert the first costume to bitmap.
+        await clickText('costume1', scope.costumesTab);
+        await clickText('Convert to Bitmap', scope.costumesTab);
+
+        // Make sure mode switches back to vector for vector costume.
+        await clickText('costume2', scope.costumesTab);
+        await clickText('Convert to Bitmap', scope.costumesTab);
+
+        // Make sure bitmap is saved by switching back and converting to vector.
+        await clickText('Sounds');
+        await clickText('Costumes');
+        await clickText('Convert to Vector', scope.costumesTab); // costume2
+        await clickText('costume1', scope.costumesTab);
+        await clickText('Convert to Vector', scope.costumesTab);
+
+        const logs = await getLogs();
+        await expect(logs).toEqual([]);
+    });
 });


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Lack of integration smoke tests for the paint editor

### Proposed Changes

_Describe what this Pull Request does_

Add a simple test to make sure converting to/from vector is properly interacting with the rest of the app, including making the paint editor load in the correct mode.

### Reason for Changes

_Explain why these changes should be made_

Nervous about merging paint editor PRs without something like this.

### Test Coverage

_Please show how you have added tests to cover your changes_


Add a test!

### Browser Coverage

n/a bc it is a test.