### PR TITLE
Show username block in sensing

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "scratch-render": "0.1.0-prerelease.20180522141925",
     "scratch-storage": "0.4.1",
     "scratch-svg-renderer": "0.1.0-prerelease.20180521194642",
-    "scratch-vm": "0.1.0-prerelease.1526929817",
+    "scratch-vm": "0.1.0-prerelease.1527185283",
     "selenium-webdriver": "3.6.0",
     "startaudiocontext": "1.2.1",
     "style-loader": "^0.21.0",

--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -461,6 +461,7 @@ const sensing = function (isStage) {
         ${blockSeparator}
         <block id="current" type="sensing_current"/>
         <block type="sensing_dayssince2000"/>
+        ${blockSeparator}
         <block type="sensing_username"/>
         ${categorySeparator}
     </category>

--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -461,6 +461,7 @@ const sensing = function (isStage) {
         ${blockSeparator}
         <block id="current" type="sensing_current"/>
         <block type="sensing_dayssince2000"/>
+        <block type="sensing_username"/>
         ${categorySeparator}
     </category>
     `;

--- a/src/lib/opcode-labels.js
+++ b/src/lib/opcode-labels.js
@@ -60,6 +60,10 @@ const opcodeMap = {
         category: 'sensing',
         label: 'loudness'
     },
+    sensing_username: {
+        category: 'sensing',
+        label: 'username'
+    },
     sensing_current: {
         category: 'sensing',
         labelFn: params => {


### PR DESCRIPTION
Shows the username block in the toolbox. Will bring in https://github.com/LLK/scratch-vm/pull/1163