### PR TITLE
Try gui build without sudo to avoid travis issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
-sudo: required
 dist: trusty
 addons:
     chrome: stable


### PR DESCRIPTION
Travis isn't working on sudo enabled builds, but I'm not sure our build needs sudo. Let's see!

Update: nope, doesn't run. Chromedriver doesn't start :( 