### PR TITLE
Disable double click and context menu in fullscreen

### DIFF
--- a/src/components/monitor/monitor.jsx
+++ b/src/components/monitor/monitor.jsx
@@ -30,6 +30,7 @@ const modes = {
 
 const MonitorComponent = props => (
     <ContextMenuTrigger
+        disable={!props.draggable}
         holdToDisplay={props.mode === 'slider' ? -1 : 1000}
         id={`monitor-${props.label}`}
     >
@@ -43,7 +44,7 @@ const MonitorComponent = props => (
             <Box
                 className={styles.monitorContainer}
                 componentRef={props.componentRef}
-                onDoubleClick={props.mode === 'list' ? null : props.onNextMode}
+                onDoubleClick={props.mode === 'list' || !props.draggable ? null : props.onNextMode}
             >
                 {React.createElement(modes[props.mode], {
                     categoryColor: categories[props.category],


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Really fixes double-clicking the monitors in fullscreen and context menu in fullscreen, unlike what https://github.com/LLK/scratch-gui/pull/2102 claims to do.

### Proposed Changes

_Describe what this Pull Request does_

Disable those two actions when in fullscreen.

### Reason for Changes

_Explain why these changes should be made_

Because I tried to fix it once, but miraculously ended up reverting the commit in https://github.com/LLK/scratch-gui/pull/2102

### Test Coverage

_Please show how you have added tests to cover your changes_

tested manually by trying to double click and right click monitors in fullscreen. You are not able to.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

n/a