### PR TITLE
Fix uint16 sound loading error

### DIFF
--- a/src/lib/default-project/index.js
+++ b/src/lib/default-project/index.js
@@ -19,12 +19,12 @@ export default [{
     id: '83a9787d4cb6f3b7632b4ddfebf74367',
     assetType: 'Sound',
     dataFormat: 'WAV',
-    data: new Uint16Array(popWav)
+    data: new Uint8Array(popWav)
 }, {
     id: '83c36d806dc92327b9e7049a565c6bff',
     assetType: 'Sound',
     dataFormat: 'WAV',
-    data: new Uint16Array(meowWav)
+    data: new Uint8Array(meowWav)
 }, {
     id: '739b5e2a2435f6e1ec2993791b423146',
     assetType: 'ImageBitmap',


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/2025

### Proposed Changes

_Describe what this Pull Request does_

Import default project sounds as uint8 instead of uint16.

This was preventing projects from being downloaded, although I'm not sure of the implications. @mzgoddard @rschamp?

Tested that you can now download the default project. 