### PR TITLE
Change styles of action menu button

### DIFF
--- a/src/components/action-menu/action-menu.css
+++ b/src/components/action-menu/action-menu.css
@@ -23,8 +23,16 @@ $more-button-size: 2.25rem;
     transition: background-color 0.2s;
 }
 
+button::-moz-focus-inner {
+    border: 0;
+}
+
 .button:hover {
     background: $pen-primary;
+}
+
+.button:active {
+    padding: inherit;
 }
 
 .button.coming-soon:hover {


### PR DESCRIPTION
### Resolves

[#2066](https://github.com/LLK/scratch-gui/issues/2066)

### Proposed Changes

In Firefox, remove the ugly border and icon offset when a "Choose a Sprite" menu button is active.

Image of Firefox's border:
![image](https://user-images.githubusercontent.com/29558846/40630514-2ad28eae-62a1-11e8-9498-12f5950f0e2a.png)

### Test Coverage

No tests needed.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
