### PR TITLE
Add instructions to PR template browser coverage section

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,6 +15,8 @@ _Explain why these changes should be made_
 _Please show how you have added tests to cover your changes_
 
 ### Browser Coverage
+Check the OS/browser combinations tested (At least 2)
+
 Mac
  * [ ] Chrome 
  * [ ] Firefox 


### PR DESCRIPTION
### Resolves

The overwhelming experience of testing every browser/OS combination.

### Proposed Changes

Adds instructions to the Browser Coverage section of the PR template to indicate that you should check at least two combinations and not necessarily all of them.

### Reason for Changes

It would take too long to test all of them and it would encourage larger PRs so you wouldn't have to test as often.  This encourages increasing coverage but makes it easier to check.