### PR TITLE
Toggle backpack when backpack host param is available

### DIFF
--- a/src/components/asset-panel/asset-panel.css
+++ b/src/components/asset-panel/asset-panel.css
@@ -16,4 +16,5 @@
     flex-grow: 1;
     flex-shrink: 1;
     border-left: 1px solid $ui-black-transparent;
+    overflow-y: auto;
 }

--- a/src/components/backpack/backpack.css
+++ b/src/components/backpack/backpack.css
@@ -17,4 +17,21 @@
     color: $text-primary;
     transition: 0.2s;
     cursor: pointer;
+    user-select: none;
+}
+
+.backpack-list {
+    position: relative;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    border-right: 1px solid $ui-black-transparent;
+    min-height: 6rem;
+}
+
+.empty-message {
+    width: 100%;
+    text-align: center;
+    font-size: 0.85rem;
+    color: $text-primary;
 }

--- a/src/components/backpack/backpack.jsx
+++ b/src/components/backpack/backpack.jsx
@@ -1,20 +1,57 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import {FormattedMessage} from 'react-intl';
 import {ComingSoonTooltip} from '../coming-soon/coming-soon.jsx';
+
 import styles from './backpack.css';
 
-const Backpack = () => (
+const Backpack = ({expanded, onToggle}) => (
     <div className={styles.backpackContainer}>
-        <div className={styles.backpackHeader}>
-            <ComingSoonTooltip place="top">
+        <div
+            className={styles.backpackHeader}
+            onClick={onToggle}
+        >
+            {onToggle ? (
                 <FormattedMessage
                     defaultMessage="Backpack"
                     description="Button to open the backpack"
                     id="gui.backpack.header"
                 />
-            </ComingSoonTooltip>
+            ) : (
+                <ComingSoonTooltip
+                    place="top"
+                    tooltipId="backpack-tooltip"
+                >
+                    <FormattedMessage
+                        defaultMessage="Backpack"
+                        description="Button to open the backpack"
+                        id="gui.backpack.header"
+                    />
+                </ComingSoonTooltip>
+            )}
         </div>
+        {expanded ? (
+            <div className={styles.backpackList}>
+                <div className={styles.emptyMessage}>
+                    <FormattedMessage
+                        defaultMessage="Backpack is empty"
+                        description="Empty backpack message"
+                        id="gui.backpack.emptyBackpack"
+                    />
+                </div>
+            </div>
+        ) : null}
     </div>
 );
+
+Backpack.propTypes = {
+    expanded: PropTypes.bool,
+    onToggle: PropTypes.func
+};
+
+Backpack.defaultProps = {
+    expanded: false,
+    onToggle: null
+};
 
 export default Backpack;

--- a/src/components/gui/gui.css
+++ b/src/components/gui/gui.css
@@ -132,7 +132,6 @@
 .tabs {
     position: relative;
     flex-grow: 1;
-    flex-shrink: 0;
     display: flex;
     flex-direction: column;
 }
@@ -140,7 +139,6 @@
 .tab-panel {
     position: relative;
     flex-grow: 1;
-    flex-shrink: 0;
     display: none;
 }
 

--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -46,8 +46,7 @@ const GUIComponent = props => {
     const {
         activeTabIndex,
         basePath,
-        backpackHost,
-        backpackVisible,
+        backpackOptions,
         blocksTabVisible,
         cardsVisible,
         children,
@@ -206,8 +205,8 @@ const GUIComponent = props => {
                                 {soundsTabVisible ? <SoundTab vm={vm} /> : null}
                             </TabPanel>
                         </Tabs>
-                        {backpackVisible ? (
-                            <Backpack host={backpackHost} />
+                        {backpackOptions.visible ? (
+                            <Backpack host={backpackOptions.host} />
                         ) : null}
                     </Box>
 
@@ -228,8 +227,10 @@ const GUIComponent = props => {
 };
 GUIComponent.propTypes = {
     activeTabIndex: PropTypes.number,
-    backpackHost: PropTypes.string,
-    backpackVisible: PropTypes.null,
+    backpackOptions: PropTypes.shape({
+        host: PropTypes.string,
+        visible: PropTypes.bool
+    }),
     basePath: PropTypes.string,
     blocksTabVisible: PropTypes.bool,
     cardsVisible: PropTypes.bool,
@@ -252,8 +253,10 @@ GUIComponent.propTypes = {
     vm: PropTypes.instanceOf(VM).isRequired
 };
 GUIComponent.defaultProps = {
-    backpackHost: null,
-    backpackVisible: false,
+    backpackOptions: {
+        host: null,
+        visible: false
+    },
     basePath: './'
 };
 export default injectIntl(GUIComponent);

--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -15,8 +15,8 @@ import StageWrapper from '../../containers/stage-wrapper.jsx';
 import Loader from '../loader/loader.jsx';
 import Box from '../box/box.jsx';
 import MenuBar from '../menu-bar/menu-bar.jsx';
-import Backpack from '../backpack/backpack.jsx';
 
+import Backpack from '../../containers/backpack.jsx';
 import PreviewModal from '../../containers/preview-modal.jsx';
 import ImportModal from '../../containers/import-modal.jsx';
 import WebGlModal from '../../containers/webgl-modal.jsx';
@@ -46,6 +46,7 @@ const GUIComponent = props => {
     const {
         activeTabIndex,
         basePath,
+        backpackHost,
         backpackVisible,
         blocksTabVisible,
         cardsVisible,
@@ -206,7 +207,7 @@ const GUIComponent = props => {
                             </TabPanel>
                         </Tabs>
                         {backpackVisible ? (
-                            <Backpack />
+                            <Backpack host={backpackHost} />
                         ) : null}
                     </Box>
 
@@ -227,6 +228,7 @@ const GUIComponent = props => {
 };
 GUIComponent.propTypes = {
     activeTabIndex: PropTypes.number,
+    backpackHost: PropTypes.string,
     backpackVisible: PropTypes.null,
     basePath: PropTypes.string,
     blocksTabVisible: PropTypes.bool,
@@ -250,6 +252,7 @@ GUIComponent.propTypes = {
     vm: PropTypes.instanceOf(VM).isRequired
 };
 GUIComponent.defaultProps = {
+    backpackHost: null,
     backpackVisible: false,
     basePath: './'
 };

--- a/src/containers/backpack.jsx
+++ b/src/containers/backpack.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import bindAll from 'lodash.bindall';
+import BackpackComponent from '../components/backpack/backpack.jsx';
+
+class Backpack extends React.Component {
+    constructor (props) {
+        super(props);
+        bindAll(this, [
+            'handleToggle'
+        ]);
+        this.state = {
+            expanded: false,
+            contents: []
+        };
+    }
+    handleToggle () {
+        this.setState({expanded: !this.state.expanded});
+    }
+    render () {
+        return (
+            <BackpackComponent
+                contents={this.state.contents}
+                expanded={this.state.expanded}
+                onToggle={this.props.host ? this.handleToggle : null}
+            />
+        );
+    }
+}
+
+Backpack.propTypes = {
+    host: PropTypes.string
+};
+
+export default Backpack;

--- a/src/playground/index.jsx
+++ b/src/playground/index.jsx
@@ -28,7 +28,9 @@ const WrappedGui = HashParserHOC(AppStateHOC(GUI));
 const backpackHostMatches = window.location.href.match(/[?&]backpack_host=(.*)&?/);
 const backpackHost = backpackHostMatches ? backpackHostMatches[1] : null;
 
-ReactDOM.render(<WrappedGui
-    backpackVisible
-    backpackHost={backpackHost}
-/>, appTarget);
+const backpackOptions = {
+    visible: true,
+    host: backpackHost
+};
+
+ReactDOM.render(<WrappedGui backpackOptions={backpackOptions} />, appTarget);

--- a/src/playground/index.jsx
+++ b/src/playground/index.jsx
@@ -24,4 +24,11 @@ document.body.appendChild(appTarget);
 GUI.setAppElement(appTarget);
 const WrappedGui = HashParserHOC(AppStateHOC(GUI));
 
-ReactDOM.render(<WrappedGui backpackVisible />, appTarget);
+// TODO a hack for testing the backpack, allow backpack host to be set by url param
+const backpackHostMatches = window.location.href.match(/[?&]backpack_host=(.*)&?/);
+const backpackHost = backpackHostMatches ? backpackHostMatches[1] : null;
+
+ReactDOM.render(<WrappedGui
+    backpackVisible
+    backpackHost={backpackHost}
+/>, appTarget);

--- a/test/integration/backpack.test.js
+++ b/test/integration/backpack.test.js
@@ -34,6 +34,10 @@ describe('Working with the how-to library', () => {
     test('Backpack can be expanded with backpack host param', async () => {
         await loadUri(`${uri}?backpack_host=some-value`);
         await clickXpath('//button[@title="tryit"]');
+
+        // Try activating the backpack from the costumes tab to make sure it isn't pushed off
+        await clickText('Costumes');
+
         // Check that the backpack header is visible and wrapped in a coming soon tooltip
         await clickText('Backpack'); // Not wrapped in tooltip
         await clickText('Backpack is empty'); // Make sure it can expand, is empty

--- a/test/integration/backpack.test.js
+++ b/test/integration/backpack.test.js
@@ -1,0 +1,43 @@
+import path from 'path';
+import SeleniumHelper from '../helpers/selenium-helper';
+
+const {
+    clickText,
+    clickXpath,
+    getDriver,
+    getLogs,
+    loadUri
+} = new SeleniumHelper();
+
+const uri = path.resolve(__dirname, '../../build/index.html');
+
+let driver;
+
+describe('Working with the how-to library', () => {
+    beforeAll(() => {
+        driver = getDriver();
+    });
+
+    afterAll(async () => {
+        await driver.quit();
+    });
+
+    test('Backpack is "Coming Soon" without backpack host param', async () => {
+        await loadUri(uri);
+        await clickXpath('//button[@title="tryit"]');
+        // Check that the backpack header is visible and wrapped in a coming soon tooltip
+        await clickText('Backpack', '*[@data-for="backpack-tooltip"]');
+        const logs = await getLogs();
+        await expect(logs).toEqual([]);
+    });
+
+    test('Backpack can be expanded with backpack host param', async () => {
+        await loadUri(`${uri}?backpack_host=some-value`);
+        await clickXpath('//button[@title="tryit"]');
+        // Check that the backpack header is visible and wrapped in a coming soon tooltip
+        await clickText('Backpack'); // Not wrapped in tooltip
+        await clickText('Backpack is empty'); // Make sure it can expand, is empty
+        const logs = await getLogs();
+        await expect(logs).toEqual([]);
+    });
+});


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Next step for backpack work.

Also includes a fix for https://github.com/LLK/scratch-gui/issues/2182

### Proposed Changes

_Describe what this Pull Request does_

Add some more skeleton for the backpack. Allow it to be passed a `host` param, which controls whether the "coming soon" tooltips appear and whether the backpack can be toggled. Right now  `contents` defaults to `[]`, so the "Backpack is empty" message will appear.

@rschamp In addition to accepting a "backpackHost" prop in the GUI container, this change also allows the index playground to read the backpack_host param from the url query string, as a first step towards making this testable. If you think this is not a good route, let me know. The alternative I considered was creating a separate playground file, but I (a) didn't want to bloat the build too much more than is needed and (b) wanted to keep the backpack stuff as close to "what everyone is using" as possible, so we can always be testing on develop. 

~Also note there is some CSS / markup that is unreachable right now because content is always empty.~ Removed them, nevermind. 


![backpack-toggler](https://user-images.githubusercontent.com/654102/40665830-41a9963c-632c-11e8-80d3-3d02d36149fa.gif)


### Reason for Changes

_Explain why these changes should be made_

Backpack needs to be toggleable! Soon it will start to be filled with content.

### Test Coverage

_Please show how you have added tests to cover your changes_

I added an integration test to cover the playground behavior I mentioned above, that it is toggleable when there is something that looks like `?backpack_host=blah` in the url.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)


Mac
 * [x] Chrome 
 * [x] Firefox 
 * [x] Safari
 
Windows
 * [x] Chrome 
 * [x] Firefox 
 * [x] Edge
 
Chromebook
 * [x] Chrome
 
iPad
* [x] Safari

Android Tablet
* [ ] Chrome
