### PR TITLE
Prevent dragging the "+" button

### DIFF
--- a/src/components/monitor/list-monitor.jsx
+++ b/src/components/monitor/list-monitor.jsx
@@ -26,7 +26,7 @@ const ListMonitor = ({draggable, label, width, height, value, onResizeMouseDown,
         </div>
         <div className={styles.listFooter}>
             <div
-                className={styles.addButton}
+                className={classNames(styles.addButton, 'no-drag')}
                 onClick={draggable ? onAdd : null}
             >
                 {'+' /* TODO waiting on asset */}


### PR DESCRIPTION
### Resolves

Fixes #2112 

### Proposed Changes

Adds the "no-drag" class to the "+" button so it doesn't 

### Reason for Changes

To prevent dragging by the "add an item" button 😛