### PR TITLE
Check for old versions of currently supported browsers

### DIFF
--- a/src/components/browser-modal/browser-modal.jsx
+++ b/src/components/browser-modal/browser-modal.jsx
@@ -31,7 +31,7 @@ const BrowserModal = ({intl, ...props}) => (
             <p>
                 { /* eslint-disable max-len */ }
                 <FormattedMessage
-                    defaultMessage="We're very sorry, but Scratch 3.0 does not support Internet Explorer, Opera or Silk. We recommend trying a newer browser such as Google Chrome, Mozilla Firefox, or Microsoft Edge."
+                    defaultMessage="We're very sorry, but Scratch 3.0 does not support this browser. We recommend installing the latest version of Google Chrome, Mozilla Firefox, or Microsoft Edge."
                     description="Unsupported browser description"
                     id="gui.unsupportedBrowser.description"
                 />

--- a/src/lib/supported-browser.js
+++ b/src/lib/supported-browser.js
@@ -11,6 +11,18 @@ export default function () {
         platform.name === 'Silk') {
         return false;
     }
-    // @todo Should also test for versions of supported browsers
+    // Check for old versions of supported browsers
+    if (platform.name === 'Chrome' &&
+        parseInt(platform.version.split('.')[0], 10) < 55) {
+        return false;
+    }
+    if (platform.name === 'Firefox' &&
+        parseInt(platform.version.split('.')[0], 10) < 53) {
+        return false;
+    }
+    if (platform.name === 'Safari' &&
+        parseInt(platform.version.split('.')[0], 10) < 10) {
+        return false;
+    }
     return true;
 }


### PR DESCRIPTION
### Resolves

#1391

### Proposed Changes

Check for Chrome < 55, Firefox < 53, and Safari < 10

### Reason for Changes

We decided that we should prevent people from using old versions.

### Test Coverage

Tried on Mac and Windows - everything was fine, but I have updated versions of all the browsers. I changed the code to check for a higher version of Chrome and was able to get the unsupported browser message.

### Browser Coverage
Mac
 * [x] Chrome 
 * [x] Firefox 
 * [x] Safari
 
Windows
 * [x] Chrome 
 * [x] Firefox 
 * [x] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
