### PR TITLE
Build scratch-* dependencies with babel-loader

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,6 +28,9 @@ const base = {
         React: 'react',
         ReactDOM: 'react-dom'
     },
+    resolve: {
+        symlinks: false
+    },
     module: {
         rules: [{
             test: /\.jsx?$/,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,7 +32,20 @@ const base = {
         rules: [{
             test: /\.jsx?$/,
             loader: 'babel-loader',
-            include: path.resolve(__dirname, 'src')
+            include: [path.resolve(__dirname, 'src'), /node_modules[\\/]scratch-[^\\/]+[\\/]src/],
+            options: {
+                // Explicitly disable babelrc so we don't catch various config
+                // in much lower dependencies.
+                babelrc: false,
+                plugins: [
+                    'syntax-dynamic-import',
+                    'transform-async-to-generator',
+                    'transform-object-rest-spread',
+                    ['react-intl', {
+                        messagesDir: './translations/messages/'
+                    }]],
+                presets: [['env', {targets: {browsers: ['last 3 versions', 'Safari >= 8', 'iOS >= 8']}}], 'react']
+            }
         },
         {
             test: /\.css$/,


### PR DESCRIPTION
### Proposed Changes

- Build scratch-* dependencies with babel-loader
- Disable babelrc use by babel-loader so lower dependencies use the stated webpack babel configuration

### Reason for Changes

Sibling of https://github.com/LLK/scratch-vm/pull/1106

