### PR TITLE
Bump scratch-blocks version

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "redux-throttle": "0.1.1",
     "rimraf": "^2.6.1",
     "scratch-audio": "0.1.0-prerelease.1523977528",
-    "scratch-blocks": "0.1.0-prerelease.1525125321",
+    "scratch-blocks": "0.1.0-prerelease.1525467275",
     "scratch-l10n": "2.0.20180108132626",
     "scratch-paint": "0.2.0-prerelease.20180504180528",
     "scratch-render": "0.1.0-prerelease.20180502115145",


### PR DESCRIPTION
Brings in https://github.com/LLK/scratch-blocks/pull/1464
