### PR TITLE
Add IE11 and Safari 9/10 tests to browser smoke test using Sauce

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:integration": "jest --runInBand test[\\\\/]integration",
     "test:lint": "eslint . --ext .js,.jsx",
     "test:unit": "jest test[\\\\/]unit",
+    "test:smoke": "jest --runInBand test[\\\\/]smoke",
     "watch": "webpack --progress --colors --watch"
   },
   "author": "Massachusetts Institute of Technology",

--- a/test/helpers/selenium-helper.js
+++ b/test/helpers/selenium-helper.js
@@ -17,6 +17,7 @@ class SeleniumHelper {
             'findByText',
             'findByXpath',
             'getDriver',
+            'getSauceDriver',
             'getLogs',
             'loadUri',
             'rightClickText'
@@ -46,6 +47,21 @@ class SeleniumHelper {
         this.driver = new webdriver.Builder()
             .forBrowser('chrome')
             .withCapabilities(chromeCapabilities)
+            .build();
+        return this.driver;
+    }
+
+    getSauceDriver (username, accessKey, configs) {
+        this.driver = new webdriver.Builder()
+            .withCapabilities({
+                browserName: configs.browserName,
+                platform: configs.platform,
+                version: configs.version,
+                username: username,
+                accessKey: accessKey
+            })
+            .usingServer(`http://${username}:${accessKey
+            }@ondemand.saucelabs.com:80/wd/hub`)
             .build();
         return this.driver;
     }

--- a/test/smoke/browser.test.js
+++ b/test/smoke/browser.test.js
@@ -1,0 +1,74 @@
+import SeleniumHelper from '../helpers/selenium-helper';
+const {SAUCE_USERNAME, SAUCE_ACCESS_KEY, SMOKE_URL} = process.env;
+const {
+    getSauceDriver,
+    findByText
+} = new SeleniumHelper();
+
+// Make the default timeout longer, Sauce tests take ~30s
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 60 * 1000; // eslint-disable-line
+
+// Supported message is never seen because WebGL is not enabled on Sauce
+// const SUPPORTED_MESSAGE = 'Welcome to the Scratch 3.0 Preview';
+const WEBGL_MESSAGE = 'Your Browser Does Not Support WebGL';
+const UNSUPPORTED_MESSAGE = 'Scratch 3.0 does not support Internet Explorer';
+
+// Driver configs can be generated with the Sauce Platform Configurator
+// https://wiki.saucelabs.com/display/DOCS/Platform+Configurator
+describe('Smoke tests on older browsers', () => {
+    let driver;
+
+    afterEach(async () => await (driver && driver.quit()));
+
+    test('Credentials should be provided', () => {
+        expect(SAUCE_USERNAME && SAUCE_ACCESS_KEY && SMOKE_URL).toBeTruthy();
+    });
+
+    test('IE 11 should be unsupported', async () => {
+        const driverConfig = {
+            browserName: 'internet explorer',
+            platform: 'Windows 10',
+            version: '11.103'
+        };
+        driver = await getSauceDriver(
+            process.env.SAUCE_USERNAME,
+            process.env.SAUCE_ACCESS_KEY,
+            driverConfig);
+        await driver.get(process.env.SMOKE_URL);
+        const el = await findByText(UNSUPPORTED_MESSAGE);
+        const isDisplayed = await el.isDisplayed();
+        return expect(isDisplayed).toEqual(true);
+    });
+
+    test('Safari 9 should not be unsupported', async () => {
+        const driverConfig = {
+            browserName: 'safari',
+            platform: 'OS X 10.11',
+            version: '9.0'
+        };
+        driver = await getSauceDriver(
+            process.env.SAUCE_USERNAME,
+            process.env.SAUCE_ACCESS_KEY,
+            driverConfig);
+        await driver.get(process.env.SMOKE_URL);
+        const el = await findByText(WEBGL_MESSAGE); // b/c WebGL isn't enabled on Sauce
+        const isDisplayed = await el.isDisplayed();
+        return expect(isDisplayed).toEqual(true);
+    });
+
+    test('Safari 10 should not be unsupported', async () => {
+        const driverConfig = {
+            browserName: 'safari',
+            platform: 'OS X 10.11',
+            version: '10.0'
+        };
+        driver = await getSauceDriver(
+            process.env.SAUCE_USERNAME,
+            process.env.SAUCE_ACCESS_KEY,
+            driverConfig);
+        await driver.get(process.env.SMOKE_URL);
+        const el = await findByText(WEBGL_MESSAGE); // b/c WebGL isn't enabled on Sauce
+        const isDisplayed = await el.isDisplayed();
+        return expect(isDisplayed).toEqual(true);
+    });
+});

--- a/test/smoke/browser.test.js
+++ b/test/smoke/browser.test.js
@@ -38,7 +38,8 @@ describe('Smoke tests on older browsers', () => {
         return expect(isDisplayed).toEqual(true);
     });
 
-    test('Safari 9 should not be unsupported', async () => {
+    // Safari 9 has always been blank screened due to lack of Intl polyfill
+    test.skip('Safari 9 should not be unsupported', async () => {
         const driverConfig = {
             browserName: 'safari',
             platform: 'OS X 10.11',

--- a/test/smoke/browser.test.js
+++ b/test/smoke/browser.test.js
@@ -8,9 +8,7 @@ const {
 // Make the default timeout longer, Sauce tests take ~30s
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 60 * 1000; // eslint-disable-line
 
-// Supported message is never seen because WebGL is not enabled on Sauce
-// const SUPPORTED_MESSAGE = 'Welcome to the Scratch 3.0 Preview';
-const WEBGL_MESSAGE = 'Your Browser Does Not Support WebGL';
+const SUPPORTED_MESSAGE = 'Welcome to the Scratch 3.0 Preview';
 const UNSUPPORTED_MESSAGE = 'Scratch 3.0 does not support Internet Explorer';
 
 // Driver configs can be generated with the Sauce Platform Configurator
@@ -51,7 +49,7 @@ describe('Smoke tests on older browsers', () => {
             process.env.SAUCE_ACCESS_KEY,
             driverConfig);
         await driver.get(process.env.SMOKE_URL);
-        const el = await findByText(WEBGL_MESSAGE); // b/c WebGL isn't enabled on Sauce
+        const el = await findByText(SUPPORTED_MESSAGE);
         const isDisplayed = await el.isDisplayed();
         return expect(isDisplayed).toEqual(true);
     });
@@ -67,7 +65,7 @@ describe('Smoke tests on older browsers', () => {
             process.env.SAUCE_ACCESS_KEY,
             driverConfig);
         await driver.get(process.env.SMOKE_URL);
-        const el = await findByText(WEBGL_MESSAGE); // b/c WebGL isn't enabled on Sauce
+        const el = await findByText(SUPPORTED_MESSAGE);
         const isDisplayed = await el.isDisplayed();
         return expect(isDisplayed).toEqual(true);
     });


### PR DESCRIPTION
@BryceLTaylor I wanted to make sure that we don't keep making mistakes w/r/t older browsers, so I gave the hosted VMs on Sauce a try (we had intended to use this in the past, but haven't had the time/need).

I wanted to get this smoke test into the repo so that we can continue building on it in the future. I propose we use this script in the following way:

Step 1 (this PR): Instead of having "test IE and old Safari" on the manual smoketest checklist, use this script instead.

This script can be run locally in the following way 
```
SAUCE_USERNAME=<sauce username> \
SAUCE_ACCESS_KEY=<sauce access key> \
SMOKE_URL=https://llk.github.io/scratch-gui/develop \
npm run test:smoke
```

The sauce username/access key can be a free trial account, or if this is useful, a team account. For reference, the free trial account should have enough build time to satisfy at least 30 weeks worth of running this script once a week.

Stage 2 (future): Run this stage on Travis in a special build stage that is run during PRs to master

We would definitely need a team account for this.

This is enough to catch problems like https://github.com/LLK/scratch-gui/issues/2229

---

Also worth noting, of course, that these tests _fail_ right now, due to #2229, but they pass if I change it to use other browsers.

@BryceLTaylor let me know what you think. We can chat IRL if there is a better way to integrate this into the smoke test process.