### PR TITLE
Hide field editors when a modal is shown

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -96,10 +96,16 @@ class Blocks extends React.Component {
             this.props.toolboxXML !== nextProps.toolboxXML ||
             this.props.extensionLibraryVisible !== nextProps.extensionLibraryVisible ||
             this.props.customProceduresVisible !== nextProps.customProceduresVisible ||
-            this.props.locale !== nextProps.locale
+            this.props.locale !== nextProps.locale ||
+            this.props.anyModalVisible !== nextProps.anyModalVisible
         );
     }
     componentDidUpdate (prevProps) {
+        // If any modals are open, call hideChaff to close z-indexed field editors
+        if (this.props.anyModalVisible && !prevProps.anyModalVisible) {
+            this.ScratchBlocks.hideChaff();
+        }
+
         if (prevProps.locale !== this.props.locale) {
             this.props.vm.setLocale(this.props.locale, this.props.messages);
         }
@@ -317,6 +323,7 @@ class Blocks extends React.Component {
     render () {
         /* eslint-disable no-unused-vars */
         const {
+            anyModalVisible,
             customProceduresVisible,
             extensionLibraryVisible,
             options,
@@ -368,6 +375,7 @@ class Blocks extends React.Component {
 }
 
 Blocks.propTypes = {
+    anyModalVisible: PropTypes.bool,
     customProceduresVisible: PropTypes.bool,
     extensionLibraryVisible: PropTypes.bool,
     isVisible: PropTypes.bool,
@@ -437,6 +445,7 @@ Blocks.defaultProps = {
 };
 
 const mapStateToProps = state => ({
+    anyModalVisible: Object.keys(state.modals).some(key => state.modals[key]),
     extensionLibraryVisible: state.modals.extensionLibrary,
     locale: state.intl.locale,
     messages: state.intl.messages,


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/1129

### Proposed Changes

_Describe what this Pull Request does_

Have the blocks container watch for changes to modals states and call `hideChaff` to close active field editors when a modal is shown.

Tested manually:

This is on develop:
![hiding-fields-develop](https://user-images.githubusercontent.com/654102/40312667-7c0db3b8-5ce1-11e8-9fe5-e43becc9d2cc.gif)


And this is what it does now:
![hiding-fields-fixed](https://user-images.githubusercontent.com/654102/40312679-869673ba-5ce1-11e8-8eff-a20102c7eb48.gif)
