### PR TITLE
remove question event listener on stage unmount

### DIFF
--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -79,6 +79,7 @@ class Stage extends React.Component {
         this.detachMouseEvents(this.canvas);
         this.detachRectEvents();
         this.stopColorPickingLoop();
+        this.props.vm.runtime.removeListener('QUESTION', this.questionListener);
     }
     questionListener (question) {
         this.setState({question: question});


### PR DESCRIPTION
### Resolves

Found issue when building routing on top of Scratch GUI. Returning to Scratch GUI would yield error of:

```
Warning: Can only update a mounted or mounting component. This usually means you called setState, replaceState, or forceUpdate on an unmounted component. This is a no-op.

Please check the code for the Stage component.
```

It seems like other listeners are removed on `componentWillMount` so this matches that pattern with the question listener. I tested multiple `setState`s and this line of code stopped the error from occurring.

### Proposed Changes

Removes event listener from question on `componentWillUnmount` of stage component (container)

### Reason for Changes

Error seen in console.

<img width="1280" alt="screen shot 2018-05-12 at 12 40 01 pm" src="https://user-images.githubusercontent.com/5384581/39960178-a1239668-55e3-11e8-95d0-de2cb37b229e.png">

### Test Coverage

I'm not sure how to create the tests for this. Would be interested in learning.

### Browser Coverage
Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
