### PR TITLE
Add setAppElement to GUI

### DIFF
--- a/src/components/modal/modal.css
+++ b/src/components/modal/modal.css
@@ -11,6 +11,10 @@
     background-color: $ui-modal-overlay;
 }
 
+.modal-content * {
+    box-sizing: border-box;
+}
+
 .modal-content {
     margin: 100px auto;
     outline: none;

--- a/src/containers/gui.jsx
+++ b/src/containers/gui.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import VM from 'scratch-vm';
 import {connect} from 'react-redux';
+import ReactModal from 'react-modal';
 
 import {openExtensionLibrary} from '../reducers/modals';
 import {
@@ -120,4 +121,7 @@ const ConnectedGUI = connect(
     mapDispatchToProps,
 )(GUI);
 
-export default ProjectLoaderHOC(AppStateHOC(vmListenerHOC(ConnectedGUI)));
+const WrappedGui = ProjectLoaderHOC(AppStateHOC(vmListenerHOC(ConnectedGUI)));
+
+WrappedGui.setAppElement = ReactModal.setAppElement;
+export default WrappedGui;

--- a/src/playground/index.jsx
+++ b/src/playground/index.jsx
@@ -1,7 +1,6 @@
 import 'es6-object-assign/auto';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import Modal from 'react-modal';
 
 import analytics from '../lib/analytics';
 import GUI from '../containers/gui.jsx';
@@ -20,6 +19,6 @@ const appTarget = document.createElement('div');
 appTarget.className = styles.app;
 document.body.appendChild(appTarget);
 
-Modal.setAppElement(appTarget);
+GUI.setAppElement(appTarget);
 
 ReactDOM.render(<GUI />, appTarget);


### PR DESCRIPTION
### Resolves

#1853 

### Proposed Changes

Add setAppElement to exported GUI. Consumers of GUI (e.g. playground, www) must call `GUI.setAppElement()` 

Modals are added at the root, so the modal needs to explicitly set `box-sizing` to work outside of playground.

### Reason for Changes

Eliminate warnings

### Test Coverage

Usual tests run

### Browser Coverage
Mac
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
