### PR TITLE
Add "read-only" slider and list monitors.

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "scratch-render": "0.1.0-prerelease.20180508205430",
     "scratch-storage": "0.4.1",
     "scratch-svg-renderer": "0.1.0-prerelease.20180423193917",
-    "scratch-vm": "0.1.0-prerelease.1525460669",
+    "scratch-vm": "0.1.0-prerelease.1525837283",
     "selenium-webdriver": "3.6.0",
     "startaudiocontext": "1.2.1",
     "style-loader": "^0.21.0",

--- a/src/components/monitor-list/monitor-list.jsx
+++ b/src/components/monitor-list/monitor-list.jsx
@@ -12,20 +12,25 @@ const MonitorList = props => (
         // Use static `monitor-overlay` class for bounds of draggables
         className={classNames(styles.monitorList, 'monitor-overlay')}
     >
-        {props.monitors.valueSeq().map(monitorData => (
-            <Monitor
-                id={monitorData.id}
-                key={monitorData.id}
-                mode={monitorData.mode}
-                opcode={monitorData.opcode}
-                params={monitorData.params}
-                spriteName={monitorData.spriteName}
-                value={monitorData.value}
-                x={monitorData.x}
-                y={monitorData.y}
-                onDragEnd={props.onMonitorChange}
-            />
-        ))}
+        {props.monitors.valueSeq().filter(m => m.visible)
+            .map(monitorData => (
+                <Monitor
+                    height={monitorData.height}
+                    id={monitorData.id}
+                    key={monitorData.id}
+                    max={monitorData.sliderMax}
+                    min={monitorData.sliderMin}
+                    mode={monitorData.mode}
+                    opcode={monitorData.opcode}
+                    params={monitorData.params}
+                    spriteName={monitorData.spriteName}
+                    value={monitorData.value}
+                    width={monitorData.width}
+                    x={monitorData.x}
+                    y={monitorData.y}
+                    onDragEnd={props.onMonitorChange}
+                />
+            ))}
     </Box>
 );
 

--- a/src/components/monitor/list-monitor.jsx
+++ b/src/components/monitor/list-monitor.jsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styles from './monitor.css';
+
+const ListMonitor = ({categoryColor, label, width, height, value}) => (
+    <div
+        className={styles.listMonitor}
+        style={{
+            width: `${width || 80}px`,
+            height: `${height || 200}px`
+        }}
+    >
+        <div className={styles.listHeader}>
+            {label}
+        </div>
+        <div className={styles.listBody}>
+            {!value || value.length === 0 ? (
+                <div className={styles.listEmpty}>
+                    {'(empty)' /* @todo not translating, awaiting design */}
+                </div>
+            ) : value.map((v, i) => (
+                <div
+                    className={styles.listRow}
+                    key={`label-${i}`}
+                >
+                    <div className={styles.listIndex}>{i + 1 /* one indexed */}</div>
+                    <div
+                        className={styles.listValue}
+                        style={{background: categoryColor}}
+                    >
+                        <div className={styles.valueInner}>{v}</div>
+                    </div>
+                </div>
+            ))}
+        </div>
+        <div className={styles.listFooter}>
+            <div className={styles.footerButton}>
+                {/* @todo add button here */}
+            </div>
+            <div className={styles.footerLength}>
+                <span className={styles.lengthNumber}>
+                    {value.length}
+                </span>
+            </div>
+            <div className={styles.resizeHandle}>
+                {/* @todo resize handle */}
+            </div>
+        </div>
+    </div>
+);
+
+ListMonitor.propTypes = {
+    categoryColor: PropTypes.string.isRequired,
+    height: PropTypes.number,
+    label: PropTypes.string.isRequired,
+    value: PropTypes.arrayOf(PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number
+    ])),
+    width: PropTypes.number
+};
+
+ListMonitor.defaultProps = {
+    width: 80,
+    height: 200
+};
+
+export default ListMonitor;

--- a/src/components/monitor/monitor.css
+++ b/src/components/monitor/monitor.css
@@ -25,6 +25,7 @@
 
 .default-monitor {
     display: flex;
+    flex-direction: column;
     padding: 3px;
 }
 
@@ -52,4 +53,82 @@
     color: white;
     font-size: 1rem;
     transform: translateZ(0); /* Fixes flickering in Safari */
