### PR TITLE
Fix default costume index for cat sprite

### DIFF
--- a/src/lib/libraries/sprites.json
+++ b/src/lib/libraries/sprites.json
@@ -1626,7 +1626,9 @@
         "name": "Cat",
         "md5": "09dc888b0b7df19f70d81588ae73420e.svg",
         "type": "sprite",
-        "tags": [],
+        "tags": [
+            "animals"
+        ],
         "info": [
             0,
             2,
@@ -1662,7 +1664,7 @@
                     "rotationCenterY": 55
                 }
             ],
-            "currentCostumeIndex": 1,
+            "currentCostumeIndex": 0,
             "scratchX": 0,
             "scratchY": 0,
             "scale": 1,


### PR DESCRIPTION
### Resolves
Resolves GH-1995

### Proposed Changes
- Fixes default costume index (`0`) for cat sprite
- Adds `animals` tag to cat sprites

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [x] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
