### PR TITLE
Feature/refactor gui store

### DIFF
--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -48,6 +48,7 @@ const GUIComponent = props => {
         cardsVisible,
         children,
         costumesTabVisible,
+        enableCommunity,
         importInfoVisible,
         intl,
         isPlayerOnly,
@@ -108,7 +109,7 @@ const GUIComponent = props => {
             {cardsVisible ? (
                 <Cards />
             ) : null}
-            <MenuBar />
+            <MenuBar enableCommunity={enableCommunity} />
             <Box className={styles.bodyWrapper}>
                 <Box className={styles.flexWrapper}>
                     <Box className={styles.editorWrapper}>
@@ -224,6 +225,7 @@ GUIComponent.propTypes = {
     cardsVisible: PropTypes.bool,
     children: PropTypes.node,
     costumesTabVisible: PropTypes.bool,
+    enableCommunity: PropTypes.bool,
     importInfoVisible: PropTypes.bool,
     intl: intlShape.isRequired,
     isPlayerOnly: PropTypes.bool,

--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -15,6 +15,7 @@ import {MenuItem, MenuSection} from '../menu/menu.jsx';
 import ProjectSaver from '../../containers/project-saver.jsx';
 
 import {openTipsLibrary} from '../../reducers/modals';
+import {setPlayer} from '../../reducers/mode';
 import {
     openFileMenu,
     closeFileMenu,
@@ -263,19 +264,33 @@ const MenuBar = props => (
                 </MenuBarItemTooltip>
             </div>
             <div className={classNames(styles.menuBarItem, styles.communityButtonWrapper)}>
-                <MenuBarItemTooltip id="community-button">
+                {props.enableCommunity ?
                     <Button
                         className={classNames(styles.communityButton)}
                         iconClassName={styles.communityButtonIcon}
                         iconSrc={communityIcon}
+                        onClick={props.onSeeCommunity}
                     >
                         <FormattedMessage
                             defaultMessage="See Community"
                             description="Label for see community button"
                             id="gui.menuBar.seeCommunity"
                         />
-                    </Button>
-                </MenuBarItemTooltip>
+                    </Button> :
+                    <MenuBarItemTooltip id="community-button">
+                        <Button
+                            className={classNames(styles.communityButton)}
+                            iconClassName={styles.communityButtonIcon}
+                            iconSrc={communityIcon}
+                        >
+                            <FormattedMessage
+                                defaultMessage="See Community"
+                                description="Label for see community button"
+                                id="gui.menuBar.seeCommunity"
+                            />
+                        </Button>
+                    </MenuBarItemTooltip>
+                }
             </div>
         </div>
         <div className={classNames(styles.menuBarItem, styles.feedbackButtonWrapper)}>
@@ -352,12 +367,14 @@ const MenuBar = props => (
 
 MenuBar.propTypes = {
     editMenuOpen: PropTypes.bool,
+    enableCommunity: PropTypes.bool,
     fileMenuOpen: PropTypes.bool,
     onClickEdit: PropTypes.func,
     onClickFile: PropTypes.func,
     onOpenTipLibrary: PropTypes.func,
     onRequestCloseEdit: PropTypes.func,
-    onRequestCloseFile: PropTypes.func
+    onRequestCloseFile: PropTypes.func,
+    onSeeCommunity: PropTypes.func
 };
 
 const mapStateToProps = state => ({
@@ -370,7 +387,8 @@ const mapDispatchToProps = dispatch => ({
     onClickFile: () => dispatch(openFileMenu()),
     onRequestCloseFile: () => dispatch(closeFileMenu()),
     onClickEdit: () => dispatch(openEditMenu()),
-    onRequestCloseEdit: () => dispatch(closeEditMenu())
+    onRequestCloseEdit: () => dispatch(closeEditMenu()),
+    onSeeCommunity: () => dispatch(setPlayer(true))
 });
 
 export default connect(

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -445,12 +445,12 @@ Blocks.defaultProps = {
 };
 
 const mapStateToProps = state => ({
-    anyModalVisible: Object.keys(state.modals).some(key => state.modals[key]),
-    extensionLibraryVisible: state.modals.extensionLibrary,
+    anyModalVisible: Object.keys(state.scratchGui.modals).some(key => state.scratchGui.modals[key]),
+    extensionLibraryVisible: state.scratchGui.modals.extensionLibrary,
     locale: state.intl.locale,
     messages: state.intl.messages,
-    toolboxXML: state.toolbox.toolboxXML,
-    customProceduresVisible: state.customProcedures.active
+    toolboxXML: state.scratchGui.toolbox.toolboxXML,
+    customProceduresVisible: state.scratchGui.customProcedures.active
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -445,7 +445,10 @@ Blocks.defaultProps = {
 };
 
 const mapStateToProps = state => ({
-    anyModalVisible: Object.keys(state.scratchGui.modals).some(key => state.scratchGui.modals[key]),
+    anyModalVisible: (
+        Object.keys(state.scratchGui.modals).some(key => state.scratchGui.modals[key]) ||
+        state.scratchGui.mode.isFullScreen
+    ),
     extensionLibraryVisible: state.scratchGui.modals.extensionLibrary,
     locale: state.intl.locale,
     messages: state.intl.messages,

--- a/src/containers/cards.jsx
+++ b/src/containers/cards.jsx
@@ -17,13 +17,13 @@ import {
 import CardsComponent from '../components/cards/cards.jsx';
 
 const mapStateToProps = state => ({
-    visible: state.cards.visible,
-    content: state.cards.content,
-    activeDeckId: state.cards.activeDeckId,
-    step: state.cards.step,
-    x: state.cards.x,
-    y: state.cards.y,
-    dragging: state.cards.dragging
+    visible: state.scratchGui.cards.visible,
+    content: state.scratchGui.cards.content,
+    activeDeckId: state.scratchGui.cards.activeDeckId,
+    step: state.scratchGui.cards.step,
+    x: state.scratchGui.cards.x,
+    y: state.scratchGui.cards.y,
+    dragging: state.scratchGui.cards.dragging
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/containers/costume-tab.jsx
+++ b/src/containers/costume-tab.jsx
@@ -337,12 +337,12 @@ CostumeTab.propTypes = {
 };
 
 const mapStateToProps = state => ({
-    editingTarget: state.targets.editingTarget,
-    sprites: state.targets.sprites,
-    stage: state.targets.stage,
-    cameraModalVisible: state.modals.cameraCapture,
-    costumeLibraryVisible: state.modals.costumeLibrary,
-    backdropLibraryVisible: state.modals.backdropLibrary
+    editingTarget: state.scratchGui.targets.editingTarget,
+    sprites: state.scratchGui.targets.sprites,
+    stage: state.scratchGui.targets.stage,
+    cameraModalVisible: state.scratchGui.modals.cameraCapture,
+    costumeLibraryVisible: state.scratchGui.modals.costumeLibrary,
+    backdropLibraryVisible: state.scratchGui.modals.backdropLibrary
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/containers/custom-procedures.jsx
+++ b/src/containers/custom-procedures.jsx
@@ -147,7 +147,7 @@ CustomProcedures.defaultProps = {
 };
 
 const mapStateToProps = state => ({
-    mutator: state.customProcedures.mutator
+    mutator: state.scratchGui.customProcedures.mutator
 });
 
 export default connect(

--- a/src/containers/gui.jsx
+++ b/src/containers/gui.jsx
@@ -24,12 +24,13 @@ class GUI extends React.Component {
     constructor (props) {
         super(props);
         this.state = {
-            loading: true,
+            loading: !props.vm.initialized,
             loadingError: false,
             errorMessage: ''
         };
     }
     componentDidMount () {
+        if (this.props.vm.initialized) return;
         this.audioEngine = new AudioEngine();
         this.props.vm.attachAudioEngine(this.audioEngine);
         this.props.vm.loadProject(this.props.projectData)
@@ -44,6 +45,7 @@ class GUI extends React.Component {
                 // error page gets rendered if project failed to load
                 this.setState({loadingError: true, errorMessage: e});
             });
+        this.props.vm.initialized = true;
     }
     componentWillReceiveProps (nextProps) {
         if (this.props.projectData !== nextProps.projectData) {

--- a/src/containers/gui.jsx
+++ b/src/containers/gui.jsx
@@ -109,8 +109,10 @@ const mapStateToProps = state => ({
     isPlayerOnly: state.scratchGui.mode.isPlayerOnly,
     loadingStateVisible: state.scratchGui.modals.loadingProject,
     previewInfoVisible: state.scratchGui.modals.previewInfo,
-    targetIsStage: state.scratchGui.targets.stage &&
-    state.scratchGui.targets.stage.id === state.scratchGui.targets.editingTarget,
+    targetIsStage: (
+        state.scratchGui.targets.stage &&
+        state.scratchGui.targets.stage.id === state.scratchGui.targets.editingTarget
+    ),
     soundsTabVisible: state.scratchGui.editorTab.activeTabIndex === SOUNDS_TAB_INDEX,
     tipsLibraryVisible: state.scratchGui.modals.tipsLibrary
 });

--- a/src/containers/gui.jsx
+++ b/src/containers/gui.jsx
@@ -13,7 +13,6 @@ import {
     COSTUMES_TAB_INDEX,
     SOUNDS_TAB_INDEX
 } from '../reducers/editor-tab';
-import {setPlayer} from '../reducers/mode';
 
 import ProjectLoaderHOC from '../lib/project-loader-hoc.jsx';
 import vmListenerHOC from '../lib/vm-listener-hoc.jsx';
@@ -120,8 +119,7 @@ const mapDispatchToProps = dispatch => ({
     onExtensionButtonClick: () => dispatch(openExtensionLibrary()),
     onActivateTab: tab => dispatch(activateTab(tab)),
     onActivateCostumesTab: () => dispatch(activateTab(COSTUMES_TAB_INDEX)),
-    onActivateSoundsTab: () => dispatch(activateTab(SOUNDS_TAB_INDEX)),
-    onSetPlayerMode: player => dispatch(setPlayer(player))
+    onActivateSoundsTab: () => dispatch(activateTab(SOUNDS_TAB_INDEX))
 });
 
 const ConnectedGUI = connect(

--- a/src/containers/gui.jsx
+++ b/src/containers/gui.jsx
@@ -5,6 +5,7 @@ import VM from 'scratch-vm';
 import {connect} from 'react-redux';
 import ReactModal from 'react-modal';
 
+import ErrorBoundary from './error-boundary.jsx';
 import {openExtensionLibrary} from '../reducers/modals';
 import {
     activateTab,
@@ -13,7 +14,6 @@ import {
     SOUNDS_TAB_INDEX
 } from '../reducers/editor-tab';
 
-import AppStateHOC from '../lib/app-state-hoc.jsx';
 import ProjectLoaderHOC from '../lib/project-loader-hoc.jsx';
 import vmListenerHOC from '../lib/vm-listener-hoc.jsx';
 
@@ -73,13 +73,15 @@ class GUI extends React.Component {
             ...componentProps
         } = this.props;
         return (
-            <GUIComponent
-                loading={fetchingProject || this.state.loading || loadingStateVisible}
-                vm={vm}
-                {...componentProps}
-            >
-                {children}
-            </GUIComponent>
+            <ErrorBoundary action="Top Level App">
+                <GUIComponent
+                    loading={fetchingProject || this.state.loading || loadingStateVisible}
+                    vm={vm}
+                    {...componentProps}
+                >
+                    {children}
+                </GUIComponent>
+            </ErrorBoundary>
         );
     }
 }
@@ -102,6 +104,7 @@ const mapStateToProps = state => ({
     cardsVisible: state.cards.visible,
     costumesTabVisible: state.editorTab.activeTabIndex === COSTUMES_TAB_INDEX,
     importInfoVisible: state.modals.importInfo,
+    isPlayerOnly: state.mode.isPlayerOnly,
     loadingStateVisible: state.modals.loadingProject,
     previewInfoVisible: state.modals.previewInfo,
     targetIsStage: state.targets.stage && state.targets.stage.id === state.targets.editingTarget,
@@ -121,7 +124,7 @@ const ConnectedGUI = connect(
     mapDispatchToProps,
 )(GUI);
 
-const WrappedGui = ProjectLoaderHOC(AppStateHOC(vmListenerHOC(ConnectedGUI)));
+const WrappedGui = ProjectLoaderHOC(vmListenerHOC(ConnectedGUI));
 
 WrappedGui.setAppElement = ReactModal.setAppElement;
 export default WrappedGui;

--- a/src/containers/gui.jsx
+++ b/src/containers/gui.jsx
@@ -13,6 +13,7 @@ import {
     COSTUMES_TAB_INDEX,
     SOUNDS_TAB_INDEX
 } from '../reducers/editor-tab';
+import {setPlayer} from '../reducers/mode';
 
 import ProjectLoaderHOC from '../lib/project-loader-hoc.jsx';
 import vmListenerHOC from '../lib/vm-listener-hoc.jsx';
@@ -99,24 +100,26 @@ GUI.propTypes = {
 GUI.defaultProps = GUIComponent.defaultProps;
 
 const mapStateToProps = state => ({
-    activeTabIndex: state.editorTab.activeTabIndex,
-    blocksTabVisible: state.editorTab.activeTabIndex === BLOCKS_TAB_INDEX,
-    cardsVisible: state.cards.visible,
-    costumesTabVisible: state.editorTab.activeTabIndex === COSTUMES_TAB_INDEX,
-    importInfoVisible: state.modals.importInfo,
-    isPlayerOnly: state.mode.isPlayerOnly,
-    loadingStateVisible: state.modals.loadingProject,
-    previewInfoVisible: state.modals.previewInfo,
-    targetIsStage: state.targets.stage && state.targets.stage.id === state.targets.editingTarget,
-    soundsTabVisible: state.editorTab.activeTabIndex === SOUNDS_TAB_INDEX,
-    tipsLibraryVisible: state.modals.tipsLibrary
+    activeTabIndex: state.scratchGui.editorTab.activeTabIndex,
+    blocksTabVisible: state.scratchGui.editorTab.activeTabIndex === BLOCKS_TAB_INDEX,
+    cardsVisible: state.scratchGui.cards.visible,
+    costumesTabVisible: state.scratchGui.editorTab.activeTabIndex === COSTUMES_TAB_INDEX,
+    importInfoVisible: state.scratchGui.modals.importInfo,
+    isPlayerOnly: state.scratchGui.mode.isPlayerOnly,
+    loadingStateVisible: state.scratchGui.modals.loadingProject,
+    previewInfoVisible: state.scratchGui.modals.previewInfo,
+    targetIsStage: state.scratchGui.targets.stage &&
+    state.scratchGui.targets.stage.id === state.scratchGui.targets.editingTarget,
+    soundsTabVisible: state.scratchGui.editorTab.activeTabIndex === SOUNDS_TAB_INDEX,
+    tipsLibraryVisible: state.scratchGui.modals.tipsLibrary
 });
 
 const mapDispatchToProps = dispatch => ({
     onExtensionButtonClick: () => dispatch(openExtensionLibrary()),
     onActivateTab: tab => dispatch(activateTab(tab)),
     onActivateCostumesTab: () => dispatch(activateTab(COSTUMES_TAB_INDEX)),
-    onActivateSoundsTab: () => dispatch(activateTab(SOUNDS_TAB_INDEX))
+    onActivateSoundsTab: () => dispatch(activateTab(SOUNDS_TAB_INDEX)),
+    onSetPlayerMode: player => dispatch(setPlayer(player))
 });
 
 const ConnectedGUI = connect(

--- a/src/containers/monitor-list.jsx
+++ b/src/containers/monitor-list.jsx
@@ -33,7 +33,7 @@ MonitorList.propTypes = {
     moveMonitorRect: PropTypes.func.isRequired
 };
 const mapStateToProps = state => ({
-    monitors: state.monitors
+    monitors: state.scratchGui.monitors
 });
 const mapDispatchToProps = dispatch => ({
     moveMonitorRect: (id, x, y) => dispatch(moveMonitorRect(id, x, y))

--- a/src/containers/monitor.jsx
+++ b/src/containers/monitor.jsx
@@ -152,7 +152,7 @@ Monitor.propTypes = {
     y: PropTypes.number
 };
 const mapStateToProps = state => ({
-    monitorLayout: state.monitorLayout
+    monitorLayout: state.scratchGui.monitorLayout
 });
 const mapDispatchToProps = dispatch => ({
     addMonitorRect: (id, rect, savePosition) =>

--- a/src/containers/paint-editor-wrapper.jsx
+++ b/src/containers/paint-editor-wrapper.jsx
@@ -66,7 +66,7 @@ const mapStateToProps = (state, {selectedCostumeIndex}) => {
         editingTarget,
         sprites,
         stage
-    } = state.targets;
+    } = state.scratchGui.targets;
     const target = editingTarget && sprites[editingTarget] ? sprites[editingTarget] : stage;
     const costume = target && target.costumes[selectedCostumeIndex];
     return {
@@ -75,7 +75,7 @@ const mapStateToProps = (state, {selectedCostumeIndex}) => {
         rotationCenterY: costume && costume.rotationCenterY,
         imageFormat: costume && costume.dataFormat,
         imageId: editingTarget && `${editingTarget}${costume.skinId}`,
-        vm: state.vm
+        vm: state.scratchGui.vm
     };
 };
 

--- a/src/containers/project-loader.jsx
+++ b/src/containers/project-loader.jsx
@@ -100,7 +100,7 @@ ProjectLoader.propTypes = {
 };
 
 const mapStateToProps = state => ({
-    vm: state.vm
+    vm: state.scratchGui.vm
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/containers/project-saver.jsx
+++ b/src/containers/project-saver.jsx
@@ -69,7 +69,7 @@ ProjectSaver.propTypes = {
 };
 
 const mapStateToProps = state => ({
-    vm: state.vm
+    vm: state.scratchGui.vm
 });
 
 export default connect(

--- a/src/containers/record-modal.jsx
+++ b/src/containers/record-modal.jsx
@@ -139,7 +139,7 @@ RecordModal.propTypes = {
 };
 
 const mapStateToProps = state => ({
-    vm: state.vm
+    vm: state.scratchGui.vm
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/containers/sound-editor.jsx
+++ b/src/containers/sound-editor.jsx
@@ -211,17 +211,17 @@ SoundEditor.propTypes = {
 };
 
 const mapStateToProps = (state, {soundIndex}) => {
-    const sprite = state.vm.editingTarget.sprite;
+    const sprite = state.scratchGui.vm.editingTarget.sprite;
     // Make sure the sound index doesn't go out of range.
     const index = soundIndex < sprite.sounds.length ? soundIndex : sprite.sounds.length - 1;
-    const sound = state.vm.editingTarget.sprite.sounds[index];
-    const audioBuffer = state.vm.getSoundBuffer(index);
+    const sound = state.scratchGui.vm.editingTarget.sprite.sounds[index];
+    const audioBuffer = state.scratchGui.vm.getSoundBuffer(index);
     return {
         soundId: sound.soundId,
         sampleRate: audioBuffer.sampleRate,
         samples: audioBuffer.getChannelData(0),
         name: sound.name,
-        vm: state.vm
+        vm: state.scratchGui.vm
     };
 };
 

--- a/src/containers/sound-tab.jsx
+++ b/src/containers/sound-tab.jsx
@@ -241,11 +241,11 @@ SoundTab.propTypes = {
 };
 
 const mapStateToProps = state => ({
-    editingTarget: state.targets.editingTarget,
-    sprites: state.targets.sprites,
-    stage: state.targets.stage,
-    soundLibraryVisible: state.modals.soundLibrary,
-    soundRecorderVisible: state.modals.soundRecorder
+    editingTarget: state.scratchGui.targets.editingTarget,
+    sprites: state.scratchGui.targets.sprites,
+    stage: state.scratchGui.targets.stage,
+    soundLibraryVisible: state.scratchGui.modals.soundLibrary,
+    soundRecorderVisible: state.scratchGui.modals.soundRecorder
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/containers/sprite-selector-item.jsx
+++ b/src/containers/sprite-selector-item.jsx
@@ -79,9 +79,9 @@ SpriteSelectorItem.propTypes = {
 };
 
 const mapStateToProps = (state, {assetId, costumeURL, id}) => ({
-    costumeURL: costumeURL || (assetId && state.vm.runtime.storage.get(assetId).encodeDataURI()),
-    receivedBlocks: state.hoveredTarget.receivedBlocks &&
-            state.hoveredTarget.sprite === id
+    costumeURL: costumeURL || (assetId && state.scratchGui.vm.runtime.storage.get(assetId).encodeDataURI()),
+    receivedBlocks: state.scratchGui.hoveredTarget.receivedBlocks &&
+            state.scratchGui.hoveredTarget.sprite === id
 });
 const mapDispatchToProps = dispatch => ({
     dispatchSetHoveredSprite: spriteId => {

--- a/src/containers/stage-header.jsx
+++ b/src/containers/stage-header.jsx
@@ -50,9 +50,9 @@ StageHeader.propTypes = {
 };
 
 const mapStateToProps = state => ({
-    stageSize: state.stageSize.stageSize,
-    isFullScreen: state.mode.isFullScreen,
-    isPlayerOnly: state.mode.isPlayerOnly
+    stageSize: state.scratchGui.stageSize.stageSize,
+    isFullScreen: state.scratchGui.mode.isFullScreen,
+    isPlayerOnly: state.scratchGui.mode.isPlayerOnly
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/containers/stage-selector.jsx
+++ b/src/containers/stage-selector.jsx
@@ -99,8 +99,8 @@ StageSelector.propTypes = {
 };
 
 const mapStateToProps = (state, {assetId}) => ({
-    url: assetId && state.vm.runtime.storage.get(assetId).encodeDataURI(),
-    vm: state.vm
+    url: assetId && state.scratchGui.vm.runtime.storage.get(assetId).encodeDataURI(),
+    vm: state.scratchGui.vm
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -395,10 +395,10 @@ Stage.defaultProps = {
 };
 
 const mapStateToProps = state => ({
-    isColorPicking: state.colorPicker.active,
-    isFullScreen: state.mode.isFullScreen,
+    isColorPicking: state.scratchGui.colorPicker.active,
+    isFullScreen: state.scratchGui.mode.isFullScreen,
     // Do not use editor drag style in fullscreen or player mode.
-    useEditorDragStyle: !(state.mode.isFullScreen || state.mode.isPlayerOnly)
+    useEditorDragStyle: !(state.scratchGui.mode.isFullScreen || state.scratchGui.mode.isPlayerOnly)
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/containers/target-pane.jsx
+++ b/src/containers/target-pane.jsx
@@ -144,10 +144,10 @@ TargetPane.propTypes = {
 };
 
 const mapStateToProps = state => ({
-    editingTarget: state.targets.editingTarget,
-    hoveredTarget: state.hoveredTarget,
-    sprites: Object.keys(state.targets.sprites).reduce((sprites, k) => {
-        let {direction, size, x, y, ...sprite} = state.targets.sprites[k];
+    editingTarget: state.scratchGui.targets.editingTarget,
+    hoveredTarget: state.scratchGui.hoveredTarget,
+    sprites: Object.keys(state.scratchGui.targets.sprites).reduce((sprites, k) => {
+        let {direction, size, x, y, ...sprite} = state.scratchGui.targets.sprites[k];
         if (typeof direction !== 'undefined') direction = Math.round(direction);
         if (typeof x !== 'undefined') x = Math.round(x);
         if (typeof y !== 'undefined') y = Math.round(y);
@@ -155,9 +155,9 @@ const mapStateToProps = state => ({
         sprites[k] = {...sprite, direction, size, x, y};
         return sprites;
     }, {}),
-    stage: state.targets.stage,
-    raiseSprites: state.blockDrag,
-    spriteLibraryVisible: state.modals.spriteLibrary
+    stage: state.scratchGui.targets.stage,
+    raiseSprites: state.scratchGui.blockDrag,
+    spriteLibraryVisible: state.scratchGui.modals.spriteLibrary
 });
 const mapDispatchToProps = dispatch => ({
     onNewSpriteClick: e => {

--- a/src/containers/tips-library.jsx
+++ b/src/containers/tips-library.jsx
@@ -61,7 +61,7 @@ TipsLibrary.propTypes = {
 };
 
 const mapStateToProps = state => ({
-    visible: state.modals.tipsLibrary
+    visible: state.scratchGui.modals.tipsLibrary
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/index.js
+++ b/src/index.js
@@ -1,19 +1,15 @@
 import GUI from './containers/gui.jsx';
-import GuiReducer, {guiInitialState, initFullScreen, initPlayer} from './reducers/gui';
+import GuiReducer, {guiInitialState, guiMiddleware, initFullScreen, initPlayer} from './reducers/gui';
 import {ScratchPaintReducer} from 'scratch-paint';
 import IntlReducer from './reducers/intl';
 import {setFullScreen, setPlayer} from './reducers/mode';
 import {setAppElement} from 'react-modal';
-import {applyMiddleware, compose} from 'redux';
-import throttle from 'redux-throttle';
 
 const guiReducers = {
     intl: IntlReducer,
     scratchGui: GuiReducer,
     scratchPaint: ScratchPaintReducer
 };
-
-const guiMiddleware = compose(applyMiddleware(throttle(300, {leading: true, trailing: true})));
 
 export {
     GUI as default,

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,28 @@
+import GUI from './containers/gui.jsx';
+import GuiReducer, {guiInitialState, initFullScreen, initPlayer} from './reducers/gui';
+import {ScratchPaintReducer} from 'scratch-paint';
+import IntlReducer from './reducers/intl';
+import {setFullScreen, setPlayer} from './reducers/mode';
+import {setAppElement} from 'react-modal';
+import {applyMiddleware, compose} from 'redux';
+import throttle from 'redux-throttle';
+
+const guiReducers = {
+    intl: IntlReducer,
+    scratchGui: GuiReducer,
+    scratchPaint: ScratchPaintReducer
+};
+
+const guiMiddleware = compose(applyMiddleware(throttle(300, {leading: true, trailing: true})));
+
+export {
+    GUI as default,
+    setAppElement,
+    guiReducers,
+    guiInitialState,
+    guiMiddleware,
+    initPlayer,
+    initFullScreen,
+    setFullScreen,
+    setPlayer
+};

--- a/src/lib/app-state-hoc.jsx
+++ b/src/lib/app-state-hoc.jsx
@@ -1,25 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {Provider} from 'react-redux';
-import {createStore, applyMiddleware, combineReducers, compose} from 'redux';
-import throttle from 'redux-throttle';
+import {createStore, combineReducers, compose} from 'redux';
 
 import {intlShape} from 'react-intl';
 import {IntlProvider, updateIntl} from 'react-intl-redux';
 import intlReducer from '../reducers/intl.js';
 
-import guiReducer, {guiInitialState, initFullScreen, initPlayer} from '../reducers/gui';
+import guiReducer, {guiInitialState, guiMiddleware, initFullScreen, initPlayer} from '../reducers/gui';
 
 import {setPlayer, setFullScreen} from '../reducers/mode.js';
 
 import {ScratchPaintReducer} from 'scratch-paint';
 
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
-const enhancer = composeEnhancers(
-    applyMiddleware(
-        throttle(300, {leading: true, trailing: true})
-    )
-);
+const enhancer = composeEnhancers(guiMiddleware);
 
 /*
  * Higher Order Component to provide redux state. If an `intl` prop is provided

--- a/src/lib/app-state-hoc.jsx
+++ b/src/lib/app-state-hoc.jsx
@@ -9,7 +9,6 @@ import {IntlProvider, updateIntl} from 'react-intl-redux';
 import {intlInitialState} from '../reducers/intl.js';
 import {initialState as modeInitialState, setPlayer, setFullScreen} from '../reducers/mode.js';
 import reducer from '../reducers/gui';
-import ErrorBoundary from '../containers/error-boundary.jsx';
 
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 const enhancer = composeEnhancers(
@@ -68,12 +67,16 @@ const AppStateHOC = function (WrappedComponent) {
             }
         }
         render () {
+            const {
+                intl, // eslint-disable-line no-unused-vars
+                isFullScreen, // eslint-disable-line no-unused-vars
+                isPlayerOnly, // eslint-disable-line no-unused-vars
+                ...componentProps
+            } = this.props;
             return (
                 <Provider store={this.store}>
                     <IntlProvider>
-                        <ErrorBoundary action="Top Level App">
-                            <WrappedComponent {...this.props} />
-                        </ErrorBoundary>
+                        <WrappedComponent {...componentProps} />
                     </IntlProvider>
                 </Provider>
             );

--- a/src/lib/vm-listener-hoc.jsx
+++ b/src/lib/vm-listener-hoc.jsx
@@ -96,7 +96,7 @@ const vmListenerHOC = function (WrappedComponent) {
         attachKeyboardEvents: true
     };
     const mapStateToProps = state => ({
-        vm: state.vm
+        vm: state.scratchGui.vm
     });
     const mapDispatchToProps = dispatch => ({
         onTargetsUpdate: data => {

--- a/src/playground/blocks-only.jsx
+++ b/src/playground/blocks-only.jsx
@@ -10,7 +10,7 @@ import AppStateHOC from '../lib/app-state-hoc.jsx';
 
 import styles from './blocks-only.css';
 
-const mapStateToProps = state => ({vm: state.vm});
+const mapStateToProps = state => ({vm: state.scratchGui.vm});
 
 const VMBlocks = connect(mapStateToProps)(Blocks);
 const VMControls = connect(mapStateToProps)(Controls);

--- a/src/playground/blocks-only.jsx
+++ b/src/playground/blocks-only.jsx
@@ -6,6 +6,7 @@ import Controls from '../containers/controls.jsx';
 import Blocks from '../containers/blocks.jsx';
 import GUI from '../containers/gui.jsx';
 import HashParserHOC from '../lib/hash-parser-hoc.jsx';
+import AppStateHOC from '../lib/app-state-hoc.jsx';
 
 import styles from './blocks-only.css';
 
@@ -26,7 +27,7 @@ const BlocksOnly = props => (
     </GUI>
 );
 
-const App = HashParserHOC(BlocksOnly);
+const App = HashParserHOC(AppStateHOC(BlocksOnly));
 
 const appTarget = document.createElement('div');
 document.body.appendChild(appTarget);

--- a/src/playground/compatibility-testing.jsx
+++ b/src/playground/compatibility-testing.jsx
@@ -1,19 +1,11 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {connect} from 'react-redux';
 
-import Controls from '../containers/controls.jsx';
-import Stage from '../containers/stage.jsx';
-import Box from '../components/box/box.jsx';
 import GUI from '../containers/gui.jsx';
 import HashParserHOC from '../lib/hash-parser-hoc.jsx';
 import AppStateHOC from '../lib/app-state-hoc.jsx';
 const WrappedGui = HashParserHOC(AppStateHOC(GUI));
 
-const mapStateToProps = state => ({vm: state.vm});
-
-const VMStage = connect(mapStateToProps)(Stage);
-const VMControls = connect(mapStateToProps)(Controls);
 
 const DEFAULT_PROJECT_ID = '10015059';
 

--- a/src/playground/compatibility-testing.jsx
+++ b/src/playground/compatibility-testing.jsx
@@ -7,6 +7,8 @@ import Stage from '../containers/stage.jsx';
 import Box from '../components/box/box.jsx';
 import GUI from '../containers/gui.jsx';
 import HashParserHOC from '../lib/hash-parser-hoc.jsx';
+import AppStateHOC from '../lib/app-state-hoc.jsx';
+const WrappedGui = HashParserHOC(AppStateHOC(GUI));
 
 const mapStateToProps = state => ({vm: state.vm});
 
@@ -37,27 +39,12 @@ class Player extends React.Component {
         this.setState({projectId: window.location.hash.substring(1)});
     }
     render () {
-        const width = 480;
-        const height = 360;
         return (
             <div style={{display: 'flex'}}>
-                <GUI
-                    {...this.props}
-                    width={width}
-                >
-                    <Box height={40}>
-                        <VMControls
-                            style={{
-                                marginRight: 10,
-                                height: 40
-                            }}
-                        />
-                    </Box>
-                    <VMStage
-                        height={height}
-                        width={width}
-                    />
-                </GUI>
+                <WrappedGui
+                    isPlayerOnly
+                    isFullScreen={false}
+                />
                 <iframe
                     allowFullScreen
                     allowTransparency
@@ -71,9 +58,7 @@ class Player extends React.Component {
     }
 }
 
-const App = HashParserHOC(Player);
-
 const appTarget = document.createElement('div');
 document.body.appendChild(appTarget);
 
-ReactDOM.render(<App />, appTarget);
+ReactDOM.render(<Player />, appTarget);

--- a/src/playground/index.jsx
+++ b/src/playground/index.jsx
@@ -5,6 +5,7 @@ import ReactDOM from 'react-dom';
 import analytics from '../lib/analytics';
 import GUI from '../containers/gui.jsx';
 import HashParserHOC from '../lib/hash-parser-hoc.jsx';
+import AppStateHOC from '../lib/app-state-hoc.jsx';
 
 import styles from './index.css';
 
@@ -21,6 +22,6 @@ appTarget.className = styles.app;
 document.body.appendChild(appTarget);
 
 GUI.setAppElement(appTarget);
-const WrappedGui = HashParserHOC(GUI);
+const WrappedGui = HashParserHOC(AppStateHOC(GUI));
 
 ReactDOM.render(<WrappedGui />, appTarget);

--- a/src/playground/player.jsx
+++ b/src/playground/player.jsx
@@ -4,7 +4,8 @@ import ReactDOM from 'react-dom';
 import Box from '../components/box/box.jsx';
 import GUI from '../containers/gui.jsx';
 import HashParserHOC from '../lib/hash-parser-hoc.jsx';
-const WrappedGui = HashParserHOC(GUI);
+import AppStateHOC from '../lib/app-state-hoc.jsx';
+const WrappedGui = HashParserHOC(AppStateHOC(GUI));
 
 if (process.env.NODE_ENV === 'production' && typeof window === 'object') {
     // Warn before navigating away

--- a/src/reducers/block-drag.js
+++ b/src/reducers/block-drag.js
@@ -24,5 +24,6 @@ const updateBlockDrag = function (areBlocksOverGui) {
 
 export {
     reducer as default,
+    initialState as blockDragInitialState,
     updateBlockDrag
 };

--- a/src/reducers/cards.js
+++ b/src/reducers/cards.js
@@ -107,6 +107,7 @@ const endDrag = function () {
 
 export {
     reducer as default,
+    initialState as cardsInitialState,
     activateDeck,
     viewCards,
     closeCards,

--- a/src/reducers/color-picker.js
+++ b/src/reducers/color-picker.js
@@ -34,6 +34,7 @@ const setCallback = callback => ({type: SET_CALLBACK, callback: callback});
 
 export {
     reducer as default,
+    initialState as colorPickerInitialState,
     activateColorPicker,
     deactivateColorPicker,
     setCallback

--- a/src/reducers/custom-procedures.js
+++ b/src/reducers/custom-procedures.js
@@ -60,6 +60,7 @@ const deactivateCustomProcedures = mutator => ({
 
 export {
     reducer as default,
+    initialState as customProceduresInitialState,
     activateCustomProcedures,
     deactivateCustomProcedures
 };

--- a/src/reducers/editor-tab.js
+++ b/src/reducers/editor-tab.js
@@ -30,6 +30,7 @@ const activateTab = function (tab) {
 
 export {
     reducer as default,
+    initialState as editorTabInitialState,
     activateTab,
     BLOCKS_TAB_INDEX,
     COSTUMES_TAB_INDEX,

--- a/src/reducers/gui.js
+++ b/src/reducers/gui.js
@@ -1,23 +1,60 @@
 import {combineReducers} from 'redux';
-import cardsReducer from './cards';
-import colorPickerReducer from './color-picker';
-import customProceduresReducer from './custom-procedures';
-import blockDragReducer from './block-drag';
-import editorTabReducer from './editor-tab';
-import hoveredTargetReducer from './hovered-target';
-import intlReducer from './intl';
-import menuReducer from './menus';
-import modalReducer from './modals';
-import modeReducer from './mode';
-import monitorReducer from './monitors';
-import monitorLayoutReducer from './monitor-layout';
-import targetReducer from './targets';
-import toolboxReducer from './toolbox';
-import vmReducer from './vm';
-import stageSizeReducer from './stage-size';
-import {ScratchPaintReducer} from 'scratch-paint';
+import cardsReducer, {cardsInitialState} from './cards';
+import colorPickerReducer, {colorPickerInitialState} from './color-picker';
+import customProceduresReducer, {customProceduresInitialState} from './custom-procedures';
+import blockDragReducer, {blockDragInitialState} from './block-drag';
+import editorTabReducer, {editorTabInitialState} from './editor-tab';
+import hoveredTargetReducer, {hoveredTargetInitialState} from './hovered-target';
+import menuReducer, {menuInitialState} from './menus';
+import modalReducer, {modalsInitialState} from './modals';
+import modeReducer, {modeInitialState} from './mode';
+import monitorReducer, {monitorsInitialState} from './monitors';
+import monitorLayoutReducer, {monitorLayoutInitialState} from './monitor-layout';
+import stageSizeReducer, {stageSizeInitialState} from './stage-size';
+import targetReducer, {targetsInitialState} from './targets';
+import toolboxReducer, {toolboxInitialState} from './toolbox';
+import vmReducer, {vmInitialState} from './vm';
 
-export default combineReducers({
+
+const guiInitialState = {
+    blockDrag: blockDragInitialState,
+    cards: cardsInitialState,
+    colorPicker: colorPickerInitialState,
+    customProcedures: customProceduresInitialState,
+    editorTab: editorTabInitialState,
+    mode: modeInitialState,
+    hoveredTarget: hoveredTargetInitialState,
+    stageSize: stageSizeInitialState,
+    menus: menuInitialState,
+    modals: modalsInitialState,
+    monitors: monitorsInitialState,
+    monitorLayout: monitorLayoutInitialState,
+    targets: targetsInitialState,
+    toolbox: toolboxInitialState,
+    vm: vmInitialState
+};
+
+const initPlayer = function (currentState) {
+    return Object.assign(
+        {},
+        currentState,
+        {mode: {
+            isFullScreen: currentState.mode.isFullScreen,
+            isPlayerOnly: true
+        }}
+    );
+};
+const initFullScreen = function (currentState) {
+    return Object.assign(
+        {},
+        currentState,
+        {mode: {
+            isFullScreen: true,
+            isPlayerOnly: currentState.mode.isPlayerOnly
+        }}
+    );
+};
+const guiReducer = combineReducers({
     blockDrag: blockDragReducer,
     cards: cardsReducer,
     colorPicker: colorPickerReducer,
@@ -25,7 +62,6 @@ export default combineReducers({
     editorTab: editorTabReducer,
     mode: modeReducer,
     hoveredTarget: hoveredTargetReducer,
-    intl: intlReducer,
     stageSize: stageSizeReducer,
     menus: menuReducer,
     modals: modalReducer,
@@ -33,6 +69,12 @@ export default combineReducers({
     monitorLayout: monitorLayoutReducer,
     targets: targetReducer,
     toolbox: toolboxReducer,
-    vm: vmReducer,
-    scratchPaint: ScratchPaintReducer
+    vm: vmReducer
 });
+
+export {
+    guiReducer as default,
+    guiInitialState,
+    initFullScreen,
+    initPlayer
+};

--- a/src/reducers/gui.js
+++ b/src/reducers/gui.js
@@ -1,4 +1,4 @@
-import {combineReducers} from 'redux';
+import {applyMiddleware, compose, combineReducers} from 'redux';
 import cardsReducer, {cardsInitialState} from './cards';
 import colorPickerReducer, {colorPickerInitialState} from './color-picker';
 import customProceduresReducer, {customProceduresInitialState} from './custom-procedures';
@@ -14,7 +14,9 @@ import stageSizeReducer, {stageSizeInitialState} from './stage-size';
 import targetReducer, {targetsInitialState} from './targets';
 import toolboxReducer, {toolboxInitialState} from './toolbox';
 import vmReducer, {vmInitialState} from './vm';
+import throttle from 'redux-throttle';
 
+const guiMiddleware = compose(applyMiddleware(throttle(300, {leading: true, trailing: true})));
 
 const guiInitialState = {
     blockDrag: blockDragInitialState,
@@ -75,6 +77,7 @@ const guiReducer = combineReducers({
 export {
     guiReducer as default,
     guiInitialState,
+    guiMiddleware,
     initFullScreen,
     initPlayer
 };

--- a/src/reducers/hovered-target.js
+++ b/src/reducers/hovered-target.js
@@ -43,6 +43,7 @@ const setReceivedBlocks = function (receivedBlocks) {
 
 export {
     reducer as default,
+    initialState as hoveredTargetInitialState,
     setHoveredSprite,
     setReceivedBlocks
 };

--- a/src/reducers/menus.js
+++ b/src/reducers/menus.js
@@ -35,13 +35,14 @@ const closeMenu = menu => ({
 });
 const openFileMenu = () => openMenu(MENU_FILE);
 const closeFileMenu = () => closeMenu(MENU_FILE);
-const fileMenuOpen = state => state.menus[MENU_FILE];
+const fileMenuOpen = state => state.scratchGui.menus[MENU_FILE];
 const openEditMenu = () => openMenu(MENU_EDIT);
 const closeEditMenu = () => closeMenu(MENU_EDIT);
-const editMenuOpen = state => state.menus[MENU_EDIT];
+const editMenuOpen = state => state.scratchGui.menus[MENU_EDIT];
 
 export {
     reducer as default,
+    initialState as menuInitialState,
     openFileMenu,
     closeFileMenu,
     openEditMenu,

--- a/src/reducers/modals.js
+++ b/src/reducers/modals.js
@@ -137,6 +137,7 @@ const closeTipsLibrary = function () {
 };
 export {
     reducer as default,
+    initialState as modalsInitialState,
     openBackdropLibrary,
     openCameraCapture,
     openCostumeLibrary,

--- a/src/reducers/mode.js
+++ b/src/reducers/mode.js
@@ -39,7 +39,7 @@ const setPlayer = function (isPlayerOnly) {
 
 export {
     reducer as default,
-    initialState,
+    initialState as modeInitialState,
     setFullScreen,
     setPlayer
 };

--- a/src/reducers/monitor-layout.js
+++ b/src/reducers/monitor-layout.js
@@ -307,6 +307,7 @@ const removeMonitorRect = function (monitorId) {
 
 export {
     reducer as default,
+    initialState as monitorLayoutInitialState,
     addMonitorRect,
     getInitialPosition,
     moveMonitorRect,

--- a/src/reducers/monitors.js
+++ b/src/reducers/monitors.js
@@ -25,5 +25,6 @@ const updateMonitors = function (monitors) {
 
 export {
     reducer as default,
+    initialState as monitorsInitialState,
     updateMonitors
 };

--- a/src/reducers/stage-size.js
+++ b/src/reducers/stage-size.js
@@ -31,6 +31,7 @@ const setStageSize = function (stageSize) {
 
 export {
     reducer as default,
+    initialState as stageSizeInitialState,
     setStageSize,
     STAGE_SIZES
 };

--- a/src/reducers/targets.js
+++ b/src/reducers/targets.js
@@ -39,5 +39,6 @@ const updateTargets = function (targetList, editingTarget) {
 };
 export {
     reducer as default,
+    initialState as targetsInitialState,
     updateTargets
 };

--- a/src/reducers/toolbox.js
+++ b/src/reducers/toolbox.js
@@ -26,5 +26,6 @@ const updateToolbox = function (toolboxXML) {
 
 export {
     reducer as default,
+    initialState as toolboxInitialState,
     updateToolbox
 };

--- a/src/reducers/vm.js
+++ b/src/reducers/vm.js
@@ -23,5 +23,6 @@ const setVM = function (vm) {
 };
 export {
     reducer as default,
+    initialState as vmInitialState,
     setVM
 };

--- a/test/unit/containers/sound-editor.test.jsx
+++ b/test/unit/containers/sound-editor.test.jsx
@@ -35,7 +35,7 @@ describe('Sound Editor Container', () => {
                 }
             }
         };
-        store = mockStore({vm});
+        store = mockStore({scratchGui: {vm: vm}});
     });
 
     test('should pass the correct data to the component from the store', () => {

--- a/test/unit/containers/sprite-selector-item.test.jsx
+++ b/test/unit/containers/sprite-selector-item.test.jsx
@@ -36,7 +36,9 @@ describe('SpriteSelectorItem Container', () => {
     };
 
     beforeEach(() => {
-        store = mockStore({hoveredTarget: {receivedBlocks: false, sprite: null}});
+        store = mockStore({scratchGui: {
+            hoveredTarget: {receivedBlocks: false, sprite: null}}
+        });
         className = 'ponies';
         costumeURL = 'https://scratch.mit.edu/foo/bar/pony';
         id = 1337;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -166,7 +166,7 @@ module.exports = [
         defaultsDeep({}, base, {
             target: 'web',
             entry: {
-                'scratch-gui': './src/containers/gui.jsx'
+                'scratch-gui': './src/index.js'
             },
             output: {
                 libraryTarget: 'umd',
@@ -179,7 +179,6 @@ module.exports = [
             module: {
                 rules: base.module.rules.concat([
                     {
-                      
                         test: /\.(svg|png|wav|gif|jpg)$/,
                         loader: 'file-loader',
                         options: {


### PR DESCRIPTION
### Proposed Changes

Refactor the gui redux store to allow it to be a part of an enclosing app's store. 
Also provide a way for an enclosing app to set the mode, along with a function to handle switching to editor mode (aka 'see inside').

### Reason for Changes

Needed for new project page

### Test Coverage

Current tests run.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
