### PR TITLE
Fix toolbox refreshing for new variables after switching tabs

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -125,6 +125,8 @@ class Blocks extends React.Component {
         if (this.props.isVisible) { // Scripts tab
             this.workspace.setVisible(true);
             this.props.vm.refreshWorkspace();
+            // Re-enable toolbox refreshes without causing one. See #updateToolbox for more info.
+            this.workspace.toolboxRefreshEnabled_ = true;
             window.dispatchEvent(new Event('resize'));
         } else {
             this.workspace.setVisible(false);


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/2120

### Proposed Changes

_Describe what this Pull Request does_

re-enable toolbox refreshing, the way we do after doing a real toolbox refresh, after the blocks tab is re-shown after being hidden. 

The full workspace refresh which is done the line before causes refreshing to be disabled. See the comments on line 148-150 for more info.

### Reason for Changes

_Explain why these changes should be made_

Toolbox refreshing was not happening when it needed to after switching tabs. 

### Test Coverage

_Please show how you have added tests to cover your changes_

Repro the test case in the lined issue.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

not browser related.

----
/cc @gnarf, @rschamp