### PR TITLE
Force a min viewport size to scroll around the UI instead of breaking

### DIFF
--- a/src/playground/index.css
+++ b/src/playground/index.css
@@ -8,7 +8,7 @@ body,
 
     /* Setting min height/width makes the UI scroll below those sizes */
     min-width: 1024px;
-    min-height: 670px; /* Min height to fit sprite/backdrop button */
+    min-height: 640px; /* Min height to fit sprite/backdrop button */
 }
 
 /* @todo: move globally? Safe / side FX, for blocks particularly? */

--- a/src/playground/index.css
+++ b/src/playground/index.css
@@ -5,6 +5,10 @@ body,
     width: 100%; 
     height: 100%;
     margin: 0;
+
+    /* Setting min height/width makes the UI scroll below those sizes */
+    min-width: 1024px;
+    min-height: 670px; /* Min height to fit sprite/backdrop button */
 }
 
 /* @todo: move globally? Safe / side FX, for blocks particularly? */


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/2027

### Proposed Changes

_Describe what this Pull Request does_

Force the preview wrapper to have a minimum width/height so that the UI scrolls below those points. We have a pretty well defined minimum viewport size that we have not designed below, so instead of allowing things to just look broken below that point, make it so the entire UI scrolls. 

### Reason for Changes

_Explain why these changes should be made_

TL;DR Instead of being super broken on unsupported screen sizes, allow the UI to scroll around to make the intention clear: you need to see this on a bigger window.

Issues with viewports smaller than we have designed for have been reported often, including issues with windows that are too short (so the add-sprite/backdrop buttons mush upwards) or browsers that are too narrow (the linked issue from @RoboErikG. 

Talking with @carljbowman this seems like a good compromise: we are not implementing a fully responsive UI down to mobile right now, so make it clear that this is not the intention by making the UI clearly a view into a larger space, instead of just looking weird and broken.

This is the current situation:
below our minimum height
![min-height-current](https://user-images.githubusercontent.com/654102/40381932-0a63037c-5dcb-11e8-8ea2-abf646c81938.gif)
below our minimum width
![min-width-current](https://user-images.githubusercontent.com/654102/40381930-089b55a8-5dcb-11e8-9afd-e1fa3d1226ed.gif)

Here is what happens with minimum height:
![min-height](https://user-images.githubusercontent.com/654102/40381753-90308f20-5dca-11e8-9de8-b64c617672a5.gif)

and min width
![min-width](https://user-images.githubusercontent.com/654102/40381902-f4df8c1e-5dca-11e8-9462-5e2e56504954.gif)


### Test Coverage

_Please show how you have added tests to cover your changes_

