### PR TITLE
Hide block inputs when entering fullscreen mode

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -445,7 +445,8 @@ Blocks.defaultProps = {
 };
 
 const mapStateToProps = state => ({
-    anyModalVisible: Object.keys(state.modals).some(key => state.modals[key]),
+    anyModalVisible: Object.keys(state.modals).some(key => state.modals[key]) ||
+            state.mode.isFullScreen,
     extensionLibraryVisible: state.modals.extensionLibrary,
     locale: state.intl.locale,
     messages: state.intl.messages,


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/2009

### Proposed Changes

_Describe what this Pull Request does_

A small follow-up to https://github.com/LLK/scratch-gui/pull/2107 that adds the fullscreen mode state flag to the list of "visible modals", making it hide block field editors/ reported values when entering fullscreen mode. 

### Reason for Changes

_Explain why these changes should be made_

https://github.com/LLK/scratch-gui/issues/2009 and the recently submitted duplicate https://github.com/LLK/scratch-gui/issues/2113

### Test Coverage

_Please show how you have added tests to cover your changes_


Tested by following the directions in the linked issues.
