### PR TITLE
Don’t load null project id

### DIFF
--- a/src/lib/project-loader-hoc.jsx
+++ b/src/lib/project-loader-hoc.jsx
@@ -21,7 +21,9 @@ const ProjectLoaderHOC = function (WrappedComponent) {
             };
         }
         componentDidMount () {
-            this.updateProject(this.props.projectId);
+            if (this.props.projectId || this.props.projectId === 0) {
+                this.updateProject(this.props.projectId);
+            }
         }
         componentWillUpdate (nextProps) {
             if (this.props.projectId !== nextProps.projectId) {


### PR DESCRIPTION
Only call updateProject to load the project if there is a project id, or it’s the default project id.

### Resolves

There's an error in the console `TypeError: Cannot read property 'split' of null` due to loading a null project id in the project-loader-hoc. 

### Proposed Changes

Check the projectId before calling `updateProject`

### Test Coverage

Tests pass and no more TypeErrors in the console.

/cc @kchadha 

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
