### PR TITLE
Backpack load contents from server

### DIFF
--- a/src/components/backpack/backpack.css
+++ b/src/components/backpack/backpack.css
@@ -26,12 +26,30 @@
     flex-direction: row;
     align-items: center;
     border-right: 1px solid $ui-black-transparent;
-    min-height: 6rem;
+    min-height: 5.5rem;
 }
 
-.empty-message {
+/* Absolute position the inner list to allow scrolling inside flex sized container */
+.backpack-list-inner {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    overflow-x: auto;
+}
+
+.status-message {
     width: 100%;
     text-align: center;
     font-size: 0.85rem;
     color: $text-primary;
+}
+
+.backpack-item {
+    min-width: 4rem;
+    margin: 0 0.25rem;
 }

--- a/src/components/backpack/backpack.jsx
+++ b/src/components/backpack/backpack.jsx
@@ -84,12 +84,12 @@ const Backpack = ({contents, error, expanded, loading, onToggle}) => (
 );
 
 Backpack.propTypes = {
-    contents: PropTypes.shape({
+    contents: PropTypes.arrayOf(PropTypes.shape({
         id: PropTypes.string,
         thumbnailUrl: PropTypes.string,
         type: PropTypes.string,
         name: PropTypes.string
-    }),
+    })),
     error: PropTypes.bool,
     expanded: PropTypes.bool,
     loading: PropTypes.bool,

--- a/src/components/backpack/backpack.jsx
+++ b/src/components/backpack/backpack.jsx
@@ -8,7 +8,7 @@ import styles from './backpack.css';
 // TODO make sprite selector item not require onClick
 const noop = () => {};
 
-const Backpack = ({contents, expanded, loading, onToggle}) => (
+const Backpack = ({contents, error, expanded, loading, onToggle}) => (
     <div className={styles.backpackContainer}>
         <div
             className={styles.backpackHeader}
@@ -35,37 +35,47 @@ const Backpack = ({contents, expanded, loading, onToggle}) => (
         </div>
         {expanded ? (
             <div className={styles.backpackList}>
-                {loading ? (
+                {error ? (
                     <div className={styles.statusMessage}>
                         <FormattedMessage
-                            defaultMessage="Loading..."
-                            description="Loading backpack message"
-                            id="gui.backpack.loadingBackpack"
+                            defaultMessage="Error loading backpack"
+                            description="Error backpack message"
+                            id="gui.backpack.errorBackpack"
                         />
                     </div>
                 ) : (
-                    contents.length > 0 ? (
-                        <div className={styles.backpackListInner}>
-                            {contents.map(item => (
-                                <SpriteSelectorItem
-                                    className={styles.backpackItem}
-                                    costumeURL={item.thumbnailUrl}
-                                    details={item.name}
-                                    key={item.id}
-                                    name={item.type}
-                                    selected={false}
-                                    onClick={noop}
-                                />
-                            ))}
-                        </div>
-                    ) : (
+                    loading ? (
                         <div className={styles.statusMessage}>
                             <FormattedMessage
-                                defaultMessage="Backpack is empty"
-                                description="Empty backpack message"
-                                id="gui.backpack.emptyBackpack"
+                                defaultMessage="Loading..."
+                                description="Loading backpack message"
+                                id="gui.backpack.loadingBackpack"
                             />
                         </div>
+                    ) : (
+                        contents.length > 0 ? (
+                            <div className={styles.backpackListInner}>
+                                {contents.map(item => (
+                                    <SpriteSelectorItem
+                                        className={styles.backpackItem}
+                                        costumeURL={item.thumbnailUrl}
+                                        details={item.name}
+                                        key={item.id}
+                                        name={item.type}
+                                        selected={false}
+                                        onClick={noop}
+                                    />
+                                ))}
+                            </div>
+                        ) : (
+                            <div className={styles.statusMessage}>
+                                <FormattedMessage
+                                    defaultMessage="Backpack is empty"
+                                    description="Empty backpack message"
+                                    id="gui.backpack.emptyBackpack"
+                                />
+                            </div>
+                        )
                     )
                 )}
             </div>
@@ -80,6 +90,7 @@ Backpack.propTypes = {
         type: PropTypes.string,
         name: PropTypes.string
     }),
+    error: PropTypes.bool,
     expanded: PropTypes.bool,
     loading: PropTypes.bool,
     onToggle: PropTypes.func

--- a/src/components/backpack/backpack.jsx
+++ b/src/components/backpack/backpack.jsx
@@ -2,10 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {FormattedMessage} from 'react-intl';
 import {ComingSoonTooltip} from '../coming-soon/coming-soon.jsx';
-
+import SpriteSelectorItem from '../../containers/sprite-selector-item.jsx';
 import styles from './backpack.css';
 
-const Backpack = ({expanded, onToggle}) => (
+// TODO make sprite selector item not require onClick
+const noop = () => {};
+
+const Backpack = ({contents, expanded, loading, onToggle}) => (
     <div className={styles.backpackContainer}>
         <div
             className={styles.backpackHeader}
@@ -32,25 +35,60 @@ const Backpack = ({expanded, onToggle}) => (
         </div>
         {expanded ? (
             <div className={styles.backpackList}>
-                <div className={styles.emptyMessage}>
-                    <FormattedMessage
-                        defaultMessage="Backpack is empty"
-                        description="Empty backpack message"
-                        id="gui.backpack.emptyBackpack"
-                    />
-                </div>
+                {loading ? (
+                    <div className={styles.statusMessage}>
+                        <FormattedMessage
+                            defaultMessage="Loading..."
+                            description="Loading backpack message"
+                            id="gui.backpack.loadingBackpack"
+                        />
+                    </div>
+                ) : (
+                    contents.length > 0 ? (
+                        <div className={styles.backpackListInner}>
+                            {contents.map(item => (
+                                <SpriteSelectorItem
+                                    className={styles.backpackItem}
+                                    costumeURL={item.thumbnailUrl}
+                                    details={item.name}
+                                    key={item.id}
+                                    name={item.type}
+                                    selected={false}
+                                    onClick={noop}
+                                />
+                            ))}
+                        </div>
+                    ) : (
+                        <div className={styles.statusMessage}>
+                            <FormattedMessage
+                                defaultMessage="Backpack is empty"
+                                description="Empty backpack message"
+                                id="gui.backpack.emptyBackpack"
+                            />
+                        </div>
+                    )
+                )}
             </div>
         ) : null}
     </div>
 );
 
 Backpack.propTypes = {
+    contents: PropTypes.shape({
+        id: PropTypes.string,
+        thumbnailUrl: PropTypes.string,
+        type: PropTypes.string,
+        name: PropTypes.string
+    }),
     expanded: PropTypes.bool,
+    loading: PropTypes.bool,
     onToggle: PropTypes.func
 };
 
 Backpack.defaultProps = {
+    contents: [],
     expanded: false,
+    loading: false,
     onToggle: null
 };
 

--- a/src/containers/backpack.jsx
+++ b/src/containers/backpack.jsx
@@ -2,26 +2,51 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import bindAll from 'lodash.bindall';
 import BackpackComponent from '../components/backpack/backpack.jsx';
+import {getBackpackContents} from '../lib/backpack-api';
+import {connect} from 'react-redux';
 
 class Backpack extends React.Component {
     constructor (props) {
         super(props);
         bindAll(this, [
-            'handleToggle'
+            'handleToggle',
+            'refreshContents'
         ]);
         this.state = {
+            offset: 0,
+            itemsPerPage: 20,
+            loading: false,
             expanded: false,
             contents: []
         };
     }
     handleToggle () {
-        this.setState({expanded: !this.state.expanded});
+        const newState = !this.state.expanded;
+        this.setState({expanded: newState, offset: 0});
+        if (newState) {
+            this.refreshContents();
+        }
+    }
+    refreshContents () {
+        if (this.props.token && this.props.username) {
+            this.setState({loading: true});
+            getBackpackContents({
+                host: this.props.host,
+                token: this.props.token,
+                username: this.props.username,
+                offset: this.state.offset,
+                limit: this.state.itemsPerPage
+            }).then(contents => {
+                this.setState({contents, loading: false});
+            });
+        }
     }
     render () {
         return (
             <BackpackComponent
                 contents={this.state.contents}
                 expanded={this.state.expanded}
+                loading={this.state.loading}
                 onToggle={this.props.host ? this.handleToggle : null}
             />
         );
@@ -29,7 +54,27 @@ class Backpack extends React.Component {
 }
 
 Backpack.propTypes = {
-    host: PropTypes.string
+    host: PropTypes.string,
+    token: PropTypes.string,
+    username: PropTypes.string
 };
 
-export default Backpack;
+const mapStateToProps = state => {
+    // Look for the session state provided by scratch-www
+    if (state.session && state.session.session) {
+        return {
+            token: state.session.session.token,
+            username: state.session.session.username
+        };
+    }
+    // Otherwise try to pull testing params out of the URL, or return nulls
+    // TODO a hack for testing the backpack
+    const tokenMatches = window.location.href.match(/[?&]token=([^&]*)&?/);
+    const usernameMatches = window.location.href.match(/[?&]username=([^&]*)&?/);
+    return {
+        token: tokenMatches ? tokenMatches[1] : null,
+        username: usernameMatches ? usernameMatches[1] : null
+    };
+};
+
+export default connect(mapStateToProps)(Backpack);

--- a/src/containers/backpack.jsx
+++ b/src/containers/backpack.jsx
@@ -13,6 +13,7 @@ class Backpack extends React.Component {
             'refreshContents'
         ]);
         this.state = {
+            error: false,
             offset: 0,
             itemsPerPage: 20,
             loading: false,
@@ -29,22 +30,27 @@ class Backpack extends React.Component {
     }
     refreshContents () {
         if (this.props.token && this.props.username) {
-            this.setState({loading: true});
+            this.setState({loading: true, error: false});
             getBackpackContents({
                 host: this.props.host,
                 token: this.props.token,
                 username: this.props.username,
                 offset: this.state.offset,
                 limit: this.state.itemsPerPage
-            }).then(contents => {
-                this.setState({contents, loading: false});
-            });
+            })
+                .then(contents => {
+                    this.setState({contents, loading: false});
+                })
+                .catch(() => {
+                    this.setState({error: true, loading: false});
+                });
         }
     }
     render () {
         return (
             <BackpackComponent
                 contents={this.state.contents}
+                error={this.state.error}
                 expanded={this.state.expanded}
                 loading={this.state.loading}
                 onToggle={this.props.host ? this.handleToggle : null}

--- a/src/lib/backpack-api.js
+++ b/src/lib/backpack-api.js
@@ -1,18 +1,28 @@
+import xhr from 'xhr';
+
 const getBackpackContents = ({
     host,
     username,
     token,
     limit,
     offset
-}) => fetch(`${host}${username}?limit=${limit}&offset=${offset}`, {
-    headers: {'x-token': token}
-})
-    .then(d => d.json())
-    .then(items => items.map(item =>
+}) => new Promise((resolve, reject) => {
+    xhr({
+        method: 'GET',
+        uri: `${host}${username}?limit=${limit}&offset=${offset}`,
+        headers: {'x-token': token},
+        json: true
+    }, (error, response) => {
+        if (error || response.statusCode !== 200) {
+            return reject();
+        }
         // Add a new property for the full thumbnail url, which includes the host.
         // TODO retreiving the images through storage would allow us to remove this.
-        Object.assign(item, {thumbnailUrl: `${host}${item.thumbnail}`})
-    ));
+        return resolve(response.body.map(item => (
+            Object.assign({}, item, {thumbnailUrl: `${host}/${item.thumbnail}`})
+        )));
+    });
+});
 
 export {
     getBackpackContents

--- a/src/lib/backpack-api.js
+++ b/src/lib/backpack-api.js
@@ -1,0 +1,19 @@
+const getBackpackContents = ({
+    host,
+    username,
+    token,
+    limit,
+    offset
+}) => fetch(`${host}${username}?limit=${limit}&offset=${offset}`, {
+    headers: {'x-token': token}
+})
+    .then(d => d.json())
+    .then(items => items.map(item =>
+        // Add a new property for the full thumbnail url, which includes the host.
+        // TODO retreiving the images through storage would allow us to remove this.
+        Object.assign(item, {thumbnailUrl: `${host}${item.thumbnail}`})
+    ));
+
+export {
+    getBackpackContents
+};

--- a/src/playground/index.jsx
+++ b/src/playground/index.jsx
@@ -25,7 +25,7 @@ GUI.setAppElement(appTarget);
 const WrappedGui = HashParserHOC(AppStateHOC(GUI));
 
 // TODO a hack for testing the backpack, allow backpack host to be set by url param
-const backpackHostMatches = window.location.href.match(/[?&]backpack_host=(.*)&?/);
+const backpackHostMatches = window.location.href.match(/[?&]backpack_host=([^&]*)&?/);
 const backpackHost = backpackHostMatches ? backpackHostMatches[1] : null;
 
 const backpackOptions = {


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Next step for the backpack is to get basic loading of the backpack contents into the list. This PR loads up the first page of contents.

The functionality here is very limited (just loads a single page into the list), but this PR is mostly about infrastructure in terms of backpack-api and session token/username information.

As a compromise to allow the backpack to be tested independently from the servers, I made the backpack container first try to get session information from the state tree matching `scratch-www`, then if that is not available try to get it from url params the same way the host is retrieved. 

I've tested this using the backpack server locally, using the included dummy scratchteam/sessionid user. 

It loads content when the backpack is toggled, and looks like this:
![image](https://user-images.githubusercontent.com/654102/40732122-9d7775f4-6400-11e8-9883-9618def5c9bd.png)

Depends on https://github.com/LLK/scratch-gui/pull/2175, the first two commits are shared, look at the last two commits for these changes