### PR TITLE
Update scratch-render to get the babel-built version of fonts

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "scratch-blocks": "0.1.0-prerelease.1525981783",
     "scratch-l10n": "2.0.20180108132626",
     "scratch-paint": "0.2.0-prerelease.20180511152319",
-    "scratch-render": "0.1.0-prerelease.20180511184906",
+    "scratch-render": "0.1.0-prerelease.20180514172756",
     "scratch-storage": "0.4.1",
     "scratch-svg-renderer": "0.1.0-prerelease.20180511144653",
     "scratch-vm": "0.1.0-prerelease.1526052228",


### PR DESCRIPTION
See https://github.com/LLK/scratch-render/commit/6cff0f984f753f5c7eb441e74302d218f566bf17