### PR TITLE
Block Vivaldi

### DIFF
--- a/src/components/browser-modal/browser-modal.jsx
+++ b/src/components/browser-modal/browser-modal.jsx
@@ -31,7 +31,7 @@ const BrowserModal = ({intl, ...props}) => (
             <p>
                 { /* eslint-disable max-len */ }
                 <FormattedMessage
-                    defaultMessage="We're very sorry, but Scratch 3.0 does not support Internet Explorer, Opera or Silk. We recommend trying a newer browser such as Google Chrome, Mozilla Firefox, or Microsoft Edge."
+                    defaultMessage="We're very sorry, but Scratch 3.0 does not support Internet Explorer, Vivaldi, Opera or Silk. We recommend trying a newer browser such as Google Chrome, Mozilla Firefox, or Microsoft Edge."
                     description="Unsupported browser description"
                     id="gui.unsupportedBrowser.description"
                 />

--- a/src/lib/supported-browser.js
+++ b/src/lib/supported-browser.js
@@ -6,6 +6,7 @@ import bowser from 'bowser';
  */
 export default function () {
     if (bowser.msie ||
+        bowser.vivaldi ||
         bowser.opera ||
         bowser.silk) {
         return false;


### PR DESCRIPTION
### Resolves
#2018 

### Proposed Changes
Blocked Vivaldi and Changed browser-modal's text.
### Reason for Changes
#1460 
### Test Coverage
Tested on my PC, Windows 7 Home Premium, Firefox (not blocked), Chrome (not blocked), and **Vivaldi (blocked)**
### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Edge

* [x] Vivaldi (blocked successfully)
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
