### PR TITLE
Limit toolbox updates

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -223,19 +223,15 @@ class Blocks extends React.Component {
         // Remove and reattach the workspace listener (but allow flyout events)
         this.workspace.removeChangeListener(this.props.vm.blockListener);
         const dom = this.ScratchBlocks.Xml.textToDom(data.xml);
-        // @todo This line rerenders toolbox, and the change in the toolbox XML also rerenders the toolbox.
-        // We should only rerender the toolbox once. See https://github.com/LLK/scratch-gui/issues/901
         this.ScratchBlocks.Xml.clearWorkspaceAndLoadFromXml(dom, this.workspace);
         this.workspace.addChangeListener(this.props.vm.blockListener);
 
         if (this.props.vm.editingTarget && this.state.workspaceMetrics[this.props.vm.editingTarget.id]) {
-            setTimeout(() => {
-                const {scrollX, scrollY, scale} = this.state.workspaceMetrics[this.props.vm.editingTarget.id];
-                this.workspace.scrollX = scrollX;
-                this.workspace.scrollY = scrollY;
-                this.workspace.scale = scale;
-                this.workspace.resize();
-            }, 0);
+            const {scrollX, scrollY, scale} = this.state.workspaceMetrics[this.props.vm.editingTarget.id];
+            this.workspace.scrollX = scrollX;
+            this.workspace.scrollY = scrollY;
+            this.workspace.scale = scale;
+            this.workspace.resize();
         }
     }
     handleExtensionAdded (blocksInfo) {

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -104,8 +104,8 @@ class Blocks extends React.Component {
             const categoryName = this.workspace.toolbox_.getSelectedCategoryName();
             const offset = this.workspace.toolbox_.getCategoryScrollOffset();
             // rather than update the toolbox "sync" -- update it in the next frame
-            clearTimeout(this.toolboxUpdate);
-            this.toolboxUpdate = setTimeout(() => {
+            clearTimeout(this.toolboxUpdateTimeout);
+            this.toolboxUpdateTimeout = setTimeout(() => {
                 this.workspace.updateToolbox(this.props.toolboxXML);
                 const currentCategoryPos = this.workspace.toolbox_.getCategoryPositionByName(categoryName);
                 const currentCategoryLen = this.workspace.toolbox_.getCategoryLengthByName(categoryName);
@@ -132,7 +132,7 @@ class Blocks extends React.Component {
     componentWillUnmount () {
         this.detachVM();
         this.workspace.dispose();
-        clearTimeout(this.toolboxUpdate);
+        clearTimeout(this.toolboxUpdateTimeout);
     }
     attachVM () {
         this.workspace.addChangeListener(this.props.vm.blockListener);

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -70,6 +70,12 @@ class Blocks extends React.Component {
         );
         this.workspace = this.ScratchBlocks.inject(this.blocks, workspaceConfig);
 
+        // we actually never want the workspace to enable "refresh toolbox" - this basically re-renders the entire toolbox
+        // every time we reset the workspace.  We call updateToolbox as a part of componentDidUpdate so the toolbox will
+        // still correctly be updated
+        this.setToolboxRefreshEnabled = this.workspace.setToolboxRefreshEnabled.bind(this.workspace);
+        this.workspace.setToolboxRefreshEnabled = () => this.setToolboxRefreshEnabled(false);
+
         // @todo change this when blockly supports UI events
         addFunctionListener(this.workspace, 'translate', this.onWorkspaceMetricsChange);
         addFunctionListener(this.workspace, 'zoom', this.onWorkspaceMetricsChange);
@@ -97,14 +103,18 @@ class Blocks extends React.Component {
         if (prevProps.toolboxXML !== this.props.toolboxXML) {
             const categoryName = this.workspace.toolbox_.getSelectedCategoryName();
             const offset = this.workspace.toolbox_.getCategoryScrollOffset();
-            this.workspace.updateToolbox(this.props.toolboxXML);
-            const currentCategoryPos = this.workspace.toolbox_.getCategoryPositionByName(categoryName);
-            const currentCategoryLen = this.workspace.toolbox_.getCategoryLengthByName(categoryName);
-            if (offset < currentCategoryLen) {
-                this.workspace.toolbox_.setFlyoutScrollPos(currentCategoryPos + offset);
-            } else {
-                this.workspace.toolbox_.setFlyoutScrollPos(currentCategoryPos);
-            }
+            // rather than update the toolbox "sync" -- update it in the next frame
+            clearTimeout(this.toolboxUpdate);
+            this.toolboxUpdate = setTimeout(() => {
+                this.workspace.updateToolbox(this.props.toolboxXML);
+                const currentCategoryPos = this.workspace.toolbox_.getCategoryPositionByName(categoryName);
+                const currentCategoryLen = this.workspace.toolbox_.getCategoryLengthByName(categoryName);
+                if (offset < currentCategoryLen) {
+                    this.workspace.toolbox_.setFlyoutScrollPos(currentCategoryPos + offset);
+                } else {
+                    this.workspace.toolbox_.setFlyoutScrollPos(currentCategoryPos);
+                }
+            }, 0);
         }
         if (this.props.isVisible === prevProps.isVisible) {
             return;
@@ -122,6 +132,7 @@ class Blocks extends React.Component {
     componentWillUnmount () {
         this.detachVM();
         this.workspace.dispose();
+        clearTimeout(this.toolboxUpdate);
     }
     attachVM () {
         this.workspace.addChangeListener(this.props.vm.blockListener);
@@ -218,11 +229,13 @@ class Blocks extends React.Component {
         this.workspace.addChangeListener(this.props.vm.blockListener);
 
         if (this.props.vm.editingTarget && this.state.workspaceMetrics[this.props.vm.editingTarget.id]) {
-            const {scrollX, scrollY, scale} = this.state.workspaceMetrics[this.props.vm.editingTarget.id];
-            this.workspace.scrollX = scrollX;
-            this.workspace.scrollY = scrollY;
-            this.workspace.scale = scale;
-            this.workspace.resize();
+            setTimeout(() => {
+                const {scrollX, scrollY, scale} = this.state.workspaceMetrics[this.props.vm.editingTarget.id];
+                this.workspace.scrollX = scrollX;
+                this.workspace.scrollY = scrollY;
+                this.workspace.scale = scale;
+                this.workspace.resize();
+            }, 0);
         }
     }
     handleExtensionAdded (blocksInfo) {

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -70,9 +70,9 @@ class Blocks extends React.Component {
         );
         this.workspace = this.ScratchBlocks.inject(this.blocks, workspaceConfig);
 
-        // we actually never want the workspace to enable "refresh toolbox" - this basically re-renders the entire toolbox
-        // every time we reset the workspace.  We call updateToolbox as a part of componentDidUpdate so the toolbox will
-        // still correctly be updated
+        // we actually never want the workspace to enable "refresh toolbox" - this basically re-renders the
+        // entire toolbox every time we reset the workspace.  We call updateToolbox as a part of
+        // componentDidUpdate so the toolbox will still correctly be updated
         this.setToolboxRefreshEnabled = this.workspace.setToolboxRefreshEnabled.bind(this.workspace);
         this.workspace.setToolboxRefreshEnabled = () => this.setToolboxRefreshEnabled(false);
 

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -74,7 +74,9 @@ class Blocks extends React.Component {
         // entire toolbox every time we reset the workspace.  We call updateToolbox as a part of
         // componentDidUpdate so the toolbox will still correctly be updated
         this.setToolboxRefreshEnabled = this.workspace.setToolboxRefreshEnabled.bind(this.workspace);
-        this.workspace.setToolboxRefreshEnabled = () => this.setToolboxRefreshEnabled(false);
+        this.workspace.setToolboxRefreshEnabled = () => {
+            this.setToolboxRefreshEnabled(false);
+        };
 
         // @todo change this when blockly supports UI events
         addFunctionListener(this.workspace, 'translate', this.onWorkspaceMetricsChange);
@@ -107,6 +109,11 @@ class Blocks extends React.Component {
             clearTimeout(this.toolboxUpdateTimeout);
             this.toolboxUpdateTimeout = setTimeout(() => {
                 this.workspace.updateToolbox(this.props.toolboxXML);
+                // In order to catch any changes that mutate the toolbox during "normal runtime"
+                // (variable changes/etc), re-enable toolbox refresh.
+                // Using the setter function will rerender the entire toolbox which we just rendered.
+                this.workspace.toolboxRefreshEnabled_ = true;
+
                 const currentCategoryPos = this.workspace.toolbox_.getCategoryPositionByName(categoryName);
                 const currentCategoryLen = this.workspace.toolbox_.getCategoryLengthByName(categoryName);
                 if (offset < currentCategoryLen) {


### PR DESCRIPTION
This is already landed on the performance branch -- #1784 

-----

### Resolves

#901

### Proposed Changes

* Force the `toolboxRefreshEnabled` flag on the workspace to always be false (regardless of what `Blockly.Xml.domToWorkspace` says)
* Defer the toolbox update a frame to allow the click handler to return earlier

### Reason for Changes

* scratch-blocks internally will set `toolboxRefreshEnabled` on the workspace after it finishes updating.  This causes an immediate re-render of the current toolbox, which we then give new XML for immediately following, basically re-rendering the entire toolbox again. 
* Removes approximately 400ms from the click event handler.
* Defers 200ms of it to the "next frame" so it still feels a bit jumpy, but since nothing really changes much you don't notice it.
