### PR TITLE
Fix linting errors from eslint-plugin-react

### DIFF
--- a/src/.eslintrc.js
+++ b/src/.eslintrc.js
@@ -13,5 +13,10 @@ module.exports = {
         'import/no-amd': 'error',
         'import/no-nodejs-modules': 'error',
         'react/jsx-no-literals': 'error'
+    },
+    settings: {
+        react: {
+            version: '16.2' // Prevent 16.3 lifecycle method errors
+        }
     }
 };


### PR DESCRIPTION
eslint-plugin-react assumes you are the most recent stable version of react, which is 16.3, which deprecates certain lifecycle methods. We are not using 16.3 yet, so manually specify the react version for now instead. There does not seem to be an option for using the version listed in the package json 😢 