### PR TITLE
Project loader refactor

### DIFF
--- a/src/components/stage-wrapper/stage-wrapper.css
+++ b/src/components/stage-wrapper/stage-wrapper.css
@@ -1,7 +1,7 @@
 @import "../../css/units.css";
 @import "../../css/colors.css";
 
-.stage-wrapper {
+.stage-wrapper * {
     box-sizing: border-box;
 }
 

--- a/src/lib/hash-parser-hoc.jsx
+++ b/src/lib/hash-parser-hoc.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import bindAll from 'lodash.bindall';
 
 /* Higher Order Component to get the project id from location.hash
  * @param {React.Component} WrappedComponent component to receive projectData prop
@@ -8,24 +9,22 @@ const HashParserHOC = function (WrappedComponent) {
     class HashParserComponent extends React.Component {
         constructor (props) {
             super(props);
-            this.fetchProjectId = this.fetchProjectId.bind(this);
-            this.updateProject = this.updateProject.bind(this);
+            bindAll(this, [
+                'handleHashChange'
+            ]);
             this.state = {
                 projectId: null
             };
         }
         componentDidMount () {
-            window.addEventListener('hashchange', this.updateProject);
-            this.updateProject();
+            window.addEventListener('hashchange', this.handleHashChange);
+            this.handleHashChange();
         }
         componentWillUnmount () {
-            window.removeEventListener('hashchange', this.updateProject);
+            window.removeEventListener('hashchange', this.handleHashChange);
         }
-        fetchProjectId () {
-            return window.location.hash.substring(1);
-        }
-        updateProject () {
-            let projectId = this.fetchProjectId();
+        handleHashChange () {
+            let projectId = window.location.hash.substring(1);
             if (projectId !== this.state.projectId) {
                 if (projectId.length < 1) projectId = 0;
                 this.setState({projectId: projectId});

--- a/src/lib/hash-parser-hoc.jsx
+++ b/src/lib/hash-parser-hoc.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+
+/* Higher Order Component to get the project id from location.hash
+ * @param {React.Component} WrappedComponent component to receive projectData prop
+ * @returns {React.Component} component with project loading behavior
+ */
+const HashParserHOC = function (WrappedComponent) {
+    class HashParserComponent extends React.Component {
+        constructor (props) {
+            super(props);
+            this.fetchProjectId = this.fetchProjectId.bind(this);
+            this.updateProject = this.updateProject.bind(this);
+            this.state = {
+                projectId: null
+            };
+        }
+        componentDidMount () {
+            window.addEventListener('hashchange', this.updateProject);
+            this.updateProject();
+        }
+        componentWillUnmount () {
+            window.removeEventListener('hashchange', this.updateProject);
+        }
+        fetchProjectId () {
+            return window.location.hash.substring(1);
+        }
+        updateProject () {
+            let projectId = this.fetchProjectId();
+            if (projectId !== this.state.projectId) {
+                if (projectId.length < 1) projectId = 0;
+                this.setState({projectId: projectId});
+            }
+        }
+        render () {
+            return (
+                <WrappedComponent
+                    projectId={this.state.projectId}
+                    {...this.props}
+                />
+            );
+        }
+    }
+
+    return HashParserComponent;
+};
+
+export {
+    HashParserHOC as default
+};

--- a/src/lib/project-loader-hoc.jsx
+++ b/src/lib/project-loader-hoc.jsx
@@ -5,9 +5,8 @@ import analytics from './analytics';
 import log from './log';
 import storage from './storage';
 
-/* Higher Order Component to provide behavior for loading projects by id from
- * the window's hash (#this part in the url) or by projectId prop passed in from
- * the parent (i.e. scratch-www)
+/* Higher Order Component to provide behavior for loading projects by id. If
+ * there's no id, the default project is loaded.
  * @param {React.Component} WrappedComponent component to receive projectData prop
  * @returns {React.Component} component with project loading behavior
  */
@@ -15,52 +14,40 @@ const ProjectLoaderHOC = function (WrappedComponent) {
     class ProjectLoaderComponent extends React.Component {
         constructor (props) {
             super(props);
-            this.fetchProjectId = this.fetchProjectId.bind(this);
             this.updateProject = this.updateProject.bind(this);
             this.state = {
-                projectId: null,
                 projectData: null,
                 fetchingProject: false
             };
         }
         componentDidMount () {
-            window.addEventListener('hashchange', this.updateProject);
-            this.updateProject();
+            this.updateProject(this.props.projectId);
         }
-        componentWillUpdate (nextProps, nextState) {
-            if (this.state.projectId !== nextState.projectId) {
+        componentWillUpdate (nextProps) {
+            if (this.props.projectId !== nextProps.projectId) {
                 this.setState({fetchingProject: true}, () => {
-                    storage
-                        .load(storage.AssetType.Project, this.state.projectId, storage.DataFormat.JSON)
-                        .then(projectAsset => projectAsset && this.setState({
-                            projectData: projectAsset.data,
-                            fetchingProject: false
-                        }))
-                        .catch(err => log.error(err));
+                    this.updateProject(nextProps.projectId);
                 });
             }
         }
-        componentWillUnmount () {
-            window.removeEventListener('hashchange', this.updateProject);
-        }
-        fetchProjectId () {
-            return window.location.hash.substring(1);
-        }
-        updateProject () {
-            let projectId = this.props.projectId || this.fetchProjectId();
-            if (projectId !== this.state.projectId) {
-                if (projectId.length < 1) projectId = 0;
-                this.setState({projectId: projectId});
-
-                if (projectId !== 0) {
-                    analytics.event({
-                        category: 'project',
-                        action: 'Load Project',
-                        value: projectId,
-                        nonInteraction: true
-                    });
-                }
-            }
+        updateProject (projectId) {
+            storage
+                .load(storage.AssetType.Project, projectId, storage.DataFormat.JSON)
+                .then(projectAsset => projectAsset && this.setState({
+                    projectData: projectAsset.data,
+                    fetchingProject: false
+                }))
+                .then(() => {
+                    if (projectId !== 0) {
+                        analytics.event({
+                            category: 'project',
+                            action: 'Load Project',
+                            value: projectId,
+                            nonInteraction: true
+                        });
+                    }
+                })
+                .catch(err => log.error(err));
         }
         render () {
             const {
@@ -78,7 +65,10 @@ const ProjectLoaderHOC = function (WrappedComponent) {
         }
     }
     ProjectLoaderComponent.propTypes = {
-        projectId: PropTypes.string
+        projectId: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+    };
+    ProjectLoaderComponent.defaultProps = {
+        projectId: 0
     };
 
     return ProjectLoaderComponent;

--- a/src/playground/blocks-only.jsx
+++ b/src/playground/blocks-only.jsx
@@ -5,7 +5,7 @@ import {connect} from 'react-redux';
 import Controls from '../containers/controls.jsx';
 import Blocks from '../containers/blocks.jsx';
 import GUI from '../containers/gui.jsx';
-import ProjectLoaderHOC from '../lib/project-loader-hoc.jsx';
+import HashParserHOC from '../lib/hash-parser-hoc.jsx';
 
 import styles from './blocks-only.css';
 
@@ -26,7 +26,7 @@ const BlocksOnly = props => (
     </GUI>
 );
 
-const App = ProjectLoaderHOC(BlocksOnly);
+const App = HashParserHOC(BlocksOnly);
 
 const appTarget = document.createElement('div');
 document.body.appendChild(appTarget);

--- a/src/playground/compatibility-testing.jsx
+++ b/src/playground/compatibility-testing.jsx
@@ -6,7 +6,7 @@ import Controls from '../containers/controls.jsx';
 import Stage from '../containers/stage.jsx';
 import Box from '../components/box/box.jsx';
 import GUI from '../containers/gui.jsx';
-import ProjectLoaderHOC from '../lib/project-loader-hoc.jsx';
+import HashParserHOC from '../lib/hash-parser-hoc.jsx';
 
 const mapStateToProps = state => ({vm: state.vm});
 
@@ -71,7 +71,7 @@ class Player extends React.Component {
     }
 }
 
-const App = ProjectLoaderHOC(Player);
+const App = HashParserHOC(Player);
 
 const appTarget = document.createElement('div');
 document.body.appendChild(appTarget);

--- a/src/playground/index.jsx
+++ b/src/playground/index.jsx
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom';
 
 import analytics from '../lib/analytics';
 import GUI from '../containers/gui.jsx';
+import HashParserHOC from '../lib/hash-parser-hoc.jsx';
 
 import styles from './index.css';
 
@@ -20,5 +21,6 @@ appTarget.className = styles.app;
 document.body.appendChild(appTarget);
 
 GUI.setAppElement(appTarget);
+const WrappedGui = HashParserHOC(GUI);
 
-ReactDOM.render(<GUI />, appTarget);
+ReactDOM.render(<WrappedGui />, appTarget);

--- a/src/playground/player.jsx
+++ b/src/playground/player.jsx
@@ -3,6 +3,8 @@ import ReactDOM from 'react-dom';
 
 import Box from '../components/box/box.jsx';
 import GUI from '../containers/gui.jsx';
+import HashParserHOC from '../lib/hash-parser-hoc.jsx';
+const WrappedGui = HashParserHOC(GUI);
 
 if (process.env.NODE_ENV === 'production' && typeof window === 'object') {
     // Warn before navigating away
@@ -12,7 +14,7 @@ if (process.env.NODE_ENV === 'production' && typeof window === 'object') {
 import styles from './player.css';
 const Player = () => (
     <Box className={styles.stageOnly}>
-        <GUI
+        <WrappedGui
             isPlayerOnly
             isFullScreen={false}
         />

--- a/test/unit/util/hash-project-loader-hoc.test.jsx
+++ b/test/unit/util/hash-project-loader-hoc.test.jsx
@@ -1,64 +1,34 @@
 import React from 'react';
-import ProjectLoaderHOC from '../../../src/lib/project-loader-hoc.jsx';
 import HashParserHOC from '../../../src/lib/hash-parser-hoc.jsx';
-import storage from '../../../src/lib/storage';
 import {mount} from 'enzyme';
 
 jest.mock('react-ga');
 
-describe('Hash/ProjectLoaderHOC', () => {
-    test('when there is no project data, it renders null', () => {
-        const Component = ({projectData}) => <div>{projectData}</div>;
-        const WrappedComponent = HashParserHOC(ProjectLoaderHOC(Component));
+describe('HashParserHOC', () => {
+    test('when there is a hash, it passes the hash as projectId', () => {
+        const Component = ({projectId}) => <div>{projectId}</div>;
+        const WrappedComponent = HashParserHOC(Component);
         window.location.hash = '#winning';
-        const originalLoad = storage.load;
-        storage.load = jest.fn(() => Promise.resolve(null));
-        const mounted = mount(<WrappedComponent />);
-        storage.load = originalLoad;
-        window.location.hash = '';
-        const mountedDiv = mounted.find('div');
-        expect(mountedDiv.exists()).toEqual(false);
-    });
-
-    test('when there is no hash, it loads the default project', () => {
-        const Component = ({projectData}) => <div>{projectData}</div>;
-        const WrappedComponent = HashParserHOC(ProjectLoaderHOC(Component));
-        window.location.hash = '';
-        const originalLoad = storage.load;
-        storage.load = jest.fn((type, id) => Promise.resolve(id));
-        const mounted = mount(<WrappedComponent />);
-        expect(mounted.state().projectId).toEqual(0);
-        expect(storage.load).toHaveBeenCalledWith(
-            storage.AssetType.Project, 0, storage.DataFormat.JSON
-        );
-        storage.load = originalLoad;
-    });
-
-    test('when there is a hash, it tries to load that project', () => {
-        const Component = ({projectData}) => <div>{projectData}</div>;
-        const WrappedComponent = HashParserHOC(ProjectLoaderHOC(Component));
-        window.location.hash = '#winning';
-        const originalLoad = storage.load;
-        storage.load = jest.fn((type, id) => Promise.resolve({data: id}));
         const mounted = mount(<WrappedComponent />);
         expect(mounted.state().projectId).toEqual('winning');
-        expect(storage.load).toHaveBeenLastCalledWith(
-            storage.AssetType.Project, 'winning', storage.DataFormat.JSON
-        );
-        storage.load = originalLoad;
     });
 
-    test('when hash change happens, the project data state is changed', () => {
-        const Component = ({projectData}) => <div>{projectData}</div>;
-        const WrappedComponent = HashParserHOC(ProjectLoaderHOC(Component));
+    test('when there is no hash, it passes 0 as the projectId', () => {
+        const Component = ({projectId}) => <div>{projectId}</div>;
+        const WrappedComponent = HashParserHOC(Component);
         window.location.hash = '';
         const mounted = mount(<WrappedComponent />);
         expect(mounted.state().projectId).toEqual(0);
-        const originalLoad = storage.load;
-        storage.load = jest.fn((type, id) => Promise.resolve({data: id}));
+    });
+
+    test('when hash change happens, the projectId state is changed', () => {
+        const Component = ({projectId}) => <div>{projectId}</div>;
+        const WrappedComponent = HashParserHOC(Component);
+        window.location.hash = '';
+        const mounted = mount(<WrappedComponent />);
+        expect(mounted.state().projectId).toEqual(0);
         window.location.hash = '#winning';
-        mounted.instance().updateProject();
+        mounted.instance().handleHashChange();
         expect(mounted.state().projectId).toEqual('winning');
-        storage.load = originalLoad;
     });
 });

--- a/test/unit/util/hash-project-loader-hoc.test.jsx
+++ b/test/unit/util/hash-project-loader-hoc.test.jsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import ProjectLoaderHOC from '../../../src/lib/project-loader-hoc.jsx';
+import HashParserHOC from '../../../src/lib/hash-parser-hoc.jsx';
+import storage from '../../../src/lib/storage';
+import {mount} from 'enzyme';
+
+jest.mock('react-ga');
+
+describe('Hash/ProjectLoaderHOC', () => {
+    test('when there is no project data, it renders null', () => {
+        const Component = ({projectData}) => <div>{projectData}</div>;
+        const WrappedComponent = HashParserHOC(ProjectLoaderHOC(Component));
+        window.location.hash = '#winning';
+        const originalLoad = storage.load;
+        storage.load = jest.fn(() => Promise.resolve(null));
+        const mounted = mount(<WrappedComponent />);
+        storage.load = originalLoad;
+        window.location.hash = '';
+        const mountedDiv = mounted.find('div');
+        expect(mountedDiv.exists()).toEqual(false);
+    });
+
+    test('when there is no hash, it loads the default project', () => {
+        const Component = ({projectData}) => <div>{projectData}</div>;
+        const WrappedComponent = HashParserHOC(ProjectLoaderHOC(Component));
+        window.location.hash = '';
+        const originalLoad = storage.load;
+        storage.load = jest.fn((type, id) => Promise.resolve(id));
+        const mounted = mount(<WrappedComponent />);
+        expect(mounted.state().projectId).toEqual(0);
+        expect(storage.load).toHaveBeenCalledWith(
+            storage.AssetType.Project, 0, storage.DataFormat.JSON
+        );
+        storage.load = originalLoad;
+    });
+
+    test('when there is a hash, it tries to load that project', () => {
+        const Component = ({projectData}) => <div>{projectData}</div>;
+        const WrappedComponent = HashParserHOC(ProjectLoaderHOC(Component));
+        window.location.hash = '#winning';
+        const originalLoad = storage.load;
+        storage.load = jest.fn((type, id) => Promise.resolve({data: id}));
+        const mounted = mount(<WrappedComponent />);
+        expect(mounted.state().projectId).toEqual('winning');
+        expect(storage.load).toHaveBeenLastCalledWith(
+            storage.AssetType.Project, 'winning', storage.DataFormat.JSON
+        );
+        storage.load = originalLoad;
+    });
+
+    test('when hash change happens, the project data state is changed', () => {
+        const Component = ({projectData}) => <div>{projectData}</div>;
+        const WrappedComponent = HashParserHOC(ProjectLoaderHOC(Component));
+        window.location.hash = '';
+        const mounted = mount(<WrappedComponent />);
+        expect(mounted.state().projectId).toEqual(0);
+        const originalLoad = storage.load;
+        storage.load = jest.fn((type, id) => Promise.resolve({data: id}));
+        window.location.hash = '#winning';
+        mounted.instance().updateProject();
+        expect(mounted.state().projectId).toEqual('winning');
+        storage.load = originalLoad;
+    });
+});

--- a/test/unit/util/project-loader-hoc.test.jsx
+++ b/test/unit/util/project-loader-hoc.test.jsx
@@ -33,4 +33,15 @@ describe('ProjectLoaderHOC', () => {
         storage.load = originalLoad;
     });
 
+    test('when there is no project data, it renders null', () => {
+        const Component = ({projectData}) => <div>{projectData}</div>;
+        const WrappedComponent = ProjectLoaderHOC(Component);
+        const originalLoad = storage.load;
+        storage.load = jest.fn(() => Promise.resolve(null));
+        const mounted = mount(<WrappedComponent />);
+        storage.load = originalLoad;
+        const mountedDiv = mounted.find('div');
+        expect(mountedDiv.exists()).toEqual(false);
+    });
+
 });

--- a/test/unit/util/project-loader-hoc.test.jsx
+++ b/test/unit/util/project-loader-hoc.test.jsx
@@ -6,58 +6,31 @@ import {mount} from 'enzyme';
 jest.mock('react-ga');
 
 describe('ProjectLoaderHOC', () => {
-    test('when there is no project data, it renders null', () => {
-        const Component = ({projectData}) => <div>{projectData}</div>;
-        const WrappedComponent = ProjectLoaderHOC(Component);
-        window.location.hash = '#winning';
-        const originalLoad = storage.load;
-        storage.load = jest.fn(() => Promise.resolve(null));
-        const mounted = mount(<WrappedComponent />);
-        storage.load = originalLoad;
-        window.location.hash = '';
-        const mountedDiv = mounted.find('div');
-        expect(mountedDiv.exists()).toEqual(false);
-    });
 
-    test('when there is no hash, it loads the default project', () => {
+    test('when there is no id, it loads (default) project id 0', () => {
         const Component = ({projectData}) => <div>{projectData}</div>;
         const WrappedComponent = ProjectLoaderHOC(Component);
-        window.location.hash = '';
         const originalLoad = storage.load;
         storage.load = jest.fn((type, id) => Promise.resolve(id));
         const mounted = mount(<WrappedComponent />);
-        expect(mounted.state().projectId).toEqual(0);
+        expect(mounted.props().projectId).toEqual(0);
         expect(storage.load).toHaveBeenCalledWith(
             storage.AssetType.Project, 0, storage.DataFormat.JSON
         );
         storage.load = originalLoad;
     });
 
-    test('when there is a hash, it tries to load that project', () => {
+    test('when there is an id, it tries to load that project', () => {
         const Component = ({projectData}) => <div>{projectData}</div>;
         const WrappedComponent = ProjectLoaderHOC(Component);
-        window.location.hash = '#winning';
         const originalLoad = storage.load;
         storage.load = jest.fn((type, id) => Promise.resolve({data: id}));
-        const mounted = mount(<WrappedComponent />);
-        expect(mounted.state().projectId).toEqual('winning');
+        const mounted = mount(<WrappedComponent projectId="100" />);
+        expect(mounted.props().projectId).toEqual('100');
         expect(storage.load).toHaveBeenLastCalledWith(
-            storage.AssetType.Project, 'winning', storage.DataFormat.JSON
+            storage.AssetType.Project, '100', storage.DataFormat.JSON
         );
         storage.load = originalLoad;
     });
 
-    test('when hash change happens, the project data state is changed', () => {
-        const Component = ({projectData}) => <div>{projectData}</div>;
-        const WrappedComponent = ProjectLoaderHOC(Component);
-        window.location.hash = '';
-        const mounted = mount(<WrappedComponent />);
-        expect(mounted.state().projectId).toEqual(0);
-        const originalLoad = storage.load;
-        storage.load = jest.fn((type, id) => Promise.resolve({data: id}));
-        window.location.hash = '#winning';
-        mounted.instance().updateProject();
-        expect(mounted.state().projectId).toEqual('winning');
-        storage.load = originalLoad;
-    });
 });


### PR DESCRIPTION
### Proposed Changes

Separate getting the project id from the `location.hash` (needed for playground) from loading the project by Id - needed by all uses of GUI.

### Reason for Changes

When GUI is embedded (e.g. in www), it will be passed the project id, and the main app will be managing the URL.

### Test Coverage

Changed the current project-loader test to check that hash-parser+project-loader continues to work as before. Added new project loader test.

### Browser Coverage
Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [x] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
