### PR TITLE
Large readout mode for monitors

### DIFF
--- a/src/components/context-menu/context-menu.css
+++ b/src/components/context-menu/context-menu.css
@@ -13,7 +13,7 @@
     box-shadow: 0px 0px 5px 1px $ui-black-transparent;
     pointer-events: none;
     transition: opacity 0.2s ease;
-    z-index: 100;
+    z-index: 200; /* Above the stage */
 }
 
 .menu-item {

--- a/src/components/monitor-list/monitor-list.jsx
+++ b/src/components/monitor-list/monitor-list.jsx
@@ -1,15 +1,16 @@
 import React from 'react';
+import classNames from 'classnames';
 import Box from '../box/box.jsx';
 import Monitor from '../../containers/monitor.jsx';
 import PropTypes from 'prop-types';
 import {OrderedMap} from 'immutable';
 
-
 import styles from './monitor-list.css';
 
 const MonitorList = props => (
     <Box
-        className={styles.monitorList}
+        // Use static `monitor-overlay` class for bounds of draggables
+        className={classNames(styles.monitorList, 'monitor-overlay')}
     >
         {props.monitors.valueSeq().map(monitorData => (
             <Monitor

--- a/src/components/monitor/default-monitor.jsx
+++ b/src/components/monitor/default-monitor.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styles from './monitor.css';
+
+const DefaultMonitor = ({categoryColor, label, value}) => (
+    <div className={styles.defaultMonitor}>
+        <div className={styles.label}>
+            {label}
+        </div>
+        <div
+            className={styles.value}
+            style={{background: categoryColor}}
+        >
+            {value}
+        </div>
+    </div>
+);
+
+DefaultMonitor.propTypes = {
+    categoryColor: PropTypes.string.isRequired,
+    label: PropTypes.string.isRequired,
+    value: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number
+    ])
+};
+
+export default DefaultMonitor;

--- a/src/components/monitor/large-monitor.jsx
+++ b/src/components/monitor/large-monitor.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styles from './monitor.css';
+
+const LargeMonitor = ({categoryColor, value}) => (
+    <div className={styles.largeMonitor}>
+        <div
+            className={styles.largeValue}
+            style={{background: categoryColor}}
+        >
+            {value}
+        </div>
+    </div>
+);
+
+LargeMonitor.propTypes = {
+    categoryColor: PropTypes.string,
+    value: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number
+    ])
+};
+
+export default LargeMonitor;

--- a/src/components/monitor/monitor.css
+++ b/src/components/monitor/monitor.css
@@ -1,18 +1,17 @@
 @import "../../css/units.css";
 @import "../../css/colors.css";
 
-.monitor {
+.monitor-container {
     position: absolute;
-    padding: 3px;
     background: $ui-primary;
     z-index: 100;
     border: 1px solid $ui-black-transparent;
     border-radius: calc($space / 2);
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
     font-size: 0.75rem;
-    display: flex;
     transition: box-shadow 0.2s;
     pointer-events: all;
+    overflow: hidden;
 }
 
 .monitor:hover {
@@ -22,6 +21,11 @@
 .dragging {
     z-index: 101;
     box-shadow: 3px 3px 5px #888888;
+}
+
+.default-monitor {
+    display: flex;
+    padding: 3px;
 }
 
 .label {
@@ -37,4 +41,13 @@
     margin: 0 5px;
     border-radius: calc($space / 2);
     padding: 0 2px;
+}
+
+.large-value {
+    min-height: 1.5rem;
+    min-width: 3rem;
+    padding: 0.25rem;
+    text-align: center;
+    color: white;
+    font-size: 1rem;
 }

--- a/src/components/monitor/monitor.css
+++ b/src/components/monitor/monitor.css
@@ -41,6 +41,7 @@
     margin: 0 5px;
     border-radius: calc($space / 2);
     padding: 0 2px;
+    transform: translateZ(0); /* Fixes flickering in Safari */
 }
 
 .large-value {
@@ -50,4 +51,5 @@
     text-align: center;
     color: white;
     font-size: 1rem;
+    transform: translateZ(0); /* Fixes flickering in Safari */
 }

--- a/src/components/monitor/monitor.jsx
+++ b/src/components/monitor/monitor.jsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Draggable from 'react-draggable';
+import {FormattedMessage} from 'react-intl';
+import {ContextMenuTrigger} from 'react-contextmenu';
+import {ContextMenu, MenuItem} from '../context-menu/context-menu.jsx';
 import Box from '../box/box.jsx';
 import DefaultMonitor from './default-monitor.jsx';
 import LargeMonitor from './large-monitor.jsx';
@@ -22,32 +25,57 @@ const types = {
 };
 
 const MonitorComponent = props => (
-    <Draggable
-        bounds="parent"
-        defaultClassNameDragging={styles.dragging}
-        onStop={props.onDragEnd}
-    >
-        <Box
-            className={styles.monitorContainer}
-            componentRef={props.componentRef}
+    <ContextMenuTrigger id={`monitor-${props.label}`}>
+        <Draggable
+            bounds=".monitor-overlay" // Class for monitor container
+            defaultClassNameDragging={styles.dragging}
+            onStop={props.onDragEnd}
         >
-            {types[props.type]({
-                categoryColor: categories[props.category],
-                label: props.label,
-                value: props.value
-            })}
-        </Box>
-    </Draggable>
+            <Box
+                className={styles.monitorContainer}
+                componentRef={props.componentRef}
+                onDoubleClick={props.onNextType}
+            >
+                {types[props.type]({
+                    categoryColor: categories[props.category],
+                    label: props.label,
+                    value: props.value
+                })}
+            </Box>
+        </Draggable>
+        <ContextMenu id={`monitor-${props.label}`}>
+            <MenuItem onClick={props.onSetTypeToDefault}>
+                <FormattedMessage
+                    defaultMessage="normal readout"
+                    description="Menu item to switch to the default monitor"
+                    id="gui.monitor.contextMenu.default"
+                />
+            </MenuItem>
+            <MenuItem onClick={props.onSetTypeToLarge}>
+                <FormattedMessage
+                    defaultMessage="large readout"
+                    description="Menu item to switch to the large monitor"
+                    id="gui.monitor.contextMenu.large"
+                />
+            </MenuItem>
+        </ContextMenu>
+    </ContextMenuTrigger>
+
 );
 
 MonitorComponent.categories = categories;
+
+const monitorTypes = Object.keys(types);
 
 MonitorComponent.propTypes = {
     category: PropTypes.oneOf(Object.keys(categories)),
     componentRef: PropTypes.func.isRequired,
     label: PropTypes.string.isRequired,
     onDragEnd: PropTypes.func.isRequired,
-    type: PropTypes.oneOf(Object.keys(types)),
+    onNextType: PropTypes.func.isRequired,
+    onSetTypeToDefault: PropTypes.func.isRequired,
+    onSetTypeToLarge: PropTypes.func.isRequired,
+    type: PropTypes.oneOf(monitorTypes),
     value: PropTypes.oneOfType([
         PropTypes.string,
         PropTypes.number])
@@ -58,4 +86,7 @@ MonitorComponent.defaultProps = {
     type: 'default'
 };
 
-export default MonitorComponent;
+export {
+    MonitorComponent as default,
+    monitorTypes
+};

--- a/src/components/monitor/monitor.jsx
+++ b/src/components/monitor/monitor.jsx
@@ -2,6 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Draggable from 'react-draggable';
 import Box from '../box/box.jsx';
+import DefaultMonitor from './default-monitor.jsx';
+import LargeMonitor from './large-monitor.jsx';
+
 import styles from './monitor.css';
 
 const categories = {
@@ -13,6 +16,11 @@ const categories = {
     list: '#FC662C'
 };
 
+const types = {
+    default: DefaultMonitor,
+    large: LargeMonitor
+};
+
 const MonitorComponent = props => (
     <Draggable
         bounds="parent"
@@ -20,18 +28,14 @@ const MonitorComponent = props => (
         onStop={props.onDragEnd}
     >
         <Box
-            className={styles.monitor}
+            className={styles.monitorContainer}
             componentRef={props.componentRef}
         >
-            <Box className={styles.label}>
-                {props.label}
-            </Box>
-            <Box
-                className={styles.value}
-                style={{background: categories[props.category]}}
-            >
-                {props.value}
-            </Box>
+            {types[props.type]({
+                categoryColor: categories[props.category],
+                label: props.label,
+                value: props.value
+            })}
         </Box>
     </Draggable>
 );
@@ -43,13 +47,15 @@ MonitorComponent.propTypes = {
     componentRef: PropTypes.func.isRequired,
     label: PropTypes.string.isRequired,
     onDragEnd: PropTypes.func.isRequired,
+    type: PropTypes.oneOf(Object.keys(types)),
     value: PropTypes.oneOfType([
         PropTypes.string,
         PropTypes.number])
 };
 
 MonitorComponent.defaultProps = {
-    category: 'data'
+    category: 'data',
+    type: 'default'
 };
 
 export default MonitorComponent;

--- a/src/containers/monitor.jsx
+++ b/src/containers/monitor.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import monitorAdapter from '../lib/monitor-adapter.js';
-import MonitorComponent from '../components/monitor/monitor.jsx';
+import MonitorComponent, {monitorTypes} from '../components/monitor/monitor.jsx';
 import {addMonitorRect, getInitialPosition, resizeMonitorRect, removeMonitorRect} from '../reducers/monitor-layout';
 
 import {connect} from 'react-redux';
@@ -13,8 +13,16 @@ class Monitor extends React.Component {
         super(props);
         bindAll(this, [
             'handleDragEnd',
+            'handleNextType',
+            'handleSetTypeToDefault',
+            'handleSetTypeToLarge',
             'setElement'
         ]);
+
+        // @todo this eventually will be stored in the VM
+        this.state = {
+            type: 'default'
+        };
     }
     componentDidMount () {
         let rect;
@@ -59,6 +67,18 @@ class Monitor extends React.Component {
             parseInt(this.element.style.top, 10) + y
         );
     }
+    handleNextType () {
+        // @todo the type list needs to be filtered for current available types
+        // i.e. no sliders for read-only monitors, only list type for list vars.
+        const typeIndex = monitorTypes.indexOf(this.state.type);
+        this.setState({type: monitorTypes[(typeIndex + 1) % monitorTypes.length]});
+    }
+    handleSetTypeToDefault () {
+        this.setState({type: 'default'});
+    }
+    handleSetTypeToLarge () {
+        this.setState({type: 'large'});
+    }
     setElement (monitorElt) {
         this.element = monitorElt;
     }
@@ -68,7 +88,11 @@ class Monitor extends React.Component {
             <MonitorComponent
                 componentRef={this.setElement}
                 {...monitorProps}
+                type={this.state.type}
                 onDragEnd={this.handleDragEnd}
+                onNextType={this.handleNextType}
+                onSetTypeToDefault={this.handleSetTypeToDefault}
+                onSetTypeToLarge={this.handleSetTypeToLarge}
             />
         );
     }


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

One of the parts of finishing monitors.

### Proposed Changes

_Describe what this Pull Request does_

Implement the large monitor mode, including:
1. Temporary state storage for monitor type, will eventually be moved to VM
2. Context menu for changing between normal/large readout. Copied language from S2.
3. Double click action for cycling through the monitor types available.

I tried to make the large monitors match S2 style and size wise as much as possible.

### Test Coverage

_Please show how you have added tests to cover your changes_

No automated tests for monitors yet... :(

### Browser Coverage

Tested: dragging monitors, context menu layers above other monitors, double click changes monitor mode.

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [x] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [x] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [x] Safari

Android Tablet
* [ ] Chrome
