### PR TITLE
Publish develop builds to NPM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,9 @@ deploy:
   script: npm run --silent deploy -- -x -a -r https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
 - provider: npm
   on:
-    branch: master
+    branch:
+    - master
+    - develop
   skip_cleanup: true
   email: $NPM_EMAIL
   api_key: $NPM_TOKEN


### PR DESCRIPTION
This brings scratch-gui in line with the rest of the scratch-* packages, and what scratch-www needs for the project preview page.
