### PR TITLE
Move error boundary out beyond the project loader

### DIFF
--- a/src/containers/gui.jsx
+++ b/src/containers/gui.jsx
@@ -5,7 +5,7 @@ import VM from 'scratch-vm';
 import {connect} from 'react-redux';
 import ReactModal from 'react-modal';
 
-import ErrorBoundary from './error-boundary.jsx';
+import ErrorBoundaryHOC from '../lib/error-boundary-hoc.jsx';
 import {openExtensionLibrary} from '../reducers/modals';
 import {
     activateTab,
@@ -75,15 +75,13 @@ class GUI extends React.Component {
             ...componentProps
         } = this.props;
         return (
-            <ErrorBoundary action="Top Level App">
-                <GUIComponent
-                    loading={fetchingProject || this.state.loading || loadingStateVisible}
-                    vm={vm}
-                    {...componentProps}
-                >
-                    {children}
-                </GUIComponent>
-            </ErrorBoundary>
+            <GUIComponent
+                loading={fetchingProject || this.state.loading || loadingStateVisible}
+                vm={vm}
+                {...componentProps}
+            >
+                {children}
+            </GUIComponent>
         );
     }
 }
@@ -129,7 +127,9 @@ const ConnectedGUI = connect(
     mapDispatchToProps,
 )(GUI);
 
-const WrappedGui = ProjectLoaderHOC(vmListenerHOC(ConnectedGUI));
+const WrappedGui = ErrorBoundaryHOC('Top Level App')(
+    ProjectLoaderHOC(vmListenerHOC(ConnectedGUI))
+);
 
 WrappedGui.setAppElement = ReactModal.setAppElement;
 export default WrappedGui;


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_
Fixes https://github.com/LLK/scratch-gui/issues/2137#issuecomment-391474843

### Proposed Changes

_Describe what this Pull Request does_

Move the error boundary outside of the project loader hoc. 

### Reason for Changes

_Explain why these changes should be made_

/cc @chrisgarrity 

### Test Coverage

_Please show how you have added tests to cover your changes_

Tested by loading a project with a non-existent asset. we get back to where preview is where we show the "oops" screen instead of a blank one. 

I'm looking into how we can get it to load the default asset instead of breaking entirely.
