### PR TITLE
Add missing quotes to .babelrc configuration

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,5 +6,5 @@
         ["react-intl", {
             "messagesDir": "./translations/messages/"
         }]],
-    "presets": [["env", {"targets": {browsers: ["last 3 versions", "Safari >= 8", "iOS >= 8"]}}], "react"]
+    "presets": [["env", {"targets": {"browsers": ["last 3 versions", "Safari >= 8", "iOS >= 8"]}}], "react"]
 }


### PR DESCRIPTION
### Proposed Changes

Add missing quotes to .babelrc configuration

### Reason for Changes

At worst, `.babelrc` missing quotes may cause errors in tools using it. At best, its just a typo that should be fixed for clarity.