### PR TITLE
Add random backdrop menu option

### DIFF
--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -64,7 +64,9 @@ export default function (vm) {
     const backdropsMenu = function () {
         if (vm.runtime.targets[0] && vm.runtime.targets[0].getCostumes().length > 0) {
             return vm.runtime.targets[0].getCostumes().map(costume => [costume.name, costume.name])
-                .concat([['next backdrop', 'next backdrop'], ['previous backdrop', 'previous backdrop']]);
+                .concat([['next backdrop', 'next backdrop'],
+                    ['previous backdrop', 'previous backdrop'],
+                    ['random backdrop', 'random backdrop']]);
         }
         return [['', '']];
     };


### PR DESCRIPTION
### Resolves

Resolves LLK/scratch-blocks#1500
Depends on LLK/scratch-vm#1122

### Proposed Changes

Adds the "random backdrop" option to the `backdropsMenu` menu.

### Reason for Changes

To resolve a help wanted issue.

### Test Coverage

Existing tests pass.

### Browser Coverage
Irrelevant - adding an item to a list is browser-independent.