### PR TITLE
Replace white rectangle bitmap with empty svg for default backdrop

### DIFF
--- a/src/lib/default-project/project.json
+++ b/src/lib/default-project/project.json
@@ -15,11 +15,10 @@
       "currentCostume": 0,
       "costumes": [
         {
-          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "assetId": "cd21514d0531fdffb22204e0ec5ed84a",
           "name": "backdrop1",
-          "bitmapResolution": 1,
-          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
-          "dataFormat": "png",
+          "md5ext": "cd21514d0531fdffb22204e0ec5ed84a.svg",
+          "dataFormat": "svg",
           "rotationCenterX": 240,
           "rotationCenterY": 180
         }


### PR DESCRIPTION
### Resolves
Resolves GH-2074

### Proposed Changes
- Replaces white bitmap rectangle with an empty SVG for the default backdrop

### Reason for Changes
- We should bias users towards using the vector editor (particularly during the preview period)
- Resolves (albeit in a "treat the symptom and not the disease sort of way) issue with the default backdrop scaling in Scratch 3.0.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [x] Safari
 
Windows
 * [x] Chrome 
 * [x] Firefox 
 * [x] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
