### PR TITLE
Show a coming-soon backpack

### DIFF
--- a/src/components/backpack/backpack.css
+++ b/src/components/backpack/backpack.css
@@ -1,0 +1,20 @@
+@import "../../css/units.css";
+@import "../../css/colors.css";
+
+.backpack-container {
+    flex-shrink: 1;
+    position: relative;
+}
+
+.backpack-header {
+    margin-top: 0.5rem;
+    border: 1px solid $ui-black-transparent;
+    border-top-right-radius: $space;
+    background: $ui-white;
+    padding: 0.25rem;
+    text-align: center;
+    font-size: 0.85rem;
+    color: $text-primary;
+    transition: 0.2s;
+    cursor: pointer;
+}

--- a/src/components/backpack/backpack.jsx
+++ b/src/components/backpack/backpack.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import {FormattedMessage} from 'react-intl';
+import {ComingSoonTooltip} from '../coming-soon/coming-soon.jsx';
+import styles from './backpack.css';
+
+const Backpack = () => (
+    <div className={styles.backpackContainer}>
+        <div className={styles.backpackHeader}>
+            <ComingSoonTooltip place="top">
+                <FormattedMessage
+                    defaultMessage="Backpack"
+                    description="Button to open the backpack"
+                    id="gui.backpack.header"
+                />
+            </ComingSoonTooltip>
+        </div>
+    </div>
+);
+
+export default Backpack;

--- a/src/components/blocks/blocks.css
+++ b/src/components/blocks/blocks.css
@@ -9,6 +9,7 @@
     left: 0;
     border: 1px solid $ui-black-transparent;
     border-top-right-radius: $space;
+    border-bottom-right-radius: $space;
 }
 
 .blocks :global(.blocklyMainBackground) {

--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -15,6 +15,7 @@ import StageWrapper from '../../containers/stage-wrapper.jsx';
 import Loader from '../loader/loader.jsx';
 import Box from '../box/box.jsx';
 import MenuBar from '../menu-bar/menu-bar.jsx';
+import Backpack from '../backpack/backpack.jsx';
 
 import PreviewModal from '../../containers/preview-modal.jsx';
 import ImportModal from '../../containers/import-modal.jsx';
@@ -44,6 +45,7 @@ const GUIComponent = props => {
     const {
         activeTabIndex,
         basePath,
+        backpackVisible,
         blocksTabVisible,
         cardsVisible,
         children,
@@ -202,6 +204,9 @@ const GUIComponent = props => {
                                 {soundsTabVisible ? <SoundTab vm={vm} /> : null}
                             </TabPanel>
                         </Tabs>
+                        {backpackVisible ? (
+                            <Backpack />
+                        ) : null}
                     </Box>
 
                     <Box className={styles.stageAndTargetWrapper}>
@@ -220,6 +225,7 @@ const GUIComponent = props => {
 };
 GUIComponent.propTypes = {
     activeTabIndex: PropTypes.number,
+    backpackVisible: PropTypes.null,
     basePath: PropTypes.string,
     blocksTabVisible: PropTypes.bool,
     cardsVisible: PropTypes.bool,
@@ -242,6 +248,7 @@ GUIComponent.propTypes = {
     vm: PropTypes.instanceOf(VM).isRequired
 };
 GUIComponent.defaultProps = {
+    backpackVisible: false,
     basePath: './'
 };
 export default injectIntl(GUIComponent);

--- a/src/playground/index.jsx
+++ b/src/playground/index.jsx
@@ -24,4 +24,4 @@ document.body.appendChild(appTarget);
 GUI.setAppElement(appTarget);
 const WrappedGui = HashParserHOC(AppStateHOC(GUI));
 
-ReactDOM.render(<WrappedGui />, appTarget);
+ReactDOM.render(<WrappedGui backpackVisible />, appTarget);


### PR DESCRIPTION
Another small step toward the backpack! The bottom bar with coming soon.

![image](https://user-images.githubusercontent.com/654102/40436696-8b9d39ba-5e81-11e8-8520-af6e91c47c23.png)

@carljbowman I want to make sure the colors on this are right. 

@thisandagain @rschamp I want to make sure I understand what we want in the stand-alone preview build. This PR allows the backpack visibility to be controlled via a prop (to make it easier to remove for offline build, etc.) but I did enable it for the standalone preview build. Is that what we want to do? Or did we want to hide it completely from preview? 