### PR TITLE
Fix several minor monitor issues from recent testing

### DIFF
--- a/src/components/monitor-list/monitor-list.jsx
+++ b/src/components/monitor-list/monitor-list.jsx
@@ -10,7 +10,12 @@ import styles from './monitor-list.css';
 const stageSizeToTransform = ({width, height, widthDefault, heightDefault}) => {
     const scaleX = width / widthDefault;
     const scaleY = height / heightDefault;
-    return `scale(${scaleX},${scaleY})`;
+    if (scaleX === 1 && scaleY === 1) {
+        // Do not set a transform if the scale is 1 because
+        // it messes up `position: fixed` elements like the context menu.
+        return;
+    }
+    return {transform: `scale(${scaleX},${scaleY})`};
 };
 
 const MonitorList = props => (
@@ -24,9 +29,7 @@ const MonitorList = props => (
     >
         <Box
             className={styles.monitorListScaler}
-            style={{
-                transform: stageSizeToTransform(props.stageSize)
-            }}
+            style={stageSizeToTransform(props.stageSize)}
         >
             {props.monitors.valueSeq().filter(m => m.visible)
                 .map(monitorData => (

--- a/src/components/monitor/monitor.css
+++ b/src/components/monitor/monitor.css
@@ -154,6 +154,7 @@
     outline: none;
     font-size: 0.75rem;
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    width: 100%;
 }
 
 .remove-button {

--- a/src/components/monitor/monitor.css
+++ b/src/components/monitor/monitor.css
@@ -85,7 +85,6 @@
     width: 100%;
     display: flex;
     flex-direction: column;
-    overflow-y: scroll;
     overflow-x: hidden;
     height: calc(100% - 44px);
 }
@@ -160,7 +159,7 @@
 .remove-button {
     position: absolute;
     top: 4px;
-    right: 3px;
+    right: 6px;
     cursor: pointer;
     color: $ui-white;
 }

--- a/src/components/monitor/monitor.css
+++ b/src/components/monitor/monitor.css
@@ -62,6 +62,7 @@
 
 .slider {
     width: 100%;
+    transform: translateZ(0); /* Fixes flickering in Safari */
 }
 
 .list-monitor {

--- a/src/components/monitor/monitor.css
+++ b/src/components/monitor/monitor.css
@@ -60,6 +60,10 @@
     flex-direction: row;
 }
 
+.slider {
+    width: 100%;
+}
+
 .list-monitor {
     display: flex;
     flex-direction: column;

--- a/src/components/monitor/monitor.jsx
+++ b/src/components/monitor/monitor.jsx
@@ -43,7 +43,7 @@ const MonitorComponent = props => (
             <Box
                 className={styles.monitorContainer}
                 componentRef={props.componentRef}
-                onDoubleClick={props.mode === 'list' || !props.draggable ? null : props.onNextMode}
+                onDoubleClick={props.mode === 'list' ? null : props.onNextMode}
             >
                 {React.createElement(modes[props.mode], {
                     categoryColor: categories[props.category],

--- a/src/components/monitor/monitor.jsx
+++ b/src/components/monitor/monitor.jsx
@@ -43,7 +43,7 @@ const MonitorComponent = props => (
             <Box
                 className={styles.monitorContainer}
                 componentRef={props.componentRef}
-                onDoubleClick={props.mode === 'list' ? null : props.onNextMode}
+                onDoubleClick={props.mode === 'list' || !props.draggable ? null : props.onNextMode}
             >
                 {React.createElement(modes[props.mode], {
                     categoryColor: categories[props.category],

--- a/src/components/monitor/slider-monitor.jsx
+++ b/src/components/monitor/slider-monitor.jsx
@@ -25,7 +25,6 @@ const SliderMonitor = ({categoryColor, label, min, max, value, onSliderUpdate}) 
                 type="range"
                 value={value}
                 onChange={onSliderUpdate}
-                // @todo onChange callback
             />
         </div>
 

--- a/src/components/monitor/slider-monitor.jsx
+++ b/src/components/monitor/slider-monitor.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
 import styles from './monitor.css';
 
 const SliderMonitor = ({categoryColor, label, min, max, value, onSliderUpdate}) => (
@@ -17,7 +19,7 @@ const SliderMonitor = ({categoryColor, label, min, max, value, onSliderUpdate}) 
         </div>
         <div className={styles.row}>
             <input
-                className="no-drag" // Class used on parent Draggable to prevent drags
+                className={classNames(styles.slider, 'no-drag')} // Class used on parent Draggable to prevent drags
                 max={max}
                 min={min}
                 type="range"


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Several issues in https://github.com/LLK/scratch-gui/issues/2097:
* [x] Double-clicking a monitor while in full screen mode should not switch its state @ericrosenbaum 
* [x] On a list monitor with a lot of items, I can scroll, but I cannot drag the scrollbar to scroll @ercrosenbaum
* [x]  Selected list monitor slots focus area does not cover full width of slot if the list monitor is wide @kchadha
* [x]  Editable text area of list monitor isn’t the whole width @BryceLTaylor 
* [x]  Slider monitor background vanishes up when you slide the slider (Safari) @rschamp As seen on Master
* [x]  Can scroll horizontally the list monitor so the numbers disappear @BryceLTaylor

Fixes https://github.com/LLK/scratch-gui/pull/2102
Fixes https://github.com/LLK/scratch-gui/issues/2088

### Proposed Changes

_Describe what this Pull Request does_

See commits individually for each fixes details. Just CSS stuff.