### PR TITLE
Force the tooltips to close to fix touch devices

### DIFF
--- a/src/components/action-menu/action-menu.jsx
+++ b/src/components/action-menu/action-menu.jsx
@@ -66,6 +66,7 @@ class ActionMenu extends React.Component {
     handleTouchOutside (e) {
         if (this.state.isOpen && !this.containerRef.contains(e.target)) {
             this.setState({isOpen: false});
+            ReactTooltip.hide();
         }
     }
     clickDelayer (fn) {
@@ -74,6 +75,7 @@ class ActionMenu extends React.Component {
         // for now all this work is to ensure the menu closes BEFORE the
         // (possibly slow) action is started.
         return event => {
+            ReactTooltip.hide();
             this.setState({forceHide: true, isOpen: false}, () => {
                 if (fn) fn(event);
                 setTimeout(() => this.setState({forceHide: false}));


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/1891

### Proposed Changes

_Describe what this Pull Request does_

Force the tooltips to go away, because they do not play nicely with touch since they are based on mouse position.

### Reason for Changes

_Explain why these changes should be made_

The action menus are awkward on touch because they stay open!

### Test Coverage

_Please show how you have added tests to cover your changes_

Tested on various touch devices.

Broken

![action-menu-broken](https://user-images.githubusercontent.com/654102/40445697-df6025bc-5e9a-11e8-9b08-3e7ce1c28d5e.gif)


Fixed

![action-menu-fixed](https://user-images.githubusercontent.com/654102/40445688-d992edcc-5e9a-11e8-8908-0988b4447123.gif)

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [x] Chrome
 
iPad
* [x] Safari

Android Tablet
* [ ] Chrome
