### PR TITLE
Reset scroll position when clicking library category button

### DIFF
--- a/src/components/library/library.jsx
+++ b/src/components/library/library.jsx
@@ -43,6 +43,12 @@ class LibraryComponent extends React.Component {
             selectedTag: ALL_TAG_TITLE.toLowerCase()
         };
     }
+    componentDidUpdate (prevProps, prevState) {
+        if (prevState.filterQuery !== this.state.filterQuery ||
+            prevState.selectedTag !== this.state.selectedTag) {
+            this.scrollToTop();
+        }
+    }
     handleBlur (id) {
         this.handleMouseLeave(id);
     }
@@ -58,7 +64,6 @@ class LibraryComponent extends React.Component {
             filterQuery: '',
             selectedTag: tag.toLowerCase()
         });
-        this.scrollToTop();
     }
     handleMouseEnter (id) {
         if (this.props.onItemMouseEnter) this.props.onItemMouseEnter(this.getFilteredData()[id]);
@@ -71,7 +76,6 @@ class LibraryComponent extends React.Component {
             filterQuery: event.target.value,
             selectedTag: ALL_TAG_TITLE.toLowerCase()
         });
-        this.scrollToTop();
     }
     handleFilterClear () {
         this.setState({filterQuery: ''});

--- a/src/components/library/library.jsx
+++ b/src/components/library/library.jsx
@@ -34,7 +34,8 @@ class LibraryComponent extends React.Component {
             'handleMouseEnter',
             'handleMouseLeave',
             'handleSelect',
-            'handleTagClick'
+            'handleTagClick',
+            'setFilteredDataRef'
         ]);
         this.state = {
             selectedItem: null,
@@ -57,6 +58,7 @@ class LibraryComponent extends React.Component {
             filterQuery: '',
             selectedTag: tag.toLowerCase()
         });
+        this.scrollToTop();
     }
     handleMouseEnter (id) {
         if (this.props.onItemMouseEnter) this.props.onItemMouseEnter(this.getFilteredData()[id]);
@@ -69,6 +71,7 @@ class LibraryComponent extends React.Component {
             filterQuery: event.target.value,
             selectedTag: ALL_TAG_TITLE.toLowerCase()
         });
+        this.scrollToTop();
     }
     handleFilterClear () {
         this.setState({filterQuery: ''});
@@ -91,6 +94,12 @@ class LibraryComponent extends React.Component {
                 .map(String.prototype.toLowerCase.call, String.prototype.toLowerCase)
                 .indexOf(this.state.selectedTag) !== -1
         ));
+    }
+    scrollToTop () {
+        this.filteredDataRef.scrollTop = 0;
+    }
+    setFilteredDataRef (ref) {
+        this.filteredDataRef = ref;
     }
     render () {
         return (
@@ -141,6 +150,7 @@ class LibraryComponent extends React.Component {
                     className={classNames(styles.libraryScrollGrid, {
                         [styles.withFilterBar]: this.props.filterable || this.props.tags
                     })}
+                    ref={this.setFilteredDataRef}
                 >
                     {this.getFilteredData().map((dataItem, index) => {
                         const scratchURL = dataItem.md5 ?


### PR DESCRIPTION
### Resolves

[#2099](https://github.com/LLK/scratch-gui/issues/2099)

### Proposed Changes

When a library category button is clicked or the search query is modified, reset the scroll position to the top.

### Test Coverage

No tests needed.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
