### PR TITLE
Change list wraparound logic when shift-tab pressed

### DIFF
--- a/src/containers/list-monitor.jsx
+++ b/src/containers/list-monitor.jsx
@@ -72,7 +72,7 @@ class ListMonitor extends React.Component {
         else if (e.key === 'ArrowDown') navigateDirection = 1;
         if (navigateDirection) {
             this.handleDeactivate(); // Submit in-progress edits
-            const newIndex = (previouslyActiveIndex + navigateDirection) % this.props.value.length;
+            const newIndex = this.wrapListIndex(previouslyActiveIndex + navigateDirection, this.props.value.length);
             this.setState({
                 activeIndex: newIndex,
                 activeValue: this.props.value[newIndex]
@@ -87,7 +87,7 @@ class ListMonitor extends React.Component {
                 .concat([newListItemValue])
                 .concat(listValue.slice(previouslyActiveIndex + newValueOffset));
             setVariableValue(vm, targetId, variableId, newListValue);
-            const newIndex = (previouslyActiveIndex + newValueOffset) % newListValue.length;
+            const newIndex = this.wrapListIndex(previouslyActiveIndex + newValueOffset, newListValue.length);
             this.setState({
                 activeIndex: newIndex,
                 activeValue: newListItemValue
@@ -144,6 +144,11 @@ class ListMonitor extends React.Component {
         window.addEventListener('mouseup', onMouseUp);
 
     }
+
+    wrapListIndex (index, length) {
+        return (index + length) % length;
+    }
+
     render () {
         const {
             vm, // eslint-disable-line no-unused-vars


### PR DESCRIPTION
### Resolves

[#2177](https://github.com/LLK/scratch-gui/issues/2177)

### Proposed Changes

Currently, when shift-tab is pressed on a focused list item, the list monitor shifts focus to the previous element. However, this does not work if the first list item is focused.

### Test Coverage

No tests needed.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
