### PR TITLE
Fix monitor scaling, positioning and draggability in fullscreen mode

### DIFF
--- a/src/components/monitor-list/monitor-list.css
+++ b/src/components/monitor-list/monitor-list.css
@@ -1,7 +1,10 @@
 .monitor-list {
-    width: 100%;
-    height: 100%;
+    /* Width/height are set by the component, margin: auto centers in fullscreen */
+    margin: auto;
     pointer-events: none;
+}
+
+.monitor-list-scaler {
     /* Scaling for monitors should happen from the top left */
     transform-origin: left top;
 }

--- a/src/components/monitor-list/monitor-list.css
+++ b/src/components/monitor-list/monitor-list.css
@@ -2,4 +2,6 @@
     width: 100%;
     height: 100%;
     pointer-events: none;
+    /* Scaling for monitors should happen from the top left */
+    transform-origin: left top;
 }

--- a/src/components/monitor-list/monitor-list.jsx
+++ b/src/components/monitor-list/monitor-list.jsx
@@ -31,6 +31,7 @@ const MonitorList = props => (
             {props.monitors.valueSeq().filter(m => m.visible)
                 .map(monitorData => (
                     <Monitor
+                        draggable={props.draggable}
                         height={monitorData.height}
                         id={monitorData.id}
                         key={monitorData.id}
@@ -53,6 +54,7 @@ const MonitorList = props => (
 );
 
 MonitorList.propTypes = {
+    draggable: PropTypes.bool.isRequired,
     monitors: PropTypes.instanceOf(OrderedMap),
     onMonitorChange: PropTypes.func.isRequired,
     stageSize: PropTypes.shape({

--- a/src/components/monitor-list/monitor-list.jsx
+++ b/src/components/monitor-list/monitor-list.jsx
@@ -7,10 +7,19 @@ import {OrderedMap} from 'immutable';
 
 import styles from './monitor-list.css';
 
+const stageSizeToTransform = ({width, height, widthDefault, heightDefault}) => {
+    const scaleX = width / widthDefault;
+    const scaleY = height / heightDefault;
+    return `scale(${scaleX},${scaleY})`;
+};
+
 const MonitorList = props => (
     <Box
         // Use static `monitor-overlay` class for bounds of draggables
         className={classNames(styles.monitorList, 'monitor-overlay')}
+        style={{
+            transform: stageSizeToTransform(props.stageSize)
+        }}
     >
         {props.monitors.valueSeq().filter(m => m.visible)
             .map(monitorData => (
@@ -37,7 +46,13 @@ const MonitorList = props => (
 
 MonitorList.propTypes = {
     monitors: PropTypes.instanceOf(OrderedMap),
-    onMonitorChange: PropTypes.func.isRequired
+    onMonitorChange: PropTypes.func.isRequired,
+    stageSize: PropTypes.shape({
+        width: PropTypes.number,
+        height: PropTypes.number,
+        widthDefault: PropTypes.number,
+        heightDefault: PropTypes.number
+    }).isRequired
 };
 
 export default MonitorList;

--- a/src/components/monitor-list/monitor-list.jsx
+++ b/src/components/monitor-list/monitor-list.jsx
@@ -18,29 +18,37 @@ const MonitorList = props => (
         // Use static `monitor-overlay` class for bounds of draggables
         className={classNames(styles.monitorList, 'monitor-overlay')}
         style={{
-            transform: stageSizeToTransform(props.stageSize)
+            width: props.stageSize.width,
+            height: props.stageSize.height
         }}
     >
-        {props.monitors.valueSeq().filter(m => m.visible)
-            .map(monitorData => (
-                <Monitor
-                    height={monitorData.height}
-                    id={monitorData.id}
-                    key={monitorData.id}
-                    max={monitorData.sliderMax}
-                    min={monitorData.sliderMin}
-                    mode={monitorData.mode}
-                    opcode={monitorData.opcode}
-                    params={monitorData.params}
-                    spriteName={monitorData.spriteName}
-                    targetId={monitorData.targetId}
-                    value={monitorData.value}
-                    width={monitorData.width}
-                    x={monitorData.x}
-                    y={monitorData.y}
-                    onDragEnd={props.onMonitorChange}
-                />
-            ))}
+        <Box
+            className={styles.monitorListScaler}
+            style={{
+                transform: stageSizeToTransform(props.stageSize)
+            }}
+        >
+            {props.monitors.valueSeq().filter(m => m.visible)
+                .map(monitorData => (
+                    <Monitor
+                        height={monitorData.height}
+                        id={monitorData.id}
+                        key={monitorData.id}
+                        max={monitorData.sliderMax}
+                        min={monitorData.sliderMin}
+                        mode={monitorData.mode}
+                        opcode={monitorData.opcode}
+                        params={monitorData.params}
+                        spriteName={monitorData.spriteName}
+                        targetId={monitorData.targetId}
+                        value={monitorData.value}
+                        width={monitorData.width}
+                        x={monitorData.x}
+                        y={monitorData.y}
+                        onDragEnd={props.onMonitorChange}
+                    />
+                ))}
+        </Box>
     </Box>
 );
 

--- a/src/components/monitor/list-monitor-scroller.jsx
+++ b/src/components/monitor/list-monitor-scroller.jsx
@@ -20,7 +20,7 @@ class ListMonitorScroller extends React.Component {
     }
     noRowsRenderer () {
         return (
-            <div className={styles.listEmpty}>
+            <div className={classNames(styles.listRow, styles.listEmpty)}>
                 {'(empty)' /* TODO waiting for design before translation */}
             </div>
         );

--- a/src/components/monitor/list-monitor-scroller.jsx
+++ b/src/components/monitor/list-monitor-scroller.jsx
@@ -37,9 +37,9 @@ class ListMonitorScroller extends React.Component {
                     className={styles.listValue}
                     dataIndex={index}
                     style={{background: this.props.categoryColor}}
-                    onClick={this.handleEventFactory(index)}
+                    onClick={this.props.draggable ? this.handleEventFactory(index) : null}
                 >
-                    {this.props.activeIndex === index ? (
+                    {this.props.draggable && this.props.activeIndex === index ? (
                         <div className={styles.inputWrapper}>
                             <input
                                 autoFocus
@@ -93,6 +93,7 @@ ListMonitorScroller.propTypes = {
     activeIndex: PropTypes.number,
     activeValue: PropTypes.string,
     categoryColor: PropTypes.string,
+    draggable: PropTypes.bool,
     height: PropTypes.number,
     onActivate: PropTypes.func,
     onDeactivate: PropTypes.func,

--- a/src/components/monitor/list-monitor.jsx
+++ b/src/components/monitor/list-monitor.jsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import styles from './monitor.css';
 import ListMonitorScroller from './list-monitor-scroller.jsx';
 
-const ListMonitor = ({label, width, height, value, onResizeMouseDown, onAdd, ...rowProps}) => (
+const ListMonitor = ({draggable, label, width, height, value, onResizeMouseDown, onAdd, ...rowProps}) => (
     <div
         className={styles.listMonitor}
         style={{
@@ -17,6 +17,7 @@ const ListMonitor = ({label, width, height, value, onResizeMouseDown, onAdd, ...
         </div>
         <div className={styles.listBody}>
             <ListMonitorScroller
+                draggable={draggable}
                 height={height}
                 values={value}
                 width={width}
@@ -26,7 +27,7 @@ const ListMonitor = ({label, width, height, value, onResizeMouseDown, onAdd, ...
         <div className={styles.listFooter}>
             <div
                 className={styles.addButton}
-                onClick={onAdd}
+                onClick={draggable ? onAdd : null}
             >
                 {'+' /* TODO waiting on asset */}
             </div>
@@ -35,7 +36,7 @@ const ListMonitor = ({label, width, height, value, onResizeMouseDown, onAdd, ...
             </div>
             <div
                 className={classNames(styles.resizeHandle, 'no-drag')}
-                onMouseDown={onResizeMouseDown}
+                onMouseDown={draggable ? onResizeMouseDown : null}
             >
                 {'=' /* TODO waiting on asset */}
             </div>
@@ -46,6 +47,7 @@ const ListMonitor = ({label, width, height, value, onResizeMouseDown, onAdd, ...
 ListMonitor.propTypes = {
     activeIndex: PropTypes.number,
     categoryColor: PropTypes.string.isRequired,
+    draggable: PropTypes.bool.isRequired,
     height: PropTypes.number,
     label: PropTypes.string.isRequired,
     onActivate: PropTypes.func,

--- a/src/components/monitor/monitor.css
+++ b/src/components/monitor/monitor.css
@@ -139,6 +139,7 @@
     padding: 3px 5px;
     min-height: 22px;
     overflow: hidden; /* Don't let long values escape container */
+    user-select: text; /* Allow selecting list values for 2.0 compatibility, only relevant in player */
 }
 
 .list-input {

--- a/src/components/monitor/monitor.css
+++ b/src/components/monitor/monitor.css
@@ -93,6 +93,7 @@
     align-items: center;
     padding: 2px;
     flex-shrink: 0;
+    transform: translateZ(0); /* Keep sharp when scaled */
 }
 
 .list-index {

--- a/src/components/monitor/monitor.css
+++ b/src/components/monitor/monitor.css
@@ -138,6 +138,7 @@
 .value-inner {
     padding: 3px 5px;
     min-height: 22px;
+    overflow: hidden; /* Don't let long values escape container */
 }
 
 .list-input {

--- a/src/components/monitor/monitor.jsx
+++ b/src/components/monitor/monitor.jsx
@@ -37,6 +37,7 @@ const MonitorComponent = props => (
             bounds=".monitor-overlay" // Class for monitor container
             cancel=".no-drag" // Class used for slider input to prevent drag
             defaultClassNameDragging={styles.dragging}
+            disabled={!props.draggable}
             onStop={props.onDragEnd}
         >
             <Box
@@ -88,6 +89,7 @@ const monitorModes = Object.keys(modes);
 MonitorComponent.propTypes = {
     category: PropTypes.oneOf(Object.keys(categories)),
     componentRef: PropTypes.func.isRequired,
+    draggable: PropTypes.bool.isRequired,
     label: PropTypes.string.isRequired,
     mode: PropTypes.oneOf(monitorModes),
     onDragEnd: PropTypes.func.isRequired,

--- a/src/components/stage/stage.jsx
+++ b/src/components/stage/stage.jsx
@@ -21,6 +21,7 @@ const StageComponent = props => {
         onDeactivateColorPicker,
         question,
         onQuestionAnswered,
+        useEditorDragStyle,
         ...boxProps
     } = props;
 
@@ -47,7 +48,10 @@ const StageComponent = props => {
                     {...boxProps}
                 />
                 <Box className={styles.monitorWrapper}>
-                    <MonitorList stageSize={stageSize} />
+                    <MonitorList
+                        draggable={useEditorDragStyle}
+                        stageSize={stageSize}
+                    />
                 </Box>
                 {isColorPicking && colorInfo ? (
                     <Box className={styles.colorPickerWrapper}>
@@ -98,6 +102,7 @@ StageComponent.propTypes = {
     onDeactivateColorPicker: PropTypes.func,
     onQuestionAnswered: PropTypes.func,
     question: PropTypes.string,
+    useEditorDragStyle: PropTypes.bool,
     width: PropTypes.number
 };
 StageComponent.defaultProps = {

--- a/src/components/stage/stage.jsx
+++ b/src/components/stage/stage.jsx
@@ -47,7 +47,7 @@ const StageComponent = props => {
                     {...boxProps}
                 />
                 <Box className={styles.monitorWrapper}>
-                    <MonitorList />
+                    <MonitorList stageSize={stageSize} />
                 </Box>
                 {isColorPicking && colorInfo ? (
                     <Box className={styles.colorPickerWrapper}>

--- a/src/containers/monitor.jsx
+++ b/src/containers/monitor.jsx
@@ -103,6 +103,7 @@ class Monitor extends React.Component {
             <MonitorComponent
                 componentRef={this.setElement}
                 {...monitorProps}
+                draggable={this.props.draggable}
                 height={this.props.height}
                 max={this.props.max}
                 min={this.props.min}
@@ -121,6 +122,7 @@ class Monitor extends React.Component {
 
 Monitor.propTypes = {
     addMonitorRect: PropTypes.func.isRequired,
+    draggable: PropTypes.bool,
     height: PropTypes.number,
     id: PropTypes.string.isRequired,
     max: PropTypes.number,

--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -363,7 +363,6 @@ class Stage extends React.Component {
         const {
             vm, // eslint-disable-line no-unused-vars
             onActivateColorPicker, // eslint-disable-line no-unused-vars
-            useEditorDragStyle, // eslint-disable-line no-unused-vars
             ...props
         } = this.props;
         return (


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/1235

Also fixes several other issues in addition to the monitor scaling and positioning:
- Monitors should not be draggable when in fullscreen/player mode
- List monitors should not be editable in fullscreen/player mode, fully:
    - Should not be resizable
    - Should not be able to add elements via `+` button
    - Should not be able to edit elements via text inputs
    - Should be able to select text of list monitors in player mode

### Proposed Changes

_Describe what this Pull Request does_

Fix the above issues in a couple of commits:
- Propagate the `useEditorDragStyle` property from the stage down the the monitors and use it correctly to disable dragging and edit-ability of list fields
- Fix the markup/css so that monitors are positioned above the stage in fullscreen mode
- Add a `transform: scale` to make the monitors as big as the stage has gotten.

### Reason for Changes

_Explain why these changes should be made_

2.0 compatibility 

### Test Coverage

_Please show how you have added tests to cover your changes_

Nothing automated here, but for smoketest make sure to try:
- trying to move monitors in fullscreen mode (shouldn't be able to)
- place monitors precisely and then enter fullscreen mode
- make sure slider monitors _do_ work in fullscreen mode.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [x] Safari
 
Windows
 * [x] Chrome 
 * [x] Firefox 
 * [x] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [x] Safari

Android Tablet
* [ ] Chrome