+}
+
+.row {
+    display: flex;
+    flex-direction: row;
+}
+
+.list-monitor {
+    min-width: 80px;
+    display: flex;
+    flex-direction: column;
+}
+
+.list-header {
+    background: $ui-white;
+    border-bottom: 1px solid $ui-black-transparent;
+    text-align: center;
+    padding: 3px;
+    font-size: 0.75rem;
+    font-weight: bold;
+    color: $text-primary;
+    width: 100%;
+}
+
+.list-body {
+    background: $ui-primary;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    overflow-y: scroll;
+    height: calc(100% - 44px);
+}
+
+.list-row {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-around;
+    align-items: center;
+    padding: 2px;
+    flex-shrink: 0;
+}
+
+.list-index {
+    font-weight: bold;
+    color: $text-primary;
+    margin: 0 3px;
+}
+
+.list-value {
+    min-width: 40px;
+    text-align: left;
+    color: white;
+    margin: 0 3px;
+    border-radius: calc($space / 2);
+    border: 1px solid $ui-black-transparent;
+    flex-grow: 1;
+}
+
+.list-footer {
+    background: $ui-white;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    padding: 3px;
+    font-size: 0.75rem;
+    font-weight: bold;
+    color: $text-primary;
+}
+
+.list-empty {
+    text-align: center;
+    width: 100%;
+    padding: 5px;
+}
+
+.input-wrapper {
+    position: relative;
+    overflow: hidden;
 }

--- a/src/components/monitor/monitor.css
+++ b/src/components/monitor/monitor.css
@@ -132,3 +132,8 @@
     position: relative;
     overflow: hidden;
 }
+
+.value-inner {
+    padding: 3px 5px;
+    min-height: 22px;
+}

--- a/src/components/monitor/monitor.jsx
+++ b/src/components/monitor/monitor.jsx
@@ -7,6 +7,8 @@ import {ContextMenu, MenuItem} from '../context-menu/context-menu.jsx';
 import Box from '../box/box.jsx';
 import DefaultMonitor from './default-monitor.jsx';
 import LargeMonitor from './large-monitor.jsx';
+import SliderMonitor from './slider-monitor.jsx';
+import ListMonitor from './list-monitor.jsx';
 
 import styles from './monitor.css';
 
