### PR TITLE
Make sure no sentry config for local development

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -112,7 +112,7 @@ module.exports = [
                 chunks: ['lib', 'gui'],
                 template: 'src/playground/index.ejs',
                 title: 'Scratch 3.0 GUI',
-                sentryConfig: '"' + process.env.SENTRY_CONFIG + '"'
+                sentryConfig: process.env.SENTRY_CONFIG ? '"' + process.env.SENTRY_CONFIG + '"' : null
             }),
             new HtmlWebpackPlugin({
                 chunks: ['lib', 'blocksonly'],


### PR DESCRIPTION
Last pr fixed it for production, this PR makes sure you don't have sentry in local development, which should make debugging a lot easier.