@@ -21,44 +23,62 @@ const categories = {
 
 const modes = {
     default: DefaultMonitor,
-    large: LargeMonitor
+    large: LargeMonitor,
+    slider: SliderMonitor,
+    list: ListMonitor
 };
 
 const MonitorComponent = props => (
     <ContextMenuTrigger id={`monitor-${props.label}`}>
         <Draggable
             bounds=".monitor-overlay" // Class for monitor container
+            cancel=".no-drag" // Class used for slider input to prevent drag
             defaultClassNameDragging={styles.dragging}
             onStop={props.onDragEnd}
         >
             <Box
                 className={styles.monitorContainer}
                 componentRef={props.componentRef}
-                onDoubleClick={props.onNextMode}
+                onDoubleClick={props.mode === 'list' ? null : props.onNextMode}
             >
                 {(modes[props.mode] || modes.default)({ // Use default until other modes arrive
                     categoryColor: categories[props.category],
                     label: props.label,
-                    value: props.value
+                    value: props.value,
+                    width: props.width,
+                    height: props.height,
+                    min: props.min,
+                    max: props.max
                 })}
             </Box>
         </Draggable>
-        <ContextMenu id={`monitor-${props.label}`}>
-            <MenuItem onClick={props.onSetModeToDefault}>
-                <FormattedMessage
-                    defaultMessage="normal readout"
-                    description="Menu item to switch to the default monitor"
-                    id="gui.monitor.contextMenu.default"
-                />
-            </MenuItem>
-            <MenuItem onClick={props.onSetModeToLarge}>
-                <FormattedMessage
-                    defaultMessage="large readout"
-                    description="Menu item to switch to the large monitor"
-                    id="gui.monitor.contextMenu.large"
-                />
-            </MenuItem>
-        </ContextMenu>
+        {props.mode === 'list' ? null : (
+            <ContextMenu id={`monitor-${props.label}`}>
+                <MenuItem onClick={props.onSetModeToDefault}>
+                    <FormattedMessage
+                        defaultMessage="normal readout"
+                        description="Menu item to switch to the default monitor"
+                        id="gui.monitor.contextMenu.default"
+                    />
+                </MenuItem>
+                <MenuItem onClick={props.onSetModeToLarge}>
+                    <FormattedMessage
+                        defaultMessage="large readout"
+                        description="Menu item to switch to the large monitor"
+                        id="gui.monitor.contextMenu.large"
+                    />
+                </MenuItem>
+                {props.onSetModeToSlider ? (
+                    <MenuItem onClick={props.onSetModeToSlider}>
+                        <FormattedMessage
+                            defaultMessage="slider"
+                            description="Menu item to switch to the slider monitor"
+                            id="gui.monitor.contextMenu.slider"
+                        />
+                    </MenuItem>
+                ) : null}
+            </ContextMenu>
+        )}
     </ContextMenuTrigger>
 
 );
@@ -70,15 +90,25 @@ const monitorModes = Object.keys(modes);
 MonitorComponent.propTypes = {
     category: PropTypes.oneOf(Object.keys(categories)),
     componentRef: PropTypes.func.isRequired,
+    height: PropTypes.number,
     label: PropTypes.string.isRequired,
+    max: PropTypes.number,
+    min: PropTypes.number,
     mode: PropTypes.oneOf(monitorModes),
     onDragEnd: PropTypes.func.isRequired,
     onNextMode: PropTypes.func.isRequired,
     onSetModeToDefault: PropTypes.func.isRequired,
     onSetModeToLarge: PropTypes.func.isRequired,
+    onSetModeToSlider: PropTypes.func,
     value: PropTypes.oneOfType([
         PropTypes.string,
-        PropTypes.number])
+        PropTypes.number,
+        PropTypes.arrayOf(PropTypes.oneOfType([
+            PropTypes.string,
+            PropTypes.number
+        ]))
+    ]),
+    width: PropTypes.number
 };
 
 MonitorComponent.defaultProps = {

--- a/src/components/monitor/slider-monitor.jsx
+++ b/src/components/monitor/slider-monitor.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styles from './monitor.css';
 
-const DefaultMonitor = ({categoryColor, label, value}) => (
+const SliderMonitor = ({categoryColor, label, min, max, value}) => (
     <div className={styles.defaultMonitor}>
         <div className={styles.row}>
             <div className={styles.label}>
@@ -15,16 +15,35 @@ const DefaultMonitor = ({categoryColor, label, value}) => (
                 {value}
             </div>
         </div>
+        <div className={styles.row}>
+            <input
+                className="no-drag" // Class used on parent Draggable to prevent drags
+                max={max}
+                min={min}
+                type="range"
+                value={value}
+                // @todo onChange callback
+            />
+        </div>
+
     </div>
 );
 
-DefaultMonitor.propTypes = {
+SliderMonitor.propTypes = {
     categoryColor: PropTypes.string.isRequired,
     label: PropTypes.string.isRequired,
+    max: PropTypes.number,
+    min: PropTypes.number,
+    // @todo callback for change events
     value: PropTypes.oneOfType([
         PropTypes.string,
         PropTypes.number
     ])
 };
 
-export default DefaultMonitor;
+SliderMonitor.defaultProps = {
+    min: 0,
+    max: 100
+};
+
+export default SliderMonitor;

--- a/src/containers/monitor.jsx
+++ b/src/containers/monitor.jsx
@@ -97,7 +97,6 @@ class Monitor extends React.Component {
         this.element = monitorElt;
     }
     render () {
-        // console.log(this.props);
         const monitorProps = monitorAdapter(this.props);
         const showSliderOption = availableModes(this.props.opcode).indexOf('slider') !== -1;
         return (

--- a/src/containers/monitor.jsx
+++ b/src/containers/monitor.jsx
@@ -8,6 +8,17 @@ import {addMonitorRect, getInitialPosition, resizeMonitorRect, removeMonitorRect
 
 import {connect} from 'react-redux';
 
+const availableModes = opcode => (
+    monitorModes.filter(t => {
+        if (opcode === 'data_variable') {
+            return t !== 'list';
+        } else if (opcode === 'data_listcontents') {
+            return t === 'list';
+        }
+        return t !== 'slider' && t !== 'list';
+    })
+);
+
 class Monitor extends React.Component {
     constructor (props) {
         super(props);
@@ -16,6 +27,7 @@ class Monitor extends React.Component {
             'handleNextMode',
             'handleSetModeToDefault',
             'handleSetModeToLarge',
+            'handleSetModeToSlider',
             'setElement'
         ]);
 
@@ -68,10 +80,9 @@ class Monitor extends React.Component {
         );
     }
     handleNextMode () {
-        // @todo the mode list needs to be filtered for current available modes
-        // i.e. no sliders for read-only monitors, only list for list vars.
-        const modeIndex = monitorModes.indexOf(this.state.mode);
-        this.setState({mode: monitorModes[(modeIndex + 1) % monitorModes.length]});
+        const modes = availableModes(this.props.opcode);
+        const modeIndex = modes.indexOf(this.state.mode);
+        this.setState({mode: modes[(modeIndex + 1) % modes.length]});
     }
     handleSetModeToDefault () {
         this.setState({mode: 'default'});
@@ -79,20 +90,30 @@ class Monitor extends React.Component {
     handleSetModeToLarge () {
         this.setState({mode: 'large'});
     }
+    handleSetModeToSlider () {
+        this.setState({mode: 'slider'});
+    }
     setElement (monitorElt) {
         this.element = monitorElt;
     }
     render () {
+        // console.log(this.props);
         const monitorProps = monitorAdapter(this.props);
+        const showSliderOption = availableModes(this.props.opcode).indexOf('slider') !== -1;
         return (
             <MonitorComponent
                 componentRef={this.setElement}
                 {...monitorProps}
+                height={this.props.height}
+                max={this.props.max}
+                min={this.props.min}
                 mode={this.state.mode}
+                width={this.props.width}
                 onDragEnd={this.handleDragEnd}
                 onNextMode={this.handleNextMode}
                 onSetModeToDefault={this.handleSetModeToDefault}
                 onSetModeToLarge={this.handleSetModeToLarge}
+                onSetModeToSlider={showSliderOption ? this.handleSetModeToSlider : null}
             />
         );
     }
@@ -100,7 +121,10 @@ class Monitor extends React.Component {
 
 Monitor.propTypes = {
     addMonitorRect: PropTypes.func.isRequired,
+    height: PropTypes.number,
     id: PropTypes.string.isRequired,
+    max: PropTypes.number,
+    min: PropTypes.number,
     mode: PropTypes.oneOf(['default', 'slider', 'large', 'list']),
     monitorLayout: PropTypes.shape({
         monitors: PropTypes.object,
@@ -112,7 +136,15 @@ Monitor.propTypes = {
     removeMonitorRect: PropTypes.func.isRequired,
     resizeMonitorRect: PropTypes.func.isRequired,
     spriteName: PropTypes.string, // eslint-disable-line react/no-unused-prop-types
-    value: PropTypes.string.isRequired, // eslint-disable-line react/no-unused-prop-types
+    value: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number,
+        PropTypes.arrayOf(PropTypes.oneOfType([
+            PropTypes.string,
+            PropTypes.number
+        ]))
+    ]), // eslint-disable-line react/no-unused-prop-types
+    width: PropTypes.number,
     x: PropTypes.number,
     y: PropTypes.number
 };

--- a/src/lib/monitor-adapter.js
+++ b/src/lib/monitor-adapter.js
@@ -10,7 +10,7 @@ const isUndefined = a => typeof a === 'undefined';
  *     with given target ID. The name of the target sprite when the monitor was created
  * @param {string} block.opcode - The opcode of the monitor
  * @param {object} block.params - Extra params to the monitor block
- * @param {string} block.value - The monitor value
+ * @param {string|number|Array} block.value - The monitor value
  * @return {object} The adapted monitor with label and category
  */
 export default function ({id, spriteName, opcode, params, value}) {
@@ -25,8 +25,8 @@ export default function ({id, spriteName, opcode, params, value}) {
     }
 
     // If value is a number, round it to six decimal places
-    if (typeof value === 'number' || (typeof value === 'string' && String(parseFloat(value)) === value)) {
-        value = Number(Number(value).toFixed(6));
+    if (typeof value === 'number') {
+        value = Number(value.toFixed(6));
     }
     
     return {id, label, category, value};


### PR DESCRIPTION
## Resolves

_What Github issue does this resolve (please include link)?_

Adds first iteration UI for list and slider monitors. They are "read-only" in this PR, i.e. they cannot be edited, the sliders do not work. I wanted to do that in a separate PR, because it may require VM APIs that do not exist yet.

### Proposed Changes

_Describe what this Pull Request does_

You can now:
- Create list monitors from scratch 3 toolbox
- Import list monitors with the XY/width/height set from scratch 2
- Use double-click or context menu to change variable monitors to slider mode.

Manually tested along with monitor imports:

![image](https://user-images.githubusercontent.com/654102/39830653-13f9e742-5390-11e8-92e2-63e368ba610b.png)

Depends on https://github.com/LLK/scratch-vm/pull/1128, which is merged, i'll update this PR when it is built.
