### PR TITLE
Update libraries

### DIFF
--- a/src/lib/libraries/backdrops.json
+++ b/src/lib/libraries/backdrops.json
@@ -15,6 +15,36 @@
         ]
     },
     {
+        "name": "Bedroom",
+        "md5": "e2f8b0dbd0a65d2ad8bfc21616662a6a.png",
+        "type": "backdrop",
+        "tags": [
+            "indoors",
+            "home",
+            "house"
+        ],
+        "info": [
+            960,
+            720,
+            2
+        ]
+    },
+    {
+        "name": "Bedroom 2",
+        "md5": "8cc0b88d53345b3e337e8f028a32a4e7.png",
+        "type": "backdrop",
+        "tags": [
+            "indoors",
+            "home",
+            "house"
+        ],
+        "info": [
+            960,
+            720,
+            2
+        ]
+    },
+    {
         "name": "Blue Sky",
         "md5": "e7c147730f19d284bcd7b3f00af19bb6.svg",
         "type": "backdrop",
@@ -55,6 +85,36 @@
         ]
     },
     {
+        "name": "Brick Wall",
+        "md5": "7e5327c68ff6ddabc48dbfe4717a04fe.png",
+        "type": "backdrop",
+        "tags": [
+            "outdoors",
+            "music",
+            "dance"
+        ],
+        "info": [
+            960,
+            720,
+            2
+        ]
+    },
+    {
+        "name": "Brick Wall 2",
+        "md5": "82d867fcd9f1b5f49e29c2f853d55665.png",
+        "type": "backdrop",
+        "tags": [
+            "outdoors",
+            "music",
+            "dance"
+        ],
+        "info": [
+            960,
+            720,
+            2
+        ]
+    },
+    {
         "name": "Circles",
         "md5": "4e29033ec2b891a8f1ca21242811d403.svg",
         "type": "backdrop",
@@ -65,6 +125,51 @@
             480,
             360,
             1
+        ]
+    },
+    {
+        "name": "Concert",
+        "md5": "c8d90320d2966c08af8cdd1c6a7a93b5.png",
+        "type": "backdrop",
+        "tags": [
+            "indoors",
+            "music",
+            "andrew rae"
+        ],
+        "info": [
+            960,
+            720,
+            2
+        ]
+    },
+    {
+        "name": "Galaxy",
+        "md5": "5fab1922f254ae9fd150162c3e392bef.png",
+        "type": "backdrop",
+        "tags": [
+            "space",
+            "stars",
+            "nasa"
+        ],
+        "info": [
+            960,
+            720,
+            2
+        ]
+    },
+    {
+        "name": "Graffiti",
+        "md5": "4a876066505dc5ea3b72b390ca266769.png",
+        "type": "backdrop",
+        "tags": [
+            "outdoors",
+            "music",
+            "dance"
+        ],
+        "info": [
+            960,
+            720,
+            2
         ]
     },
     {
@@ -91,6 +196,21 @@
             480,
             360,
             1
+        ]
+    },
+    {
+        "name": "Jungle",
+        "md5": "f4f908da19e2753f3ed679d7b37650ca.png",
+        "type": "backdrop",
+        "tags": [
+            "outdoors",
+            "forest",
+            "robert hunter"
+        ],
+        "info": [
+            960,
+            720,
+            2
         ]
     },
     {
@@ -122,6 +242,53 @@
         ]
     },
     {
+        "name": "Moon",
+        "md5": "0b1d2eaf22d62ef88de80ccde5578fba.png",
+        "type": "backdrop",
+        "tags": [
+            "space",
+            "nasa",
+            "apollo"
+        ],
+        "info": [
+            960,
+            720,
+            2
+        ]
+    },
+    {
+        "name": "Mountain",
+        "md5": "f84989feee2cf462a1c597169777ee3c.png",
+        "type": "backdrop",
+        "tags": [
+            "outdoors",
+            "snow",
+            "cave",
+            "robert hunter"
+        ],
+        "info": [
+            960,
+            720,
+            2
+        ]
+    },
+    {
+        "name": "Nebula",
+        "md5": "9b5cdbd596da1b6149f56b794b6394f4.png",
+        "type": "backdrop",
+        "tags": [
+            "space",
+            "nasa",
+            "bubble",
+            "hubble"
+        ],
+        "info": [
+            960,
+            720,
+            2
+        ]
+    },
+    {
         "name": "Ocean",
         "md5": "fb907f72b310acc8b95cbf2d2cccabc9.svg",
         "type": "backdrop",
@@ -136,6 +303,20 @@
         ]
     },
     {
+        "name": "Ocean 2",
+        "md5": "1517c21786d2d0edc2f3037408d850bd.png",
+        "type": "backdrop",
+        "tags": [
+            "water",
+            "underwater"
+        ],
+        "info": [
+            960,
+            720,
+            2
+        ]
+    },
+    {
         "name": "Party",
         "md5": "108160d0e44d1c340182e31c9dc0758a.svg",
         "type": "backdrop",
@@ -147,6 +328,22 @@
             480,
             360,
             1
+        ]
+    },
+    {
+        "name": "Party Room",
+        "md5": "9aeff3d99d0a1845ad46955c8820cb5e.png",
+        "type": "backdrop",
+        "tags": [
+            "music",
+            "indoors",
+            "disco",
+            "dance"
+        ],
+        "info": [
+            960,
+            720,
+            2
         ]
     },
     {
@@ -195,32 +392,117 @@
         ]
     },
     {
+        "name": "Soccer",
+        "md5": "04a63154f04b09494354090f7cc2f1b9.png",
+        "type": "backdrop",
+        "tags": [
+            "soccer",
+            "football",
+            "sports",
+            "alex eben meyer"
+        ],
+        "info": [
+            960,
+            720,
+            2
+        ]
+    },
+    {
+        "name": "Soccer 2",
+        "md5": "b0dc1268cb595aaeef405bce40d1639c.png",
+        "type": "backdrop",
+        "tags": [
+            "soccer",
+            "football",
+            "sports",
+            "alex eben meyer"
+        ],
+        "info": [
+            960,
+            720,
+            2
+        ]
+    },
+    {
         "name": "Space",
-        "md5": "b579aeeb143e79c47e2e65cbd3c0fe36.svg",
+        "md5": "84208d9a3718ec3c9fc5a32a792fa1d0.png",
         "type": "backdrop",
         "tags": [
             "space",
             "moon",
-            "saturn",
-            "stars"
+            "science fiction",
+            "planet",
+            "wren mcdonald"
         ],
         "info": [
-            480,
-            360,
-            1
+            960,
+            720,
+            2
         ]
     },
     {
-        "name": "Spotlight-stage2",
-        "md5": "12288218b23a264c84bd3c22bd03e90a.svg",
+        "name": "Space 2",
+        "md5": "32b2316fd375faa18088f6c57ebb1c8d.png",
         "type": "backdrop",
         "tags": [
-            "music"
+            "space",
+            "moon",
+            "science fiction",
+            "planet",
+            "wren mcdonald"
         ],
         "info": [
-            480,
-            360,
-            1
+            960,
+            720,
+            2
+        ]
+    },
+    {
+        "name": "Space 3",
+        "md5": "20344b0edcc498281e4cb80242a72667.png",
+        "type": "backdrop",
+        "tags": [
+            "space",
+            "moon",
+            "science fiction",
+            "planet",
+            "wren mcdonald"
+        ],
+        "info": [
+            960,
+            720,
+            2
+        ]
+    },
+    {
+        "name": "Space 4",
+        "md5": "0c450891306fa63ef02aa0fda7fd0ef9.png",
+        "type": "backdrop",
+        "tags": [
+            "space",
+            "moon",
+            "science fiction",
+            "planet",
+            "wren mcdonald"
+        ],
+        "info": [
+            960,
+            720,
+            2
+        ]
+    },
+    {
+        "name": "Stars",
+        "md5": "47282ff0f7047c6fab9c94b531abf721.png",
+        "type": "backdrop",
+        "tags": [
+            "space",
+            "nasa"
+        ],
+        "info": [
+            960,
+            720,
+            2
         ]
     },
     {
@@ -234,6 +516,21 @@
             480,
             360,
             1
+        ]
+    },
+    {
+        "name": "Theatre",
+        "md5": "c2b097bc5cdb6a14ef5485202bc5ee76.png",
+        "type": "backdrop",
+        "tags": [
+            "indoors",
+            "music",
+            "andrew rae"
+        ],
+        "info": [
+            960,
+            720,
+            2
         ]
     },
     {

--- a/src/lib/libraries/costumes.json
+++ b/src/lib/libraries/costumes.json
@@ -3,7 +3,11 @@
         "name": "Abby-a",
         "md5": "afab2d2141e9811bd89e385e9628cb5f.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "people",
+            "person",
+            "drawing"
+        ],
         "info": [
             31,
             100,
@@ -14,7 +18,11 @@
         "name": "Abby-b",
         "md5": "1e0116c7c2e5e80c679d0b33f1f5cfb7.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "people",
+            "person",
+            "drawing"
+        ],
         "info": [
             31,
             100,
@@ -25,7 +33,11 @@
         "name": "Abby-c",
         "md5": "b6e23922f23b49ddc6f62f675e77417c.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "people",
+            "person",
+            "drawing"
+        ],
         "info": [
             32,
             100,
@@ -36,7 +48,11 @@
         "name": "Abby-d",
         "md5": "2193cf08f74b8354f7c4fac37a06ea24.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "people",
+            "person",
+            "drawing"
+        ],
         "info": [
             31,
             100,
@@ -47,7 +63,12 @@
         "name": "Apple",
         "md5": "831ccd4741a7a56d85f6698a21f4ca69.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "food",
+            "red",
+            "crunchy",
+            "fruit"
+        ],
         "info": [
             31,
             31,
@@ -58,7 +79,11 @@
         "name": "Arrow1-a",
         "md5": "62f8794dd120e9b4ead4d098d50fc64b.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "icons",
+            "symbols",
+            "right"
+        ],
         "info": [
             28,
             23,
@@ -69,7 +94,11 @@
         "name": "Arrow1-b",
         "md5": "a157dc7e33d7c7a048af933de999e397.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "icons",
+            "symbols",
+            "left"
+        ],
         "info": [
             28,
             23,
@@ -80,7 +109,11 @@
         "name": "Arrow1-c",
         "md5": "d3b389e91f7beb22b2b1a80af09990ee.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "icons",
+            "symbols",
+            "down"
+        ],
         "info": [
             23,
             28,
@@ -91,7 +124,11 @@
         "name": "Arrow1-d",
         "md5": "412717ff731e9f19003a5840054057eb.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "icons",
+            "symbols",
+            "up"
+        ],
         "info": [
             23,
             28,
@@ -102,7 +139,10 @@
         "name": "Avery Walking-a",
         "md5": "ed334e546806dfbf26d2591d7ddb12d0.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "people",
+            "walking"
+        ],
         "info": [
             50,
             95,
@@ -113,7 +153,10 @@
         "name": "Avery Walking-b",
         "md5": "c295731e8666ad2e1575fb4b4f82988d.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "people",
+            "walking"
+        ],
         "info": [
             50,
             102,
@@ -124,7 +167,10 @@
         "name": "Avery Walking-c",
         "md5": "597a834225c9949e419dff7db1bc2453.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "people",
+            "walking"
+        ],
         "info": [
             48,
             95,
@@ -135,7 +181,10 @@
         "name": "Avery Walking-d",
         "md5": "ce9622d11d24607eec7988196b38c3c6.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "people",
+            "walking"
+        ],
         "info": [
             50,
             101,
@@ -146,7 +195,9 @@
         "name": "Avery-a",
         "md5": "21393c9114c7d34b1df7ccd12c793672.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "people"
+        ],
         "info": [
             39,
             94,
@@ -157,7 +208,9 @@
         "name": "Avery-b",
         "md5": "cc55f2f09599edc4ae0876e8b3d187d0.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "people"
+        ],
         "info": [
             39,
             94,
@@ -168,7 +221,14 @@
         "name": "Ball-a",
         "md5": "10117ddaefa98d819f2b1df93805622f.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "round",
+            "game",
+            "bounce",
+            "circle",
+            "yellow",
+            "things"
+        ],
         "info": [
             22,
             22,
@@ -179,7 +239,14 @@
         "name": "Ball-b",
         "md5": "6e6330cad7750ea7e9dc88402661deb8.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "round",
+            "game",
+            "bounce",
+            "circle",
+            "blue",
+            "things"
+        ],
         "info": [
             22,
             22,
@@ -190,7 +257,14 @@
         "name": "Ball-c",
         "md5": "bb45ed5db278f15c17c012c34a6b160f.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "round",
+            "game",
+            "bounce",
+            "circle",
+            "pink",
+            "things"
+        ],
         "info": [
             22,
             22,
@@ -201,7 +275,14 @@
         "name": "Ball-d",
         "md5": "5d494659deae5c0de06b5885f5524276.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "round",
+            "game",
+            "bounce",
+            "circle",
+            "green",
+            "things"
+        ],
         "info": [
             22,
             22,
@@ -212,7 +293,14 @@
         "name": "Ball-e",
         "md5": "e80c98bc62fd32e8df81642af11ffb1a.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "round",
+            "game",
+            "bounce",
+            "circle",
+            "purple",
+            "things"
+        ],
         "info": [
             22,
             22,
@@ -223,7 +311,9 @@
         "name": "Ballerina-a",
         "md5": "6051bb7008cf17c8853a6f81f04c8a0f.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "dance"
+        ],
         "info": [
             75,
             75,
@@ -234,7 +324,9 @@
         "name": "Ballerina-b",
         "md5": "8bc5e47fb1439e29e11e9e3f2e20c6de.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "dance"
+        ],
         "info": [
             75,
             75,
@@ -245,7 +337,9 @@
         "name": "Ballerina-c",
         "md5": "6d3a07761b294f705987b0af58f8e335.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "dance"
+        ],
         "info": [
             75,
             75,
@@ -256,7 +350,9 @@
         "name": "Ballerina-d",
         "md5": "c3164795edf39e436272f425b4f5e487.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "dance"
+        ],
         "info": [
             75,
             75,
@@ -267,7 +363,14 @@
         "name": "Balloon1-a",
         "md5": "bc96a1fb5fe794377acd44807e421ce2.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "party",
+            "pop",
+            "flying",
+            "helium",
+            "blue",
+            "things"
+        ],
         "info": [
             32,
             94,
@@ -278,7 +381,14 @@
         "name": "Balloon1-b",
         "md5": "d7bb51d9c38af6314bd2b4058d2a592d.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "party",
+            "pop",
+            "flying",
+            "helium",
+            "yellow",
+            "things"
+        ],
         "info": [
             31,
             94,
@@ -289,7 +399,14 @@
         "name": "Balloon1-c",
         "md5": "247cef27b665d77d9efaca69327cae77.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "party",
+            "pop",
+            "flying",
+            "helium",
+            "purple",
+            "things"
+        ],
         "info": [
             31,
             94,
@@ -317,7 +434,12 @@
         "name": "Baseball",
         "md5": "6e13ef53885d2cfca9a54cc5c3f6c20f.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "sports",
+            "round",
+            "summer",
+            "things"
+        ],
         "info": [
             34,
             31,
@@ -328,7 +450,11 @@
         "name": "Basketball",
         "md5": "b15c425f3eef68e7d095ee91321cb52a.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "sports",
+            "basketball",
+            "alex eben meyer"
+        ],
         "info": [
             26,
             26,
@@ -339,7 +465,13 @@
         "name": "Bat1-a",
         "md5": "7ad915f8e0884f497a24d5bb61ea8a4a.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "flying",
+            "holiday",
+            "nature",
+            "castle"
+        ],
         "info": [
             75,
             75,
@@ -350,7 +482,13 @@
         "name": "Bat1-b",
         "md5": "f127434672b872a902346ef3c1af45f2.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "flying",
+            "holiday",
+            "nature",
+            "castle"
+        ],
         "info": [
             75,
             75,
@@ -361,7 +499,13 @@
         "name": "Bat2-a",
         "md5": "647d4bd53163f94a7dabf623ccab7fd3.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "flying",
+            "holiday",
+            "nature",
+            "castle"
+        ],
         "info": [
             75,
             75,
@@ -372,7 +516,13 @@
         "name": "Bat2-b",
         "md5": "8aa1d20e4f7761becbe9bafa75290465.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "flying",
+            "holiday",
+            "nature",
+            "castle"
+        ],
         "info": [
             75,
             75,
@@ -383,7 +533,12 @@
         "name": "Beachball",
         "md5": "87d64cab74c64b31498cc85f07510ee4.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "round",
+            "sports",
+            "bounce",
+            "inflatable"
+        ],
         "info": [
             34,
             33,
@@ -394,7 +549,11 @@
         "name": "Bear-a",
         "md5": "5a4148d7684fc95f38c58a1672062c9e.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "ipzy",
+            "walking"
+        ],
         "info": [
             100,
             90,
@@ -405,7 +564,11 @@
         "name": "Bear-b",
         "md5": "d6517131718621a7aae8fc4f27de1ded.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "ipzy",
+            "walking"
+        ],
         "info": [
             80,
             140,
@@ -416,7 +579,11 @@
         "name": "Bear-walk-a",
         "md5": "d15eddb1a0f0ff0fa867bc006b46685d.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "ipzy",
+            "walking"
+        ],
         "info": [
             130,
             94,
@@ -427,7 +594,11 @@
         "name": "Bear-walk-b",
         "md5": "06e3f1bcf4f46b83df3820d92430f202.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "ipzy",
+            "walking"
+        ],
         "info": [
             130,
             94,
@@ -438,7 +609,11 @@
         "name": "Bear-walk-c",
         "md5": "13a3584040c9903b1824bb249d7f8a0e.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "ipzy",
+            "walking"
+        ],
         "info": [
             130,
             94,
@@ -449,7 +624,11 @@
         "name": "Bear-walk-d",
         "md5": "c5d49a105619c497be45a5d2c43a740a.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "ipzy",
+            "walking"
+        ],
         "info": [
             130,
             94,
@@ -460,7 +639,11 @@
         "name": "Bear-walk-e",
         "md5": "ece252d79c2d30c647c43c58986d9671.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "ipzy",
+            "walking"
+        ],
         "info": [
             130,
             94,
@@ -471,7 +654,11 @@
         "name": "Bear-walk-f",
         "md5": "ff66b87efec0e647dc30ec58df168ec4.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "ipzy",
+            "walking"
+        ],
         "info": [
             130,
             94,
@@ -482,7 +669,11 @@
         "name": "Bear-walk-g",
         "md5": "d1404b12adf0d6b1b881f0dca47ce21a.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "ipzy",
+            "walking"
+        ],
         "info": [
             130,
             94,
@@ -493,7 +684,11 @@
         "name": "Bear-walk-h",
         "md5": "489055be58a7d9806e1d50455c88c399.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "ipzy",
+            "walking"
+        ],
         "info": [
             130,
             94,
@@ -504,7 +699,10 @@
         "name": "Bear1-a",
         "md5": "598722f70e86e6f9b23ef97680baaa9c.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "mammal"
+        ],
         "info": [
             56,
             93,
@@ -515,7 +713,10 @@
         "name": "Bear1-b",
         "md5": "76ceb0de4409f42713b50cbc1fb45af5.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "mammal"
+        ],
         "info": [
             56,
             93,
@@ -526,7 +727,10 @@
         "name": "Bear2-a",
         "md5": "3eb8e16a983ff23c418374389c81bd30.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "bear"
+        ],
         "info": [
             37,
             42,
@@ -537,7 +741,10 @@
         "name": "Bear2-b",
         "md5": "12bb6960ac01b65ae9b5e5e7f79700ac.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "bear"
+        ],
         "info": [
             51,
             42,
@@ -548,7 +755,12 @@
         "name": "Beetle",
         "md5": "e1ce8f153f011fdd52486c91c6ed594d.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "insect",
+            "bug",
+            "antennae"
+        ],
         "info": [
             43,
             38,
@@ -559,7 +771,12 @@
         "name": "Bell1",
         "md5": "f35056c772395455d703773657e1da6e.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "music",
+            "holiday",
+            "ring",
+            "things"
+        ],
         "info": [
             59,
             69,
@@ -567,32 +784,16 @@
         ]
     },
     {
-        "name": "Bells-a",
-        "md5": "1f151bee966df3f0c41138941713280e.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            53,
-            51,
-            1
-        ]
-    },
-    {
-        "name": "Bells-b",
-        "md5": "5b3879a162881aed93169bf0a6680f45.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            48,
-            31,
-            1
-        ]
-    },
-    {
         "name": "Ben-a",
         "md5": "7f32d8d78ad64f50c018b7b578de2e18.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "sports",
+            "soccer",
+            "football",
+            "people",
+            "alex eben meyer"
+        ],
         "info": [
             76,
             75,
@@ -603,7 +804,13 @@
         "name": "Ben-b",
         "md5": "fb012e5d1baf80d33ae95fba3511151a.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "sports",
+            "soccer",
+            "football",
+            "people",
+            "alex eben meyer"
+        ],
         "info": [
             76,
             75,
@@ -614,7 +821,13 @@
         "name": "Ben-c",
         "md5": "be0b1397965cf8ff2c4cecb84795138a.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "sports",
+            "soccer",
+            "football",
+            "people",
+            "alex eben meyer"
+        ],
         "info": [
             76,
             75,
@@ -625,7 +838,13 @@
         "name": "Ben-d",
         "md5": "e2aefdb538ebbb24e1ab1464f75ef134.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "sports",
+            "soccer",
+            "football",
+            "people",
+            "alex eben meyer"
+        ],
         "info": [
             76,
             75,
@@ -636,7 +855,10 @@
         "name": "Bowl-a",
         "md5": "86f616639846f06fef29931e6b9b59de.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "thing",
+            "food"
+        ],
         "info": [
             30,
             15,
@@ -647,7 +869,9 @@
         "name": "Bowtie-a",
         "md5": "534d9924d2f9bfe240f041e3ce55ccf5.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fashion"
+        ],
         "info": [
             11,
             4,
@@ -658,7 +882,9 @@
         "name": "Bowtie-b",
         "md5": "8be1e90e19cd1faced8a2e83c2b5c90d.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fashion"
+        ],
         "info": [
             11,
             4,
@@ -669,7 +895,10 @@
         "name": "Bread",
         "md5": "68366160ce0ac1221cdde4455eca9cba.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "food",
+            "ipzy"
+        ],
         "info": [
             37,
             12,
@@ -680,7 +909,12 @@
         "name": "Broom",
         "md5": "836197f784bc4c4decfb1a5a60ca6c56.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "ipzy",
+            "flying",
+            "things"
+        ],
         "info": [
             135,
             25,
@@ -691,7 +925,12 @@
         "name": "Building-a",
         "md5": "d713270e235851e5962becd73a951771.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "things",
+            "city",
+            "flying",
+            "architecture"
+        ],
         "info": [
             40,
             30,
@@ -702,7 +941,12 @@
         "name": "Building-b",
         "md5": "8c2d59c50a97d33b096f629258f02be6.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "things",
+            "city",
+            "flying",
+            "architecture"
+        ],
         "info": [
             46,
             -11,
@@ -713,7 +957,12 @@
         "name": "Building-c",
         "md5": "7f3f51f495c39809bed95991dfa1f80d.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "things",
+            "city",
+            "flying",
+            "architecture"
+        ],
         "info": [
             25,
             17,
@@ -724,7 +973,12 @@
         "name": "Building-d",
         "md5": "bbe68ab80b36e4c71f4e28414c7f781e.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "things",
+            "city",
+            "flying",
+            "architecture"
+        ],
         "info": [
             59,
             -10,
@@ -735,7 +989,12 @@
         "name": "Building-e",
         "md5": "1beeb8f034a1128c9a799297b0b7fc26.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "things",
+            "city",
+            "flying",
+            "architecture"
+        ],
         "info": [
             36,
             55,
@@ -746,7 +1005,12 @@
         "name": "Building-f",
         "md5": "451e0a565e95d945fe2addfe609ee9df.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "things",
+            "city",
+            "flying",
+            "architecture"
+        ],
         "info": [
             41,
             27,
@@ -757,7 +1021,12 @@
         "name": "Building-g",
         "md5": "58b3c9b7a41dde698fa2b427b502c1fa.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "things",
+            "city",
+            "flying",
+            "architecture"
+        ],
         "info": [
             64,
             -65,
@@ -768,7 +1037,12 @@
         "name": "Building-h",
         "md5": "e952c8b14eeac894302d07d37a45ed99.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "things",
+            "city",
+            "flying",
+            "architecture"
+        ],
         "info": [
             33,
             136,
@@ -779,7 +1053,12 @@
         "name": "Building-i",
         "md5": "b00b1123e3bfcb600242528d059ffcfb.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "things",
+            "city",
+            "flying",
+            "architecture"
+        ],
         "info": [
             31,
             -12,
@@ -790,7 +1069,12 @@
         "name": "Building-j",
         "md5": "e08fd1a7397efcfe0e3691f945693cb4.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "things",
+            "city",
+            "flying",
+            "architecture"
+        ],
         "info": [
             29,
             33,
@@ -801,7 +1085,14 @@
         "name": "Butterfly1-a",
         "md5": "836d4cc7889f4a1cbcb0303934f31f79.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "drawing",
+            "happy",
+            "bug",
+            "insect",
+            "antennae"
+        ],
         "info": [
             75,
             75,
@@ -812,7 +1103,14 @@
         "name": "Butterfly1-b",
         "md5": "55dd0671a359d7c35f7b78f4176660e8.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "drawing",
+            "happy",
+            "bug",
+            "insect",
+            "antennae"
+        ],
         "info": [
             75,
             75,
@@ -823,7 +1121,14 @@
         "name": "Butterfly2",
         "md5": "a0216895beade6afc6d42bd5bb43faea.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "drawing",
+            "happy",
+            "bug",
+            "insect",
+            "antennae"
+        ],
         "info": [
             75,
             75,
@@ -834,7 +1139,14 @@
         "name": "Butterfly3",
         "md5": "8907a43cf08b0a9134969023be2074c5.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "drawing",
+            "happy",
+            "bug",
+            "insect",
+            "antennae"
+        ],
         "info": [
             75,
             75,
@@ -845,7 +1157,12 @@
         "name": "Button1",
         "md5": "7ef67c5bc8cf7df64fdb3b1d6b250f71.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "icons",
+            "round",
+            "green",
+            "games"
+        ],
         "info": [
             72,
             72,
@@ -856,7 +1173,11 @@
         "name": "Button2-a",
         "md5": "c0051ff23e9aae78295964206793c1e3.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "icons",
+            "blue",
+            "games"
+        ],
         "info": [
             72,
             72,
@@ -867,7 +1188,11 @@
         "name": "Button2-b",
         "md5": "712a561dc0ad66e348b8247e566b50ef.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "icons",
+            "orange",
+            "games"
+        ],
         "info": [
             72,
             72,
@@ -878,7 +1203,11 @@
         "name": "Button3-a",
         "md5": "ffb2a9c21084c58fdb677c8d12a97519.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "icons",
+            "gray",
+            "games"
+        ],
         "info": [
             72,
             72,
@@ -889,7 +1218,11 @@
         "name": "Button3-b",
         "md5": "7a9ccb55e4da36f48811ab125d2492e0.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "icons",
+            "blue",
+            "games"
+        ],
         "info": [
             72,
             72,
@@ -900,7 +1233,10 @@
         "name": "Button4-a",
         "md5": "ecfe263bc256349777e571eaf39761d4.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "icons",
+            "checkmark"
+        ],
         "info": [
             35,
             34,
@@ -911,7 +1247,10 @@
         "name": "Button4-b",
         "md5": "9c49edde00b80cd22d636a0577a9b1c9.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "icons",
+            "checkmark"
+        ],
         "info": [
             35,
             34,
@@ -922,7 +1261,12 @@
         "name": "Button5-a",
         "md5": "71e97245b7be4fd6fe3ba8cdeecadaf1.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "icons",
+            "symbols",
+            "x",
+            "black"
+        ],
         "info": [
             72,
             72,
@@ -933,7 +1277,12 @@
         "name": "Button5-b",
         "md5": "54cd55512f7571060e6e64168e541222.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "icons",
+            "symbols",
+            "x",
+            "red"
+        ],
         "info": [
             72,
             72,
@@ -944,7 +1293,15 @@
         "name": "Cake-a",
         "md5": "97ab3596dc06510e963fa29795e663bf.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "food",
+            "bakery",
+            "baking",
+            "frosting",
+            "sprinkles",
+            "sprankles",
+            "dragable"
+        ],
         "info": [
             64,
             50,
@@ -955,7 +1312,16 @@
         "name": "Cake-b",
         "md5": "61d5481955a2f42cb843d09506f6744e.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "food",
+            "bakery",
+            "baking",
+            "frosting",
+            "sprinkles",
+            "sprankles",
+            "dragable",
+            "lie"
+        ],
         "info": [
             64,
             42,
@@ -966,7 +1332,12 @@
         "name": "Casey-a",
         "md5": "30a4dafa852311b2a07d72e1bb060326.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "sports",
+            "basketball",
+            "people",
+            "alex eben meyer"
+        ],
         "info": [
             82,
             72,
@@ -977,7 +1348,12 @@
         "name": "Casey-b",
         "md5": "c8c0a25bebac8b35b8eae7ddd716d061.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "sports",
+            "basketball",
+            "people",
+            "alex eben meyer"
+        ],
         "info": [
             82,
             72,
@@ -988,7 +1364,12 @@
         "name": "Casey-c",
         "md5": "104d363c48c373384c6c80abbbbb0ad6.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "sports",
+            "basketball",
+            "people",
+            "alex eben meyer"
+        ],
         "info": [
             61,
             61,
@@ -999,7 +1380,12 @@
         "name": "Casey-d",
         "md5": "3d4bddb908bf912b938c111bfa38c28a.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "sports",
+            "basketball",
+            "people",
+            "alex eben meyer"
+        ],
         "info": [
             82,
             72,
@@ -1010,7 +1396,15 @@
         "name": "Cat1",
         "md5": "09dc888b0b7df19f70d81588ae73420e.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "cat",
+            "kitten",
+            "kitty",
+            "mammal",
+            "orange",
+            "scratch cat"
+        ],
         "info": [
             47,
             55,
@@ -1021,7 +1415,12 @@
         "name": "Cat1 Flying-a",
         "md5": "1e81725d2d2c7de4a2dd4a145198a43c.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "cat",
+            "kitty",
+            "kitten"
+        ],
         "info": [
             67,
             48,
@@ -1032,7 +1431,13 @@
         "name": "Cat1 Flying-b",
         "md5": "0d192725870ef0eda50d91cab0e3c9c5.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "flying",
+            "cat",
+            "kitty",
+            "kitten"
+        ],
         "info": [
             42,
             44,
@@ -1043,7 +1448,15 @@
         "name": "Cat2",
         "md5": "3696356a03a8d938318876a593572843.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "cat",
+            "kitten",
+            "kitty",
+            "mammal",
+            "orange",
+            "scratch cat"
+        ],
         "info": [
             47,
             55,
@@ -1054,7 +1467,12 @@
         "name": "Centaur-a",
         "md5": "45c1890ae0ab41f24f67ea74bec006c9.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "people",
+            "ipzy",
+            "emotions"
+        ],
         "info": [
             110,
             140,
@@ -1065,7 +1483,12 @@
         "name": "Centaur-b",
         "md5": "783e8cd43e0c1feca25f639cb5cbc7da.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "people",
+            "ipzy",
+            "emotions"
+        ],
         "info": [
             110,
             140,
@@ -1076,7 +1499,12 @@
         "name": "Centaur-c",
         "md5": "d09f7160383c6399354c3d9960e852db.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "people",
+            "ipzy",
+            "emotions"
+        ],
         "info": [
             110,
             140,
@@ -1087,7 +1515,12 @@
         "name": "Centaur-d",
         "md5": "1ba8b4d384f995688c1b7048d1935697.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "people",
+            "ipzy",
+            "emotions"
+        ],
         "info": [
             110,
             140,
@@ -1098,7 +1531,11 @@
         "name": "Cloud",
         "md5": "47005a1f20309f577a03a67abbb6b94e.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "thing",
+            "weather",
+            "whether"
+        ],
         "info": [
             71,
             45,
@@ -1109,7 +1546,12 @@
         "name": "Cloud-a",
         "md5": "c7d7de8e29179407f03b054fa640f4d0.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "flying",
+            "weather",
+            "things",
+            "sky"
+        ],
         "info": [
             76,
             19,
@@ -1120,7 +1562,12 @@
         "name": "Cloud-b",
         "md5": "d8595350ebb460494c9189dabb968336.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "flying",
+            "weather",
+            "things",
+            "sky"
+        ],
         "info": [
             101,
             20,
@@ -1131,7 +1578,12 @@
         "name": "Cloud-c",
         "md5": "395fc991e64ac0a4aa46758ab4bc65cb.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "flying",
+            "weather",
+            "things",
+            "sky"
+        ],
         "info": [
             97,
             9,
@@ -1142,7 +1594,12 @@
         "name": "Cloud-d",
         "md5": "1767e704acb11ffa409f77cc79ba7e86.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "flying",
+            "weather",
+            "things",
+            "sky"
+        ],
         "info": [
             87,
             21,
@@ -1153,7 +1610,10 @@
         "name": "Convertible3",
         "md5": "b6ac3c9e1789cba2302d2ef82d62d019.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "transportation",
+            "things"
+        ],
         "info": [
             75,
             75,
@@ -1164,7 +1624,18 @@
         "name": "Crab-a",
         "md5": "114249a5660f7948663d95de575cfd8d.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "crustacean",
+            "antennae",
+            "baltimore",
+            "maryland",
+            "underwater",
+            "ocean",
+            "sea",
+            "summer",
+            "arthropod"
+        ],
         "info": [
             75,
             75,
@@ -1175,7 +1646,18 @@
         "name": "Crab-b",
         "md5": "9bf050664e68c10d2616e85f2873be09.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "crustacean",
+            "antennae",
+            "baltimore",
+            "maryland",
+            "underwater",
+            "ocean",
+            "sea",
+            "summer",
+            "arthropod"
+        ],
         "info": [
             75,
             75,
@@ -1186,7 +1668,13 @@
         "name": "Creature1-a",
         "md5": "a560c6eab2e1de2462bdaeb1d698736c.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "people",
+            "animals",
+            "fantasy",
+            "monsters",
+            "holiday"
+        ],
         "info": [
             54,
             80,
@@ -1197,7 +1685,13 @@
         "name": "Creature1-b",
         "md5": "8042b71fc2ae322151c0a3a163701333.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "people",
+            "animals",
+            "fantasy",
+            "monsters",
+            "holiday"
+        ],
         "info": [
             60,
             78,
@@ -1208,7 +1702,13 @@
         "name": "Creature1-c",
         "md5": "e12a83c8f1c0545b59fe8673e9fac79c.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "people",
+            "animals",
+            "fantasy",
+            "monsters",
+            "holiday"
+        ],
         "info": [
             63,
             164,
@@ -1219,7 +1719,11 @@
         "name": "Crystal-a",
         "md5": "8520264d48537bea17b7f6d18e9bb558.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "ipzy",
+            "things"
+        ],
         "info": [
             15,
             15,
@@ -1230,7 +1734,11 @@
         "name": "Crystal-b",
         "md5": "b62ce1dc2d34741bad036664a01912fb.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "ipzy",
+            "things"
+        ],
         "info": [
             12,
             24,
@@ -1241,7 +1749,10 @@
         "name": "Dani-a",
         "md5": "f3038fb0f4a00806b02081c6789dd8cf.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "people",
+            "fashion"
+        ],
         "info": [
             49,
             115,
@@ -1252,7 +1763,10 @@
         "name": "Dani-b",
         "md5": "e5c7dd4905a78e1d54087b7165dd1e8c.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "people",
+            "fashion"
+        ],
         "info": [
             82,
             115,
@@ -1263,7 +1777,10 @@
         "name": "Dani-c",
         "md5": "cbc5f9c67022af201d498bc9b35608b8.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "people",
+            "fashion"
+        ],
         "info": [
             49,
             113,
@@ -1274,7 +1791,9 @@
         "name": "Dee-a",
         "md5": "aa239b7ccdce6bddf06900c709525764.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "people"
+        ],
         "info": [
             52,
             99,
@@ -1285,7 +1804,9 @@
         "name": "Dee-b",
         "md5": "62b4ac1b735599e21af77c390b178095.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "people"
+        ],
         "info": [
             33,
             99,
@@ -1296,7 +1817,9 @@
         "name": "Dee-c",
         "md5": "6aa6196ce3245e93b8d1299f33adffcd.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "people"
+        ],
         "info": [
             36,
             102,
@@ -1307,7 +1830,9 @@
         "name": "Dee-d",
         "md5": "2159a6be8f7ff450d0b5e938ca34a3f4.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "people"
+        ],
         "info": [
             33,
             99,
@@ -1318,7 +1843,9 @@
         "name": "Dee-e",
         "md5": "e358d2a7e3a0a680928657161ce81a0a.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "people"
+        ],
         "info": [
             32,
             99,
@@ -1329,7 +1856,9 @@
         "name": "Devin-a",
         "md5": "b1897e56265470b55fa65fabe2423c55.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "people"
+        ],
         "info": [
             39,
             95,
@@ -1340,7 +1869,9 @@
         "name": "Devin-b",
         "md5": "873fbd641768c8f753a6568da97633e7.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "people"
+        ],
         "info": [
             40,
             96,
@@ -1351,7 +1882,9 @@
         "name": "Devin-c",
         "md5": "eac3c03d86cebb42c8f30e373cb7f623.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "people"
+        ],
         "info": [
             32,
             95,
@@ -1362,7 +1895,9 @@
         "name": "Devin-d",
         "md5": "fa6a75afb0e4b822b91d8bb20d40c68f.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "people"
+        ],
         "info": [
             41,
             95,
@@ -1373,7 +1908,12 @@
         "name": "Dinosaur1-a",
         "md5": "75d367961807fff8e81f556da81dec24.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "dinosaur",
+            "alex eben meyer",
+            "sauropod"
+        ],
         "info": [
             98,
             92,
@@ -1384,7 +1924,12 @@
         "name": "Dinosaur1-b",
         "md5": "ecdaee9c08ae68fd7a67f81302f00a97.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "dinosaur",
+            "alex eben meyer",
+            "sauropod"
+        ],
         "info": [
             98,
             47,
@@ -1395,7 +1940,12 @@
         "name": "Dinosaur1-c",
         "md5": "02078a81abd2e10cb62ebcc853a40c92.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "dinosaur",
+            "alex eben meyer",
+            "sauropod"
+        ],
         "info": [
             81,
             91,
@@ -1406,7 +1956,12 @@
         "name": "Dinosaur1-d",
         "md5": "c9ed031bc9bf11416142880f89436be9.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "dinosaur",
+            "alex eben meyer",
+            "sauropod"
+        ],
         "info": [
             98,
             91,
@@ -1417,7 +1972,12 @@
         "name": "Dinosaur2-a",
         "md5": "5493f5deffe7aed451cd8b255740de4a.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "dinosaur",
+            "triceratops",
+            "alex eben meyer"
+        ],
         "info": [
             115,
             72,
@@ -1428,7 +1988,12 @@
         "name": "Dinosaur2-b",
         "md5": "70bba739b7df0bd08abb31026d078ee7.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "dinosaur",
+            "triceratops",
+            "alex eben meyer"
+        ],
         "info": [
             74,
             67,
@@ -1439,7 +2004,12 @@
         "name": "Dinosaur2-c",
         "md5": "4a51679d86aafcc9cee1c010fc141288.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "dinosaur",
+            "triceratops",
+            "alex eben meyer"
+        ],
         "info": [
             62,
             67,
@@ -1450,7 +2020,12 @@
         "name": "Dinosaur2-d",
         "md5": "47053664449b24749aaf199925b19f8e.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "dinosaur",
+            "triceratops",
+            "alex eben meyer"
+        ],
         "info": [
             71,
             66,
@@ -1461,7 +2036,13 @@
         "name": "Dinosaur3-a",
         "md5": "17636db6f607c14a03a36e18abfea86a.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "dinosaur",
+            "pteranodon",
+            "flying",
+            "alex eben meyer"
+        ],
         "info": [
             115,
             72,
@@ -1472,7 +2053,13 @@
         "name": "Dinosaur3-b",
         "md5": "1b20afc713b04ca5d01b25d050aa35ac.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "dinosaur",
+            "pteranodon",
+            "flying",
+            "alex eben meyer"
+        ],
         "info": [
             115,
             72,
@@ -1483,7 +2070,13 @@
         "name": "Dinosaur3-c",
         "md5": "4700613077afa7c62659b3fd7d7c748e.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "dinosaur",
+            "pteranodon",
+            "flying",
+            "alex eben meyer"
+        ],
         "info": [
             115,
             72,
@@ -1494,7 +2087,13 @@
         "name": "Dinosaur3-d",
         "md5": "a03f110ed12b73acc9bd84037fd6ae96.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "dinosaur",
+            "pteranodon",
+            "flying",
+            "alex eben meyer"
+        ],
         "info": [
             115,
             72,
@@ -1505,7 +2104,12 @@
         "name": "Dinosaur3-e",
         "md5": "00e24e40535a1a621fee0f70895b2b61.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "dinosaur",
+            "pteranodon",
+            "alex eben meyer"
+        ],
         "info": [
             115,
             72,
@@ -1516,7 +2120,14 @@
         "name": "Dinosaur4-a",
         "md5": "9da591f8a6da251c800adb12a02c43cb.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "dinosaur",
+            "tyrannosaurus",
+            "t-rex",
+            "trex",
+            "alex eben meyer"
+        ],
         "info": [
             59,
             54,
@@ -1527,7 +2138,14 @@
         "name": "Dinosaur4-b",
         "md5": "a3028e87caeb8338f50b2c6dec9f23d2.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "dinosaur",
+            "tyrannosaurus",
+            "t-rex",
+            "trex",
+            "alex eben meyer"
+        ],
         "info": [
             86,
             54,
@@ -1538,7 +2156,14 @@
         "name": "Dinosaur4-c",
         "md5": "9a4bbc1b104c8112be82c252a6ecfd11.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "dinosaur",
+            "tyrannosaurus",
+            "t-rex",
+            "trex",
+            "alex eben meyer"
+        ],
         "info": [
             59,
             54,
@@ -1549,7 +2174,14 @@
         "name": "Dinosaur4-d",
         "md5": "45061ff84a25723625d04f0476687633.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "dinosaur",
+            "tyrannosaurus",
+            "t-rex",
+            "trex",
+            "alex eben meyer"
+        ],
         "info": [
             89,
             90,
@@ -1560,7 +2192,14 @@
         "name": "Diver1",
         "md5": "853803d5600b66538474909c5438c8ee.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "people",
+            "underwater",
+            "ocean",
+            "sea",
+            "summer",
+            "swimming"
+        ],
         "info": [
             75,
             75,
@@ -1571,7 +2210,14 @@
         "name": "Diver2",
         "md5": "248d3e69ada69a64b1077149ef6a931a.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "people",
+            "underwater",
+            "ocean",
+            "sea",
+            "summer",
+            "swimming"
+        ],
         "info": [
             75,
             75,
@@ -1582,7 +2228,12 @@
         "name": "Dog1-a",
         "md5": "39ddefa0cc58f3b1b06474d63d81ef56.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "puppy",
+            "puppies",
+            "mammals"
+        ],
         "info": [
             83,
             80,
@@ -1593,7 +2244,12 @@
         "name": "Dog1-b",
         "md5": "598f4aa3d8f671375d1d2b3acf753416.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "puppy",
+            "puppies",
+            "mammals"
+        ],
         "info": [
             83,
             80,
@@ -1604,7 +2260,12 @@
         "name": "Dog2-a",
         "md5": "e921f865b19b27cd99e16a341dbf09c2.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "puppy",
+            "puppies",
+            "mammals"
+        ],
         "info": [
             75,
             75,
@@ -1615,7 +2276,12 @@
         "name": "Dog2-b",
         "md5": "891f2fb7daf79ba8b224a9173eeb0a63.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "puppy",
+            "puppies",
+            "mammals"
+        ],
         "info": [
             75,
             75,
@@ -1626,7 +2292,12 @@
         "name": "Dog2-c",
         "md5": "cd236d5eef4431dea82983ac9eec406b.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "puppy",
+            "puppies",
+            "mammals"
+        ],
         "info": [
             75,
             75,
@@ -1637,7 +2308,16 @@
         "name": "Donut",
         "md5": "9e7b4d153421dae04a24571d7e079e85.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "food",
+            "sweets",
+            "bakery",
+            "baking",
+            "homer",
+            "frosting",
+            "sprinkles",
+            "sprankles"
+        ],
         "info": [
             73,
             15,
@@ -1648,7 +2328,12 @@
         "name": "Dorian-a",
         "md5": "b042b1a5fde03dd5abbc2f3f78d11a2c.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "sports",
+            "basketball",
+            "people",
+            "alex eben meyer"
+        ],
         "info": [
             82,
             72,
@@ -1659,7 +2344,12 @@
         "name": "Dorian-b",
         "md5": "d0b58b672606601ecfa3a406b537fa10.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "sports",
+            "basketball",
+            "people",
+            "alex eben meyer"
+        ],
         "info": [
             82,
             72,
@@ -1670,7 +2360,12 @@
         "name": "Dorian-c",
         "md5": "445e461c73a5920098764a4cbad5bfe0.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "sports",
+            "basketball",
+            "people",
+            "alex eben meyer"
+        ],
         "info": [
             82,
             72,
@@ -1681,7 +2376,12 @@
         "name": "Dorian-d",
         "md5": "ba93ede3bbf75c0f707b0fb982bc27e8.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "sports",
+            "basketball",
+            "people",
+            "alex eben meyer"
+        ],
         "info": [
             82,
             72,
@@ -1692,7 +2392,11 @@
         "name": "Dot-a",
         "md5": "47c975e37f9a89c01d0d4d6fd17ef847.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "space",
+            "dog",
+            "wren mcdonald"
+        ],
         "info": [
             52,
             69,
@@ -1703,7 +2407,11 @@
         "name": "Dot-b",
         "md5": "a9b7d5f7afa0c69c4044a3f541b9ab90.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "space",
+            "dog",
+            "wren mcdonald"
+        ],
         "info": [
             65,
             69,
@@ -1714,7 +2422,11 @@
         "name": "Dot-c",
         "md5": "5b7967159c9b83b0d0ed4f051ec2c9e9.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "space",
+            "dog",
+            "wren mcdonald"
+        ],
         "info": [
             49,
             70,
@@ -1725,7 +2437,11 @@
         "name": "Dot-d",
         "md5": "23ffa385654304e4cac454390dde3606.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "space",
+            "dog",
+            "wren mcdonald"
+        ],
         "info": [
             59,
             69,
@@ -1736,7 +2452,11 @@
         "name": "Dove-a",
         "md5": "6dde2b880ad6ddeaea2a53821befb86d.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "bird",
+            "flying"
+        ],
         "info": [
             86,
             59,
@@ -1747,7 +2467,11 @@
         "name": "Dove-b",
         "md5": "1c0bc118044d7f6033bc9cd1ef555590.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "bird",
+            "flying"
+        ],
         "info": [
             88,
             57,
@@ -1758,7 +2482,12 @@
         "name": "Dragon-a",
         "md5": "8aed65cee4cfe22b4f4b8e749092dbbb.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "animals",
+            "ipzy",
+            "flying"
+        ],
         "info": [
             210,
             150,
@@ -1769,7 +2498,12 @@
         "name": "Dragon-b",
         "md5": "c3360f16bb78b136d9911325da9fda49.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "animals",
+            "ipzy",
+            "flying"
+        ],
         "info": [
             210,
             150,
@@ -1780,7 +2514,12 @@
         "name": "Dragon-c",
         "md5": "e81af82ebde008c167ebc6874df3ecb4.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "animals",
+            "ipzy",
+            "flying"
+        ],
         "info": [
             210,
             150,
@@ -1823,7 +2562,10 @@
         "name": "Drum-a",
         "md5": "dd66742bc2a3cfe5a6f9f540afd2e15c.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "music",
+            "andrew rae"
+        ],
         "info": [
             43,
             60,
@@ -1834,7 +2576,10 @@
         "name": "Drum-b",
         "md5": "9c9d371da382c227e43f09b1a748c554.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "music",
+            "andrew rae"
+        ],
         "info": [
             43,
             60,
@@ -1845,7 +2590,10 @@
         "name": "Drum-cymbal-a",
         "md5": "d6d41862fda966df1455d2dbff5e1988.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "music",
+            "andrew rae"
+        ],
         "info": [
             30,
             74,
@@ -1856,7 +2604,10 @@
         "name": "Drum-cymbal-b",
         "md5": "e6b7d7d8874bc4b7be58afe927157554.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "music",
+            "andrew rae"
+        ],
         "info": [
             30,
             74,
@@ -1867,7 +2618,10 @@
         "name": "Drum-highhat-a",
         "md5": "81fb79151a63cb096258607451cc2cf5.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "music",
+            "andrew rae"
+        ],
         "info": [
             33,
             73,
@@ -1878,7 +2632,10 @@
         "name": "Drum-highhat-b",
         "md5": "e3c273e4ad1a24583064f9b61fcd753a.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "music",
+            "andrew rae"
+        ],
         "info": [
             33,
             73,
@@ -1889,7 +2646,10 @@
         "name": "Drum-kit",
         "md5": "131d040d86ecea62ccd175a8709c7866.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "music",
+            "andrew rae"
+        ],
         "info": [
             58,
             78,
@@ -1900,7 +2660,10 @@
         "name": "Drum-kit-b",
         "md5": "ff14be049146cf9ab142e0951cb9b735.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "music",
+            "andrew rae"
+        ],
         "info": [
             58,
             78,
@@ -1911,7 +2674,10 @@
         "name": "Drum-snare-a",
         "md5": "b0255be93e3c8be6ac687f4199a25c4b.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "music",
+            "andrew rae"
+        ],
         "info": [
             23,
             50,
@@ -1922,7 +2688,10 @@
         "name": "Drum-snare-b",
         "md5": "f6d2f2a6e1055dab6262336625ddf652.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "music",
+            "andrew rae"
+        ],
         "info": [
             36,
             66,
@@ -1933,7 +2702,13 @@
         "name": "Duck",
         "md5": "c3baf7eedfbdac8cd1e4f1f1f779dc0c.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "chrisg",
+            "quack",
+            "birds",
+            "birb"
+        ],
         "info": [
             61,
             59,
@@ -1944,7 +2719,9 @@
         "name": "Earth",
         "md5": "814197522984a302972998b1a7f92d91.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "space"
+        ],
         "info": [
             72,
             72,
@@ -1955,7 +2732,11 @@
         "name": "Egg-a",
         "md5": "bc723738dfe626c5c3bb90970d985961.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "food",
+            "breakfast",
+            "alex eben meyer"
+        ],
         "info": [
             68,
             54,
@@ -1966,7 +2747,11 @@
         "name": "Egg-b",
         "md5": "83016b7ff817f99be4a454600b4a78fc.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "food",
+            "breakfast",
+            "alex eben meyer"
+        ],
         "info": [
             68,
             54,
@@ -1977,7 +2762,11 @@
         "name": "Egg-c",
         "md5": "d9a44d151fbd909bdbbcf7877055af6d.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "food",
+            "breakfast",
+            "alex eben meyer"
+        ],
         "info": [
             68,
             54,
@@ -1988,7 +2777,11 @@
         "name": "Egg-d",
         "md5": "c91c7f72b8523b0910a84bce7d99c37b.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "food",
+            "breakfast",
+            "alex eben meyer"
+        ],
         "info": [
             68,
             54,
@@ -1999,7 +2792,11 @@
         "name": "Egg-e",
         "md5": "65c15516e62596e1f72e874359fc7254.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "food",
+            "breakfast",
+            "alex eben meyer"
+        ],
         "info": [
             68,
             54,
@@ -2010,7 +2807,11 @@
         "name": "Elephant-a",
         "md5": "b3515b3805938b0fae4e527aa0b4524e.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "mammals",
+            "pachydermata"
+        ],
         "info": [
             107,
             33,
@@ -2021,7 +2822,11 @@
         "name": "Elephant-b",
         "md5": "bce91fa266220d3679a4c19c4e38b1f7.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "mammals",
+            "pachydermata"
+        ],
         "info": [
             95,
             40,
@@ -2032,7 +2837,12 @@
         "name": "Elf-a",
         "md5": "00748a750dc4fd754ce4debb5e3595c0.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "people",
+            "ipzy",
+            "emotions"
+        ],
         "info": [
             50,
             140,
@@ -2043,7 +2853,12 @@
         "name": "Elf-b",
         "md5": "91815a19569ef9f0ef68bca56bb80446.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "people",
+            "ipzy",
+            "emotions"
+        ],
         "info": [
             50,
             140,
@@ -2054,7 +2869,12 @@
         "name": "Elf-c",
         "md5": "8153eaf84bc3db9a671cafd34506243b.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "people",
+            "ipzy",
+            "emotions"
+        ],
         "info": [
             50,
             140,
@@ -2065,7 +2885,12 @@
         "name": "Elf-d",
         "md5": "2432797fc69a62fc643505b0ba039169.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "people",
+            "ipzy",
+            "emotions"
+        ],
         "info": [
             50,
             140,
@@ -2076,7 +2901,12 @@
         "name": "Elf-e",
         "md5": "a06e6c93b143ae2a7b776bd1deee6b59.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "people",
+            "ipzy",
+            "emotions"
+        ],
         "info": [
             50,
             140,
@@ -2098,7 +2928,12 @@
         "name": "Fairy-a",
         "md5": "fe97687c7f1b747bb6f41c252cc5926a.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "people",
+            "ipzy",
+            "emotions"
+        ],
         "info": [
             85,
             140,
@@ -2109,7 +2944,12 @@
         "name": "Fairy-b",
         "md5": "c8e0d935b2e4372ecc813705a79be3eb.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "people",
+            "ipzy",
+            "emotions"
+        ],
         "info": [
             85,
             140,
@@ -2120,7 +2960,12 @@
         "name": "Fairy-c",
         "md5": "4d0740d1b5be93256ad235062daa876b.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "people",
+            "ipzy",
+            "emotions"
+        ],
         "info": [
             85,
             140,
@@ -2131,7 +2976,12 @@
         "name": "Fairy-d",
         "md5": "ca555dadd377431e38a3bc67ece4d36a.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "people",
+            "ipzy",
+            "emotions"
+        ],
         "info": [
             85,
             140,
@@ -2142,7 +2992,12 @@
         "name": "Fairy-e",
         "md5": "a681f6d6044abdebcdd6634ce85da484.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "people",
+            "ipzy",
+            "emotions"
+        ],
         "info": [
             85,
             140,
@@ -2153,7 +3008,13 @@
         "name": "Fish-a",
         "md5": "8598752b1b7b9892c23817c4ed848e7d.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "ocean",
+            "sea",
+            "underwater",
+            "daria skrybchencko"
+        ],
         "info": [
             63,
             45,
@@ -2164,7 +3025,13 @@
         "name": "Fish-b",
         "md5": "52032e4310f9855b89f873b528a5e928.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "ocean",
+            "sea",
+            "underwater",
+            "daria skrybchencko"
+        ],
         "info": [
             63,
             45,
@@ -2175,7 +3042,13 @@
         "name": "Fish-c",
         "md5": "06c139dcfe45bf31ef45e7030b77dc36.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "ocean",
+            "sea",
+            "underwater",
+            "daria skrybchencko"
+        ],
         "info": [
             63,
             45,
@@ -2186,7 +3059,13 @@
         "name": "Fish-d",
         "md5": "6a3a2c97374c157e0dbc0a03c2079284.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "ocean",
+            "sea",
+            "underwater",
+            "daria skrybchencko"
+        ],
         "info": [
             63,
             45,
@@ -2197,7 +3076,11 @@
         "name": "Fox-a",
         "md5": "fab5488e600e81565f0fc285fc7050f8.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "mammal",
+            "robert hunter"
+        ],
         "info": [
             94,
             54,
@@ -2208,7 +3091,11 @@
         "name": "Fox-b",
         "md5": "afb192ae250a74dfac18bfc52d1d6266.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "mammal",
+            "robert hunter"
+        ],
         "info": [
             94,
             54,
@@ -2219,7 +3106,11 @@
         "name": "Fox-c",
         "md5": "29f858d384db7998c0e5183f6a31a3b4.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "mammal",
+            "robert hunter"
+        ],
         "info": [
             94,
             54,
@@ -2230,7 +3121,14 @@
         "name": "Frog",
         "md5": "285483a688eed2ff8010c65112f99c41.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "amphibian",
+            "nature",
+            "hopping",
+            "green",
+            "wart"
+        ],
         "info": [
             48,
             30,
@@ -2241,7 +3139,10 @@
         "name": "Fruitsalad",
         "md5": "dbf8cc34f7ca18b4a008d2890dba56b7.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "food",
+            "fruit"
+        ],
         "info": [
             30,
             22,
@@ -2252,7 +3153,12 @@
         "name": "Ghost1 ",
         "md5": "c88579c578f2d171de78612f2ff9c9d9.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "castle",
+            "spirit",
+            "spooky"
+        ],
         "info": [
             60,
             63,
@@ -2263,7 +3169,12 @@
         "name": "Ghost2-a",
         "md5": "607be245da950af1a4e4d79acfda46e3.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "spooky",
+            "spirit",
+            "castle"
+        ],
         "info": [
             75,
             75,
@@ -2274,7 +3185,12 @@
         "name": "Ghost2-b",
         "md5": "b9e2ebbe17c617ac182abd8bc1627693.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "spooky",
+            "spirit",
+            "castle"
+        ],
         "info": [
             75,
             75,
@@ -2285,7 +3201,10 @@
         "name": "Gift-a",
         "md5": "abeae2217b3ce67b1ff761cd7a89274d.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "thing",
+            "holiday"
+        ],
         "info": [
             33,
             25,
@@ -2296,7 +3215,10 @@
         "name": "Gift-b",
         "md5": "5cae973c98f2d98b51e6c6b3c9602f8c.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "thing",
+            "holiday"
+        ],
         "info": [
             33,
             26,
@@ -2307,7 +3229,10 @@
         "name": "Giga Walk1",
         "md5": "f76bc420011db2cdb2de378c1536f6da.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "walking"
+        ],
         "info": [
             70,
             107,
@@ -2318,7 +3243,10 @@
         "name": "Giga Walk2",
         "md5": "43b5874e8a54f93bd02727f0abf6905b.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "walking"
+        ],
         "info": [
             71,
             107,
@@ -2329,7 +3257,10 @@
         "name": "Giga Walk3",
         "md5": "9aab3bbb375765391978be4f6d478ab3.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "walking"
+        ],
         "info": [
             71,
             107,
@@ -2340,7 +3271,10 @@
         "name": "Giga Walk4",
         "md5": "22e4ae40919cf0fe6b4d7649d14a6e71.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "walking"
+        ],
         "info": [
             73,
             110,
@@ -2351,7 +3285,11 @@
         "name": "Giga-a",
         "md5": "93cb048a1d199f92424b9c097fa5fa38.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "drawing",
+            "happy"
+        ],
         "info": [
             72,
             96,
@@ -2362,7 +3300,11 @@
         "name": "Giga-b",
         "md5": "528613711a7eae3a929025be04db081c.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "drawing",
+            "happy"
+        ],
         "info": [
             72,
             96,
@@ -2373,7 +3315,11 @@
         "name": "Giga-c",
         "md5": "ee4dd21d7ca6d1b889ee25d245cbcc66.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "drawing",
+            "happy"
+        ],
         "info": [
             73,
             96,
@@ -2384,7 +3330,11 @@
         "name": "Giga-d",
         "md5": "7708e2d9f83a01476ee6d17aa540ddf1.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "drawing",
+            "mad"
+        ],
         "info": [
             73,
             96,
@@ -2395,7 +3345,11 @@
         "name": "Glass Water-a",
         "md5": "c364b9e1f4bcdc61705032d89eaaa0a1.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "food",
+            "things",
+            "underwater"
+        ],
         "info": [
             39,
             48,
@@ -2406,7 +3360,12 @@
         "name": "Glass Water-b",
         "md5": "bc07ce6a2004ac91ce704531a1c526e5.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "food",
+            "things",
+            "eaten",
+            "empty"
+        ],
         "info": [
             39,
             48,
@@ -2417,7 +3376,10 @@
         "name": "Glasses",
         "md5": "5fcf716b53f223bc86b10ab0eca3e162.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "things",
+            "fashion"
+        ],
         "info": [
             16,
             9,
@@ -2428,7 +3390,12 @@
         "name": "Goalie-a",
         "md5": "86b0610ea21fdecb99795c5e6d52768c.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "sports",
+            "soccer",
+            "football",
+            "alex eben meyer"
+        ],
         "info": [
             76,
             68,
@@ -2439,7 +3406,12 @@
         "name": "Goalie-b",
         "md5": "af3ef5125d187772240a1120e7eb67ac.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "sports",
+            "soccer",
+            "football",
+            "alex eben meyer"
+        ],
         "info": [
             76,
             68,
@@ -2450,7 +3422,12 @@
         "name": "Goalie-c",
         "md5": "7c9377cedae11a094d2e77bed3edb884.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "sports",
+            "soccer",
+            "football",
+            "alex eben meyer"
+        ],
         "info": [
             76,
             68,
@@ -2461,7 +3438,12 @@
         "name": "Goalie-d",
         "md5": "bd628034d356d30b0e9b563447471290.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "sports",
+            "soccer",
+            "football",
+            "alex eben meyer"
+        ],
         "info": [
             76,
             68,
@@ -2472,7 +3454,12 @@
         "name": "Goalie-e",
         "md5": "b3f6c4c0be9a0f71e9486dea51e513c3.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "sports",
+            "soccer",
+            "football",
+            "alex eben meyer"
+        ],
         "info": [
             76,
             68,
@@ -2483,7 +3470,11 @@
         "name": "Goblin-a",
         "md5": "f10eaedff51f50f0809a7b4b310337fa.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "ipzy",
+            "emotions"
+        ],
         "info": [
             40,
             80,
@@ -2494,7 +3485,11 @@
         "name": "Goblin-b",
         "md5": "71e7c77d89299cd99739b1216fc03a85.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "ipzy",
+            "emotions"
+        ],
         "info": [
             40,
             80,
@@ -2505,7 +3500,11 @@
         "name": "Goblin-c",
         "md5": "ab0611427d6f9b54d83672cf9e554876.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "ipzy",
+            "emotions"
+        ],
         "info": [
             40,
             80,
@@ -2516,7 +3515,11 @@
         "name": "Goblin-d",
         "md5": "87dd413e7a8545bea9b3da208a5d5735.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "ipzy",
+            "emotions"
+        ],
         "info": [
             40,
             80,
@@ -2527,7 +3530,12 @@
         "name": "Gobo-a",
         "md5": "1f5ea0d12f85aed2e471cdd21b0bd6d7.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "drawing",
+            "jenkins",
+            "ganglia"
+        ],
         "info": [
             47,
             55,
@@ -2538,7 +3546,12 @@
         "name": "Gobo-b",
         "md5": "73e493e4abd5d0954b677b97abcb7116.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "drawing",
+            "jenkins",
+            "ganglia"
+        ],
         "info": [
             47,
             55,
@@ -2549,7 +3562,12 @@
         "name": "Gobo-c",
         "md5": "bc68a6bdf300df7b53d73b38f74c844e.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "drawing",
+            "jenkins",
+            "ganglia"
+        ],
         "info": [
             47,
             55,
@@ -2560,7 +3578,9 @@
         "name": "Green Flag",
         "md5": "173e20ac537d2c278ed621be3db3fc87.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "thing"
+        ],
         "info": [
             70,
             30,
@@ -2571,7 +3591,12 @@
         "name": "Griffin-a",
         "md5": "d2ddc25b224ad72240f92e632afc7c69.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "animals",
+            "ipzy",
+            "flying"
+        ],
         "info": [
             150,
             110,
@@ -2582,7 +3607,12 @@
         "name": "Griffin-fly-a",
         "md5": "03d75e0c7c34e8618545a5f4913db4ea.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "animals",
+            "ipzy",
+            "flying"
+        ],
         "info": [
             150,
             110,
@@ -2593,7 +3623,12 @@
         "name": "Griffin-fly-b",
         "md5": "ff0795d15b6f3990345f72bc483a3353.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "animals",
+            "ipzy",
+            "flying"
+        ],
         "info": [
             150,
             110,
@@ -2604,7 +3639,10 @@
         "name": "Guitar-a",
         "md5": "cb8c2a5e69da7538e1dd73cb7ff4a666.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "music",
+            "andrew rae"
+        ],
         "info": [
             47,
             83,
@@ -2615,7 +3653,10 @@
         "name": "Guitar-b",
         "md5": "fed44bd1091628c060f45060a84f2885.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "music",
+            "andrew rae"
+        ],
         "info": [
             47,
             83,
@@ -2626,7 +3667,10 @@
         "name": "Guitar-electric1-a",
         "md5": "b2b469b9d11fd23bdd671eab94dc58ff.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "music",
+            "andrew rae"
+        ],
         "info": [
             42,
             85,
@@ -2637,7 +3681,10 @@
         "name": "Guitar-electric1-b",
         "md5": "3632184c19c66a088a99568570d61b13.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "music",
+            "andrew rae"
+        ],
         "info": [
             42,
             85,
@@ -2648,7 +3695,10 @@
         "name": "Guitar-electric2-a",
         "md5": "1fc433b89038f9e16092c9f4d7514cca.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "music",
+            "andrew rae"
+        ],
         "info": [
             38,
             94,
@@ -2659,7 +3709,10 @@
         "name": "Guitar-electric2-b",
         "md5": "7b843dbc93d4b2ea31fa67cca3d5077c.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "music",
+            "andrew rae"
+        ],
         "info": [
             38,
             94,
@@ -2670,7 +3723,9 @@
         "name": "Hat",
         "md5": "b3beb1f52d371428d70b65a0c4c5c001.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "Fashion"
+        ],
         "info": [
             52,
             60,
@@ -2681,7 +3736,9 @@
         "name": "Hat Beanie",
         "md5": "3271da33e4108ed08a303c2244739fbf.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fashion"
+        ],
         "info": [
             28,
             19,
@@ -2703,7 +3760,10 @@
         "name": "Hat Winter",
         "md5": "6c2ee1b97f6ec2b3457a25a3975a2009.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fashion",
+            "winter"
+        ],
         "info": [
             26,
             101,
@@ -2714,7 +3774,10 @@
         "name": "Hat Wizard",
         "md5": "581571e8c8f5adeb01565e12b1b77b58.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fashion",
+            "fantasy"
+        ],
         "info": [
             76,
             69,
@@ -2725,7 +3788,10 @@
         "name": "Headband",
         "md5": "961148d1605a1bd8ce80ed8d39e831c2.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fashion",
+            "antennae"
+        ],
         "info": [
             53,
             43,
@@ -2736,7 +3802,10 @@
         "name": "Heart Code",
         "md5": "497c5df9e02467202ff93096dccaf91f.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "food",
+            "sweethearts"
+        ],
         "info": [
             58,
             61,
@@ -2747,7 +3816,9 @@
         "name": "Heart Face",
         "md5": "4ab84263da32069cf97cc0fa52729a0d.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "emotions"
+        ],
         "info": [
             59,
             52,
@@ -2758,7 +3829,10 @@
         "name": "Heart Love It",
         "md5": "d448acd247f10f32bef7823cd433f928.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "food",
+            "sweethearts"
+        ],
         "info": [
             58,
             61,
@@ -2769,7 +3843,13 @@
         "name": "Heart Purple",
         "md5": "b15362bb6b02a59e364db9081ccf19aa.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "holiday",
+            "purple",
+            "shape",
+            "love",
+            "emotions"
+        ],
         "info": [
             66,
             62,
@@ -2780,7 +3860,13 @@
         "name": "Heart Red",
         "md5": "6e79e087c866a016f99ee482e1aeba47.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "holiday",
+            "red",
+            "shape",
+            "love",
+            "emotions"
+        ],
         "info": [
             65,
             56,
@@ -2791,7 +3877,10 @@
         "name": "Heart Smile",
         "md5": "74a8f75d139d330b715787edbbacd83d.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "food",
+            "sweethearts"
+        ],
         "info": [
             58,
             61,
@@ -2802,7 +3891,10 @@
         "name": "Heart Sweet",
         "md5": "a39d78d33b051e8b12a4b2a10d77b249.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "food",
+            "sweethearts"
+        ],
         "info": [
             58,
             61,
@@ -2813,7 +3905,12 @@
         "name": "Hedgehog-a",
         "md5": "32416e6b2ef8e45fb5fd10778c1b9a9f.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "daria skrybchencko",
+            "mammal",
+            "spikey"
+        ],
         "info": [
             71,
             56,
@@ -2824,7 +3921,12 @@
         "name": "Hedgehog-b",
         "md5": "4d3ccc06660e07b55bd38246e1f82f7f.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "daria skrybchencko",
+            "mammal",
+            "spikey"
+        ],
         "info": [
             71,
             56,
@@ -2835,7 +3937,12 @@
         "name": "Hedgehog-c",
         "md5": "2446f79c0f553594cfbcdbe6b1e459a5.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "daria skrybchencko",
+            "mammal",
+            "spikey"
+        ],
         "info": [
             71,
             56,
@@ -2846,7 +3953,12 @@
         "name": "Hedgehog-d",
         "md5": "bdb7c8e86125092da0c4848d1ffd901c.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "daria skrybchencko",
+            "mammal",
+            "spikey"
+        ],
         "info": [
             71,
             56,
@@ -2857,7 +3969,12 @@
         "name": "Hedgehog-e",
         "md5": "78a0e3789f6d778e20f9bf3d308a0b19.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "daria skrybchencko",
+            "mammal",
+            "spikey"
+        ],
         "info": [
             61,
             45,
@@ -2868,7 +3985,14 @@
         "name": "Hippo1-a",
         "md5": "c1353c4a5eec5e6f32ed053e6f6e8f99.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "mammals",
+            "flying",
+            "fantasy",
+            "insect",
+            "pachydermata"
+        ],
         "info": [
             69,
             65,
@@ -2879,7 +4003,14 @@
         "name": "Hippo1-b",
         "md5": "e65ed93bbb9cccf698fc7e774ab609a6.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "mammals",
+            "flying",
+            "fantasy",
+            "insect",
+            "pachydermata"
+        ],
         "info": [
             69,
             68,
@@ -2890,7 +4021,10 @@
         "name": "Home Button",
         "md5": "1bac530a0701a8fc88bb0802ae6787a3.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "ui",
+            "thing"
+        ],
         "info": [
             72,
             72,
@@ -2901,7 +4035,14 @@
         "name": "Horse1-a",
         "md5": "32f4d80477cd070cb0848e555d374060.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "hoof",
+            "hooves",
+            "mammal",
+            "racing",
+            "saddle"
+        ],
         "info": [
             119,
             83,
@@ -2912,7 +4053,14 @@
         "name": "Horse1-b",
         "md5": "ffa6431c5ef2a4e975ecffacdb0efea7.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "hoof",
+            "hooves",
+            "mammal",
+            "racing",
+            "saddle"
+        ],
         "info": [
             103,
             97,
@@ -2923,7 +4071,12 @@
         "name": "Jamie-a",
         "md5": "90f9166fe6500d0c0caad8b1964d6b74.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "sports",
+            "basketball",
+            "people",
+            "alex eben meyer"
+        ],
         "info": [
             82,
             105,
@@ -2934,7 +4087,12 @@
         "name": "Jamie-b",
         "md5": "c3d96ef7e99440c2fa76effce1235d3f.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "sports",
+            "basketball",
+            "people",
+            "alex eben meyer"
+        ],
         "info": [
             82,
             105,
@@ -2945,7 +4103,12 @@
         "name": "Jamie-c",
         "md5": "1fb8b9ca79f2c0a327913bd647b53fe5.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "sports",
+            "basketball",
+            "people",
+            "alex eben meyer"
+        ],
         "info": [
             82,
             105,
@@ -2956,7 +4119,12 @@
         "name": "Jamie-d",
         "md5": "4adb87e6123161fcaf02f7ac022a5757.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "sports",
+            "basketball",
+            "people",
+            "alex eben meyer"
+        ],
         "info": [
             82,
             105,
@@ -2967,7 +4135,12 @@
         "name": "Jar-a",
         "md5": "73784b267083733e08bcf06aa7d6536a.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "food",
+            "ipzy",
+            "things",
+            "fruit"
+        ],
         "info": [
             20,
             25,
@@ -2978,7 +4151,11 @@
         "name": "Jar-b",
         "md5": "a37eb72115966a75bc1bf521deeccc0c.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "food",
+            "ipzy",
+            "things"
+        ],
         "info": [
             20,
             25,
@@ -2989,7 +4166,9 @@
         "name": "Jeans-a",
         "md5": "4e283da8c59bcbb9803bdc0016b14c21.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fashion"
+        ],
         "info": [
             22,
             25,
@@ -3000,7 +4179,9 @@
         "name": "Jeans-b",
         "md5": "01732aa03a48482093fbed3ea402c4a9.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fashion"
+        ],
         "info": [
             22,
             25,
@@ -3011,7 +4192,12 @@
         "name": "Jellyfish-a",
         "md5": "9e6563e417350af3094c2ed02b9b0bbd.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "ocean",
+            "underwater",
+            "daria skrybchencko"
+        ],
         "info": [
             99,
             86,
@@ -3022,7 +4208,12 @@
         "name": "Jellyfish-b",
         "md5": "31a42fad0891f1298c522a6d5008930a.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "ocean",
+            "underwater",
+            "daria skrybchencko"
+        ],
         "info": [
             99,
             86,
@@ -3033,7 +4224,12 @@
         "name": "Jellyfish-c",
         "md5": "697262d9ed04467bae52cca786c36bd3.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "ocean",
+            "underwater",
+            "daria skrybchencko"
+        ],
         "info": [
             99,
             86,
@@ -3044,7 +4240,12 @@
         "name": "Jellyfish-d",
         "md5": "6a949493aaf62954f1c74f8369d494c4.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "ocean",
+            "underwater",
+            "daria skrybchencko"
+        ],
         "info": [
             99,
             86,
@@ -3055,7 +4256,13 @@
         "name": "Jordyn-a",
         "md5": "8dd2a2abbb8e639da8576b6e72ef9e59.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "sports",
+            "soccer",
+            "football",
+            "people",
+            "alex eben meyer"
+        ],
         "info": [
             76,
             68,
@@ -3066,7 +4273,13 @@
         "name": "Jordyn-b",
         "md5": "9665f543147961551d8dc6f612d9cc41.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "sports",
+            "soccer",
+            "football",
+            "people",
+            "alex eben meyer"
+        ],
         "info": [
             76,
             68,
@@ -3077,7 +4290,13 @@
         "name": "Jordyn-c",
         "md5": "ec8c2286070c77ebd9dd40c96eaae3fc.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "sports",
+            "soccer",
+            "football",
+            "people",
+            "alex eben meyer"
+        ],
         "info": [
             76,
             68,
@@ -3088,7 +4307,13 @@
         "name": "Jordyn-d",
         "md5": "1f9ed7f29800f31ce2ee53196143a3c8.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "sports",
+            "soccer",
+            "football",
+            "people",
+            "alex eben meyer"
+        ],
         "info": [
             76,
             68,
@@ -3099,7 +4324,10 @@
         "name": "Key",
         "md5": "af35300cef35803e11f4ed744dc5e818.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "thing"
+        ],
         "info": [
             42,
             27,
@@ -3110,7 +4338,10 @@
         "name": "Keyboard-a",
         "md5": "c67d180e964926b6393ac14781541b39.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "music",
+            "andrew rae"
+        ],
         "info": [
             72,
             68,
@@ -3121,7 +4352,10 @@
         "name": "Keyboard-b",
         "md5": "dbaf62b33de45093c3c7d13b5d49d637.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "music",
+            "andrew rae"
+        ],
         "info": [
             72,
             68,
@@ -3132,7 +4366,11 @@
         "name": "Kiran-a",
         "md5": "9de23c4a7a7fbb67136b539241346854.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "space",
+            "people",
+            "wren mcdonald"
+        ],
         "info": [
             67,
             95,
@@ -3143,7 +4381,11 @@
         "name": "Kiran-b",
         "md5": "f1e74f3c02333e9e2068e8baf4e77aa0.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "space",
+            "people",
+            "wren mcdonald"
+        ],
         "info": [
             67,
             95,
@@ -3154,7 +4396,11 @@
         "name": "Kiran-c",
         "md5": "e2482cf509c312935f08be0e2e2c9d84.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "space",
+            "people",
+            "wren mcdonald"
+        ],
         "info": [
             67,
             95,
@@ -3165,7 +4411,11 @@
         "name": "Kiran-d",
         "md5": "569e736b519199efddfbae2572f7e92b.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "space",
+            "people",
+            "wren mcdonald"
+        ],
         "info": [
             67,
             95,
@@ -3176,7 +4426,11 @@
         "name": "Kiran-e",
         "md5": "2261bed0f2cc819def17969158297b4f.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "space",
+            "people",
+            "wren mcdonald"
+        ],
         "info": [
             77,
             95,
@@ -3187,7 +4441,11 @@
         "name": "Kiran-f",
         "md5": "d7f44adb3dc7906b9dfb3599a028e0d6.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "space",
+            "people",
+            "wren mcdonald"
+        ],
         "info": [
             62,
             94,
@@ -3198,7 +4456,11 @@
         "name": "Knight",
         "md5": "f2c5e8bc24d001b81566879dbf2f1a13.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "people",
+            "castle",
+            "armor"
+        ],
         "info": [
             75,
             75,
@@ -3209,7 +4471,12 @@
         "name": "Ladybug2",
         "md5": "f16a1ccc69a4a8190a927f1595aa7bfa.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "insect",
+            "bug",
+            "antennae"
+        ],
         "info": [
             41,
             43,
@@ -3220,7 +4487,13 @@
         "name": "Ladybug2-a",
         "md5": "c018a3eed966d5f92c69f2188dfd2aae.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animal",
+            "insect",
+            "arthropod",
+            "antennae",
+            "aphids"
+        ],
         "info": [
             49,
             28,
@@ -3242,7 +4515,10 @@
         "name": "Laptop",
         "md5": "76f456b30b98eeefd7c942b27b524e31.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "things",
+            "computers"
+        ],
         "info": [
             75,
             75,
@@ -3253,7 +4529,13 @@
         "name": "Lightning",
         "md5": "c2d636ab2b491e591536afc3d49cbecd.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "weather",
+            "whether",
+            "fantasy",
+            "storm",
+            "thunder"
+        ],
         "info": [
             21,
             83,
@@ -3264,7 +4546,11 @@
         "name": "Line",
         "md5": "1b2cfb4d4746522aeb84e16a62820299.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "lava",
+            "shape",
+            "red"
+        ],
         "info": [
             239,
             7,
@@ -3275,7 +4561,15 @@
         "name": "Lion-a",
         "md5": "692a3c84366bf8ae4d16858e20e792f5.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "mammals",
+            "big cat",
+            "carnivore",
+            "king",
+            "jungle",
+            "roar"
+        ],
         "info": [
             75,
             75,
@@ -3286,7 +4580,15 @@
         "name": "Lion-b",
         "md5": "a519ef168a345a2846d0201bf092a6d0.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "mammals",
+            "big cat",
+            "carnivore",
+            "king",
+            "jungle",
+            "roar"
+        ],
         "info": [
             75,
             75,
@@ -3297,7 +4599,11 @@
         "name": "Llama",
         "md5": "07158eb6d62e309bb60a6bc36baf2300.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "mammal",
+            "robert hunter"
+        ],
         "info": [
             100,
             100,
@@ -3308,7 +4614,11 @@
         "name": "Llama-b",
         "md5": "2021eea71514bd2b23e96076750727ae.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "mammal",
+            "robert hunter"
+        ],
         "info": [
             100,
             100,
@@ -3319,7 +4629,11 @@
         "name": "Llama-c",
         "md5": "7837d7247acbc4eebb793452a35aa1f5.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "mammal",
+            "robert hunter"
+        ],
         "info": [
             100,
             100,
@@ -3330,7 +4644,11 @@
         "name": "Magicwand",
         "md5": "3db9bfe57d561557795633c5cda44e8c.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "things",
+            "zap"
+        ],
         "info": [
             41,
             18,
@@ -3341,7 +4659,12 @@
         "name": "Max-a",
         "md5": "e10cca3bdbc09d039c2f937574f7a6ea.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "sports",
+            "basketball",
+            "people",
+            "alex eben meyer"
+        ],
         "info": [
             82,
             68,
@@ -3352,7 +4675,12 @@
         "name": "Max-b",
         "md5": "6d8ee139a741cf945d600a8cef0ea2e6.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "sports",
+            "basketball",
+            "people",
+            "alex eben meyer"
+        ],
         "info": [
             82,
             68,
@@ -3363,7 +4691,12 @@
         "name": "Max-c",
         "md5": "aa66109994d27de02711f6a0ef6de9ec.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "sports",
+            "basketball",
+            "people",
+            "alex eben meyer"
+        ],
         "info": [
             82,
             68,
@@ -3374,7 +4707,12 @@
         "name": "Max-d",
         "md5": "a0dbf509d542c7eff6d2ddfc9c9410f1.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "sports",
+            "basketball",
+            "people",
+            "alex eben meyer"
+        ],
         "info": [
             82,
             68,
@@ -3385,7 +4723,12 @@
         "name": "Mermaid-a",
         "md5": "36db41c47259881c26d9b98a806d3308.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "people",
+            "underwater",
+            "ipzy"
+        ],
         "info": [
             92,
             130,
@@ -3396,7 +4739,12 @@
         "name": "Mermaid-b",
         "md5": "564bf3f466df3b3e8aba71eeae8255ab.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "people",
+            "underwater",
+            "ipzy"
+        ],
         "info": [
             92,
             130,
@@ -3407,7 +4755,12 @@
         "name": "Mermaid-swim-a",
         "md5": "9f973b89b68f7d8147f157cbac8af341.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "people",
+            "underwater",
+            "ipzy"
+        ],
         "info": [
             150,
             115,
@@ -3418,7 +4771,12 @@
         "name": "Mermaid-swim-b",
         "md5": "2295784bb8e6354bfa7676089235cb9f.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "people",
+            "underwater",
+            "ipzy"
+        ],
         "info": [
             150,
             115,
@@ -3429,7 +4787,10 @@
         "name": "Microphone-a",
         "md5": "9126b6362313e20578fb88d38902cd4c.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "music",
+            "andrew rae"
+        ],
         "info": [
             40,
             88,
@@ -3440,7 +4801,10 @@
         "name": "Microphone-b",
         "md5": "29988ebbde49beaceb06d9eb66138b80.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "music",
+            "andrew rae"
+        ],
         "info": [
             40,
             88,
@@ -3451,7 +4815,11 @@
         "name": "Milk-a",
         "md5": "e6a7964bc4ea38c79a5a31d6ddfb5ba9.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "food",
+            "drink",
+            "alex eben meyer"
+        ],
         "info": [
             68,
             71,
@@ -3462,7 +4830,11 @@
         "name": "Milk-b",
         "md5": "82d4c1855fe0d400433c7344fb2af3b5.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "food",
+            "drink",
+            "alex eben meyer"
+        ],
         "info": [
             68,
             71,
@@ -3473,7 +4845,11 @@
         "name": "Milk-c",
         "md5": "50afc991b6fdad4b6547ba98ecf8a6af.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "food",
+            "drink",
+            "alex eben meyer"
+        ],
         "info": [
             47,
             44,
@@ -3484,7 +4860,11 @@
         "name": "Milk-d",
         "md5": "8fc7606a176149d225a541a04fa67473.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "food",
+            "drink",
+            "alex eben meyer"
+        ],
         "info": [
             68,
             71,
@@ -3495,7 +4875,11 @@
         "name": "Milk-e",
         "md5": "f2373d449b1226c44436dced422c2935.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "food",
+            "drink",
+            "alex eben meyer"
+        ],
         "info": [
             68,
             71,
@@ -3506,7 +4890,11 @@
         "name": "Monet-a",
         "md5": "11c46aaa5e30ad46f5c1883d6feb47b8.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "space",
+            "people",
+            "wren mcdonald"
+        ],
         "info": [
             64,
             87,
@@ -3517,7 +4905,11 @@
         "name": "Monet-b",
         "md5": "9c8f83e39dc8ac49d57c0622ffe2063f.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "space",
+            "people",
+            "wren mcdonald"
+        ],
         "info": [
             64,
             87,
@@ -3528,7 +4920,11 @@
         "name": "Monet-c",
         "md5": "4435678d26e8fbc266d647693f65f5d7.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "space",
+            "people",
+            "wren mcdonald"
+        ],
         "info": [
             64,
             87,
@@ -3539,7 +4935,11 @@
         "name": "Monet-d",
         "md5": "42113ca3eca593c3a8f232a9202d6f14.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "space",
+            "people",
+            "wren mcdonald"
+        ],
         "info": [
             82,
             87,
@@ -3550,7 +4950,11 @@
         "name": "Monet-e",
         "md5": "e530d0dac5290c5366af719cfb4e5953.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "space",
+            "people",
+            "wren mcdonald"
+        ],
         "info": [
             65,
             89,
@@ -3561,7 +4965,12 @@
         "name": "Monkey-a",
         "md5": "6e4de762dbd52cd2b6356694a9668211.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "mammals",
+            "primate",
+            "prehensile tail"
+        ],
         "info": [
             68,
             99,
@@ -3572,7 +4981,12 @@
         "name": "Monkey-b",
         "md5": "7662a3a0f4c6fa21fdf2de33bd80fe5f.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "mammals",
+            "primate",
+            "prehensile tail"
+        ],
         "info": [
             68,
             99,
@@ -3583,7 +4997,12 @@
         "name": "Monkey-c",
         "md5": "db8eb50b948047181922310bb94511fb.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "mammals",
+            "primate",
+            "prehensile tail"
+        ],
         "info": [
             68,
             99,
@@ -3594,7 +5013,11 @@
         "name": "Mouse1-a",
         "md5": "e1f0c26afecbe9d4b9923d8e6bf489a8.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "mammals",
+            "rodents"
+        ],
         "info": [
             50,
             27,
@@ -3605,7 +5028,11 @@
         "name": "Mouse1-b",
         "md5": "f5e477a3f94fc98ba3cd927228405646.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "mammals",
+            "rodents"
+        ],
         "info": [
             65,
             21,
@@ -3616,7 +5043,9 @@
         "name": "Muffin-a",
         "md5": "e00161f08c77d10e72e44b6e01243e63.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "food"
+        ],
         "info": [
             85,
             48,
@@ -3627,7 +5056,10 @@
         "name": "Muffin-b",
         "md5": "fb60c3f8d6a892813299daa33b91df23.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "food",
+            "eaten"
+        ],
         "info": [
             85,
             48,
@@ -3638,7 +5070,10 @@
         "name": "Nano-a",
         "md5": "02c5433118f508038484bbc5b111e187.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "drawing"
+        ],
         "info": [
             61,
             60,
@@ -3649,7 +5084,11 @@
         "name": "Nano-b",
         "md5": "10d6d9130618cd092ae02158cde2e113.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "drawing",
+            "happy"
+        ],
         "info": [
             61,
             60,
@@ -3660,7 +5099,11 @@
         "name": "Nano-c",
         "md5": "85e762d45bc626ca2edb3472c7cfaa32.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "drawing",
+            "happy"
+        ],
         "info": [
             61,
             60,
@@ -3671,7 +5114,11 @@
         "name": "Nano-d",
         "md5": "b10925346da8080443f27e7dfaeff6f7.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "drawing",
+            "angry"
+        ],
         "info": [
             61,
             60,
@@ -3682,7 +5129,10 @@
         "name": "Neigh Pony",
         "md5": "176c4fb4df80df899ca28a48bd1f0edf.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "fantasy"
+        ],
         "info": [
             74,
             78,
@@ -3693,7 +5143,12 @@
         "name": "Octopus-a",
         "md5": "038df646d2f935d2a5dd601b343fc1d9.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "ocean",
+            "underwater",
+            "daria skrybchencko"
+        ],
         "info": [
             88,
             86,
@@ -3704,7 +5159,12 @@
         "name": "Octopus-b",
         "md5": "31bdcbdf05688c01aace3fd94c5e82df.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "ocean",
+            "underwater",
+            "daria skrybchencko"
+        ],
         "info": [
             88,
             86,
@@ -3715,7 +5175,13 @@
         "name": "Octopus-c",
         "md5": "51e80c09323e36489ad452250acd827c.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "ocean",
+            "underwater",
+            "teacup",
+            "daria skrybchencko"
+        ],
         "info": [
             88,
             86,
@@ -3726,7 +5192,13 @@
         "name": "Octopus-d",
         "md5": "b4242e6cde0392bb9a5fb43a8f232962.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "ocean",
+            "underwater",
+            "pirate",
+            "daria skrybchencko"
+        ],
         "info": [
             88,
             86,
@@ -3737,7 +5209,13 @@
         "name": "Octopus-e",
         "md5": "edfda0a36d9cd8482e3a8dc317107d56.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "ocean",
+            "underwater",
+            "music",
+            "daria skrybchencko"
+        ],
         "info": [
             88,
             86,
@@ -3748,7 +5226,10 @@
         "name": "Orange",
         "md5": "780ee2ef342f79a81b4c353725331138.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "food",
+            "fruit"
+        ],
         "info": [
             19,
             18,
@@ -3759,7 +5240,11 @@
         "name": "Orange2-a",
         "md5": "89b11d2a404c3972b65743f743cc968a.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "food",
+            "fruit",
+            "eaten"
+        ],
         "info": [
             49,
             24,
@@ -3770,7 +5255,11 @@
         "name": "Orange2-b",
         "md5": "5f7998e007dfa70e70bbd8d43199ebba.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "food",
+            "fruit",
+            "eaten"
+        ],
         "info": [
             49,
             27,
@@ -3781,7 +5270,11 @@
         "name": "Orange2-c",
         "md5": "466e9e2d62ee135a2dabd5593e6f8407.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "food",
+            "fruit",
+            "eaten"
+        ],
         "info": [
             49,
             33,
@@ -3792,7 +5285,11 @@
         "name": "Owl-a",
         "md5": "a312273b198fcacf68976e3cc74fadb4.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "bird",
+            "robert hunter"
+        ],
         "info": [
             113,
             54,
@@ -3803,7 +5300,11 @@
         "name": "Owl-b",
         "md5": "c9916dcfe67302367b05be7f3e5c5ddf.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "bird",
+            "robert hunter"
+        ],
         "info": [
             113,
             54,
@@ -3814,7 +5315,11 @@
         "name": "Owl-c",
         "md5": "8ec3a2507f1d6dc9b39f7ae5a1ebfdd3.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "bird",
+            "robert hunter"
+        ],
         "info": [
             113,
             54,
@@ -3825,7 +5330,9 @@
         "name": "Paddle",
         "md5": "8038149bdfe24733ea2144d37d297815.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "thing"
+        ],
         "info": [
             44,
             7,
@@ -3836,7 +5343,12 @@
         "name": "Panther-a",
         "md5": "04ca2c122cff11b9bc23834d6f79361e.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "tiger",
+            "leopard",
+            "robert hunter"
+        ],
         "info": [
             125,
             81,
@@ -3847,7 +5359,12 @@
         "name": "Panther-b",
         "md5": "f8c33765d1105f3bb4cd145fad0f717e.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "tiger",
+            "leopard",
+            "robert hunter"
+        ],
         "info": [
             125,
             81,
@@ -3858,7 +5375,12 @@
         "name": "Panther-c",
         "md5": "096bf9cad84def12eef2b5d84736b393.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "tiger",
+            "leopard",
+            "robert hunter"
+        ],
         "info": [
             125,
             81,
@@ -3869,7 +5391,14 @@
         "name": "Parrot-a",
         "md5": "098570b8e1aa85b32f9b4eb07bea3af2.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "bird",
+            "birb",
+            "tropical",
+            "color",
+            "flying"
+        ],
         "info": [
             86,
             106,
@@ -3880,7 +5409,14 @@
         "name": "Parrot-b",
         "md5": "721255a0733c9d8d2ba518ff09b3b7cb.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "bird",
+            "birb",
+            "tropical",
+            "color",
+            "flying"
+        ],
         "info": [
             49,
             31,
@@ -3891,7 +5427,10 @@
         "name": "Partyhat1",
         "md5": "70a7f535d8857cf9175492415361c361.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fashion",
+            "holiday"
+        ],
         "info": [
             75,
             75,
@@ -3902,7 +5441,10 @@
         "name": "Pencil-a",
         "md5": "4495fcb0443cebc5d43e66243a88f1ac.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "thing",
+            "yellow"
+        ],
         "info": [
             49,
             54,
@@ -3913,7 +5455,10 @@
         "name": "Pencil-b",
         "md5": "21088922dbe127f6d2e58e2e83fb632e.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "thing",
+            "yellow"
+        ],
         "info": [
             48,
             68,
@@ -3921,10 +5466,15 @@
         ]
     },
     {
-        "name": "Penguin1-a",
+        "name": "Penguin2-a",
         "md5": "c17d9e4bdb59c574e0c34aa70af516da.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "bird",
+            "winter",
+            "antarctica"
+        ],
         "info": [
             54,
             61,
@@ -3932,10 +5482,15 @@
         ]
     },
     {
-        "name": "Penguin1-b",
+        "name": "Penguin2-b",
         "md5": "35fec7aa5f60cca945fe0615413f1f08.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "bird",
+            "winter",
+            "antarctica"
+        ],
         "info": [
             48,
             62,
@@ -3943,10 +5498,15 @@
         ]
     },
     {
-        "name": "Penguin1-c",
+        "name": "Penguin2-c",
         "md5": "18fa51a64ebd5518f0c5c465525346e5.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "bird",
+            "winter",
+            "antarctica"
+        ],
         "info": [
             48,
             61,
@@ -3954,43 +5514,13 @@
         ]
     },
     {
-        "name": "Penguin2-a",
-        "md5": "eaaaa7068e78a51d73ba437f1ec5763e.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            49,
-            79,
-            1
-        ]
-    },
-    {
-        "name": "Penguin2-b",
-        "md5": "5a80f4b2fd20d43e4f7cb4189c08d99c.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            45,
-            79,
-            1
-        ]
-    },
-    {
-        "name": "Penguin2-c",
-        "md5": "394e79f5f9a462064ece2a9a6606a07d.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            50,
-            78,
-            1
-        ]
-    },
-    {
         "name": "Pico Walk1",
         "md5": "8eab5fe20dd249bf22964298b1d377eb.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "walking"
+        ],
         "info": [
             54,
             71,
@@ -4001,7 +5531,10 @@
         "name": "Pico Walk2",
         "md5": "39ecd3c38d3f2cd81e3a17ee6c25699f.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "walking"
+        ],
         "info": [
             54,
             71,
@@ -4012,7 +5545,10 @@
         "name": "Pico Walk3",
         "md5": "43f7d92dcf9eadf77c07a6fc1eb4104f.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "walking"
+        ],
         "info": [
             54,
             70,
@@ -4023,7 +5559,10 @@
         "name": "Pico Walk4",
         "md5": "2582d012d57bca59bc0315c5c5954958.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "walking"
+        ],
         "info": [
             54,
             70,
@@ -4034,7 +5573,10 @@
         "name": "Pico-a",
         "md5": "0579fe60bb3717c49dfd7743caa84ada.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "drawing"
+        ],
         "info": [
             55,
             66,
@@ -4045,7 +5587,11 @@
         "name": "Pico-b",
         "md5": "26c688d7544757225ff51cd2fb1519b5.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "drawing",
+            "happy"
+        ],
         "info": [
             55,
             66,
@@ -4056,7 +5602,11 @@
         "name": "Pico-c",
         "md5": "adf61e2090f8060e1e8b2b0604d03751.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "drawing",
+            "happy"
+        ],
         "info": [
             55,
             66,
@@ -4067,7 +5617,11 @@
         "name": "Pico-d",
         "md5": "594704bf12e3c4d9e83bb91661ad709a.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "drawing",
+            "angry"
+        ],
         "info": [
             55,
             66,
@@ -4078,7 +5632,9 @@
         "name": "Planet2",
         "md5": "978784738c1d9dd4b1d397fd18bdf406.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "space"
+        ],
         "info": [
             72,
             72,
@@ -4089,7 +5645,11 @@
         "name": "Potion-a",
         "md5": "a317b50b255a208455a7733091adad23.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "ipzy",
+            "things"
+        ],
         "info": [
             15,
             21,
@@ -4100,7 +5660,11 @@
         "name": "Potion-b",
         "md5": "5f96576605c3a022df48278b630da745.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "ipzy",
+            "things"
+        ],
         "info": [
             15,
             28,
@@ -4111,7 +5675,11 @@
         "name": "Potion-c",
         "md5": "92d0184c28fac9acb0fb720ec599d61d.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "ipzy",
+            "things"
+        ],
         "info": [
             15,
             42,
@@ -4122,7 +5690,11 @@
         "name": "Prince",
         "md5": "a760bed1cfc28a30b2dc7fd045c90792.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "people",
+            "☥",
+            "fantasy"
+        ],
         "info": [
             75,
             75,
@@ -4133,7 +5705,13 @@
         "name": "Princess-a",
         "md5": "fcbf44a543dfda884d8acbd6af66faad.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "people",
+            "ipzy",
+            "castle",
+            "emotions"
+        ],
         "info": [
             75,
             150,
@@ -4144,7 +5722,13 @@
         "name": "Princess-b",
         "md5": "562e5eba4a598118411be3062cfbb26f.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "people",
+            "ipzy",
+            "castle",
+            "emotions"
+        ],
         "info": [
             75,
             150,
@@ -4155,7 +5739,13 @@
         "name": "Princess-c",
         "md5": "f3e5f466d406745cf1b6ce44b0567b9a.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "people",
+            "ipzy",
+            "castle",
+            "emotions"
+        ],
         "info": [
             75,
             150,
@@ -4166,7 +5756,13 @@
         "name": "Princess-d",
         "md5": "663134f64588f0c55e77767ba9039cfe.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "people",
+            "ipzy",
+            "castle",
+            "emotions"
+        ],
         "info": [
             75,
             150,
@@ -4177,7 +5773,13 @@
         "name": "Princess-e",
         "md5": "ad0ecbf907d132ddbb547666551ac087.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "people",
+            "ipzy",
+            "castle",
+            "emotions"
+        ],
         "info": [
             75,
             150,
@@ -4188,7 +5790,12 @@
         "name": "Pufferfish-a",
         "md5": "81d7db99142a39c9082be2c2183f2175.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "ocean",
+            "underwater",
+            "daria skrybchencko"
+        ],
         "info": [
             69,
             61,
@@ -4199,7 +5806,12 @@
         "name": "Pufferfish-b",
         "md5": "6ea79950db63f5ac24d6c5091df3836b.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "ocean",
+            "underwater",
+            "daria skrybchencko"
+        ],
         "info": [
             69,
             61,
@@ -4210,7 +5822,12 @@
         "name": "Pufferfish-c",
         "md5": "4acf5bc398c19d58acf69fce047ee8f6.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "ocean",
+            "underwater",
+            "daria skrybchencko"
+        ],
         "info": [
             69,
             61,
@@ -4221,7 +5838,12 @@
         "name": "Pufferfish-d",
         "md5": "c214fa8a9ceed06db03664007b8ad5c6.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "ocean",
+            "underwater",
+            "daria skrybchencko"
+        ],
         "info": [
             69,
             61,
@@ -4232,7 +5854,14 @@
         "name": "Rabbit-a",
         "md5": "2f42891c3f3d63c0e591aeabc5946533.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "daria skrybchencko",
+            "mammal",
+            "bunny",
+            "bunnies",
+            "fluffy"
+        ],
         "info": [
             84,
             84,
@@ -4243,7 +5872,14 @@
         "name": "Rabbit-b",
         "md5": "80e05ff501040cdc9f52fa6782e06fd2.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "daria skrybchencko",
+            "mammal",
+            "bunny",
+            "bunnies",
+            "fluffy"
+        ],
         "info": [
             84,
             84,
@@ -4254,7 +5890,14 @@
         "name": "Rabbit-c",
         "md5": "88ed8b7925baa025b6c7fc628a64b9b1.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "daria skrybchencko",
+            "mammal",
+            "bunny",
+            "bunnies",
+            "fluffy"
+        ],
         "info": [
             84,
             84,
@@ -4265,7 +5908,14 @@
         "name": "Rabbit-d",
         "md5": "5f3b8df4d6ab8a72e887f89f554db0be.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "daria skrybchencko",
+            "mammal",
+            "bunny",
+            "bunnies",
+            "fluffy"
+        ],
         "info": [
             84,
             84,
@@ -4276,7 +5926,14 @@
         "name": "Rabbit-e",
         "md5": "3003f1135f4aa3b6c361734243621260.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "daria skrybchencko",
+            "mammal",
+            "bunny",
+            "bunnies",
+            "fluffy"
+        ],
         "info": [
             84,
             84,
@@ -4287,7 +5944,12 @@
         "name": "Rainbow",
         "md5": "680a806bd87a28c8b25b5f9b6347f022.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "things",
+            "flying",
+            "drawing",
+            "color"
+        ],
         "info": [
             72,
             36,
@@ -4298,7 +5960,12 @@
         "name": "Referee-a",
         "md5": "0959403aeb134ed2932a85c77e261122.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "sports",
+            "soccer",
+            "football",
+            "alex eben meyer"
+        ],
         "info": [
             76,
             68,
@@ -4309,7 +5976,12 @@
         "name": "Referee-b",
         "md5": "866b9e1ad2e0584216dd45fe7d50d6f5.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "sports",
+            "soccer",
+            "football",
+            "alex eben meyer"
+        ],
         "info": [
             76,
             68,
@@ -4320,7 +5992,12 @@
         "name": "Referee-c",
         "md5": "21a3869435fbd470ef60960a78b06b16.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "sports",
+            "soccer",
+            "football",
+            "alex eben meyer"
+        ],
         "info": [
             76,
             68,
@@ -4331,7 +6008,12 @@
         "name": "Referee-d",
         "md5": "5e037aca5446a7e57093e45fe6f18c9e.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "sports",
+            "soccer",
+            "football",
+            "alex eben meyer"
+        ],
         "info": [
             76,
             68,
@@ -4342,7 +6024,11 @@
         "name": "Reindeer",
         "md5": "0fff0b181cc4d9250b5b985cc283b049.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "mammals",
+            "holiday"
+        ],
         "info": [
             39,
             70,
@@ -4353,7 +6039,11 @@
         "name": "Ripley-a",
         "md5": "417ec9f25ad70281564e85e67c97aa08.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "space",
+            "people",
+            "wren mcdonald"
+        ],
         "info": [
             57,
             89,
@@ -4364,7 +6054,11 @@
         "name": "Ripley-b",
         "md5": "e40918acf5c4d1d0d42b437b6b6e965d.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "space",
+            "people",
+            "wren mcdonald"
+        ],
         "info": [
             57,
             89,
@@ -4375,7 +6069,11 @@
         "name": "Ripley-c",
         "md5": "5fb713effcdae17208e6e89527bf720c.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "space",
+            "people",
+            "wren mcdonald"
+        ],
         "info": [
             57,
             89,
@@ -4386,7 +6084,11 @@
         "name": "Ripley-d",
         "md5": "6c6597c221c9a5b46c160f537b9795a2.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "space",
+            "people",
+            "wren mcdonald"
+        ],
         "info": [
             85,
             89,
@@ -4397,7 +6099,11 @@
         "name": "Ripley-e",
         "md5": "92909161afd79673c93a77d15fe8d456.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "space",
+            "people",
+            "wren mcdonald"
+        ],
         "info": [
             56,
             89,
@@ -4408,7 +6114,11 @@
         "name": "Ripley-f",
         "md5": "16e31a6b510ba4e8c1215e6e3a41d9f9.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "space",
+            "people",
+            "wren mcdonald"
+        ],
         "info": [
             58,
             90,
@@ -4419,7 +6129,11 @@
         "name": "Robot-a",
         "md5": "cb3985cd066ccbab11954709b3d54c17.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "space",
+            "robot",
+            "wren mcdonald"
+        ],
         "info": [
             74,
             109,
@@ -4430,7 +6144,11 @@
         "name": "Robot-b",
         "md5": "fc9276d0909539fd31c30db7b2e08bf9.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "space",
+            "robot",
+            "wren mcdonald"
+        ],
         "info": [
             56,
             97,
@@ -4441,7 +6159,11 @@
         "name": "Robot-c",
         "md5": "c5e02f00d233199fea1c51b71c402ce4.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "space",
+            "robot",
+            "wren mcdonald"
+        ],
         "info": [
             63,
             97,
@@ -4452,7 +6174,11 @@
         "name": "Robot-d",
         "md5": "ca2cf7d6c0446fbce36621006a4b0fac.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "space",
+            "robot",
+            "wren mcdonald"
+        ],
         "info": [
             59,
             95,
@@ -4463,7 +6189,10 @@
         "name": "Rocks",
         "md5": "82c79fdb6a7d9c49ab7f70ee79a3d7f8.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "things",
+            "potassium"
+        ],
         "info": [
             59,
             15,
@@ -4474,7 +6203,10 @@
         "name": "Saxophone-a",
         "md5": "e9e4297f5d7e630a384b1dea835ec72d.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "music",
+            "andrew rae"
+        ],
         "info": [
             47,
             80,
@@ -4485,7 +6217,10 @@
         "name": "Saxophone-b",
         "md5": "04e5650480bfcf9190aa35bbd8d67b8e.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "music",
+            "andrew rae"
+        ],
         "info": [
             47,
             80,
@@ -4496,7 +6231,10 @@
         "name": "Scarf1",
         "md5": "9db18d2a2b3c9859654fc1b4832e6076.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fashion",
+            "red"
+        ],
         "info": [
             54,
             36,
@@ -4507,7 +6245,10 @@
         "name": "Scarf2",
         "md5": "ce66662165e2756070f1b12e0a7cb5db.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fashion",
+            "purple"
+        ],
         "info": [
             23,
             16,
@@ -4518,7 +6259,12 @@
         "name": "Shark-a",
         "md5": "4ca6776e9c021e8b21c3346793c9361d.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "underwater",
+            "ipzy",
+            "fish"
+        ],
         "info": [
             150,
             60,
@@ -4529,7 +6275,12 @@
         "name": "Shark-b",
         "md5": "0bb623f0bbec53ee9667cee0b7ad6d47.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "underwater",
+            "ipzy",
+            "fish"
+        ],
         "info": [
             150,
             60,
@@ -4540,7 +6291,15 @@
         "name": "Shark-c",
         "md5": "afeae3f998598424f7c50918507f6ce6.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "ocean",
+            "sea",
+            "fish",
+            "teeth",
+            "carnivore",
+            "chomp"
+        ],
         "info": [
             77,
             37,
@@ -4551,7 +6310,9 @@
         "name": "Shirt Blouse",
         "md5": "918a507af6bbae9e7f36f0d949900838.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fashion"
+        ],
         "info": [
             35,
             28,
@@ -4562,7 +6323,9 @@
         "name": "Shirt Collar-a",
         "md5": "b7ecf6503e27e9ab5c086eaf07d22b94.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fashion"
+        ],
         "info": [
             30,
             57,
@@ -4595,7 +6358,9 @@
         "name": "Shirt-t",
         "md5": "5d7fa4f1788f03d2962f1624d6eac800.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fashion"
+        ],
         "info": [
             39,
             28,
@@ -4606,7 +6371,9 @@
         "name": "Shirt2-a",
         "md5": "5946e7a1e36c6d97ae47d41dd8595a41.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fashion"
+        ],
         "info": [
             39,
             48,
@@ -4617,7 +6384,9 @@
         "name": "Shirt2-a2",
         "md5": "5b78ab09592126b6bbe2d4907d203909.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fashion"
+        ],
         "info": [
             39,
             48,
@@ -4628,7 +6397,9 @@
         "name": "Shoes1",
         "md5": "ffab4cc284070b50ac317e515f59f7d8.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fashion"
+        ],
         "info": [
             36,
             23,
@@ -4639,7 +6410,9 @@
         "name": "Shoes2",
         "md5": "1dc5d568d98405c370b91a230397a7f9.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fashion"
+        ],
         "info": [
             40,
             8,
@@ -4650,7 +6423,10 @@
         "name": "Singer1",
         "md5": "e47ef1af3b925e5ac9e3b3f809d440b3.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "people",
+            "music"
+        ],
         "info": [
             75,
             75,
@@ -4661,7 +6437,10 @@
         "name": "Skates",
         "md5": "00e5e173400662875a26bb7d6556346a.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fashion",
+            "winter"
+        ],
         "info": [
             44,
             -21,
@@ -4672,7 +6451,11 @@
         "name": "Snake-a",
         "md5": "4d06e12d90479461303d828f0970f2d4.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "reptile",
+            "robert hunter"
+        ],
         "info": [
             142,
             68,
@@ -4683,7 +6466,11 @@
         "name": "Snake-b",
         "md5": "a8546a5f9ccaa2bdb678a362c50a17ec.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "reptile",
+            "robert hunter"
+        ],
         "info": [
             142,
             68,
@@ -4694,7 +6481,11 @@
         "name": "Snake-c",
         "md5": "d993a7d70179777c14ac91a07e711d90.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "reptile",
+            "robert hunter"
+        ],
         "info": [
             142,
             68,
@@ -4705,7 +6496,9 @@
         "name": "Snowflake",
         "md5": "67de2af723246de37d7379b76800ee0b.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "winter"
+        ],
         "info": [
             104,
             103,
@@ -4716,7 +6509,11 @@
         "name": "Snowman",
         "md5": "56c71c31c17b9bc66a2aab0342cf94b2.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "drawing",
+            "winter"
+        ],
         "info": [
             75,
             75,
@@ -4727,7 +6524,12 @@
         "name": "Soccer Ball",
         "md5": "81ff5ad24454e7a0f1f3ae863bb4dd25.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "sports",
+            "soccer",
+            "football",
+            "alex eben meyer"
+        ],
         "info": [
             26,
             26,
@@ -4738,7 +6540,10 @@
         "name": "Spaceship-a",
         "md5": "7d51af7c52e137ef137012595bac928d.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "space",
+            "wren mcdonald"
+        ],
         "info": [
             66,
             107,
@@ -4749,7 +6554,10 @@
         "name": "Spaceship-b",
         "md5": "ae2634705b7a4fd31f4c1d1bb0e12545.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "space",
+            "wren mcdonald"
+        ],
         "info": [
             53,
             106,
@@ -4760,7 +6568,10 @@
         "name": "Spaceship-c",
         "md5": "3d375cd033f1a7161cae56b114f4cfdb.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "space",
+            "wren mcdonald"
+        ],
         "info": [
             61,
             107,
@@ -4771,7 +6582,10 @@
         "name": "Spaceship-d",
         "md5": "a456964f32cd7e7bd83fe076bf29558b.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "space",
+            "wren mcdonald"
+        ],
         "info": [
             63,
             107,
@@ -4782,7 +6596,10 @@
         "name": "Spaceship-e",
         "md5": "5b5cc9904ba63ca2801b61a73d4dcb7e.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "space",
+            "wren mcdonald"
+        ],
         "info": [
             71,
             107,
@@ -4793,7 +6610,13 @@
         "name": "Speaker",
         "md5": "44dc3a2ec161999545914d1f77332d76.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "music",
+            "things",
+            "bass",
+            "treble",
+            "concert"
+        ],
         "info": [
             53,
             79,
@@ -4804,7 +6627,10 @@
         "name": "Star",
         "md5": "ab0914e53e360477275e58b83ec4d423.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "shapes",
+            "space"
+        ],
         "info": [
             21,
             19,
@@ -4815,7 +6641,13 @@
         "name": "Starfish-a",
         "md5": "3d1101bbc24ae292a36356af325f660c.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "echinodermata",
+            "underwater",
+            "sea",
+            "ocean"
+        ],
         "info": [
             75,
             75,
@@ -4826,7 +6658,13 @@
         "name": "Starfish-b ",
         "md5": "ad8007f4e63693984d4adc466ffa3ad2.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "echinodermata",
+            "underwater",
+            "sea",
+            "ocean"
+        ],
         "info": [
             53,
             60,
@@ -4837,7 +6675,10 @@
         "name": "Stop",
         "md5": "5b9e3e8edffb0bd4914113609eec5e04.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "shapes",
+            "things"
+        ],
         "info": [
             25,
             25,
@@ -4848,7 +6689,11 @@
         "name": "Strawberry-a",
         "md5": "734556fb8e14740f2cbc971238b71d47.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "food",
+            "fruit",
+            "alex eben meyer"
+        ],
         "info": [
             57,
             58,
@@ -4859,7 +6704,11 @@
         "name": "Strawberry-b",
         "md5": "77dadaa80bc5156f655c2196f57972f7.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "food",
+            "fruit",
+            "alex eben meyer"
+        ],
         "info": [
             57,
             58,
@@ -4870,7 +6719,11 @@
         "name": "Strawberry-c",
         "md5": "19f933b3cf3e8e150753f8fb9bb7a779.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "food",
+            "fruit",
+            "alex eben meyer"
+        ],
         "info": [
             57,
             58,
@@ -4881,7 +6734,11 @@
         "name": "Strawberry-d",
         "md5": "8e8057da8457e6167de36b7d3d28b4bb.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "food",
+            "fruit",
+            "alex eben meyer"
+        ],
         "info": [
             57,
             58,
@@ -4892,7 +6749,11 @@
         "name": "Strawberry-e",
         "md5": "5eb63e64b83f5aa5b75a55329a34efec.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "food",
+            "fruit",
+            "alex eben meyer"
+        ],
         "info": [
             57,
             58,
@@ -4903,7 +6764,14 @@
         "name": "Sun",
         "md5": "55c931c65456822c0c56a2b30e3e550d.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "space",
+            "star",
+            "hydrogen",
+            "helium",
+            "fusion",
+            "nuclear"
+        ],
         "info": [
             72,
             72,
@@ -4914,7 +6782,10 @@
         "name": "Sunglasses1",
         "md5": "424393e8705aeadcfecb8559ce4dcea2.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fashion",
+            "cool"
+        ],
         "info": [
             37,
             14,
@@ -4925,7 +6796,10 @@
         "name": "Sunglasses2",
         "md5": "3185d2295bbf2c5ebd0688c9e4f13076.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fashion",
+            "cool"
+        ],
         "info": [
             29,
             10,
@@ -4936,7 +6810,12 @@
         "name": "Taco-a",
         "md5": "d224b30c54bd4d6000c935938c7f5d7e.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "food",
+            "waffle",
+            "yum",
+            "delicious"
+        ],
         "info": [
             20,
             15,
@@ -4947,7 +6826,12 @@
         "name": "Taco-b",
         "md5": "6dee4f866d79e6475d9824ba11973037.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "food",
+            "waffle",
+            "yum",
+            "delicious"
+        ],
         "info": [
             56,
             15,
@@ -4958,7 +6842,10 @@
         "name": "Takeout-a",
         "md5": "0cfdefe0df1a032b90c8facd9f5dbe1f.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "food",
+            "alex eben meyer"
+        ],
         "info": [
             78,
             61,
@@ -4969,7 +6856,10 @@
         "name": "Takeout-b",
         "md5": "48b19c48e32c98a35836ee40e3a7accf.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "food",
+            "alex eben meyer"
+        ],
         "info": [
             78,
             61,
@@ -4980,7 +6870,10 @@
         "name": "Takeout-c",
         "md5": "22d33d87883f8fb26c642eccc9b339f0.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "food",
+            "alex eben meyer"
+        ],
         "info": [
             78,
             61,
@@ -4991,7 +6884,10 @@
         "name": "Takeout-d",
         "md5": "262f1a3730d669dc9d43b3853e397361.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "food",
+            "alex eben meyer"
+        ],
         "info": [
             78,
             61,
@@ -5002,7 +6898,10 @@
         "name": "Takeout-e",
         "md5": "528e9df8c3bd173867be4143f8563e87.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "food",
+            "alex eben meyer"
+        ],
         "info": [
             78,
             61,
@@ -5013,7 +6912,10 @@
         "name": "Tera-a",
         "md5": "b54a4a9087435863ab6f6c908f1cac99.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "drawing"
+        ],
         "info": [
             49,
             63,
@@ -5024,7 +6926,11 @@
         "name": "Tera-b",
         "md5": "1e6b3a29351cda80d1a70a3cc0e499f2.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "drawing",
+            "happy"
+        ],
         "info": [
             49,
             64,
@@ -5035,7 +6941,11 @@
         "name": "Tera-c",
         "md5": "7edf116cbb7111292361431521ae699e.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "drawing",
+            "happy"
+        ],
         "info": [
             49,
             63,
@@ -5046,7 +6956,11 @@
         "name": "Tera-d",
         "md5": "7c3c9c8b5f4ac77de2036175712a777a.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "drawing",
+            "angry"
+        ],
         "info": [
             49,
             63,
@@ -5057,7 +6971,11 @@
         "name": "Toucan-a",
         "md5": "6c8798e606abd728b112aecedb5dc249.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "bird",
+            "robert hunter"
+        ],
         "info": [
             80,
             63,
@@ -5068,7 +6986,11 @@
         "name": "Toucan-b",
         "md5": "a3e12be9efa0e7aa83778f6054c9c541.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "bird",
+            "robert hunter"
+        ],
         "info": [
             80,
             63,
@@ -5079,7 +7001,11 @@
         "name": "Toucan-c",
         "md5": "56522b58a9959fd6152060346129f7cb.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "bird",
+            "robert hunter"
+        ],
         "info": [
             80,
             63,
@@ -5090,7 +7016,11 @@
         "name": "Tree1",
         "md5": "8c40e2662c55d17bc384f47165ac43c1.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "plants",
+            "wood",
+            "forest"
+        ],
         "info": [
             77,
             126,
@@ -5101,7 +7031,11 @@
         "name": "Trees-a",
         "md5": "866ed2c2971bb04157e14e935ac8521c.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "plants",
+            "wood",
+            "forest"
+        ],
         "info": [
             49,
             94,
@@ -5112,7 +7046,11 @@
         "name": "Trees-b",
         "md5": "f1393dde1bb0fc512577995b27616d86.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "plants",
+            "wood",
+            "forest"
+        ],
         "info": [
             36,
             87,
@@ -5123,7 +7061,10 @@
         "name": "Trumpet-a",
         "md5": "8fa7459ed5877bb14c6625e688be70e7.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "music",
+            "andrew rae"
+        ],
         "info": [
             37,
             73,
@@ -5134,7 +7075,10 @@
         "name": "Trumpet-b",
         "md5": "7cedda5ec925118f237094cd05381e5d.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "music",
+            "andrew rae"
+        ],
         "info": [
             37,
             73,
@@ -5145,7 +7089,11 @@
         "name": "Unicorn",
         "md5": "bd2cf980966c13d5ad3ab403bae4bb05.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "animals",
+            "ipzy"
+        ],
         "info": [
             100,
             100,
@@ -5153,10 +7101,31 @@
         ]
     },
     {
+        "name": "Unicorn 2",
+        "md5": "a04def38351e7fd805226345cac4fbfe.svg",
+        "type": "costume",
+        "tags": [
+            "fantasy",
+            "horse",
+            "horn",
+            "rainbow"
+        ],
+        "info": [
+            75,
+            75,
+            1
+        ]
+    },
+    {
         "name": "Unicorn-run-a",
         "md5": "c6456df027561c74b70b8b25ab83fec9.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "animals",
+            "ipzy",
+            "walking"
+        ],
         "info": [
             130,
             100,
@@ -5167,7 +7136,12 @@
         "name": "Unicorn-run-b",
         "md5": "f2d6c5b62b56d0cc51598126c74e0ace.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "animals",
+            "ipzy",
+            "walking"
+        ],
         "info": [
             130,
             100,
@@ -5178,7 +7152,12 @@
         "name": "Unicorn-run-c",
         "md5": "fba367b11a710bf542333649c4d68e1e.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "animals",
+            "ipzy",
+            "walking"
+        ],
         "info": [
             130,
             100,
@@ -5189,7 +7168,12 @@
         "name": "Unicorn-run-d",
         "md5": "20bad70a67e0c7ed3255c65780cdb2a8.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "animals",
+            "ipzy",
+            "walking"
+        ],
         "info": [
             130,
             100,
@@ -5200,7 +7184,12 @@
         "name": "Unicorn-run-e",
         "md5": "39db08aafdde1542e755b8ead8df7a1f.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "animals",
+            "ipzy",
+            "walking"
+        ],
         "info": [
             130,
             100,
@@ -5211,7 +7200,12 @@
         "name": "Unicorn-run-f",
         "md5": "d66d0625702433a4cbd7591e39676700.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "animals",
+            "ipzy",
+            "walking"
+        ],
         "info": [
             130,
             100,
@@ -5222,7 +7216,9 @@
         "name": "Vest-a",
         "md5": "f8285ca9564451c62a0e3d75b8a714e8.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fashon"
+        ],
         "info": [
             18,
             62,
@@ -5233,7 +7229,9 @@
         "name": "Vest-b",
         "md5": "77d553eea3910ab8f5bac3d2da601061.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fashon"
+        ],
         "info": [
             18,
             62,
@@ -5244,7 +7242,11 @@
         "name": "Wand",
         "md5": "1aa56e9ef7043eaf36ecfe8e330271b7.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "ipzy",
+            "things"
+        ],
         "info": [
             12,
             42,
@@ -5255,7 +7257,9 @@
         "name": "Wanda",
         "md5": "450bc8fbd5ab6bc2e83576aad58cd07c.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "people"
+        ],
         "info": [
             49,
             68,
@@ -5266,7 +7270,14 @@
         "name": "Watermelon-a",
         "md5": "26fecef75cf3b6e0d98bff5c06475036.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "food",
+            "fruit",
+            "summer",
+            "seeds",
+            "seedless",
+            "plants"
+        ],
         "info": [
             40,
             27,
@@ -5277,7 +7288,13 @@
         "name": "Watermelon-b",
         "md5": "fbdaf4d1d349edd3ddf3a1c4528aa9ec.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "food",
+            "fruit",
+            "summer",
+            "seeds",
+            "plants"
+        ],
         "info": [
             22,
             27,
@@ -5288,7 +7305,13 @@
         "name": "Watermelon-c",
         "md5": "5976c10412306fc093c1d1930fa05119.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "food",
+            "fruit",
+            "summer",
+            "seeds",
+            "plants"
+        ],
         "info": [
             21,
             15,
@@ -5299,7 +7322,14 @@
         "name": "Witch",
         "md5": "c991196a708294535a1dbdce7189c23c.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "broom",
+            "wart",
+            "flying",
+            "hat",
+            "magic"
+        ],
         "info": [
             74,
             59,
@@ -5310,7 +7340,14 @@
         "name": "Witch-a",
         "md5": "cbc54e15cd62f0c16369587377636099.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "people",
+            "ipzy",
+            "castle",
+            "emotions",
+            "magic"
+        ],
         "info": [
             65,
             140,
@@ -5321,7 +7358,14 @@
         "name": "Witch-b",
         "md5": "64d2c4c51e6cb6008cd5e93f77e6f591.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "people",
+            "ipzy",
+            "castle",
+            "emotions",
+            "magic"
+        ],
         "info": [
             65,
             140,
@@ -5332,7 +7376,14 @@
         "name": "Witch-c",
         "md5": "00b768c3da5b4ee3efddf05d1eb88de2.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "people",
+            "ipzy",
+            "castle",
+            "emotions",
+            "magic"
+        ],
         "info": [
             65,
             140,
@@ -5343,7 +7394,14 @@
         "name": "Witch-d",
         "md5": "4fe4c0ee34a9028f2c6988b7294a61c1.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "people",
+            "ipzy",
+            "castle",
+            "emotions",
+            "magic"
+        ],
         "info": [
             65,
             140,
@@ -5351,21 +7409,17 @@
         ]
     },
     {
-        "name": "Wizard",
-        "md5": "4df1dd733f6ee4a2d8842478ac2c4661.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            76,
-            86,
-            1
-        ]
-    },
-    {
         "name": "Wizard-a",
         "md5": "9632aab80fce1c5bdb58150b29cb0067.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "people",
+            "ipzy",
+            "castle",
+            "emotions",
+            "magic"
+        ],
         "info": [
             87,
             150,
@@ -5376,7 +7430,14 @@
         "name": "Wizard-b",
         "md5": "36c9b8b93ddb2c392b7145862fc4e8d8.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "people",
+            "ipzy",
+            "castle",
+            "emotions",
+            "magic"
+        ],
         "info": [
             79,
             144,
@@ -5387,7 +7448,14 @@
         "name": "Wizard-c",
         "md5": "16d4d221a2182278cfa6b0621f455cf6.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "people",
+            "ipzy",
+            "castle",
+            "emotions",
+            "magic"
+        ],
         "info": [
             87,
             150,
@@ -5398,7 +7466,14 @@
         "name": "Wizard-toad-a",
         "md5": "fd5c4cce36e866489febc227e23b21aa.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "people",
+            "ipzy",
+            "castle",
+            "amphibians",
+            "magic"
+        ],
         "info": [
             87,
             80,
@@ -5409,7 +7484,14 @@
         "name": "Wizard-toad-b",
         "md5": "4c260807d4ac4c0ad39760f1efeef1de.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "fantasy",
+            "people",
+            "ipzy",
+            "castle",
+            "amphibians",
+            "magic"
+        ],
         "info": [
             87,
             80,
@@ -5417,32 +7499,13 @@
         ]
     },
     {
-        "name": "Wizard1",
-        "md5": "e085c97691d16f0cc8a595ce1137e26c.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            134,
-            153,
-            1
-        ]
-    },
-    {
-        "name": "Wizard2",
-        "md5": "6db4d9e4229dc50a1b1c91c3c8311d40.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            69,
-            93,
-            1
-        ]
-    },
-    {
         "name": "Block-a",
         "md5": "602a16930a8050e1298e1a0ae844363e.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             28,
             38,
@@ -5453,7 +7516,10 @@
         "name": "Block-b",
         "md5": "f8c683cf71660e8ac1f8855599857a25.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             29,
             42,
@@ -5464,7 +7530,10 @@
         "name": "Block-c",
         "md5": "f8f4cc686ffc5a4113a99f70b09abd32.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             35,
             43,
@@ -5475,7 +7544,10 @@
         "name": "Block-d",
         "md5": "aee2d71ef0293b33479bff9423d16b67.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             31,
             41,
@@ -5486,7 +7558,10 @@
         "name": "Block-e",
         "md5": "16c6257316ff94cc7539ccdfc24e5fb8.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             25,
             39,
@@ -5497,7 +7572,10 @@
         "name": "Block-f",
         "md5": "34c090c1f573c569332ead68cb99b595.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             23,
             40,
@@ -5508,7 +7586,10 @@
         "name": "Block-g",
         "md5": "8bb2382627004eb08ff10ea8171cc724.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             28,
             39,
@@ -5519,7 +7600,10 @@
         "name": "Block-h",
         "md5": "f1578807d4a124fc02b639a8febeaab3.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             27,
             38,
@@ -5530,7 +7614,10 @@
         "name": "Block-i",
         "md5": "341bc70442886d6fdf959f2a97a63554.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             19,
             39,
@@ -5541,7 +7628,10 @@
         "name": "Block-j",
         "md5": "4b420cce964beedf2c1dc43faa59fdec.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             25,
             41,
@@ -5552,7 +7642,10 @@
         "name": "Block-k",
         "md5": "19601cc33449813aa93a47c63167e5c1.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             24,
             40,
@@ -5563,7 +7656,10 @@
         "name": "Block-l",
         "md5": "87358e3c9b9f5be4376253ce08d0192d.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             26,
             40,
@@ -5574,7 +7670,10 @@
         "name": "Block-m",
         "md5": "7ba0642be1f0080c0d273ea96e29b1e8.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             35,
             37,
@@ -5585,7 +7684,10 @@
         "name": "Block-n",
         "md5": "6c1fbc57821744bd9356ce9a21ed70f7.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             28,
             37,
@@ -5596,7 +7698,10 @@
         "name": "Block-o",
         "md5": "e88638200a73e167d0e266a343019cec.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             32,
             40,
@@ -5607,7 +7712,10 @@
         "name": "Block-p",
         "md5": "ad2fc3a1c6538678915633a11ab6ec73.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             18,
             33,
@@ -5618,7 +7726,10 @@
         "name": "Block-q",
         "md5": "64da9da8684c74deb567dbdb661d3a52.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             26,
             33,
@@ -5629,7 +7740,10 @@
         "name": "Block-r",
         "md5": "73e8d46f7475476d8cb4cfcfc75ee50d.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             22,
             33,
@@ -5640,7 +7754,10 @@
         "name": "Block-s",
         "md5": "9feb5593fed51e88dbb3128cfc290d29.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             13,
             30,
@@ -5651,7 +7768,10 @@
         "name": "Block-t",
         "md5": "d29c1caf5cf195740c38f279e82a77a4.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             25,
             33,
@@ -5662,7 +7782,10 @@
         "name": "Block-u",
         "md5": "faef46b7bf589c36300142f6f03c5d32.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             28,
             41,
@@ -5673,7 +7796,10 @@
         "name": "Block-v",
         "md5": "65e2f4821ab084827e22920acb61c92b.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             35,
             41,
@@ -5684,7 +7810,10 @@
         "name": "Block-w",
         "md5": "5ab197b4f70b2f98a3658c7ccdc3351d.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             47,
             39,
@@ -5695,7 +7824,10 @@
         "name": "Block-x",
         "md5": "cb9dff35f05e823d954e47e4a717a48c.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             25,
             32,
@@ -5706,7 +7838,10 @@
         "name": "Block-y",
         "md5": "4c13c440bcb35c8c3aa6226374fced3f.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             26,
             33,
@@ -5717,7 +7852,10 @@
         "name": "Block-z",
         "md5": "0ccff1898f1bf1b25333d581db09fae2.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             24,
             38,
@@ -5728,7 +7866,10 @@
         "name": "Glow-0",
         "md5": "38b2b342659adc6fa289090975e0e71d.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "numbers",
+            "digits"
+        ],
         "info": [
             29,
             39,
@@ -5739,7 +7880,10 @@
         "name": "Glow-1",
         "md5": "2c88706210672655401fe09edd8ff6a7.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "numbers",
+            "digits"
+        ],
         "info": [
             24,
             39,
@@ -5750,7 +7894,10 @@
         "name": "Glow-2",
         "md5": "b9faa5708a799a1607f0325a7af2561c.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "numbers",
+            "digits"
+        ],
         "info": [
             28,
             41,
@@ -5761,7 +7908,10 @@
         "name": "Glow-3",
         "md5": "cf42a50552ce26032ead712ac4f36c23.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "numbers",
+            "digits"
+        ],
         "info": [
             33,
             42,
@@ -5772,7 +7922,10 @@
         "name": "Glow-4",
         "md5": "3ffa6aee373e28fc36b9395ac4d0467e.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "numbers",
+            "digits"
+        ],
         "info": [
             31,
             38,
@@ -5783,7 +7936,10 @@
         "name": "Glow-5",
         "md5": "85d87d32e7e9e6be122c905b0d2e7e33.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "numbers",
+            "digits"
+        ],
         "info": [
             30,
             38,
@@ -5794,7 +7950,10 @@
         "name": "Glow-6",
         "md5": "62cc2a6def27f19d11ed56e86e95aac5.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "numbers",
+            "digits"
+        ],
         "info": [
             30,
             37,
@@ -5805,7 +7964,10 @@
         "name": "Glow-7",
         "md5": "8887983eb4df2e62a2ed4770a1d98d60.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "numbers",
+            "digits"
+        ],
         "info": [
             31,
             42,
@@ -5816,7 +7978,10 @@
         "name": "Glow-8",
         "md5": "4c42c4cb0c1e090d0f9570416d3c80c8.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "numbers",
+            "digits"
+        ],
         "info": [
             31,
             37,
@@ -5827,7 +7992,10 @@
         "name": "Glow-9",
         "md5": "7bcb7e2e48f5cb770c83d4267922fec0.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "numbers",
+            "digits"
+        ],
         "info": [
             28,
             36,
@@ -5838,7 +8006,10 @@
         "name": "Glow-A",
         "md5": "d5aa299350c24c747200a64b63b1aa52.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             36,
             37,
@@ -5849,7 +8020,10 @@
         "name": "Glow-B",
         "md5": "a2e95f268a6cab03f3e94b3b0b792d83.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             32,
             35,
@@ -5860,7 +8034,10 @@
         "name": "Glow-C",
         "md5": "9779a4a40934f04a4bf84920b258d7c9.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             27,
             35,
@@ -5871,7 +8048,10 @@
         "name": "Glow-D",
         "md5": "3555b8bbbbcdc00354bf6fa81ac7042f.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             33,
             35,
@@ -5882,7 +8062,10 @@
         "name": "Glow-E",
         "md5": "44dbc655d5ac9f13618473848e23484e.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             34,
             38,
@@ -5893,7 +8076,10 @@
         "name": "Glow-F",
         "md5": "dec417e749e43d7de3985155f5f5a7a0.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             35,
             41,
@@ -5904,7 +8090,10 @@
         "name": "Glow-G",
         "md5": "cf4aa465cd8fb7049cc571d7546a7eb1.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             32,
             39,
@@ -5915,7 +8104,10 @@
         "name": "Glow-H",
         "md5": "8d9bd5f00ea1ac6f92d0f97ee491b0f3.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             35,
             46,
@@ -5926,7 +8118,10 @@
         "name": "Glow-I",
         "md5": "0e86de55840103dcd50199ab2b765de7.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             21,
             38,
@@ -5937,7 +8132,10 @@
         "name": "Glow-J",
         "md5": "b3832145eacc39f91bd3a9a6673fa05c.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             29,
             39,
@@ -5948,7 +8146,10 @@
         "name": "Glow-K",
         "md5": "f4e37a7552ba05e995613211a7146de5.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             38,
             36,
@@ -5959,7 +8160,10 @@
         "name": "Glow-L",
         "md5": "a75e45773ea6afaf8ae44f79f936fc82.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             33,
             35,
@@ -5970,7 +8174,10 @@
         "name": "Glow-M",
         "md5": "219b06faa5b816347165450d148213b4.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             42,
             39,
@@ -5981,7 +8188,10 @@
         "name": "Glow-N",
         "md5": "4b724479fb3b2184fd8be6f83fb20e54.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             37,
             39,
@@ -5992,7 +8202,10 @@
         "name": "Glow-O",
         "md5": "38b2b342659adc6fa289090975e0e71d.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             29,
             39,
@@ -6003,7 +8216,10 @@
         "name": "Glow-P",
         "md5": "1cfa849cc967069730b7e9d0809c9dc1.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             32,
             39,
@@ -6014,7 +8230,10 @@
         "name": "Glow-Q",
         "md5": "9d35979e9404ac234301269fcd7de288.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             33,
             43,
@@ -6025,7 +8244,10 @@
         "name": "Glow-R",
         "md5": "fc067ee076ecaba8430ccd54d9414c1b.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             35,
             38,
@@ -6036,7 +8258,10 @@
         "name": "Glow-S",
         "md5": "19a93db8a294ccaec4d6eef4020a446f.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             27,
             40,
@@ -6047,7 +8272,10 @@
         "name": "Glow-T",
         "md5": "d7bcda522a1e9504dafcf2fa0fcde39b.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             35,
             38,
@@ -6058,7 +8286,10 @@
         "name": "Glow-U",
         "md5": "790482a3c3691a1e96ef34eee7303872.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             37,
             37,
@@ -6069,7 +8300,10 @@
         "name": "Glow-V",
         "md5": "6a00388d8dc6be645b843cef9c22681c.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             35,
             42,
@@ -6080,7 +8314,10 @@
         "name": "Glow-W",
         "md5": "1a9ea7305a85b271c1de79beafe16cb4.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             45,
             41,
@@ -6091,7 +8328,10 @@
         "name": "Glow-X",
         "md5": "ec4e65b9ae475a676973128f4205df5f.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             40,
             39,
@@ -6102,7 +8342,10 @@
         "name": "Glow-Y",
         "md5": "683cd093bb3b254733a15df6f843464c.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             38,
             41,
@@ -6113,7 +8356,10 @@
         "name": "Glow-Z",
         "md5": "db89a4c9b123123542e0b7556ed3ff9f.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letters"
+        ],
         "info": [
             30,
             39,
@@ -6121,406 +8367,13 @@
         ]
     },
     {
-        "name": "Pixel-0",
-        "md5": "cd1f984997b44de464bbf86fc073b280.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            13,
-            18,
-            1
-        ]
-    },
-    {
-        "name": "Pixel-1",
-        "md5": "4ec3d6c4ef14112ed7c6ba6b9549da3b.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            7,
-            20,
-            1
-        ]
-    },
-    {
-        "name": "Pixel-2",
-        "md5": "d0136e77a646a3ad719aaa7f8f95a7ff.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            14,
-            17,
-            1
-        ]
-    },
-    {
-        "name": "Pixel-3",
-        "md5": "7c1700f0dcfb418662d29ba6faa114e7.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            14,
-            18,
-            1
-        ]
-    },
-    {
-        "name": "Pixel-4",
-        "md5": "6238b9b95fad7f7aa9cef9bde5bde474.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            14,
-            19,
-            1
-        ]
-    },
-    {
-        "name": "Pixel-5",
-        "md5": "aef915acf1d49deed46692411e6c6039.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            12,
-            19,
-            1
-        ]
-    },
-    {
-        "name": "Pixel-6",
-        "md5": "e6ad1d1fe44a1c63c8f99c0bbb893a44.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            14,
-            17,
-            1
-        ]
-    },
-    {
-        "name": "Pixel-7",
-        "md5": "469b4fb6f6f8721e2c244ae9c71a7e66.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            12,
-            19,
-            1
-        ]
-    },
-    {
-        "name": "Pixel-8",
-        "md5": "5bfcf2c715b81ae380ae2983bb4c5bb2.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            14,
-            19,
-            1
-        ]
-    },
-    {
-        "name": "Pixel-9",
-        "md5": "8014a66c758f1bc389194c988badb382.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            12,
-            20,
-            1
-        ]
-    },
-    {
-        "name": "Pixel-A",
-        "md5": "a54da6be420c9e8e7cb02e2a568f3442.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            14,
-            19,
-            1
-        ]
-    },
-    {
-        "name": "Pixel-B",
-        "md5": "e47682020873e276f550421f0d854523.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            14,
-            18,
-            1
-        ]
-    },
-    {
-        "name": "Pixel-C",
-        "md5": "ee1958ffbae4e0fd836622ae183b55bd.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            14,
-            20,
-            1
-        ]
-    },
-    {
-        "name": "Pixel-D",
-        "md5": "d759df99f347d9b7d59e1f703e8e1438.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            14,
-            20,
-            1
-        ]
-    },
-    {
-        "name": "Pixel-E",
-        "md5": "059a64a90014dc69c510b562cdf94df7.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            11,
-            19,
-            1
-        ]
-    },
-    {
-        "name": "Pixel-F",
-        "md5": "ebbc6dc0f7d1a89b159aac3f76fe52f4.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            10,
-            20,
-            1
-        ]
-    },
-    {
-        "name": "Pixel-G",
-        "md5": "203dfa253635f0e52059e835c51fa6f8.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            15,
-            22,
-            1
-        ]
-    },
-    {
-        "name": "Pixel-H",
-        "md5": "d9a94d9b9abc9e26eb91d22d197a1556.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            15,
-            20,
-            1
-        ]
-    },
-    {
-        "name": "Pixel-I",
-        "md5": "aeb851adc39da9582a379af1ed6d0efe.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            9,
-            21,
-            1
-        ]
-    },
-    {
-        "name": "Pixel-J",
-        "md5": "c18906f764b2889a8fc0b3c16db28bf0.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            14,
-            20,
-            1
-        ]
-    },
-    {
-        "name": "Pixel-K",
-        "md5": "4483633d2ae26987d0efe359aaf1357b.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            14,
-            20,
-            1
-        ]
-    },
-    {
-        "name": "Pixel-L",
-        "md5": "0625b64705d62748c6105e969859fe0d.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            11,
-            18,
-            1
-        ]
-    },
-    {
-        "name": "Pixel-M",
-        "md5": "46ccf731f158b9dda75f4e71a5bcd282.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            19,
-            16,
-            1
-        ]
-    },
-    {
-        "name": "Pixel-N",
-        "md5": "f9d3b49b5962ff4070fae186b8b71e39.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            14,
-            19,
-            1
-        ]
-    },
-    {
-        "name": "Pixel-O",
-        "md5": "668b21968078f3b7b1a9ccd74407fa1e.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            13,
-            19,
-            1
-        ]
-    },
-    {
-        "name": "Pixel-P",
-        "md5": "02011265d2597175c7496da667265f4a.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            13,
-            19,
-            1
-        ]
-    },
-    {
-        "name": "Pixel-Q",
-        "md5": "8c77c87dd0ed2613873cff0795ffc701.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            13,
-            21,
-            1
-        ]
-    },
-    {
-        "name": "Pixel-R",
-        "md5": "c94daea3bd1e8cec36e1aa4e0b1d3f2b.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            13,
-            19,
-            1
-        ]
-    },
-    {
-        "name": "Pixel-S",
-        "md5": "2fedb1b52f4a4500938a3a52085344e6.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            13,
-            20,
-            1
-        ]
-    },
-    {
-        "name": "Pixel-T",
-        "md5": "3f481b967f82014c7cf6dd14d438c32d.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            13,
-            20,
-            1
-        ]
-    },
-    {
-        "name": "Pixel-U",
-        "md5": "a207644e4adb613f410f80a7e123db60.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            14,
-            19,
-            1
-        ]
-    },
-    {
-        "name": "Pixel-V",
-        "md5": "1bb20febe562fa291bea94be1e2d44ba.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            14,
-            20,
-            1
-        ]
-    },
-    {
-        "name": "Pixel-W",
-        "md5": "34b628e8c84cc551a1fa740b85afb750.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            13,
-            19,
-            1
-        ]
-    },
-    {
-        "name": "Pixel-X",
-        "md5": "4cc2d68ceb08176481e882ed39e4f5d5.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            14,
-            19,
-            1
-        ]
-    },
-    {
-        "name": "Pixel-Y",
-        "md5": "e6c377982c023761796eaed1047169e6.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            13,
-            18,
-            1
-        ]
-    },
-    {
-        "name": "Pixel-Z",
-        "md5": "ecadc3a562c9aa963717fcdf07ec96b4.svg",
-        "type": "costume",
-        "tags": [],
-        "info": [
-            12,
-            18,
-            1
-        ]
-    },
-    {
         "name": "story-A-1",
         "md5": "5406b37278d819d4787a588b9c91f68e.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             23,
             26,
@@ -6531,7 +8384,10 @@
         "name": "story-A-2",
         "md5": "f277943adf8d79b41b9b568321a786ee.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             23,
             26,
@@ -6542,7 +8398,10 @@
         "name": "story-A-3",
         "md5": "cc0cc7ae3240eab7d040e148cc663325.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             22,
             24,
@@ -6553,7 +8412,10 @@
         "name": "story-B-1",
         "md5": "2a8fac3c82d95f13203843a597b5757b.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             20,
             25,
@@ -6564,7 +8426,10 @@
         "name": "story-B-2",
         "md5": "07fa4ebc421d84743b6ced189dd2f9cf.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             19,
             25,
@@ -6575,7 +8440,10 @@
         "name": "story-B-3",
         "md5": "6c9a9203155f93f24f31b30e3bd76b6d.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             18,
             23,
@@ -6586,7 +8454,10 @@
         "name": "story-C-1",
         "md5": "144845715016910e88e2a223ed4d3df1.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             22,
             26,
@@ -6597,7 +8468,10 @@
         "name": "story-C-2",
         "md5": "1045c56c4be3d8d0650579864417fbc7.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             22,
             26,
@@ -6608,7 +8482,10 @@
         "name": "story-C-3",
         "md5": "c8fd35294d17a369fecb6d6e4725d04a.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             20,
             24,
@@ -6619,7 +8496,10 @@
         "name": "story-D-1",
         "md5": "dfd362f2da975c20aa7849a8fa2fb4df.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             25,
             26,
@@ -6630,7 +8510,10 @@
         "name": "story-D-2",
         "md5": "3e4cc4cff08bb42bc690eff66dffbbe9.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             25,
             26,
@@ -6641,7 +8524,10 @@
         "name": "story-D-3",
         "md5": "bd7f984fe82d9d0fdcff0a87b3c0f9e0.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             22,
             23,
@@ -6652,7 +8538,10 @@
         "name": "story-E-1",
         "md5": "56473bacbdf6f0dbca1afb04e5aebaf7.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             20,
             25,
@@ -6663,7 +8552,10 @@
         "name": "story-E-2",
         "md5": "8bba14966fe35f0dccb66ef06a9843ca.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             20,
             25,
@@ -6674,7 +8566,10 @@
         "name": "story-E-3",
         "md5": "e8cfc63375f6d6c2a580823489427f38.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             18,
             23,
@@ -6685,7 +8580,10 @@
         "name": "story-F-1",
         "md5": "5844ff29fc8663c8613f12169d2f07ef.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             18,
             26,
@@ -6696,7 +8594,10 @@
         "name": "story-F-2",
         "md5": "0dbe4a064abea1a9a3bc0d2732643e6b.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             18,
             25,
@@ -6707,7 +8608,10 @@
         "name": "story-F-3",
         "md5": "3db373f4482e391e66d1b06335a96144.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             16,
             23,
@@ -6718,7 +8622,10 @@
         "name": "story-G-1",
         "md5": "ee6454d15fbbe93e908a2ebbfad483a0.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             23,
             25,
@@ -6729,7 +8636,10 @@
         "name": "story-G-2",
         "md5": "991023d303f79ce092f070392ffbd69f.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             23,
             25,
@@ -6740,7 +8650,10 @@
         "name": "story-G-3",
         "md5": "38f22c0d8dbe541bde409ba1f241d4c1.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             21,
             24,
@@ -6751,7 +8664,10 @@
         "name": "story-H-1",
         "md5": "2a0e1308d6cb806818af696a89b21863.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             24,
             25,
@@ -6762,7 +8678,10 @@
         "name": "story-H-2",
         "md5": "ca33be5270308a695c9b88af73f590dc.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             24,
             25,
@@ -6773,7 +8692,10 @@
         "name": "story-H-3",
         "md5": "668ba2b891f82ce78d8590f0287632b1.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             22,
             24,
@@ -6784,7 +8706,10 @@
         "name": "story-I-1",
         "md5": "705297637ea83af5b94b6fe2e34aeef4.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             9,
             26,
@@ -6795,7 +8720,10 @@
         "name": "story-I-2",
         "md5": "7b3ae96764795727fa1cb0be68a9ca5e.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             9,
             26,
@@ -6806,7 +8734,10 @@
         "name": "story-I-3",
         "md5": "3475aa570304accb7e6dbd2516234135.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             7,
             23,
@@ -6817,7 +8748,10 @@
         "name": "story-J-1",
         "md5": "ac2e7eaecb80c5501e5e56802d03af00.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             14,
             25,
@@ -6828,7 +8762,10 @@
         "name": "story-J-2",
         "md5": "0ab9a94fc2e32160efc113a8e5ffb984.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             14,
             25,
@@ -6839,7 +8776,10 @@
         "name": "story-J-3",
         "md5": "c9356a022cfbc25be6c484e9781e4637.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             12,
             24,
@@ -6850,7 +8790,10 @@
         "name": "story-K-1",
         "md5": "62dcc92dc3c6cb0271244190320c4f71.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             24,
             26,
@@ -6861,7 +8804,10 @@
         "name": "story-K-2",
         "md5": "ef02339e8a0382367f0b5a414915b885.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             24,
             26,
@@ -6872,7 +8818,10 @@
         "name": "story-K-3",
         "md5": "07977708617d12381b22d1ee0f4926a3.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             21,
             24,
@@ -6883,7 +8832,10 @@
         "name": "story-L-1",
         "md5": "7ce306e9c9c0dd0a24279606301f1d05.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             19,
             26,
@@ -6894,7 +8846,10 @@
         "name": "story-L-2",
         "md5": "067c21a9b2f91ed33e07131ce5a59210.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             19,
             26,
@@ -6905,7 +8860,10 @@
         "name": "story-L-3",
         "md5": "488d66f17c0089a7796d44cfc70792e8.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             17,
             23,
@@ -6916,7 +8874,10 @@
         "name": "story-M-1",
         "md5": "b27f166f9ab4a3fb93a50a77c58c3df3.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             30,
             25,
@@ -6927,7 +8888,10 @@
         "name": "story-M-2",
         "md5": "55f00a23d0f5cc57be9533f126a7ac8c.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             30,
             25,
@@ -6938,7 +8902,10 @@
         "name": "story-M-3",
         "md5": "613df2bd97784a239ab992f7a95458a0.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             27,
             24,
@@ -6949,7 +8916,10 @@
         "name": "story-N-1",
         "md5": "293589fd5bbc358a20c165ab49c19833.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             26,
             25,
@@ -6960,7 +8930,10 @@
         "name": "story-N-2",
         "md5": "5e07ee61cb20bc575720774584dfec53.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             26,
             25,
@@ -6971,7 +8944,10 @@
         "name": "story-N-3",
         "md5": "435697335345f946d943c1d89fdb459a.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             24,
             23,
@@ -6982,7 +8958,10 @@
         "name": "story-O-1",
         "md5": "088beed7ce0dff554da06f54d0558bc0.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             25,
             25,
@@ -6993,7 +8972,10 @@
         "name": "story-O-2",
         "md5": "e8fa671bb1ca53c044bfb27225321c25.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             24,
             25,
@@ -7004,7 +8986,10 @@
         "name": "story-O-3",
         "md5": "a132bf3d4084ef8ca9e0797f64c0f082.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             22,
             24,
@@ -7015,7 +9000,10 @@
         "name": "story-P-1",
         "md5": "ad4a101b83f28ced16849be3e393caa9.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             20,
             25,
@@ -7026,7 +9014,10 @@
         "name": "story-P-2",
         "md5": "781c42f9da36bbc0ee3775f18ac98124.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             20,
             25,
@@ -7037,7 +9028,10 @@
         "name": "story-P-3",
         "md5": "bcaec7c778920d8d74c275c1aff634fe.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             17,
             24,
@@ -7048,7 +9042,10 @@
         "name": "story-Q-1",
         "md5": "484e44f908e84d795c87cf994364e722.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             25,
             30,
@@ -7059,7 +9056,10 @@
         "name": "story-Q-2",
         "md5": "31f28be74dc7de42a5c4a38504d666ca.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             25,
             30,
@@ -7070,7 +9070,10 @@
         "name": "story-Q-3",
         "md5": "aef19097378515308e934a79f147032e.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             22,
             29,
@@ -7081,7 +9084,10 @@
         "name": "story-R-1",
         "md5": "55999cb6783ef8351d841294d75af942.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             22,
             26,
@@ -7092,7 +9098,10 @@
         "name": "story-R-2",
         "md5": "926f8ff770cb15b42b12f209fd02d98c.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             22,
             26,
@@ -7103,7 +9112,10 @@
         "name": "story-R-3",
         "md5": "a66d8f0ba6d40c624873edc8df58c014.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             20,
             23,
@@ -7114,7 +9126,10 @@
         "name": "story-S-1",
         "md5": "fca1555f335392f1c4ef620bf098c0de.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             16,
             25,
@@ -7125,7 +9140,10 @@
         "name": "story-S-2",
         "md5": "c529ed7b40f4a949539f8f454e3fe475.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             16,
             25,
@@ -7136,7 +9154,10 @@
         "name": "story-S-3",
         "md5": "e96388c9197733bdadbad3ce014c0e59.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             14,
             23,
@@ -7147,7 +9168,10 @@
         "name": "story-T-1",
         "md5": "d3b342c795a620b69639c02a419e8535.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             22,
             27,
@@ -7158,7 +9182,10 @@
         "name": "story-T-2",
         "md5": "eeb0fd25c9273747ac38766d1959ba2b.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             22,
             27,
@@ -7169,7 +9196,10 @@
         "name": "story-T-3",
         "md5": "a9683d4946b08a76864a51bd21d811cb.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             20,
             24,
@@ -7180,7 +9210,10 @@
         "name": "story-U-1",
         "md5": "fcf99b6e8aeb2d504e1e9b2194640916.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             24,
             26,
@@ -7191,7 +9224,10 @@
         "name": "story-U-2",
         "md5": "f442802f17225d6506ac9718810f179e.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             24,
             26,
@@ -7202,7 +9238,10 @@
         "name": "story-U-3",
         "md5": "0779f03a6589c60352b1d4806a4a61c0.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             21,
             24,
@@ -7213,7 +9252,10 @@
         "name": "story-V-1",
         "md5": "750b47f1de2143f76354239b27e1e5f0.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             25,
             25,
@@ -7224,7 +9266,10 @@
         "name": "story-V-2",
         "md5": "03de7add77e31799ca568a9c671012b4.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             25,
             25,
@@ -7235,7 +9280,10 @@
         "name": "story-V-3",
         "md5": "29befe20b105b69471f5507d025ec3e0.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             22,
             23,
@@ -7246,7 +9294,10 @@
         "name": "story-W-1",
         "md5": "7d9d4c0da9bd1a3ddf253d1bea26f4e9.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             37,
             25,
@@ -7257,7 +9308,10 @@
         "name": "story-W-2",
         "md5": "c0f48eb69cae4a611d3e7b7e06b0d1c1.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             37,
             25,
@@ -7268,7 +9322,10 @@
         "name": "story-W-3",
         "md5": "d1c922c9e9d53d2f6f36ca637e85de6b.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             34,
             24,
@@ -7279,7 +9336,10 @@
         "name": "story-X-1",
         "md5": "92c452555b3d5a4993f107810043ea03.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             22,
             26,
@@ -7290,7 +9350,10 @@
         "name": "story-X-2",
         "md5": "f688425da41c2b7f80d4b8752de69bc9.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             22,
             26,
@@ -7301,7 +9364,10 @@
         "name": "story-X-3",
         "md5": "ec90479a0ce3c7706f1916daef0f3c67.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             20,
             24,
@@ -7312,7 +9378,10 @@
         "name": "story-Y-1",
         "md5": "b3c252450d413fc75be0eafdbe4490dc.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             22,
             27,
@@ -7323,7 +9392,10 @@
         "name": "story-Y-2",
         "md5": "1cfa161ae5d60ea163e4e0aa34d08f02.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             22,
             27,
@@ -7334,7 +9406,10 @@
         "name": "story-Y-3",
         "md5": "a1fc3c0fa304255364c0f98547e0e448.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             20,
             24,
@@ -7345,7 +9420,10 @@
         "name": "story-Z-1",
         "md5": "86326c9180c485b557a075f4794939d7.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             19,
             26,
@@ -7356,7 +9434,10 @@
         "name": "story-Z-2",
         "md5": "e10b203e47bbb41edab78be59e628449.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             19,
             26,
@@ -7367,7 +9448,10 @@
         "name": "story-Z-3",
         "md5": "0788df7b1d9cf02dfdebc021d4f30ce4.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "alphabet",
+            "letter"
+        ],
         "info": [
             17,
             23,

--- a/src/lib/libraries/sounds.json
+++ b/src/lib/libraries/sounds.json
@@ -29,11 +29,7 @@
         "sampleCount": 44100,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "music",
-            "instruments",
-            "notes"
-        ]
+        "tags": []
     },
     {
         "name": "A Elec Piano",
@@ -41,11 +37,7 @@
         "sampleCount": 44100,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "music",
-            "instruments",
-            "notes"
-        ]
+        "tags": []
     },
     {
         "name": "A Guitar",
@@ -53,11 +45,7 @@
         "sampleCount": 31872,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "music",
-            "instruments",
-            "notes"
-        ]
+        "tags": []
     },
     {
         "name": "A Minor Ukulele",
@@ -90,11 +78,7 @@
         "sampleCount": 6472,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "music",
-            "notes",
-            "instruments"
-        ]
+        "tags": []
     },
     {
         "name": "A Trombone",
@@ -114,11 +98,7 @@
         "sampleCount": 13911,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "music",
-            "instruments",
-            "notes"
-        ]
+        "tags": []
     },
     {
         "name": "Afro String",
@@ -126,9 +106,7 @@
         "sampleCount": 9807,
         "rate": 11025,
         "format": "",
-        "tags": [
-            "instruments"
-        ]
+        "tags": []
     },
     {
         "name": "Alert",
@@ -195,11 +173,7 @@
         "sampleCount": 44100,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "music",
-            "instruments",
-            "notes"
-        ]
+        "tags": []
     },
     {
         "name": "B Elec Piano",
@@ -207,11 +181,7 @@
         "sampleCount": 44100,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "music",
-            "instruments",
-            "notes"
-        ]
+        "tags": []
     },
     {
         "name": "B Guitar",
@@ -219,11 +189,7 @@
         "sampleCount": 29504,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "music",
-            "instruments",
-            "notes"
-        ]
+        "tags": []
     },
     {
         "name": "B Piano",
@@ -243,11 +209,7 @@
         "sampleCount": 9555,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "music",
-            "notes",
-            "instruments"
-        ]
+        "tags": []
     },
     {
         "name": "B Trombone",
@@ -267,11 +229,7 @@
         "sampleCount": 14704,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "music",
-            "instruments",
-            "notes"
-        ]
+        "tags": []
     },
     {
         "name": "Baa",
@@ -309,12 +267,7 @@
         "sampleCount": 6720,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "human",
-            "percussion",
-            "music",
-            "hiphop"
-        ]
+        "tags": []
     },
     {
         "name": "Beat Box1",
@@ -348,10 +301,7 @@
         "sampleCount": 19328,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "percussion",
-            "drums"
-        ]
+        "tags": []
     },
     {
         "name": "Bell Toll",
@@ -481,9 +431,7 @@
         "sampleCount": 9037,
         "rate": 11025,
         "format": "",
-        "tags": [
-            "effects"
-        ]
+        "tags": []
     },
     {
         "name": "C Bass",
@@ -515,11 +463,7 @@
         "sampleCount": 44100,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "music",
-            "instruments",
-            "notes"
-        ]
+        "tags": []
     },
     {
         "name": "C Elec Piano",
@@ -527,11 +471,7 @@
         "sampleCount": 44100,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "music",
-            "instruments",
-            "notes"
-        ]
+        "tags": []
     },
     {
         "name": "C Guitar",
@@ -539,11 +479,7 @@
         "sampleCount": 44864,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "music",
-            "instruments",
-            "notes"
-        ]
+        "tags": []
     },
     {
         "name": "C Major Ukulele",
@@ -576,11 +512,7 @@
         "sampleCount": 9491,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "music",
-            "notes",
-            "instruments"
-        ]
+        "tags": []
     },
     {
         "name": "C Trombone",
@@ -600,11 +532,7 @@
         "sampleCount": 13118,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "music",
-            "instruments",
-            "notes"
-        ]
+        "tags": []
     },
     {
         "name": "C2 Bass",
@@ -636,11 +564,7 @@
         "sampleCount": 44100,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "music",
-            "instruments",
-            "notes"
-        ]
+        "tags": []
     },
     {
         "name": "C2 Elec Piano",
@@ -648,11 +572,7 @@
         "sampleCount": 44100,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "music",
-            "instruments",
-            "notes"
-        ]
+        "tags": []
     },
     {
         "name": "C2 Guitar",
@@ -660,11 +580,7 @@
         "sampleCount": 27712,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "music",
-            "instruments",
-            "notes"
-        ]
+        "tags": []
     },
     {
         "name": "C2 Piano",
@@ -684,11 +600,7 @@
         "sampleCount": 7349,
         "rate": 22050,
         "format": "adpcm",
-        "tags": [
-            "music",
-            "notes",
-            "instruments"
-        ]
+        "tags": []
     },
     {
         "name": "C2 Trombone",
@@ -708,11 +620,7 @@
         "sampleCount": 15849,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "music",
-            "instruments",
-            "notes"
-        ]
+        "tags": []
     },
     {
         "name": "Car Horn",
@@ -784,11 +692,12 @@
     },
     {
         "name": "Cheer",
-        "md5": "4b36eebf22be4667fc2f15b78c805b4c.wav",
-        "sampleCount": 62528,
+        "md5": "170e05c29d50918ae0b482c2955768c0.wav",
+        "sampleCount": 108864,
         "rate": 22050,
-        "format": "",
+        "format": "adpcm",
         "tags": [
+            "sports",
             "human",
             "voice"
         ]
@@ -843,12 +752,7 @@
         "sampleCount": 4224,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "human",
-            "percussion",
-            "music",
-            "hiphop"
-        ]
+        "tags": []
     },
     {
         "name": "Clapping",
@@ -912,10 +816,7 @@
         "sampleCount": 9536,
         "rate": 11025,
         "format": "",
-        "tags": [
-            "effects",
-            "electronic"
-        ]
+        "tags": []
     },
     {
         "name": "Computer Beep2",
@@ -976,12 +877,7 @@
         "sampleCount": 26883,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "human",
-            "percussion",
-            "music",
-            "hiphop"
-        ]
+        "tags": []
     },
     {
         "name": "Crash Cymbal",
@@ -989,10 +885,7 @@
         "sampleCount": 25220,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "music",
-            "percussion"
-        ]
+        "tags": []
     },
     {
         "name": "Crazy Laugh",
@@ -1143,11 +1036,7 @@
         "sampleCount": 44100,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "music",
-            "instruments",
-            "notes"
-        ]
+        "tags": []
     },
     {
         "name": "D Elec Piano",
@@ -1155,11 +1044,7 @@
         "sampleCount": 44100,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "music",
-            "instruments",
-            "notes"
-        ]
+        "tags": []
     },
     {
         "name": "D Guitar",
@@ -1167,11 +1052,7 @@
         "sampleCount": 41120,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "music",
-            "instruments",
-            "notes"
-        ]
+        "tags": []
     },
     {
         "name": "D Piano",
@@ -1191,11 +1072,7 @@
         "sampleCount": 9555,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "music",
-            "notes",
-            "instruments"
-        ]
+        "tags": []
     },
     {
         "name": "D Trombone",
@@ -1215,11 +1092,7 @@
         "sampleCount": 12702,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "music",
-            "instruments",
-            "notes"
-        ]
+        "tags": []
     },
     {
         "name": "Dance Around",
@@ -1438,12 +1311,7 @@
         "sampleCount": 6528,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "music",
-            "percussion",
-            "hiphop",
-            "kick"
-        ]
+        "tags": []
     },
     {
         "name": "Drum Bass2",
@@ -1451,12 +1319,7 @@
         "sampleCount": 3791,
         "rate": 22050,
         "format": "adpcm",
-        "tags": [
-            "music",
-            "percussion",
-            "hiphop",
-            "kick"
-        ]
+        "tags": []
     },
     {
         "name": "Drum Bass3",
@@ -1464,12 +1327,7 @@
         "sampleCount": 8576,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "music",
-            "percussion",
-            "hiphop",
-            "kick"
-        ]
+        "tags": []
     },
     {
         "name": "Drum Boing",
@@ -1634,11 +1492,7 @@
         "sampleCount": 44100,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "music",
-            "instruments",
-            "notes"
-        ]
+        "tags": []
     },
     {
         "name": "E Elec Piano",
@@ -1646,11 +1500,7 @@
         "sampleCount": 44100,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "music",
-            "instruments",
-            "notes"
-        ]
+        "tags": []
     },
     {
         "name": "E Guitar",
@@ -1658,11 +1508,7 @@
         "sampleCount": 38400,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "music",
-            "instruments",
-            "notes"
-        ]
+        "tags": []
     },
     {
         "name": "E Piano",
@@ -1682,11 +1528,7 @@
         "sampleCount": 7489,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "music",
-            "notes",
-            "instruments"
-        ]
+        "tags": []
     },
     {
         "name": "E Trombone",
@@ -1706,11 +1548,7 @@
         "sampleCount": 8680,
         "rate": 22050,
         "format": "adpcm",
-        "tags": [
-            "music",
-            "instruments",
-            "notes"
-        ]
+        "tags": []
     },
     {
         "name": "Eggs",
@@ -1825,11 +1663,7 @@
         "sampleCount": 44100,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "music",
-            "instruments",
-            "notes"
-        ]
+        "tags": []
     },
     {
         "name": "F Elec Piano",
@@ -1837,11 +1671,7 @@
         "sampleCount": 44100,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "music",
-            "instruments",
-            "notes"
-        ]
+        "tags": []
     },
     {
         "name": "F Guitar",
@@ -1849,11 +1679,7 @@
         "sampleCount": 36416,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "music",
-            "instruments",
-            "notes"
-        ]
+        "tags": []
     },
     {
         "name": "F Major Ukulele",
@@ -1886,11 +1712,7 @@
         "sampleCount": 7361,
         "rate": 22050,
         "format": "adpcm",
-        "tags": [
-            "music",
-            "notes",
-            "instruments"
-        ]
+        "tags": []
     },
     {
         "name": "F Trombone",
@@ -1910,11 +1732,7 @@
         "sampleCount": 12766,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "music",
-            "instruments",
-            "notes"
-        ]
+        "tags": []
     },
     {
         "name": "Fairydust",
@@ -1946,12 +1764,7 @@
         "sampleCount": 4416,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "effects",
-            "percussion",
-            "music",
-            "drums"
-        ]
+        "tags": []
     },
     {
         "name": "Footsteps",
@@ -1994,11 +1807,7 @@
         "sampleCount": 44100,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "music",
-            "instruments",
-            "notes"
-        ]
+        "tags": []
     },
     {
         "name": "G Elec Piano",
@@ -2006,11 +1815,7 @@
         "sampleCount": 44100,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "music",
-            "instruments",
-            "notes"
-        ]
+        "tags": []
     },
     {
         "name": "G Guitar",
@@ -2018,11 +1823,7 @@
         "sampleCount": 33600,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "music",
-            "instruments",
-            "notes"
-        ]
+        "tags": []
     },
     {
         "name": "G Piano",
@@ -2042,11 +1843,7 @@
         "sampleCount": 7349,
         "rate": 22050,
         "format": "adpcm",
-        "tags": [
-            "music",
-            "notes",
-            "instruments"
-        ]
+        "tags": []
     },
     {
         "name": "G Trombone",
@@ -2066,11 +1863,7 @@
         "sampleCount": 14640,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "music",
-            "instruments",
-            "notes"
-        ]
+        "tags": []
     },
     {
         "name": "G Ukulele",
@@ -2262,12 +2055,7 @@
         "sampleCount": 5856,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "human",
-            "percussion",
-            "music",
-            "hiphop"
-        ]
+        "tags": []
     },
     {
         "name": "Hi Na Tabla",
@@ -2323,11 +2111,7 @@
         "sampleCount": 12320,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "music",
-            "percussion",
-            "drums"
-        ]
+        "tags": []
     },
     {
         "name": "High Whoosh",
@@ -2359,11 +2143,7 @@
         "sampleCount": 2752,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "music",
-            "percussion",
-            "drums"
-        ]
+        "tags": []
     },
     {
         "name": "Hip Hop",
@@ -2506,11 +2286,7 @@
         "sampleCount": 516,
         "rate": 11025,
         "format": "",
-        "tags": [
-            "effects",
-            "space",
-            "electronic"
-        ]
+        "tags": []
     },
     {
         "name": "Laser2",
@@ -2518,11 +2294,7 @@
         "sampleCount": 755,
         "rate": 11025,
         "format": "",
-        "tags": [
-            "effects",
-            "space",
-            "electronic"
-        ]
+        "tags": []
     },
     {
         "name": "Laugh1",
@@ -2631,11 +2403,7 @@
         "sampleCount": 20000,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "music",
-            "percussion",
-            "drums"
-        ]
+        "tags": []
     },
     {
         "name": "Low Whoosh",
@@ -2885,9 +2653,7 @@
         "sampleCount": 258,
         "rate": 11025,
         "format": "",
-        "tags": [
-            "effects"
-        ]
+        "tags": []
     },
     {
         "name": "Pop2",
@@ -2995,11 +2761,7 @@
         "sampleCount": 26432,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "music",
-            "percussion",
-            "drums"
-        ]
+        "tags": []
     },
     {
         "name": "Rooster",
@@ -3030,13 +2792,7 @@
         "sampleCount": 11552,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "human",
-            "percussion",
-            "music",
-            "hiphop",
-            "voice"
-        ]
+        "tags": []
     },
     {
         "name": "Scratchy Beat",
@@ -3074,10 +2830,10 @@
     },
     {
         "name": "Screech",
-        "md5": "3676f478e5e3496034cf100d239160df.wav",
-        "sampleCount": 28928,
-        "rate": 11025,
-        "format": "",
+        "md5": "10644c5cc83a9a2dd3ab466deb0eb03d.wav",
+        "sampleCount": 12907,
+        "rate": 22050,
+        "format": "adpcm",
         "tags": [
             "animals",
             "monkey"
@@ -3133,11 +2889,7 @@
         "sampleCount": 2336,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "music",
-            "percussion",
-            "drums"
-        ]
+        "tags": []
     },
     {
         "name": "Singer1",
@@ -3231,12 +2983,7 @@
         "sampleCount": 5630,
         "rate": 22050,
         "format": "adpcm",
-        "tags": [
-            "human",
-            "percussion",
-            "music",
-            "hiphop"
-        ]
+        "tags": []
     },
     {
         "name": "Snare Beatbox2",
@@ -3244,12 +2991,7 @@
         "sampleCount": 4960,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "human",
-            "percussion",
-            "music",
-            "hiphop"
-        ]
+        "tags": []
     },
     {
         "name": "Snare Drum",
@@ -3365,11 +3107,7 @@
         "sampleCount": 41149,
         "rate": 11025,
         "format": "",
-        "tags": [
-            "space",
-            "effects",
-            "electronic"
-        ]
+        "tags": []
     },
     {
         "name": "Spiral",
@@ -3400,11 +3138,7 @@
         "sampleCount": 9600,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "percussion",
-            "drums",
-            "music"
-        ]
+        "tags": []
     },
     {
         "name": "Spooky String",
@@ -3552,11 +3286,7 @@
         "sampleCount": 3296,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "percussion",
-            "drums",
-            "music"
-        ]
+        "tags": []
     },
     {
         "name": "Techno",
@@ -3781,12 +3511,7 @@
         "sampleCount": 6624,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "human",
-            "percussion",
-            "music",
-            "hiphop"
-        ]
+        "tags": []
     },
     {
         "name": "Wand",
@@ -3801,13 +3526,12 @@
     },
     {
         "name": "Water Drop",
-        "md5": "aa488de9e2c871e9d4faecd246ed737a.wav",
-        "sampleCount": 8136,
+        "md5": "e133e625fd367d269e76964d4b722fc2.wav",
+        "sampleCount": 15131,
         "rate": 22050,
         "format": "adpcm",
         "tags": [
-            "effects",
-            "home"
+            "effects"
         ]
     },
     {
@@ -3908,12 +3632,7 @@
         "sampleCount": 7392,
         "rate": 22050,
         "format": "",
-        "tags": [
-            "human",
-            "percussion",
-            "music",
-            "hiphop"
-        ]
+        "tags": []
     },
     {
         "name": "Xylo1",

--- a/src/lib/libraries/sprites.json
+++ b/src/lib/libraries/sprites.json
@@ -1,6 +1,7 @@
 [
     {
         "name": "Abby",
+        "baseLayerID": -1,
         "md5": "afab2d2141e9811bd89e385e9628cb5f.svg",
         "type": "sprite",
         "tags": [
@@ -28,7 +29,7 @@
             "costumes": [
                 {
                     "costumeName": "abby-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 17,
                     "baseLayerMD5": "afab2d2141e9811bd89e385e9628cb5f.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 31,
@@ -36,7 +37,7 @@
                 },
                 {
                     "costumeName": "abby-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 18,
                     "baseLayerMD5": "1e0116c7c2e5e80c679d0b33f1f5cfb7.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 31,
@@ -44,7 +45,7 @@
                 },
                 {
                     "costumeName": "abby-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 19,
                     "baseLayerMD5": "b6e23922f23b49ddc6f62f675e77417c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 32,
@@ -52,7 +53,7 @@
                 },
                 {
                     "costumeName": "abby-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 20,
                     "baseLayerMD5": "2193cf08f74b8354f7c4fac37a06ea24.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 31,
@@ -72,6 +73,7 @@
     },
     {
         "name": "Apple",
+        "baseLayerID": -1,
         "md5": "831ccd4741a7a56d85f6698a21f4ca69.svg",
         "type": "sprite",
         "tags": [
@@ -100,7 +102,7 @@
             "costumes": [
                 {
                     "costumeName": "apple",
-                    "baseLayerID": -1,
+                    "baseLayerID": 1,
                     "baseLayerMD5": "831ccd4741a7a56d85f6698a21f4ca69.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 31,
@@ -120,6 +122,7 @@
     },
     {
         "name": "Arrow1",
+        "baseLayerID": -1,
         "md5": "62f8794dd120e9b4ead4d098d50fc64b.svg",
         "type": "sprite",
         "tags": [
@@ -148,7 +151,7 @@
             "costumes": [
                 {
                     "costumeName": "arrow1-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 3,
                     "baseLayerMD5": "62f8794dd120e9b4ead4d098d50fc64b.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 28,
@@ -156,7 +159,7 @@
                 },
                 {
                     "costumeName": "arrow1-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 4,
                     "baseLayerMD5": "a157dc7e33d7c7a048af933de999e397.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 28,
@@ -164,7 +167,7 @@
                 },
                 {
                     "costumeName": "arrow1-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 5,
                     "baseLayerMD5": "d3b389e91f7beb22b2b1a80af09990ee.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 23,
@@ -172,7 +175,7 @@
                 },
                 {
                     "costumeName": "arrow1-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 6,
                     "baseLayerMD5": "412717ff731e9f19003a5840054057eb.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 23,
@@ -192,6 +195,7 @@
     },
     {
         "name": "Avery",
+        "baseLayerID": -1,
         "md5": "21393c9114c7d34b1df7ccd12c793672.svg",
         "type": "sprite",
         "tags": [
@@ -217,7 +221,7 @@
             "costumes": [
                 {
                     "costumeName": "avery-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 117,
                     "baseLayerMD5": "21393c9114c7d34b1df7ccd12c793672.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 39,
@@ -225,7 +229,7 @@
                 },
                 {
                     "costumeName": "avery-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 118,
                     "baseLayerMD5": "cc55f2f09599edc4ae0876e8b3d187d0.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 39,
@@ -245,6 +249,7 @@
     },
     {
         "name": "Avery Walking",
+        "baseLayerID": -1,
         "md5": "ed334e546806dfbf26d2591d7ddb12d0.svg",
         "type": "sprite",
         "tags": [
@@ -271,7 +276,7 @@
             "costumes": [
                 {
                     "costumeName": "avery walking-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 113,
                     "baseLayerMD5": "ed334e546806dfbf26d2591d7ddb12d0.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 50,
@@ -279,7 +284,7 @@
                 },
                 {
                     "costumeName": "avery walking-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 114,
                     "baseLayerMD5": "c295731e8666ad2e1575fb4b4f82988d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 50,
@@ -287,7 +292,7 @@
                 },
                 {
                     "costumeName": "avery walking-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 115,
                     "baseLayerMD5": "597a834225c9949e419dff7db1bc2453.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 48,
@@ -295,7 +300,7 @@
                 },
                 {
                     "costumeName": "avery walking-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 116,
                     "baseLayerMD5": "ce9622d11d24607eec7988196b38c3c6.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 50,
@@ -315,6 +320,7 @@
     },
     {
         "name": "Ball",
+        "baseLayerID": -1,
         "md5": "10117ddaefa98d819f2b1df93805622f.svg",
         "type": "sprite",
         "tags": [
@@ -349,7 +355,7 @@
             "costumes": [
                 {
                     "costumeName": "ball-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 7,
                     "baseLayerMD5": "10117ddaefa98d819f2b1df93805622f.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -357,7 +363,7 @@
                 },
                 {
                     "costumeName": "ball-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 8,
                     "baseLayerMD5": "6e6330cad7750ea7e9dc88402661deb8.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -365,7 +371,7 @@
                 },
                 {
                     "costumeName": "ball-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 9,
                     "baseLayerMD5": "bb45ed5db278f15c17c012c34a6b160f.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -373,7 +379,7 @@
                 },
                 {
                     "costumeName": "ball-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 10,
                     "baseLayerMD5": "5d494659deae5c0de06b5885f5524276.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -381,7 +387,7 @@
                 },
                 {
                     "costumeName": "ball-e",
-                    "baseLayerID": -1,
+                    "baseLayerID": 11,
                     "baseLayerMD5": "e80c98bc62fd32e8df81642af11ffb1a.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -401,6 +407,7 @@
     },
     {
         "name": "Ballerina",
+        "baseLayerID": -1,
         "md5": "6051bb7008cf17c8853a6f81f04c8a0f.svg",
         "type": "sprite",
         "tags": [
@@ -427,7 +434,7 @@
             "costumes": [
                 {
                     "costumeName": "ballerina-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 0,
                     "baseLayerMD5": "6051bb7008cf17c8853a6f81f04c8a0f.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -435,7 +442,7 @@
                 },
                 {
                     "costumeName": "ballerina-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 1,
                     "baseLayerMD5": "8bc5e47fb1439e29e11e9e3f2e20c6de.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -443,7 +450,7 @@
                 },
                 {
                     "costumeName": "ballerina-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 2,
                     "baseLayerMD5": "6d3a07761b294f705987b0af58f8e335.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -451,7 +458,7 @@
                 },
                 {
                     "costumeName": "ballerina-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 3,
                     "baseLayerMD5": "c3164795edf39e436272f425b4f5e487.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -471,6 +478,7 @@
     },
     {
         "name": "Balloon1",
+        "baseLayerID": -1,
         "md5": "bc96a1fb5fe794377acd44807e421ce2.svg",
         "type": "sprite",
         "tags": [
@@ -503,7 +511,7 @@
             "costumes": [
                 {
                     "costumeName": "balloon1-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 12,
                     "baseLayerMD5": "bc96a1fb5fe794377acd44807e421ce2.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 32,
@@ -511,7 +519,7 @@
                 },
                 {
                     "costumeName": "balloon1-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 13,
                     "baseLayerMD5": "d7bb51d9c38af6314bd2b4058d2a592d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 31,
@@ -519,7 +527,7 @@
                 },
                 {
                     "costumeName": "balloon1-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 14,
                     "baseLayerMD5": "247cef27b665d77d9efaca69327cae77.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 31,
@@ -539,6 +547,7 @@
     },
     {
         "name": "Baseball",
+        "baseLayerID": -1,
         "md5": "6e13ef53885d2cfca9a54cc5c3f6c20f.svg",
         "type": "sprite",
         "tags": [
@@ -567,7 +576,7 @@
             "costumes": [
                 {
                     "costumeName": "baseball",
-                    "baseLayerID": -1,
+                    "baseLayerID": 2,
                     "baseLayerMD5": "6e13ef53885d2cfca9a54cc5c3f6c20f.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 34,
@@ -587,6 +596,7 @@
     },
     {
         "name": "Basketball",
+        "baseLayerID": -1,
         "md5": "b15c425f3eef68e7d095ee91321cb52a.svg",
         "type": "sprite",
         "tags": [
@@ -614,7 +624,7 @@
             "costumes": [
                 {
                     "costumeName": "basketball",
-                    "baseLayerID": -1,
+                    "baseLayerID": 16,
                     "baseLayerMD5": "b15c425f3eef68e7d095ee91321cb52a.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 26,
@@ -634,6 +644,7 @@
     },
     {
         "name": "Bat1",
+        "baseLayerID": -1,
         "md5": "7ad915f8e0884f497a24d5bb61ea8a4a.svg",
         "type": "sprite",
         "tags": [
@@ -664,7 +675,7 @@
             "costumes": [
                 {
                     "costumeName": "bat1-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 15,
                     "baseLayerMD5": "7ad915f8e0884f497a24d5bb61ea8a4a.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -672,7 +683,7 @@
                 },
                 {
                     "costumeName": "bat1-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 16,
                     "baseLayerMD5": "f127434672b872a902346ef3c1af45f2.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -692,6 +703,7 @@
     },
     {
         "name": "Bat2",
+        "baseLayerID": -1,
         "md5": "647d4bd53163f94a7dabf623ccab7fd3.svg",
         "type": "sprite",
         "tags": [
@@ -722,7 +734,7 @@
             "costumes": [
                 {
                     "costumeName": "bat2-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 22,
                     "baseLayerMD5": "647d4bd53163f94a7dabf623ccab7fd3.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -730,7 +742,7 @@
                 },
                 {
                     "costumeName": "bat2-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 23,
                     "baseLayerMD5": "8aa1d20e4f7761becbe9bafa75290465.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -750,6 +762,7 @@
     },
     {
         "name": "Beachball",
+        "baseLayerID": -1,
         "md5": "87d64cab74c64b31498cc85f07510ee4.svg",
         "type": "sprite",
         "tags": [
@@ -778,7 +791,7 @@
             "costumes": [
                 {
                     "costumeName": "beachball",
-                    "baseLayerID": -1,
+                    "baseLayerID": 21,
                     "baseLayerMD5": "87d64cab74c64b31498cc85f07510ee4.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 34,
@@ -798,6 +811,7 @@
     },
     {
         "name": "Bear",
+        "baseLayerID": -1,
         "md5": "5a4148d7684fc95f38c58a1672062c9e.svg",
         "type": "sprite",
         "tags": [
@@ -825,7 +839,7 @@
             "costumes": [
                 {
                     "costumeName": "bear-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 16,
                     "baseLayerMD5": "5a4148d7684fc95f38c58a1672062c9e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 100,
@@ -833,7 +847,7 @@
                 },
                 {
                     "costumeName": "bear-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 17,
                     "baseLayerMD5": "d6517131718621a7aae8fc4f27de1ded.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 80,
@@ -853,6 +867,7 @@
     },
     {
         "name": "Bear-walking",
+        "baseLayerID": -1,
         "md5": "d15eddb1a0f0ff0fa867bc006b46685d.svg",
         "type": "sprite",
         "tags": [
@@ -880,7 +895,7 @@
             "costumes": [
                 {
                     "costumeName": "bear-walk-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 18,
                     "baseLayerMD5": "d15eddb1a0f0ff0fa867bc006b46685d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 130,
@@ -888,7 +903,7 @@
                 },
                 {
                     "costumeName": "bear-walk-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 19,
                     "baseLayerMD5": "06e3f1bcf4f46b83df3820d92430f202.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 130,
@@ -896,7 +911,7 @@
                 },
                 {
                     "costumeName": "bear-walk-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 20,
                     "baseLayerMD5": "13a3584040c9903b1824bb249d7f8a0e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 130,
@@ -904,7 +919,7 @@
                 },
                 {
                     "costumeName": "bear-walk-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 21,
                     "baseLayerMD5": "c5d49a105619c497be45a5d2c43a740a.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 130,
@@ -912,7 +927,7 @@
                 },
                 {
                     "costumeName": "bear-walk-e",
-                    "baseLayerID": -1,
+                    "baseLayerID": 22,
                     "baseLayerMD5": "ece252d79c2d30c647c43c58986d9671.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 130,
@@ -920,7 +935,7 @@
                 },
                 {
                     "costumeName": "bear-walk-f",
-                    "baseLayerID": -1,
+                    "baseLayerID": 23,
                     "baseLayerMD5": "ff66b87efec0e647dc30ec58df168ec4.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 130,
@@ -928,7 +943,7 @@
                 },
                 {
                     "costumeName": "bear-walk-g",
-                    "baseLayerID": -1,
+                    "baseLayerID": 24,
                     "baseLayerMD5": "d1404b12adf0d6b1b881f0dca47ce21a.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 130,
@@ -936,7 +951,7 @@
                 },
                 {
                     "costumeName": "bear-walk-h",
-                    "baseLayerID": -1,
+                    "baseLayerID": 25,
                     "baseLayerMD5": "489055be58a7d9806e1d50455c88c399.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 130,
@@ -956,6 +971,7 @@
     },
     {
         "name": "Bear1",
+        "baseLayerID": -1,
         "md5": "598722f70e86e6f9b23ef97680baaa9c.svg",
         "type": "sprite",
         "tags": [
@@ -982,7 +998,7 @@
             "costumes": [
                 {
                     "costumeName": "bear1-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 4,
                     "baseLayerMD5": "598722f70e86e6f9b23ef97680baaa9c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 56,
@@ -990,7 +1006,7 @@
                 },
                 {
                     "costumeName": "bear1-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 5,
                     "baseLayerMD5": "76ceb0de4409f42713b50cbc1fb45af5.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 56,
@@ -1010,6 +1026,7 @@
     },
     {
         "name": "Bear2",
+        "baseLayerID": -1,
         "md5": "3eb8e16a983ff23c418374389c81bd30.svg",
         "type": "sprite",
         "tags": [
@@ -1036,7 +1053,7 @@
             "costumes": [
                 {
                     "costumeName": "bear2-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 6,
                     "baseLayerMD5": "3eb8e16a983ff23c418374389c81bd30.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 37,
@@ -1044,7 +1061,7 @@
                 },
                 {
                     "costumeName": "bear2-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 7,
                     "baseLayerMD5": "12bb6960ac01b65ae9b5e5e7f79700ac.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 51,
@@ -1064,6 +1081,7 @@
     },
     {
         "name": "Beetle",
+        "baseLayerID": -1,
         "md5": "e1ce8f153f011fdd52486c91c6ed594d.svg",
         "type": "sprite",
         "tags": [
@@ -1092,7 +1110,7 @@
             "costumes": [
                 {
                     "costumeName": "beetle",
-                    "baseLayerID": -1,
+                    "baseLayerID": 24,
                     "baseLayerMD5": "e1ce8f153f011fdd52486c91c6ed594d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 43,
@@ -1112,6 +1130,7 @@
     },
     {
         "name": "Bell",
+        "baseLayerID": -1,
         "md5": "f35056c772395455d703773657e1da6e.svg",
         "type": "sprite",
         "tags": [
@@ -1130,7 +1149,7 @@
             "sounds": [
                 {
                     "soundName": "xylo1",
-                    "soundID": -1,
+                    "soundID": 0,
                     "md5": "6ac484e97c1c1fe1384642e26a125e70.wav",
                     "sampleCount": 238232,
                     "rate": 22050,
@@ -1138,7 +1157,7 @@
                 },
                 {
                     "soundName": "bell toll",
-                    "soundID": -1,
+                    "soundID": 1,
                     "md5": "25d61e79cbeba4041eebeaebd7bf9598.wav",
                     "sampleCount": 45168,
                     "rate": 11025,
@@ -1148,7 +1167,7 @@
             "costumes": [
                 {
                     "costumeName": "bell1",
-                    "baseLayerID": -1,
+                    "baseLayerID": 25,
                     "baseLayerMD5": "f35056c772395455d703773657e1da6e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 59,
@@ -1167,62 +1186,8 @@
         }
     },
     {
-        "name": "Bells",
-        "md5": "1f151bee966df3f0c41138941713280e.svg",
-        "type": "sprite",
-        "tags": [
-            "music",
-            "holiday",
-            "instrument"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Bells",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "bells-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "1f151bee966df3f0c41138941713280e.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 53,
-                    "rotationCenterY": 51
-                },
-                {
-                    "costumeName": "bells-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "5b3879a162881aed93169bf0a6680f45.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 48,
-                    "rotationCenterY": 31
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 83,
-            "scratchY": -5,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
         "name": "Ben",
+        "baseLayerID": -1,
         "md5": "7f32d8d78ad64f50c018b7b578de2e18.svg",
         "type": "sprite",
         "tags": [
@@ -1252,7 +1217,7 @@
             "costumes": [
                 {
                     "costumeName": "ben-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 9,
                     "baseLayerMD5": "7f32d8d78ad64f50c018b7b578de2e18.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 76,
@@ -1260,7 +1225,7 @@
                 },
                 {
                     "costumeName": "ben-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 10,
                     "baseLayerMD5": "fb012e5d1baf80d33ae95fba3511151a.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 76,
@@ -1268,7 +1233,7 @@
                 },
                 {
                     "costumeName": "ben-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 11,
                     "baseLayerMD5": "be0b1397965cf8ff2c4cecb84795138a.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 76,
@@ -1276,7 +1241,7 @@
                 },
                 {
                     "costumeName": "ben-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 12,
                     "baseLayerMD5": "e2aefdb538ebbb24e1ab1464f75ef134.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 76,
@@ -1296,6 +1261,7 @@
     },
     {
         "name": "Bowl",
+        "baseLayerID": -1,
         "md5": "86f616639846f06fef29931e6b9b59de.svg",
         "type": "sprite",
         "tags": [
@@ -1322,7 +1288,7 @@
             "costumes": [
                 {
                     "costumeName": "bowl-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 8,
                     "baseLayerMD5": "86f616639846f06fef29931e6b9b59de.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 30,
@@ -1342,6 +1308,7 @@
     },
     {
         "name": "Bowtie",
+        "baseLayerID": -1,
         "md5": "534d9924d2f9bfe240f041e3ce55ccf5.svg",
         "type": "sprite",
         "tags": [
@@ -1367,7 +1334,7 @@
             "costumes": [
                 {
                     "costumeName": "bowtie-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 9,
                     "baseLayerMD5": "534d9924d2f9bfe240f041e3ce55ccf5.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 11,
@@ -1375,7 +1342,7 @@
                 },
                 {
                     "costumeName": "bowtie-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 10,
                     "baseLayerMD5": "8be1e90e19cd1faced8a2e83c2b5c90d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 11,
@@ -1395,6 +1362,7 @@
     },
     {
         "name": "Bread",
+        "baseLayerID": -1,
         "md5": "68366160ce0ac1221cdde4455eca9cba.svg",
         "type": "sprite",
         "tags": [
@@ -1421,7 +1389,7 @@
             "costumes": [
                 {
                     "costumeName": "bread",
-                    "baseLayerID": -1,
+                    "baseLayerID": 35,
                     "baseLayerMD5": "68366160ce0ac1221cdde4455eca9cba.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 37,
@@ -1441,6 +1409,7 @@
     },
     {
         "name": "Broom",
+        "baseLayerID": -1,
         "md5": "836197f784bc4c4decfb1a5a60ca6c56.svg",
         "type": "sprite",
         "tags": [
@@ -1469,7 +1438,7 @@
             "costumes": [
                 {
                     "costumeName": "broom",
-                    "baseLayerID": -1,
+                    "baseLayerID": 26,
                     "baseLayerMD5": "836197f784bc4c4decfb1a5a60ca6c56.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 135,
@@ -1489,6 +1458,7 @@
     },
     {
         "name": "Buildings",
+        "baseLayerID": -1,
         "md5": "d713270e235851e5962becd73a951771.svg",
         "type": "sprite",
         "tags": [
@@ -1517,7 +1487,7 @@
             "costumes": [
                 {
                     "costumeName": "building-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 106,
                     "baseLayerMD5": "d713270e235851e5962becd73a951771.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 40,
@@ -1525,7 +1495,7 @@
                 },
                 {
                     "costumeName": "building-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 107,
                     "baseLayerMD5": "8c2d59c50a97d33b096f629258f02be6.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 46,
@@ -1533,7 +1503,7 @@
                 },
                 {
                     "costumeName": "building-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 108,
                     "baseLayerMD5": "7f3f51f495c39809bed95991dfa1f80d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 25,
@@ -1541,7 +1511,7 @@
                 },
                 {
                     "costumeName": "building-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 109,
                     "baseLayerMD5": "bbe68ab80b36e4c71f4e28414c7f781e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 59,
@@ -1549,7 +1519,7 @@
                 },
                 {
                     "costumeName": "building-e",
-                    "baseLayerID": -1,
+                    "baseLayerID": 110,
                     "baseLayerMD5": "1beeb8f034a1128c9a799297b0b7fc26.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 36,
@@ -1557,7 +1527,7 @@
                 },
                 {
                     "costumeName": "building-f",
-                    "baseLayerID": -1,
+                    "baseLayerID": 111,
                     "baseLayerMD5": "451e0a565e95d945fe2addfe609ee9df.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 41,
@@ -1565,7 +1535,7 @@
                 },
                 {
                     "costumeName": "building-g",
-                    "baseLayerID": -1,
+                    "baseLayerID": 112,
                     "baseLayerMD5": "58b3c9b7a41dde698fa2b427b502c1fa.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 64,
@@ -1573,7 +1543,7 @@
                 },
                 {
                     "costumeName": "building-h",
-                    "baseLayerID": -1,
+                    "baseLayerID": 113,
                     "baseLayerMD5": "e952c8b14eeac894302d07d37a45ed99.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 33,
@@ -1581,7 +1551,7 @@
                 },
                 {
                     "costumeName": "building-i",
-                    "baseLayerID": -1,
+                    "baseLayerID": 114,
                     "baseLayerMD5": "b00b1123e3bfcb600242528d059ffcfb.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 31,
@@ -1589,7 +1559,7 @@
                 },
                 {
                     "costumeName": "building-j",
-                    "baseLayerID": -1,
+                    "baseLayerID": 115,
                     "baseLayerMD5": "e08fd1a7397efcfe0e3691f945693cb4.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 29,
@@ -1609,6 +1579,7 @@
     },
     {
         "name": "Butterfly1",
+        "baseLayerID": -1,
         "md5": "836d4cc7889f4a1cbcb0303934f31f79.svg",
         "type": "sprite",
         "tags": [
@@ -1640,7 +1611,7 @@
             "costumes": [
                 {
                     "costumeName": "butterfly1-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 26,
                     "baseLayerMD5": "836d4cc7889f4a1cbcb0303934f31f79.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -1648,7 +1619,7 @@
                 },
                 {
                     "costumeName": "butterfly1-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 27,
                     "baseLayerMD5": "55dd0671a359d7c35f7b78f4176660e8.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -1668,6 +1639,7 @@
     },
     {
         "name": "Butterfly2",
+        "baseLayerID": -1,
         "md5": "a0216895beade6afc6d42bd5bb43faea.svg",
         "type": "sprite",
         "tags": [
@@ -1699,7 +1671,7 @@
             "costumes": [
                 {
                     "costumeName": "butterfly2",
-                    "baseLayerID": -1,
+                    "baseLayerID": 28,
                     "baseLayerMD5": "a0216895beade6afc6d42bd5bb43faea.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -1719,6 +1691,7 @@
     },
     {
         "name": "Butterfly3",
+        "baseLayerID": -1,
         "md5": "8907a43cf08b0a9134969023be2074c5.svg",
         "type": "sprite",
         "tags": [
@@ -1750,7 +1723,7 @@
             "costumes": [
                 {
                     "costumeName": "butterfly3",
-                    "baseLayerID": -1,
+                    "baseLayerID": 29,
                     "baseLayerMD5": "8907a43cf08b0a9134969023be2074c5.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -1770,6 +1743,7 @@
     },
     {
         "name": "Button1",
+        "baseLayerID": -1,
         "md5": "7ef67c5bc8cf7df64fdb3b1d6b250f71.svg",
         "type": "sprite",
         "tags": [
@@ -1798,7 +1772,7 @@
             "costumes": [
                 {
                     "costumeName": "button1",
-                    "baseLayerID": -1,
+                    "baseLayerID": 30,
                     "baseLayerMD5": "7ef67c5bc8cf7df64fdb3b1d6b250f71.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 72,
@@ -1818,6 +1792,7 @@
     },
     {
         "name": "Button2",
+        "baseLayerID": -1,
         "md5": "c0051ff23e9aae78295964206793c1e3.svg",
         "type": "sprite",
         "tags": [
@@ -1845,7 +1820,7 @@
             "costumes": [
                 {
                     "costumeName": "button2-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 31,
                     "baseLayerMD5": "c0051ff23e9aae78295964206793c1e3.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 72,
@@ -1853,7 +1828,7 @@
                 },
                 {
                     "costumeName": "button2-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 32,
                     "baseLayerMD5": "712a561dc0ad66e348b8247e566b50ef.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 72,
@@ -1873,6 +1848,7 @@
     },
     {
         "name": "Button3",
+        "baseLayerID": -1,
         "md5": "ffb2a9c21084c58fdb677c8d12a97519.svg",
         "type": "sprite",
         "tags": [
@@ -1901,7 +1877,7 @@
             "costumes": [
                 {
                     "costumeName": "button3-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 33,
                     "baseLayerMD5": "ffb2a9c21084c58fdb677c8d12a97519.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 72,
@@ -1909,7 +1885,7 @@
                 },
                 {
                     "costumeName": "button3-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 34,
                     "baseLayerMD5": "7a9ccb55e4da36f48811ab125d2492e0.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 72,
@@ -1929,6 +1905,7 @@
     },
     {
         "name": "Button4",
+        "baseLayerID": -1,
         "md5": "ecfe263bc256349777e571eaf39761d4.svg",
         "type": "sprite",
         "tags": [
@@ -1955,7 +1932,7 @@
             "costumes": [
                 {
                     "costumeName": "button4-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 35,
                     "baseLayerMD5": "ecfe263bc256349777e571eaf39761d4.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 35,
@@ -1963,7 +1940,7 @@
                 },
                 {
                     "costumeName": "button4-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 36,
                     "baseLayerMD5": "9c49edde00b80cd22d636a0577a9b1c9.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 35,
@@ -1983,6 +1960,7 @@
     },
     {
         "name": "Button5",
+        "baseLayerID": -1,
         "md5": "71e97245b7be4fd6fe3ba8cdeecadaf1.svg",
         "type": "sprite",
         "tags": [
@@ -2012,7 +1990,7 @@
             "costumes": [
                 {
                     "costumeName": "button5-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 37,
                     "baseLayerMD5": "71e97245b7be4fd6fe3ba8cdeecadaf1.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 72,
@@ -2020,7 +1998,7 @@
                 },
                 {
                     "costumeName": "button5-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 38,
                     "baseLayerMD5": "54cd55512f7571060e6e64168e541222.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 72,
@@ -2040,6 +2018,7 @@
     },
     {
         "name": "Cake",
+        "baseLayerID": -1,
         "md5": "97ab3596dc06510e963fa29795e663bf.svg",
         "type": "sprite",
         "tags": [
@@ -2062,7 +2041,7 @@
             "sounds": [
                 {
                     "soundName": "birthday",
-                    "soundID": -1,
+                    "soundID": 4,
                     "md5": "89691587a169d935a58c48c3d4e78534.wav",
                     "sampleCount": 161408,
                     "rate": 22050,
@@ -2072,7 +2051,7 @@
             "costumes": [
                 {
                     "costumeName": "cake-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 69,
                     "baseLayerMD5": "97ab3596dc06510e963fa29795e663bf.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 64,
@@ -2080,7 +2059,7 @@
                 },
                 {
                     "costumeName": "cake-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 70,
                     "baseLayerMD5": "61d5481955a2f42cb843d09506f6744e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 64,
@@ -2100,6 +2079,7 @@
     },
     {
         "name": "Casey",
+        "baseLayerID": -1,
         "md5": "30a4dafa852311b2a07d72e1bb060326.svg",
         "type": "sprite",
         "tags": [
@@ -2128,7 +2108,7 @@
             "costumes": [
                 {
                     "costumeName": "casey-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 0,
                     "baseLayerMD5": "30a4dafa852311b2a07d72e1bb060326.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 82,
@@ -2136,7 +2116,7 @@
                 },
                 {
                     "costumeName": "casey-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 1,
                     "baseLayerMD5": "c8c0a25bebac8b35b8eae7ddd716d061.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 82,
@@ -2144,7 +2124,7 @@
                 },
                 {
                     "costumeName": "casey-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 2,
                     "baseLayerMD5": "104d363c48c373384c6c80abbbbb0ad6.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 61,
@@ -2152,7 +2132,7 @@
                 },
                 {
                     "costumeName": "casey-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 3,
                     "baseLayerMD5": "3d4bddb908bf912b938c111bfa38c28a.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 82,
@@ -2172,6 +2152,7 @@
     },
     {
         "name": "Cat",
+        "baseLayerID": -1,
         "md5": "09dc888b0b7df19f70d81588ae73420e.svg",
         "type": "sprite",
         "tags": [
@@ -2231,6 +2212,7 @@
     },
     {
         "name": "Cat1 Flying",
+        "baseLayerID": -1,
         "md5": "1e81725d2d2c7de4a2dd4a145198a43c.svg",
         "type": "sprite",
         "tags": [
@@ -2259,7 +2241,7 @@
             "costumes": [
                 {
                     "costumeName": "cat1 flying-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 55,
                     "baseLayerMD5": "1e81725d2d2c7de4a2dd4a145198a43c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 67,
@@ -2267,7 +2249,7 @@
                 },
                 {
                     "costumeName": "cat1 flying-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 56,
                     "baseLayerMD5": "0d192725870ef0eda50d91cab0e3c9c5.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 42,
@@ -2287,6 +2269,7 @@
     },
     {
         "name": "Cat2",
+        "baseLayerID": -1,
         "md5": "01ae57fd339529445cb890978ef8a054.svg",
         "type": "sprite",
         "tags": [
@@ -2306,7 +2289,7 @@
             "sounds": [
                 {
                     "soundName": "meow2",
-                    "soundID": -1,
+                    "soundID": 0,
                     "md5": "cf51a0c4088942d95bcc20af13202710.wav",
                     "sampleCount": 6512,
                     "rate": 11025,
@@ -2316,7 +2299,7 @@
             "costumes": [
                 {
                     "costumeName": "cat2",
-                    "baseLayerID": -1,
+                    "baseLayerID": 11,
                     "baseLayerMD5": "01ae57fd339529445cb890978ef8a054.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 87,
@@ -2336,6 +2319,7 @@
     },
     {
         "name": "Centaur",
+        "baseLayerID": -1,
         "md5": "45c1890ae0ab41f24f67ea74bec006c9.svg",
         "type": "sprite",
         "tags": [
@@ -2364,7 +2348,7 @@
             "costumes": [
                 {
                     "costumeName": "centaur-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 61,
                     "baseLayerMD5": "45c1890ae0ab41f24f67ea74bec006c9.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 110,
@@ -2372,7 +2356,7 @@
                 },
                 {
                     "costumeName": "centaur-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 62,
                     "baseLayerMD5": "783e8cd43e0c1feca25f639cb5cbc7da.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 110,
@@ -2380,7 +2364,7 @@
                 },
                 {
                     "costumeName": "centaur-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 63,
                     "baseLayerMD5": "d09f7160383c6399354c3d9960e852db.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 110,
@@ -2388,7 +2372,7 @@
                 },
                 {
                     "costumeName": "centaur-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 64,
                     "baseLayerMD5": "1ba8b4d384f995688c1b7048d1935697.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 110,
@@ -2408,6 +2392,7 @@
     },
     {
         "name": "Cloud",
+        "baseLayerID": -1,
         "md5": "47005a1f20309f577a03a67abbb6b94e.svg",
         "type": "sprite",
         "tags": [
@@ -2435,7 +2420,7 @@
             "costumes": [
                 {
                     "costumeName": "cloud",
-                    "baseLayerID": -1,
+                    "baseLayerID": 12,
                     "baseLayerMD5": "47005a1f20309f577a03a67abbb6b94e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 71,
@@ -2455,6 +2440,7 @@
     },
     {
         "name": "Clouds",
+        "baseLayerID": -1,
         "md5": "c7d7de8e29179407f03b054fa640f4d0.svg",
         "type": "sprite",
         "tags": [
@@ -2483,7 +2469,7 @@
             "costumes": [
                 {
                     "costumeName": "cloud-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 116,
                     "baseLayerMD5": "c7d7de8e29179407f03b054fa640f4d0.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 76,
@@ -2491,7 +2477,7 @@
                 },
                 {
                     "costumeName": "cloud-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 117,
                     "baseLayerMD5": "d8595350ebb460494c9189dabb968336.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 101,
@@ -2499,7 +2485,7 @@
                 },
                 {
                     "costumeName": "cloud-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 118,
                     "baseLayerMD5": "395fc991e64ac0a4aa46758ab4bc65cb.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 97,
@@ -2507,7 +2493,7 @@
                 },
                 {
                     "costumeName": "cloud-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 119,
                     "baseLayerMD5": "1767e704acb11ffa409f77cc79ba7e86.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 87,
@@ -2527,6 +2513,7 @@
     },
     {
         "name": "Convertible3",
+        "baseLayerID": -1,
         "md5": "b6ac3c9e1789cba2302d2ef82d62d019.svg",
         "type": "sprite",
         "tags": [
@@ -2553,7 +2540,7 @@
             "costumes": [
                 {
                     "costumeName": "convertible3",
-                    "baseLayerID": -1,
+                    "baseLayerID": 13,
                     "baseLayerMD5": "b6ac3c9e1789cba2302d2ef82d62d019.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -2573,6 +2560,7 @@
     },
     {
         "name": "Crab",
+        "baseLayerID": -1,
         "md5": "114249a5660f7948663d95de575cfd8d.svg",
         "type": "sprite",
         "tags": [
@@ -2607,7 +2595,7 @@
             "costumes": [
                 {
                     "costumeName": "crab-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 39,
                     "baseLayerMD5": "114249a5660f7948663d95de575cfd8d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -2615,7 +2603,7 @@
                 },
                 {
                     "costumeName": "crab-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 40,
                     "baseLayerMD5": "9bf050664e68c10d2616e85f2873be09.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -2635,6 +2623,7 @@
     },
     {
         "name": "Creature1",
+        "baseLayerID": -1,
         "md5": "a560c6eab2e1de2462bdaeb1d698736c.svg",
         "type": "sprite",
         "tags": [
@@ -2664,7 +2653,7 @@
             "costumes": [
                 {
                     "costumeName": "creature1-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 119,
                     "baseLayerMD5": "a560c6eab2e1de2462bdaeb1d698736c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 54,
@@ -2672,7 +2661,7 @@
                 },
                 {
                     "costumeName": "creature1-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 120,
                     "baseLayerMD5": "8042b71fc2ae322151c0a3a163701333.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 60,
@@ -2680,7 +2669,7 @@
                 },
                 {
                     "costumeName": "creature1-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 121,
                     "baseLayerMD5": "e12a83c8f1c0545b59fe8673e9fac79c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 63,
@@ -2700,6 +2689,7 @@
     },
     {
         "name": "Crystal",
+        "baseLayerID": -1,
         "md5": "8520264d48537bea17b7f6d18e9bb558.svg",
         "type": "sprite",
         "tags": [
@@ -2727,7 +2717,7 @@
             "costumes": [
                 {
                     "costumeName": "crystal-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 27,
                     "baseLayerMD5": "8520264d48537bea17b7f6d18e9bb558.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 15,
@@ -2735,7 +2725,7 @@
                 },
                 {
                     "costumeName": "crystal-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 28,
                     "baseLayerMD5": "b62ce1dc2d34741bad036664a01912fb.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 12,
@@ -2755,6 +2745,7 @@
     },
     {
         "name": "Dani",
+        "baseLayerID": -1,
         "md5": "f3038fb0f4a00806b02081c6789dd8cf.svg",
         "type": "sprite",
         "tags": [
@@ -2781,7 +2772,7 @@
             "costumes": [
                 {
                     "costumeName": "dani-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 14,
                     "baseLayerMD5": "f3038fb0f4a00806b02081c6789dd8cf.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 49,
@@ -2789,7 +2780,7 @@
                 },
                 {
                     "costumeName": "dani-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 15,
                     "baseLayerMD5": "e5c7dd4905a78e1d54087b7165dd1e8c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 82,
@@ -2797,7 +2788,7 @@
                 },
                 {
                     "costumeName": "dani-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 16,
                     "baseLayerMD5": "cbc5f9c67022af201d498bc9b35608b8.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 49,
@@ -2817,6 +2808,7 @@
     },
     {
         "name": "Dee",
+        "baseLayerID": -1,
         "md5": "aa239b7ccdce6bddf06900c709525764.svg",
         "type": "sprite",
         "tags": [
@@ -2842,7 +2834,7 @@
             "costumes": [
                 {
                     "costumeName": "dee-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 17,
                     "baseLayerMD5": "aa239b7ccdce6bddf06900c709525764.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 52,
@@ -2850,7 +2842,7 @@
                 },
                 {
                     "costumeName": "dee-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 18,
                     "baseLayerMD5": "62b4ac1b735599e21af77c390b178095.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 33,
@@ -2858,7 +2850,7 @@
                 },
                 {
                     "costumeName": "dee-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 19,
                     "baseLayerMD5": "6aa6196ce3245e93b8d1299f33adffcd.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 36,
@@ -2866,7 +2858,7 @@
                 },
                 {
                     "costumeName": "dee-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 20,
                     "baseLayerMD5": "2159a6be8f7ff450d0b5e938ca34a3f4.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 33,
@@ -2874,7 +2866,7 @@
                 },
                 {
                     "costumeName": "dee-e",
-                    "baseLayerID": -1,
+                    "baseLayerID": 21,
                     "baseLayerMD5": "e358d2a7e3a0a680928657161ce81a0a.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 32,
@@ -2894,6 +2886,7 @@
     },
     {
         "name": "Devin",
+        "baseLayerID": -1,
         "md5": "b1897e56265470b55fa65fabe2423c55.svg",
         "type": "sprite",
         "tags": [
@@ -2919,7 +2912,7 @@
             "costumes": [
                 {
                     "costumeName": "devin-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 22,
                     "baseLayerMD5": "b1897e56265470b55fa65fabe2423c55.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 39,
@@ -2927,7 +2920,7 @@
                 },
                 {
                     "costumeName": "devin-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 23,
                     "baseLayerMD5": "873fbd641768c8f753a6568da97633e7.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 40,
@@ -2935,7 +2928,7 @@
                 },
                 {
                     "costumeName": "devin-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 24,
                     "baseLayerMD5": "eac3c03d86cebb42c8f30e373cb7f623.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 32,
@@ -2943,7 +2936,7 @@
                 },
                 {
                     "costumeName": "devin-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 25,
                     "baseLayerMD5": "fa6a75afb0e4b822b91d8bb20d40c68f.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 41,
@@ -2963,6 +2956,7 @@
     },
     {
         "name": "Dinosaur1",
+        "baseLayerID": -1,
         "md5": "75d367961807fff8e81f556da81dec24.svg",
         "type": "sprite",
         "tags": [
@@ -2990,7 +2984,7 @@
             "costumes": [
                 {
                     "costumeName": "dinosaur1-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 0,
                     "baseLayerMD5": "75d367961807fff8e81f556da81dec24.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 98,
@@ -2998,7 +2992,7 @@
                 },
                 {
                     "costumeName": "dinosaur1-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 1,
                     "baseLayerMD5": "ecdaee9c08ae68fd7a67f81302f00a97.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 98,
@@ -3006,7 +3000,7 @@
                 },
                 {
                     "costumeName": "dinosaur1-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 2,
                     "baseLayerMD5": "02078a81abd2e10cb62ebcc853a40c92.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 81,
@@ -3014,7 +3008,7 @@
                 },
                 {
                     "costumeName": "dinosaur1-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 3,
                     "baseLayerMD5": "c9ed031bc9bf11416142880f89436be9.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 98,
@@ -3034,6 +3028,7 @@
     },
     {
         "name": "Dinosaur2",
+        "baseLayerID": -1,
         "md5": "5493f5deffe7aed451cd8b255740de4a.svg",
         "type": "sprite",
         "tags": [
@@ -3062,7 +3057,7 @@
             "costumes": [
                 {
                     "costumeName": "dinosaur2-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 9,
                     "baseLayerMD5": "5493f5deffe7aed451cd8b255740de4a.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 115,
@@ -3070,7 +3065,7 @@
                 },
                 {
                     "costumeName": "dinosaur2-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 10,
                     "baseLayerMD5": "70bba739b7df0bd08abb31026d078ee7.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 74,
@@ -3078,7 +3073,7 @@
                 },
                 {
                     "costumeName": "dinosaur2-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 11,
                     "baseLayerMD5": "4a51679d86aafcc9cee1c010fc141288.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 62,
@@ -3086,7 +3081,7 @@
                 },
                 {
                     "costumeName": "dinosaur2-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 12,
                     "baseLayerMD5": "47053664449b24749aaf199925b19f8e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 71,
@@ -3106,6 +3101,7 @@
     },
     {
         "name": "Dinosaur3",
+        "baseLayerID": -1,
         "md5": "17636db6f607c14a03a36e18abfea86a.svg",
         "type": "sprite",
         "tags": [
@@ -3135,7 +3131,7 @@
             "costumes": [
                 {
                     "costumeName": "dinosaur3-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 4,
                     "baseLayerMD5": "17636db6f607c14a03a36e18abfea86a.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 115,
@@ -3143,7 +3139,7 @@
                 },
                 {
                     "costumeName": "dinosaur3-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 5,
                     "baseLayerMD5": "1b20afc713b04ca5d01b25d050aa35ac.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 115,
@@ -3151,7 +3147,7 @@
                 },
                 {
                     "costumeName": "dinosaur3-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 6,
                     "baseLayerMD5": "4700613077afa7c62659b3fd7d7c748e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 115,
@@ -3159,7 +3155,7 @@
                 },
                 {
                     "costumeName": "dinosaur3-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 7,
                     "baseLayerMD5": "a03f110ed12b73acc9bd84037fd6ae96.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 115,
@@ -3167,7 +3163,7 @@
                 },
                 {
                     "costumeName": "dinosaur3-e",
-                    "baseLayerID": -1,
+                    "baseLayerID": 8,
                     "baseLayerMD5": "00e24e40535a1a621fee0f70895b2b61.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 115,
@@ -3187,6 +3183,7 @@
     },
     {
         "name": "Dinosaur4",
+        "baseLayerID": -1,
         "md5": "9da591f8a6da251c800adb12a02c43cb.svg",
         "type": "sprite",
         "tags": [
@@ -3217,7 +3214,7 @@
             "costumes": [
                 {
                     "costumeName": "dinosaur4-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 13,
                     "baseLayerMD5": "9da591f8a6da251c800adb12a02c43cb.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 59,
@@ -3225,7 +3222,7 @@
                 },
                 {
                     "costumeName": "dinosaur4-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 14,
                     "baseLayerMD5": "a3028e87caeb8338f50b2c6dec9f23d2.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 86,
@@ -3233,7 +3230,7 @@
                 },
                 {
                     "costumeName": "dinosaur4-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 15,
                     "baseLayerMD5": "9a4bbc1b104c8112be82c252a6ecfd11.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 59,
@@ -3241,7 +3238,7 @@
                 },
                 {
                     "costumeName": "dinosaur4-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 16,
                     "baseLayerMD5": "45061ff84a25723625d04f0476687633.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 89,
@@ -3261,6 +3258,7 @@
     },
     {
         "name": "Diver1",
+        "baseLayerID": -1,
         "md5": "853803d5600b66538474909c5438c8ee.svg",
         "type": "sprite",
         "tags": [
@@ -3291,7 +3289,7 @@
             "costumes": [
                 {
                     "costumeName": "diver1",
-                    "baseLayerID": -1,
+                    "baseLayerID": 41,
                     "baseLayerMD5": "853803d5600b66538474909c5438c8ee.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -3311,6 +3309,7 @@
     },
     {
         "name": "Diver2",
+        "baseLayerID": -1,
         "md5": "248d3e69ada69a64b1077149ef6a931a.svg",
         "type": "sprite",
         "tags": [
@@ -3341,7 +3340,7 @@
             "costumes": [
                 {
                     "costumeName": "diver2",
-                    "baseLayerID": -1,
+                    "baseLayerID": 42,
                     "baseLayerMD5": "248d3e69ada69a64b1077149ef6a931a.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -3361,6 +3360,7 @@
     },
     {
         "name": "Dog1",
+        "baseLayerID": -1,
         "md5": "39ddefa0cc58f3b1b06474d63d81ef56.svg",
         "type": "sprite",
         "tags": [
@@ -3379,7 +3379,7 @@
             "sounds": [
                 {
                     "soundName": "dog1",
-                    "soundID": -1,
+                    "soundID": 2,
                     "md5": "b15adefc3c12f758b6dc6a045362532f.wav",
                     "sampleCount": 3672,
                     "rate": 22050,
@@ -3389,7 +3389,7 @@
             "costumes": [
                 {
                     "costumeName": "dog1-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 57,
                     "baseLayerMD5": "39ddefa0cc58f3b1b06474d63d81ef56.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 83,
@@ -3397,7 +3397,7 @@
                 },
                 {
                     "costumeName": "dog1-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 58,
                     "baseLayerMD5": "598f4aa3d8f671375d1d2b3acf753416.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 83,
@@ -3417,6 +3417,7 @@
     },
     {
         "name": "Dog2",
+        "baseLayerID": -1,
         "md5": "e921f865b19b27cd99e16a341dbf09c2.svg",
         "type": "sprite",
         "tags": [
@@ -3435,7 +3436,7 @@
             "sounds": [
                 {
                     "soundName": "dog1",
-                    "soundID": -1,
+                    "soundID": 2,
                     "md5": "b15adefc3c12f758b6dc6a045362532f.wav",
                     "sampleCount": 3672,
                     "rate": 22050,
@@ -3445,7 +3446,7 @@
             "costumes": [
                 {
                     "costumeName": "dog2-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 59,
                     "baseLayerMD5": "e921f865b19b27cd99e16a341dbf09c2.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -3453,7 +3454,7 @@
                 },
                 {
                     "costumeName": "dog2-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 60,
                     "baseLayerMD5": "891f2fb7daf79ba8b224a9173eeb0a63.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -3461,7 +3462,7 @@
                 },
                 {
                     "costumeName": "dog2-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 61,
                     "baseLayerMD5": "cd236d5eef4431dea82983ac9eec406b.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -3481,6 +3482,7 @@
     },
     {
         "name": "Donut",
+        "baseLayerID": -1,
         "md5": "9e7b4d153421dae04a24571d7e079e85.svg",
         "type": "sprite",
         "tags": [
@@ -3513,7 +3515,7 @@
             "costumes": [
                 {
                     "costumeName": "donut",
-                    "baseLayerID": -1,
+                    "baseLayerID": 43,
                     "baseLayerMD5": "9e7b4d153421dae04a24571d7e079e85.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 73,
@@ -3533,6 +3535,7 @@
     },
     {
         "name": "Dorian",
+        "baseLayerID": -1,
         "md5": "b042b1a5fde03dd5abbc2f3f78d11a2c.svg",
         "type": "sprite",
         "tags": [
@@ -3561,7 +3564,7 @@
             "costumes": [
                 {
                     "costumeName": "dorian-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 4,
                     "baseLayerMD5": "b042b1a5fde03dd5abbc2f3f78d11a2c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 82,
@@ -3569,7 +3572,7 @@
                 },
                 {
                     "costumeName": "dorian-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 5,
                     "baseLayerMD5": "d0b58b672606601ecfa3a406b537fa10.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 82,
@@ -3577,7 +3580,7 @@
                 },
                 {
                     "costumeName": "dorian-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 6,
                     "baseLayerMD5": "445e461c73a5920098764a4cbad5bfe0.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 82,
@@ -3585,7 +3588,7 @@
                 },
                 {
                     "costumeName": "dorian-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 7,
                     "baseLayerMD5": "ba93ede3bbf75c0f707b0fb982bc27e8.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 82,
@@ -3605,6 +3608,7 @@
     },
     {
         "name": "Dot",
+        "baseLayerID": -1,
         "md5": "47c975e37f9a89c01d0d4d6fd17ef847.svg",
         "type": "sprite",
         "tags": [
@@ -3622,7 +3626,7 @@
             "sounds": [
                 {
                     "soundName": "bark",
-                    "soundID": -1,
+                    "soundID": 5,
                     "md5": "cd8fa8390b0efdd281882533fbfcfcfb.wav",
                     "sampleCount": 3168,
                     "rate": 22050,
@@ -3632,7 +3636,7 @@
             "costumes": [
                 {
                     "costumeName": "dot-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 26,
                     "baseLayerMD5": "47c975e37f9a89c01d0d4d6fd17ef847.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 52,
@@ -3640,7 +3644,7 @@
                 },
                 {
                     "costumeName": "dot-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 27,
                     "baseLayerMD5": "a9b7d5f7afa0c69c4044a3f541b9ab90.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 65,
@@ -3648,7 +3652,7 @@
                 },
                 {
                     "costumeName": "dot-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 28,
                     "baseLayerMD5": "5b7967159c9b83b0d0ed4f051ec2c9e9.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 49,
@@ -3656,7 +3660,7 @@
                 },
                 {
                     "costumeName": "dot-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 29,
                     "baseLayerMD5": "23ffa385654304e4cac454390dde3606.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 59,
@@ -3676,6 +3680,7 @@
     },
     {
         "name": "Dove",
+        "baseLayerID": -1,
         "md5": "6dde2b880ad6ddeaea2a53821befb86d.svg",
         "type": "sprite",
         "tags": [
@@ -3703,7 +3708,7 @@
             "costumes": [
                 {
                     "costumeName": "dove-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 26,
                     "baseLayerMD5": "6dde2b880ad6ddeaea2a53821befb86d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 86,
@@ -3711,7 +3716,7 @@
                 },
                 {
                     "costumeName": "dove-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 27,
                     "baseLayerMD5": "1c0bc118044d7f6033bc9cd1ef555590.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 88,
@@ -3731,6 +3736,7 @@
     },
     {
         "name": "Dragon",
+        "baseLayerID": -1,
         "md5": "8aed65cee4cfe22b4f4b8e749092dbbb.svg",
         "type": "sprite",
         "tags": [
@@ -3759,7 +3765,7 @@
             "costumes": [
                 {
                     "costumeName": "dragon-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 13,
                     "baseLayerMD5": "8aed65cee4cfe22b4f4b8e749092dbbb.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 210,
@@ -3767,7 +3773,7 @@
                 },
                 {
                     "costumeName": "dragon-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 14,
                     "baseLayerMD5": "c3360f16bb78b136d9911325da9fda49.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 210,
@@ -3775,7 +3781,7 @@
                 },
                 {
                     "costumeName": "dragon-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 15,
                     "baseLayerMD5": "e81af82ebde008c167ebc6874df3ecb4.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 210,
@@ -3795,6 +3801,7 @@
     },
     {
         "name": "Drum",
+        "baseLayerID": -1,
         "md5": "dd66742bc2a3cfe5a6f9f540afd2e15c.svg",
         "type": "sprite",
         "tags": [
@@ -3811,7 +3818,7 @@
             "sounds": [
                 {
                     "soundName": "high tom",
-                    "soundID": -1,
+                    "soundID": 32,
                     "md5": "d623f99b3c8d33932eb2c6c9cfd817c5.wav",
                     "sampleCount": 12320,
                     "rate": 22050,
@@ -3819,7 +3826,7 @@
                 },
                 {
                     "soundName": "low tom",
-                    "soundID": -1,
+                    "soundID": 33,
                     "md5": "1569bbbd8952b0575e5a5cb5aefb50ba.wav",
                     "sampleCount": 20000,
                     "rate": 22050,
@@ -3829,7 +3836,7 @@
             "costumes": [
                 {
                     "costumeName": "drum-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 10,
                     "baseLayerMD5": "dd66742bc2a3cfe5a6f9f540afd2e15c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 43,
@@ -3837,7 +3844,7 @@
                 },
                 {
                     "costumeName": "drum-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 11,
                     "baseLayerMD5": "9c9d371da382c227e43f09b1a748c554.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 43,
@@ -3857,6 +3864,7 @@
     },
     {
         "name": "Drum Kit",
+        "baseLayerID": -1,
         "md5": "131d040d86ecea62ccd175a8709c7866.svg",
         "type": "sprite",
         "tags": [
@@ -3873,7 +3881,7 @@
             "sounds": [
                 {
                     "soundName": "drum bass1",
-                    "soundID": -1,
+                    "soundID": 51,
                     "md5": "48328c874353617451e4c7902cc82817.wav",
                     "sampleCount": 6528,
                     "rate": 22050,
@@ -3881,7 +3889,7 @@
                 },
                 {
                     "soundName": "drum bass2",
-                    "soundID": -1,
+                    "soundID": 52,
                     "md5": "711a1270d1cf2e5de9b145ee539213e4.wav",
                     "sampleCount": 3791,
                     "rate": 22050,
@@ -3889,7 +3897,7 @@
                 },
                 {
                     "soundName": "drum bass3",
-                    "soundID": -1,
+                    "soundID": 53,
                     "md5": "c21704337b16359ea631b5f8eb48f765.wav",
                     "sampleCount": 8576,
                     "rate": 22050,
@@ -3897,7 +3905,7 @@
                 },
                 {
                     "soundName": "high tom",
-                    "soundID": -1,
+                    "soundID": 32,
                     "md5": "d623f99b3c8d33932eb2c6c9cfd817c5.wav",
                     "sampleCount": 12320,
                     "rate": 22050,
@@ -3905,7 +3913,7 @@
                 },
                 {
                     "soundName": "low tom",
-                    "soundID": -1,
+                    "soundID": 33,
                     "md5": "1569bbbd8952b0575e5a5cb5aefb50ba.wav",
                     "sampleCount": 20000,
                     "rate": 22050,
@@ -3915,7 +3923,7 @@
             "costumes": [
                 {
                     "costumeName": "drum-kit",
-                    "baseLayerID": -1,
+                    "baseLayerID": 20,
                     "baseLayerMD5": "131d040d86ecea62ccd175a8709c7866.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 58,
@@ -3923,7 +3931,7 @@
                 },
                 {
                     "costumeName": "drum-kit-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 21,
                     "baseLayerMD5": "ff14be049146cf9ab142e0951cb9b735.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 58,
@@ -3943,6 +3951,7 @@
     },
     {
         "name": "Drum-cymbal",
+        "baseLayerID": -1,
         "md5": "d6d41862fda966df1455d2dbff5e1988.svg",
         "type": "sprite",
         "tags": [
@@ -3959,7 +3968,7 @@
             "sounds": [
                 {
                     "soundName": "crash cymbal",
-                    "soundID": -1,
+                    "soundID": 37,
                     "md5": "f2c47a46f614f467a7ac802ed9ec3d8e.wav",
                     "sampleCount": 25220,
                     "rate": 22050,
@@ -3967,7 +3976,7 @@
                 },
                 {
                     "soundName": "splash cymbal",
-                    "soundID": -1,
+                    "soundID": 38,
                     "md5": "9d63ed5be96c43b06492e8b4a9cea8d8.wav",
                     "sampleCount": 9600,
                     "rate": 22050,
@@ -3975,7 +3984,7 @@
                 },
                 {
                     "soundName": "bell cymbal",
-                    "soundID": -1,
+                    "soundID": 39,
                     "md5": "efddec047de95492f775a1b5b2e8d19e.wav",
                     "sampleCount": 19328,
                     "rate": 22050,
@@ -3983,7 +3992,7 @@
                 },
                 {
                     "soundName": "roll cymbal",
-                    "soundID": -1,
+                    "soundID": 40,
                     "md5": "da8355d753cd2a5ddd19cb2bb41c1547.wav",
                     "sampleCount": 26432,
                     "rate": 22050,
@@ -3993,7 +4002,7 @@
             "costumes": [
                 {
                     "costumeName": "drum-cymbal-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 14,
                     "baseLayerMD5": "d6d41862fda966df1455d2dbff5e1988.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 30,
@@ -4001,7 +4010,7 @@
                 },
                 {
                     "costumeName": "drum-cymbal-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 15,
                     "baseLayerMD5": "e6b7d7d8874bc4b7be58afe927157554.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 30,
@@ -4021,6 +4030,7 @@
     },
     {
         "name": "Drum-highhat",
+        "baseLayerID": -1,
         "md5": "81fb79151a63cb096258607451cc2cf5.svg",
         "type": "sprite",
         "tags": [
@@ -4037,7 +4047,7 @@
             "sounds": [
                 {
                     "soundName": "hihat cymbal",
-                    "soundID": -1,
+                    "soundID": 50,
                     "md5": "2d01f60d0f20ab39facbf707899c6b2a.wav",
                     "sampleCount": 2752,
                     "rate": 22050,
@@ -4047,7 +4057,7 @@
             "costumes": [
                 {
                     "costumeName": "drum-highhat-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 18,
                     "baseLayerMD5": "81fb79151a63cb096258607451cc2cf5.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 33,
@@ -4055,7 +4065,7 @@
                 },
                 {
                     "costumeName": "drum-highhat-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 19,
                     "baseLayerMD5": "e3c273e4ad1a24583064f9b61fcd753a.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 33,
@@ -4075,6 +4085,7 @@
     },
     {
         "name": "Drum-snare",
+        "baseLayerID": -1,
         "md5": "b0255be93e3c8be6ac687f4199a25c4b.svg",
         "type": "sprite",
         "tags": [
@@ -4091,7 +4102,7 @@
             "sounds": [
                 {
                     "soundName": "tap snare",
-                    "soundID": -1,
+                    "soundID": 34,
                     "md5": "d55b3954d72c6275917f375e49b502f3.wav",
                     "sampleCount": 3296,
                     "rate": 22050,
@@ -4099,7 +4110,7 @@
                 },
                 {
                     "soundName": "flam snare",
-                    "soundID": -1,
+                    "soundID": 35,
                     "md5": "3b6cce9f8c56c0537ca61eee3945cd1d.wav",
                     "sampleCount": 4416,
                     "rate": 22050,
@@ -4107,7 +4118,7 @@
                 },
                 {
                     "soundName": "sidestick snare",
-                    "soundID": -1,
+                    "soundID": 36,
                     "md5": "f6868ee5cf626fc4ef3ca1119dc95592.wav",
                     "sampleCount": 2336,
                     "rate": 22050,
@@ -4117,7 +4128,7 @@
             "costumes": [
                 {
                     "costumeName": "drum-snare-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 12,
                     "baseLayerMD5": "b0255be93e3c8be6ac687f4199a25c4b.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 23,
@@ -4125,7 +4136,7 @@
                 },
                 {
                     "costumeName": "drum-snare-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 13,
                     "baseLayerMD5": "f6d2f2a6e1055dab6262336625ddf652.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 36,
@@ -4145,6 +4156,7 @@
     },
     {
         "name": "Duck",
+        "baseLayerID": -1,
         "md5": "c3baf7eedfbdac8cd1e4f1f1f779dc0c.svg",
         "type": "sprite",
         "tags": [
@@ -4164,7 +4176,7 @@
             "sounds": [
                 {
                     "soundName": "duck",
-                    "soundID": -1,
+                    "soundID": 3,
                     "md5": "af5b039e1b05e0ccb12944f648a8884e.wav",
                     "sampleCount": 5792,
                     "rate": 22050,
@@ -4174,7 +4186,7 @@
             "costumes": [
                 {
                     "costumeName": "duck",
-                    "baseLayerID": -1,
+                    "baseLayerID": 64,
                     "baseLayerMD5": "c3baf7eedfbdac8cd1e4f1f1f779dc0c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 61,
@@ -4194,6 +4206,7 @@
     },
     {
         "name": "Earth",
+        "baseLayerID": -1,
         "md5": "814197522984a302972998b1a7f92d91.svg",
         "type": "sprite",
         "tags": [
@@ -4219,7 +4232,7 @@
             "costumes": [
                 {
                     "costumeName": "earth",
-                    "baseLayerID": -1,
+                    "baseLayerID": 28,
                     "baseLayerMD5": "814197522984a302972998b1a7f92d91.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 72,
@@ -4239,6 +4252,7 @@
     },
     {
         "name": "Egg",
+        "baseLayerID": -1,
         "md5": "bc723738dfe626c5c3bb90970d985961.svg",
         "type": "sprite",
         "tags": [
@@ -4266,7 +4280,7 @@
             "costumes": [
                 {
                     "costumeName": "egg-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 5,
                     "baseLayerMD5": "bc723738dfe626c5c3bb90970d985961.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 68,
@@ -4274,7 +4288,7 @@
                 },
                 {
                     "costumeName": "egg-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 6,
                     "baseLayerMD5": "83016b7ff817f99be4a454600b4a78fc.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 68,
@@ -4282,7 +4296,7 @@
                 },
                 {
                     "costumeName": "egg-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 7,
                     "baseLayerMD5": "d9a44d151fbd909bdbbcf7877055af6d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 68,
@@ -4290,7 +4304,7 @@
                 },
                 {
                     "costumeName": "egg-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 8,
                     "baseLayerMD5": "c91c7f72b8523b0910a84bce7d99c37b.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 68,
@@ -4298,7 +4312,7 @@
                 },
                 {
                     "costumeName": "egg-e",
-                    "baseLayerID": -1,
+                    "baseLayerID": 9,
                     "baseLayerMD5": "65c15516e62596e1f72e874359fc7254.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 68,
@@ -4318,6 +4332,7 @@
     },
     {
         "name": "Elephant",
+        "baseLayerID": -1,
         "md5": "b3515b3805938b0fae4e527aa0b4524e.svg",
         "type": "sprite",
         "tags": [
@@ -4345,7 +4360,7 @@
             "costumes": [
                 {
                     "costumeName": "elephant-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 65,
                     "baseLayerMD5": "b3515b3805938b0fae4e527aa0b4524e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 107,
@@ -4353,7 +4368,7 @@
                 },
                 {
                     "costumeName": "elephant-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 66,
                     "baseLayerMD5": "bce91fa266220d3679a4c19c4e38b1f7.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 95,
@@ -4373,6 +4388,7 @@
     },
     {
         "name": "Elf",
+        "baseLayerID": -1,
         "md5": "00748a750dc4fd754ce4debb5e3595c0.svg",
         "type": "sprite",
         "tags": [
@@ -4401,7 +4417,7 @@
             "costumes": [
                 {
                     "costumeName": "elf-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 40,
                     "baseLayerMD5": "00748a750dc4fd754ce4debb5e3595c0.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 50,
@@ -4409,7 +4425,7 @@
                 },
                 {
                     "costumeName": "elf-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 41,
                     "baseLayerMD5": "91815a19569ef9f0ef68bca56bb80446.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 50,
@@ -4417,7 +4433,7 @@
                 },
                 {
                     "costumeName": "elf-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 42,
                     "baseLayerMD5": "8153eaf84bc3db9a671cafd34506243b.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 50,
@@ -4425,7 +4441,7 @@
                 },
                 {
                     "costumeName": "elf-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 43,
                     "baseLayerMD5": "2432797fc69a62fc643505b0ba039169.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 50,
@@ -4433,7 +4449,7 @@
                 },
                 {
                     "costumeName": "elf-e",
-                    "baseLayerID": -1,
+                    "baseLayerID": 44,
                     "baseLayerMD5": "a06e6c93b143ae2a7b776bd1deee6b59.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 50,
@@ -4453,6 +4469,7 @@
     },
     {
         "name": "Empty",
+        "baseLayerID": -1,
         "md5": "cd21514d0531fdffb22204e0ec5ed84a.svg",
         "type": "sprite",
         "tags": [],
@@ -4476,7 +4493,7 @@
             "costumes": [
                 {
                     "costumeName": "empty",
-                    "baseLayerID": -1,
+                    "baseLayerID": 105,
                     "baseLayerMD5": "cd21514d0531fdffb22204e0ec5ed84a.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 0,
@@ -4496,6 +4513,7 @@
     },
     {
         "name": "Fairy",
+        "baseLayerID": -1,
         "md5": "fe97687c7f1b747bb6f41c252cc5926a.svg",
         "type": "sprite",
         "tags": [
@@ -4524,7 +4542,7 @@
             "costumes": [
                 {
                     "costumeName": "fairy-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 45,
                     "baseLayerMD5": "fe97687c7f1b747bb6f41c252cc5926a.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 85,
@@ -4532,7 +4550,7 @@
                 },
                 {
                     "costumeName": "fairy-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 46,
                     "baseLayerMD5": "c8e0d935b2e4372ecc813705a79be3eb.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 85,
@@ -4540,7 +4558,7 @@
                 },
                 {
                     "costumeName": "fairy-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 47,
                     "baseLayerMD5": "4d0740d1b5be93256ad235062daa876b.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 85,
@@ -4548,7 +4566,7 @@
                 },
                 {
                     "costumeName": "fairy-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 48,
                     "baseLayerMD5": "ca555dadd377431e38a3bc67ece4d36a.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 85,
@@ -4556,7 +4574,7 @@
                 },
                 {
                     "costumeName": "fairy-e",
-                    "baseLayerID": -1,
+                    "baseLayerID": 49,
                     "baseLayerMD5": "a681f6d6044abdebcdd6634ce85da484.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 85,
@@ -4576,6 +4594,7 @@
     },
     {
         "name": "Fish",
+        "baseLayerID": -1,
         "md5": "8598752b1b7b9892c23817c4ed848e7d.svg",
         "type": "sprite",
         "tags": [
@@ -4605,7 +4624,7 @@
             "costumes": [
                 {
                     "costumeName": "fish-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 9,
                     "baseLayerMD5": "8598752b1b7b9892c23817c4ed848e7d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 63,
@@ -4613,7 +4632,7 @@
                 },
                 {
                     "costumeName": "fish-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 10,
                     "baseLayerMD5": "52032e4310f9855b89f873b528a5e928.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 63,
@@ -4621,7 +4640,7 @@
                 },
                 {
                     "costumeName": "fish-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 11,
                     "baseLayerMD5": "06c139dcfe45bf31ef45e7030b77dc36.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 63,
@@ -4629,7 +4648,7 @@
                 },
                 {
                     "costumeName": "fish-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 12,
                     "baseLayerMD5": "6a3a2c97374c157e0dbc0a03c2079284.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 63,
@@ -4649,6 +4668,7 @@
     },
     {
         "name": "Fox",
+        "baseLayerID": -1,
         "md5": "fab5488e600e81565f0fc285fc7050f8.svg",
         "type": "sprite",
         "tags": [
@@ -4676,7 +4696,7 @@
             "costumes": [
                 {
                     "costumeName": "fox-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 0,
                     "baseLayerMD5": "fab5488e600e81565f0fc285fc7050f8.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 94,
@@ -4684,7 +4704,7 @@
                 },
                 {
                     "costumeName": "fox-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 1,
                     "baseLayerMD5": "afb192ae250a74dfac18bfc52d1d6266.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 94,
@@ -4692,7 +4712,7 @@
                 },
                 {
                     "costumeName": "fox-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 2,
                     "baseLayerMD5": "29f858d384db7998c0e5183f6a31a3b4.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 94,
@@ -4712,6 +4732,7 @@
     },
     {
         "name": "Frog",
+        "baseLayerID": -1,
         "md5": "285483a688eed2ff8010c65112f99c41.svg",
         "type": "sprite",
         "tags": [
@@ -4742,7 +4763,7 @@
             "costumes": [
                 {
                     "costumeName": "frog",
-                    "baseLayerID": -1,
+                    "baseLayerID": 44,
                     "baseLayerMD5": "285483a688eed2ff8010c65112f99c41.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 48,
@@ -4762,6 +4783,7 @@
     },
     {
         "name": "Fruit Salad",
+        "baseLayerID": -1,
         "md5": "dbf8cc34f7ca18b4a008d2890dba56b7.svg",
         "type": "sprite",
         "tags": [
@@ -4788,7 +4810,7 @@
             "costumes": [
                 {
                     "costumeName": "fruitsalad",
-                    "baseLayerID": -1,
+                    "baseLayerID": 29,
                     "baseLayerMD5": "dbf8cc34f7ca18b4a008d2890dba56b7.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 30,
@@ -4808,6 +4830,7 @@
     },
     {
         "name": "Ghost1",
+        "baseLayerID": -1,
         "md5": "c88579c578f2d171de78612f2ff9c9d9.svg",
         "type": "sprite",
         "tags": [
@@ -4836,7 +4859,7 @@
             "costumes": [
                 {
                     "costumeName": "ghost1 ",
-                    "baseLayerID": -1,
+                    "baseLayerID": 45,
                     "baseLayerMD5": "c88579c578f2d171de78612f2ff9c9d9.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 60,
@@ -4856,6 +4879,7 @@
     },
     {
         "name": "Ghost2",
+        "baseLayerID": -1,
         "md5": "607be245da950af1a4e4d79acfda46e3.svg",
         "type": "sprite",
         "tags": [
@@ -4884,7 +4908,7 @@
             "costumes": [
                 {
                     "costumeName": "ghost2-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 67,
                     "baseLayerMD5": "607be245da950af1a4e4d79acfda46e3.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -4892,7 +4916,7 @@
                 },
                 {
                     "costumeName": "ghost2-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 68,
                     "baseLayerMD5": "b9e2ebbe17c617ac182abd8bc1627693.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -4912,6 +4936,7 @@
     },
     {
         "name": "Gift",
+        "baseLayerID": -1,
         "md5": "abeae2217b3ce67b1ff761cd7a89274d.svg",
         "type": "sprite",
         "tags": [
@@ -4938,7 +4963,7 @@
             "costumes": [
                 {
                     "costumeName": "gift-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 30,
                     "baseLayerMD5": "abeae2217b3ce67b1ff761cd7a89274d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 33,
@@ -4946,7 +4971,7 @@
                 },
                 {
                     "costumeName": "gift-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 31,
                     "baseLayerMD5": "5cae973c98f2d98b51e6c6b3c9602f8c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 33,
@@ -4966,6 +4991,7 @@
     },
     {
         "name": "Giga",
+        "baseLayerID": -1,
         "md5": "93cb048a1d199f92424b9c097fa5fa38.svg",
         "type": "sprite",
         "tags": [
@@ -4992,7 +5018,7 @@
             "costumes": [
                 {
                     "costumeName": "giga-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 74,
                     "baseLayerMD5": "93cb048a1d199f92424b9c097fa5fa38.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 72,
@@ -5000,7 +5026,7 @@
                 },
                 {
                     "costumeName": "giga-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 75,
                     "baseLayerMD5": "528613711a7eae3a929025be04db081c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 72,
@@ -5008,7 +5034,7 @@
                 },
                 {
                     "costumeName": "giga-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 76,
                     "baseLayerMD5": "ee4dd21d7ca6d1b889ee25d245cbcc66.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 73,
@@ -5016,7 +5042,7 @@
                 },
                 {
                     "costumeName": "giga-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 77,
                     "baseLayerMD5": "7708e2d9f83a01476ee6d17aa540ddf1.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 73,
@@ -5036,6 +5062,7 @@
     },
     {
         "name": "Giga Walking",
+        "baseLayerID": -1,
         "md5": "f76bc420011db2cdb2de378c1536f6da.svg",
         "type": "sprite",
         "tags": [
@@ -5062,7 +5089,7 @@
             "costumes": [
                 {
                     "costumeName": "Giga walk1",
-                    "baseLayerID": -1,
+                    "baseLayerID": 32,
                     "baseLayerMD5": "f76bc420011db2cdb2de378c1536f6da.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 70,
@@ -5070,7 +5097,7 @@
                 },
                 {
                     "costumeName": "Giga walk2",
-                    "baseLayerID": -1,
+                    "baseLayerID": 33,
                     "baseLayerMD5": "43b5874e8a54f93bd02727f0abf6905b.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 71,
@@ -5078,7 +5105,7 @@
                 },
                 {
                     "costumeName": "Giga walk3",
-                    "baseLayerID": -1,
+                    "baseLayerID": 34,
                     "baseLayerMD5": "9aab3bbb375765391978be4f6d478ab3.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 71,
@@ -5086,7 +5113,7 @@
                 },
                 {
                     "costumeName": "Giga walk4",
-                    "baseLayerID": -1,
+                    "baseLayerID": 35,
                     "baseLayerMD5": "22e4ae40919cf0fe6b4d7649d14a6e71.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 73,
@@ -5106,6 +5133,7 @@
     },
     {
         "name": "Glass Water",
+        "baseLayerID": -1,
         "md5": "c364b9e1f4bcdc61705032d89eaaa0a1.svg",
         "type": "sprite",
         "tags": [
@@ -5133,7 +5161,7 @@
             "costumes": [
                 {
                     "costumeName": "glass water-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 36,
                     "baseLayerMD5": "c364b9e1f4bcdc61705032d89eaaa0a1.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 39,
@@ -5141,7 +5169,7 @@
                 },
                 {
                     "costumeName": "glass water-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 37,
                     "baseLayerMD5": "bc07ce6a2004ac91ce704531a1c526e5.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 39,
@@ -5161,6 +5189,7 @@
     },
     {
         "name": "Glasses",
+        "baseLayerID": -1,
         "md5": "5fcf716b53f223bc86b10ab0eca3e162.svg",
         "type": "sprite",
         "tags": [
@@ -5187,7 +5216,7 @@
             "costumes": [
                 {
                     "costumeName": "glasses",
-                    "baseLayerID": -1,
+                    "baseLayerID": 38,
                     "baseLayerMD5": "5fcf716b53f223bc86b10ab0eca3e162.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 16,
@@ -5207,6 +5236,7 @@
     },
     {
         "name": "Goalie",
+        "baseLayerID": -1,
         "md5": "86b0610ea21fdecb99795c5e6d52768c.svg",
         "type": "sprite",
         "tags": [
@@ -5235,7 +5265,7 @@
             "costumes": [
                 {
                     "costumeName": "goalie-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 0,
                     "baseLayerMD5": "86b0610ea21fdecb99795c5e6d52768c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 76,
@@ -5243,7 +5273,7 @@
                 },
                 {
                     "costumeName": "goalie-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 1,
                     "baseLayerMD5": "af3ef5125d187772240a1120e7eb67ac.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 76,
@@ -5251,7 +5281,7 @@
                 },
                 {
                     "costumeName": "goalie-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 2,
                     "baseLayerMD5": "7c9377cedae11a094d2e77bed3edb884.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 76,
@@ -5259,7 +5289,7 @@
                 },
                 {
                     "costumeName": "goalie-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 3,
                     "baseLayerMD5": "bd628034d356d30b0e9b563447471290.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 76,
@@ -5267,7 +5297,7 @@
                 },
                 {
                     "costumeName": "goalie-e",
-                    "baseLayerID": -1,
+                    "baseLayerID": 4,
                     "baseLayerMD5": "b3f6c4c0be9a0f71e9486dea51e513c3.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 76,
@@ -5287,6 +5317,7 @@
     },
     {
         "name": "Goblin",
+        "baseLayerID": -1,
         "md5": "f10eaedff51f50f0809a7b4b310337fa.svg",
         "type": "sprite",
         "tags": [
@@ -5314,7 +5345,7 @@
             "costumes": [
                 {
                     "costumeName": "goblin-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 3,
                     "baseLayerMD5": "f10eaedff51f50f0809a7b4b310337fa.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 40,
@@ -5322,7 +5353,7 @@
                 },
                 {
                     "costumeName": "goblin-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 4,
                     "baseLayerMD5": "71e7c77d89299cd99739b1216fc03a85.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 40,
@@ -5330,7 +5361,7 @@
                 },
                 {
                     "costumeName": "goblin-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 5,
                     "baseLayerMD5": "ab0611427d6f9b54d83672cf9e554876.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 40,
@@ -5338,7 +5369,7 @@
                 },
                 {
                     "costumeName": "goblin-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 6,
                     "baseLayerMD5": "87dd413e7a8545bea9b3da208a5d5735.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 40,
@@ -5358,6 +5389,7 @@
     },
     {
         "name": "Gobo",
+        "baseLayerID": -1,
         "md5": "1f5ea0d12f85aed2e471cdd21b0bd6d7.svg",
         "type": "sprite",
         "tags": [
@@ -5386,7 +5418,7 @@
             "costumes": [
                 {
                     "costumeName": "gobo-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 71,
                     "baseLayerMD5": "1f5ea0d12f85aed2e471cdd21b0bd6d7.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 47,
@@ -5394,7 +5426,7 @@
                 },
                 {
                     "costumeName": "gobo-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 72,
                     "baseLayerMD5": "73e493e4abd5d0954b677b97abcb7116.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 47,
@@ -5402,7 +5434,7 @@
                 },
                 {
                     "costumeName": "gobo-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 73,
                     "baseLayerMD5": "bc68a6bdf300df7b53d73b38f74c844e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 47,
@@ -5422,6 +5454,7 @@
     },
     {
         "name": "Green Flag",
+        "baseLayerID": -1,
         "md5": "173e20ac537d2c278ed621be3db3fc87.svg",
         "type": "sprite",
         "tags": [
@@ -5447,7 +5480,7 @@
             "costumes": [
                 {
                     "costumeName": "green flag",
-                    "baseLayerID": -1,
+                    "baseLayerID": 39,
                     "baseLayerMD5": "173e20ac537d2c278ed621be3db3fc87.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 70,
@@ -5467,6 +5500,7 @@
     },
     {
         "name": "Griffin",
+        "baseLayerID": -1,
         "md5": "d2ddc25b224ad72240f92e632afc7c69.svg",
         "type": "sprite",
         "tags": [
@@ -5495,7 +5529,7 @@
             "costumes": [
                 {
                     "costumeName": "griffin-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 10,
                     "baseLayerMD5": "d2ddc25b224ad72240f92e632afc7c69.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 150,
@@ -5503,7 +5537,7 @@
                 },
                 {
                     "costumeName": "griffin-fly-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 11,
                     "baseLayerMD5": "ff0795d15b6f3990345f72bc483a3353.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 150,
@@ -5523,6 +5557,7 @@
     },
     {
         "name": "Griffin-flying",
+        "baseLayerID": -1,
         "md5": "03d75e0c7c34e8618545a5f4913db4ea.svg",
         "type": "sprite",
         "tags": [
@@ -5551,7 +5586,7 @@
             "costumes": [
                 {
                     "costumeName": "griffin-fly-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 12,
                     "baseLayerMD5": "03d75e0c7c34e8618545a5f4913db4ea.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 150,
@@ -5559,7 +5594,7 @@
                 },
                 {
                     "costumeName": "griffin-fly-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 11,
                     "baseLayerMD5": "ff0795d15b6f3990345f72bc483a3353.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 150,
@@ -5579,6 +5614,7 @@
     },
     {
         "name": "Guitar",
+        "baseLayerID": -1,
         "md5": "cb8c2a5e69da7538e1dd73cb7ff4a666.svg",
         "type": "sprite",
         "tags": [
@@ -5595,7 +5631,7 @@
             "sounds": [
                 {
                     "soundName": "C guitar",
-                    "soundID": -1,
+                    "soundID": 0,
                     "md5": "22baa07795a9a524614075cdea543793.wav",
                     "sampleCount": 44864,
                     "rate": 22050,
@@ -5603,7 +5639,7 @@
                 },
                 {
                     "soundName": "D guitar",
-                    "soundID": -1,
+                    "soundID": 1,
                     "md5": "2dbcfae6a55738f94bbb40aa5fcbf7ce.wav",
                     "sampleCount": 41120,
                     "rate": 22050,
@@ -5611,7 +5647,7 @@
                 },
                 {
                     "soundName": "E guitar",
-                    "soundID": -1,
+                    "soundID": 2,
                     "md5": "4b5d1da83e59bf35578324573c991666.wav",
                     "sampleCount": 38400,
                     "rate": 22050,
@@ -5619,7 +5655,7 @@
                 },
                 {
                     "soundName": "F guitar",
-                    "soundID": -1,
+                    "soundID": 3,
                     "md5": "b51d086aeb1921ec405561df52ecbc50.wav",
                     "sampleCount": 36416,
                     "rate": 22050,
@@ -5627,7 +5663,7 @@
                 },
                 {
                     "soundName": "G guitar",
-                    "soundID": -1,
+                    "soundID": 4,
                     "md5": "98a835713ecea2f3ef9f4f442d52ad20.wav",
                     "sampleCount": 33600,
                     "rate": 22050,
@@ -5635,7 +5671,7 @@
                 },
                 {
                     "soundName": "A guitar",
-                    "soundID": -1,
+                    "soundID": 5,
                     "md5": "ee753e87d212d4b2fb650ca660f1e839.wav",
                     "sampleCount": 31872,
                     "rate": 22050,
@@ -5643,7 +5679,7 @@
                 },
                 {
                     "soundName": "B guitar",
-                    "soundID": -1,
+                    "soundID": 6,
                     "md5": "2ae2d67de62df8ca54d638b4ad2466c3.wav",
                     "sampleCount": 29504,
                     "rate": 22050,
@@ -5651,7 +5687,7 @@
                 },
                 {
                     "soundName": "C2 guitar",
-                    "soundID": -1,
+                    "soundID": 7,
                     "md5": "c8d2851bd99d8e0ce6c1f05e4acc7f34.wav",
                     "sampleCount": 27712,
                     "rate": 22050,
@@ -5661,7 +5697,7 @@
             "costumes": [
                 {
                     "costumeName": "guitar-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 0,
                     "baseLayerMD5": "cb8c2a5e69da7538e1dd73cb7ff4a666.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 47,
@@ -5669,7 +5705,7 @@
                 },
                 {
                     "costumeName": "guitar-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 1,
                     "baseLayerMD5": "fed44bd1091628c060f45060a84f2885.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 47,
@@ -5689,6 +5725,7 @@
     },
     {
         "name": "Guitar-electric2",
+        "baseLayerID": -1,
         "md5": "1fc433b89038f9e16092c9f4d7514cca.svg",
         "type": "sprite",
         "tags": [
@@ -5705,7 +5742,7 @@
             "sounds": [
                 {
                     "soundName": "C elec guitar",
-                    "soundID": -1,
+                    "soundID": 8,
                     "md5": "0d340de02e14bebaf8dfa0e43eb3f1f9.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -5713,7 +5750,7 @@
                 },
                 {
                     "soundName": "D elec guitar",
-                    "soundID": -1,
+                    "soundID": 9,
                     "md5": "1b5de9866801eb2f9d4f57c7c3b473f5.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -5721,7 +5758,7 @@
                 },
                 {
                     "soundName": "E elec guitar",
-                    "soundID": -1,
+                    "soundID": 10,
                     "md5": "2e6a6ae3e0f72bf78c74def8130f459a.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -5729,7 +5766,7 @@
                 },
                 {
                     "soundName": "F elec guitar",
-                    "soundID": -1,
+                    "soundID": 11,
                     "md5": "5eb00f15f21f734986aa45156d44478d.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -5737,7 +5774,7 @@
                 },
                 {
                     "soundName": "G elec guitar",
-                    "soundID": -1,
+                    "soundID": 12,
                     "md5": "cd0d0e7dad415b2ffa2ba7a61860eaf8.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -5745,7 +5782,7 @@
                 },
                 {
                     "soundName": "A elec guitar",
-                    "soundID": -1,
+                    "soundID": 13,
                     "md5": "fa5f7fea601e9368dd68449d9a54c995.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -5753,7 +5790,7 @@
                 },
                 {
                     "soundName": "B elec guitar",
-                    "soundID": -1,
+                    "soundID": 14,
                     "md5": "81f142d0b00189703d7fe9b1f13f6f87.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -5761,7 +5798,7 @@
                 },
                 {
                     "soundName": "C2 elec guitar",
-                    "soundID": -1,
+                    "soundID": 15,
                     "md5": "3a8ed3129f22cba5b0810bc030d16b5f.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -5771,7 +5808,7 @@
             "costumes": [
                 {
                     "costumeName": "guitar-electric2-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 2,
                     "baseLayerMD5": "1fc433b89038f9e16092c9f4d7514cca.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 38,
@@ -5779,7 +5816,7 @@
                 },
                 {
                     "costumeName": "guitar-electric2-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 3,
                     "baseLayerMD5": "7b843dbc93d4b2ea31fa67cca3d5077c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 38,
@@ -5799,6 +5836,7 @@
     },
     {
         "name": "Gutar-electric1",
+        "baseLayerID": -1,
         "md5": "b2b469b9d11fd23bdd671eab94dc58ff.svg",
         "type": "sprite",
         "tags": [
@@ -5815,7 +5853,7 @@
             "sounds": [
                 {
                     "soundName": "C elec guitar",
-                    "soundID": -1,
+                    "soundID": 8,
                     "md5": "0d340de02e14bebaf8dfa0e43eb3f1f9.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -5823,7 +5861,7 @@
                 },
                 {
                     "soundName": "D elec guitar",
-                    "soundID": -1,
+                    "soundID": 9,
                     "md5": "1b5de9866801eb2f9d4f57c7c3b473f5.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -5831,7 +5869,7 @@
                 },
                 {
                     "soundName": "E elec guitar",
-                    "soundID": -1,
+                    "soundID": 10,
                     "md5": "2e6a6ae3e0f72bf78c74def8130f459a.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -5839,7 +5877,7 @@
                 },
                 {
                     "soundName": "F elec guitar",
-                    "soundID": -1,
+                    "soundID": 11,
                     "md5": "5eb00f15f21f734986aa45156d44478d.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -5847,7 +5885,7 @@
                 },
                 {
                     "soundName": "G elec guitar",
-                    "soundID": -1,
+                    "soundID": 12,
                     "md5": "cd0d0e7dad415b2ffa2ba7a61860eaf8.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -5855,7 +5893,7 @@
                 },
                 {
                     "soundName": "A elec guitar",
-                    "soundID": -1,
+                    "soundID": 13,
                     "md5": "fa5f7fea601e9368dd68449d9a54c995.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -5863,7 +5901,7 @@
                 },
                 {
                     "soundName": "B elec guitar",
-                    "soundID": -1,
+                    "soundID": 14,
                     "md5": "81f142d0b00189703d7fe9b1f13f6f87.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -5871,7 +5909,7 @@
                 },
                 {
                     "soundName": "C2 elec guitar",
-                    "soundID": -1,
+                    "soundID": 15,
                     "md5": "3a8ed3129f22cba5b0810bc030d16b5f.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -5881,7 +5919,7 @@
             "costumes": [
                 {
                     "costumeName": "guitar-electric1-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 4,
                     "baseLayerMD5": "b2b469b9d11fd23bdd671eab94dc58ff.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 42,
@@ -5889,7 +5927,7 @@
                 },
                 {
                     "costumeName": "guitar-electric1-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 5,
                     "baseLayerMD5": "3632184c19c66a088a99568570d61b13.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 42,
@@ -5909,6 +5947,7 @@
     },
     {
         "name": "Hat",
+        "baseLayerID": -1,
         "md5": "b3beb1f52d371428d70b65a0c4c5c001.svg",
         "type": "sprite",
         "tags": [
@@ -5934,7 +5973,7 @@
             "costumes": [
                 {
                     "costumeName": "Hat",
-                    "baseLayerID": -1,
+                    "baseLayerID": 40,
                     "baseLayerMD5": "b3beb1f52d371428d70b65a0c4c5c001.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 52,
@@ -5954,6 +5993,7 @@
     },
     {
         "name": "Hat Beanie",
+        "baseLayerID": -1,
         "md5": "3271da33e4108ed08a303c2244739fbf.svg",
         "type": "sprite",
         "tags": [
@@ -5979,7 +6019,7 @@
             "costumes": [
                 {
                     "costumeName": "hat beanie",
-                    "baseLayerID": -1,
+                    "baseLayerID": 41,
                     "baseLayerMD5": "3271da33e4108ed08a303c2244739fbf.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 28,
@@ -5999,6 +6039,7 @@
     },
     {
         "name": "Hat Party1",
+        "baseLayerID": -1,
         "md5": "70a7f535d8857cf9175492415361c361.svg",
         "type": "sprite",
         "tags": [
@@ -6025,7 +6066,7 @@
             "costumes": [
                 {
                     "costumeName": "partyhat1",
-                    "baseLayerID": -1,
+                    "baseLayerID": 42,
                     "baseLayerMD5": "70a7f535d8857cf9175492415361c361.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -6045,6 +6086,7 @@
     },
     {
         "name": "Hat Party2",
+        "baseLayerID": -1,
         "md5": "9b7a84fe3e50621752917e4e484a1e2f.svg",
         "type": "sprite",
         "tags": [
@@ -6071,7 +6113,7 @@
             "costumes": [
                 {
                     "costumeName": "hat party2-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 43,
                     "baseLayerMD5": "9b7a84fe3e50621752917e4e484a1e2f.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -6091,6 +6133,7 @@
     },
     {
         "name": "Hat Winter",
+        "baseLayerID": -1,
         "md5": "6c2ee1b97f6ec2b3457a25a3975a2009.svg",
         "type": "sprite",
         "tags": [
@@ -6117,7 +6160,7 @@
             "costumes": [
                 {
                     "costumeName": "hat winter",
-                    "baseLayerID": -1,
+                    "baseLayerID": 44,
                     "baseLayerMD5": "6c2ee1b97f6ec2b3457a25a3975a2009.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 26,
@@ -6137,6 +6180,7 @@
     },
     {
         "name": "Hat Wizard",
+        "baseLayerID": -1,
         "md5": "581571e8c8f5adeb01565e12b1b77b58.svg",
         "type": "sprite",
         "tags": [
@@ -6163,7 +6207,7 @@
             "costumes": [
                 {
                     "costumeName": "hat wizard",
-                    "baseLayerID": -1,
+                    "baseLayerID": 45,
                     "baseLayerMD5": "581571e8c8f5adeb01565e12b1b77b58.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 76,
@@ -6183,6 +6227,7 @@
     },
     {
         "name": "Headband",
+        "baseLayerID": -1,
         "md5": "961148d1605a1bd8ce80ed8d39e831c2.svg",
         "type": "sprite",
         "tags": [
@@ -6209,7 +6254,7 @@
             "costumes": [
                 {
                     "costumeName": "headband",
-                    "baseLayerID": -1,
+                    "baseLayerID": 46,
                     "baseLayerMD5": "961148d1605a1bd8ce80ed8d39e831c2.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 53,
@@ -6229,6 +6274,7 @@
     },
     {
         "name": "Heart",
+        "baseLayerID": -1,
         "md5": "6e79e087c866a016f99ee482e1aeba47.svg",
         "type": "sprite",
         "tags": [
@@ -6258,7 +6304,7 @@
             "costumes": [
                 {
                     "costumeName": "heart red",
-                    "baseLayerID": -1,
+                    "baseLayerID": 47,
                     "baseLayerMD5": "6e79e087c866a016f99ee482e1aeba47.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 65,
@@ -6266,7 +6312,7 @@
                 },
                 {
                     "costumeName": "heart purple",
-                    "baseLayerID": -1,
+                    "baseLayerID": 48,
                     "baseLayerMD5": "b15362bb6b02a59e364db9081ccf19aa.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 66,
@@ -6286,6 +6332,7 @@
     },
     {
         "name": "Heart Candy",
+        "baseLayerID": -1,
         "md5": "d448acd247f10f32bef7823cd433f928.svg",
         "type": "sprite",
         "tags": [
@@ -6311,7 +6358,7 @@
             "costumes": [
                 {
                     "costumeName": "heart love it",
-                    "baseLayerID": -1,
+                    "baseLayerID": 49,
                     "baseLayerMD5": "d448acd247f10f32bef7823cd433f928.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 58,
@@ -6319,7 +6366,7 @@
                 },
                 {
                     "costumeName": "heart code",
-                    "baseLayerID": -1,
+                    "baseLayerID": 50,
                     "baseLayerMD5": "497c5df9e02467202ff93096dccaf91f.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 58,
@@ -6327,7 +6374,7 @@
                 },
                 {
                     "costumeName": "heart sweet",
-                    "baseLayerID": -1,
+                    "baseLayerID": 51,
                     "baseLayerMD5": "a39d78d33b051e8b12a4b2a10d77b249.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 58,
@@ -6335,7 +6382,7 @@
                 },
                 {
                     "costumeName": "heart smile",
-                    "baseLayerID": -1,
+                    "baseLayerID": 52,
                     "baseLayerMD5": "74a8f75d139d330b715787edbbacd83d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 58,
@@ -6355,6 +6402,7 @@
     },
     {
         "name": "Heart Face",
+        "baseLayerID": -1,
         "md5": "4ab84263da32069cf97cc0fa52729a0d.svg",
         "type": "sprite",
         "tags": [
@@ -6380,7 +6428,7 @@
             "costumes": [
                 {
                     "costumeName": "heart face",
-                    "baseLayerID": -1,
+                    "baseLayerID": 53,
                     "baseLayerMD5": "4ab84263da32069cf97cc0fa52729a0d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 59,
@@ -6400,6 +6448,7 @@
     },
     {
         "name": "Hedgehog",
+        "baseLayerID": -1,
         "md5": "32416e6b2ef8e45fb5fd10778c1b9a9f.svg",
         "type": "sprite",
         "tags": [
@@ -6428,7 +6477,7 @@
             "costumes": [
                 {
                     "costumeName": "hedgehog-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 0,
                     "baseLayerMD5": "32416e6b2ef8e45fb5fd10778c1b9a9f.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 71,
@@ -6436,7 +6485,7 @@
                 },
                 {
                     "costumeName": "hedgehog-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 1,
                     "baseLayerMD5": "4d3ccc06660e07b55bd38246e1f82f7f.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 71,
@@ -6444,7 +6493,7 @@
                 },
                 {
                     "costumeName": "hedgehog-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 2,
                     "baseLayerMD5": "2446f79c0f553594cfbcdbe6b1e459a5.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 71,
@@ -6452,7 +6501,7 @@
                 },
                 {
                     "costumeName": "hedgehog-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 3,
                     "baseLayerMD5": "bdb7c8e86125092da0c4848d1ffd901c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 71,
@@ -6460,7 +6509,7 @@
                 },
                 {
                     "costumeName": "hedgehog-e",
-                    "baseLayerID": -1,
+                    "baseLayerID": 4,
                     "baseLayerMD5": "78a0e3789f6d778e20f9bf3d308a0b19.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 61,
@@ -6480,6 +6529,7 @@
     },
     {
         "name": "Hippo1",
+        "baseLayerID": -1,
         "md5": "c1353c4a5eec5e6f32ed053e6f6e8f99.svg",
         "type": "sprite",
         "tags": [
@@ -6512,7 +6562,7 @@
             "costumes": [
                 {
                     "costumeName": "hippo1-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 78,
                     "baseLayerMD5": "c1353c4a5eec5e6f32ed053e6f6e8f99.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 69,
@@ -6520,7 +6570,7 @@
                 },
                 {
                     "costumeName": "hippo1-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 79,
                     "baseLayerMD5": "e65ed93bbb9cccf698fc7e774ab609a6.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 69,
@@ -6540,6 +6590,7 @@
     },
     {
         "name": "Home Button",
+        "baseLayerID": -1,
         "md5": "1bac530a0701a8fc88bb0802ae6787a3.svg",
         "type": "sprite",
         "tags": [
@@ -6566,7 +6617,7 @@
             "costumes": [
                 {
                     "costumeName": "home button",
-                    "baseLayerID": -1,
+                    "baseLayerID": 54,
                     "baseLayerMD5": "1bac530a0701a8fc88bb0802ae6787a3.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 72,
@@ -6586,6 +6637,7 @@
     },
     {
         "name": "Horse1",
+        "baseLayerID": -1,
         "md5": "32f4d80477cd070cb0848e555d374060.svg",
         "type": "sprite",
         "tags": [
@@ -6606,7 +6658,7 @@
             "sounds": [
                 {
                     "soundName": "horse",
-                    "soundID": -1,
+                    "soundID": 5,
                     "md5": "45ffcf97ee2edca0199ff5aa71a5b72e.wav",
                     "sampleCount": 14464,
                     "rate": 11025,
@@ -6614,7 +6666,7 @@
                 },
                 {
                     "soundName": "horse gallop",
-                    "soundID": -1,
+                    "soundID": 6,
                     "md5": "058a34b5fb8b57178b5322d994b6b8c8.wav",
                     "sampleCount": 38336,
                     "rate": 11025,
@@ -6624,7 +6676,7 @@
             "costumes": [
                 {
                     "costumeName": "horse1-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 80,
                     "baseLayerMD5": "32f4d80477cd070cb0848e555d374060.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 119,
@@ -6632,7 +6684,7 @@
                 },
                 {
                     "costumeName": "horse1-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 81,
                     "baseLayerMD5": "ffa6431c5ef2a4e975ecffacdb0efea7.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 103,
@@ -6652,6 +6704,7 @@
     },
     {
         "name": "Jamie",
+        "baseLayerID": -1,
         "md5": "90f9166fe6500d0c0caad8b1964d6b74.svg",
         "type": "sprite",
         "tags": [
@@ -6680,7 +6733,7 @@
             "costumes": [
                 {
                     "costumeName": "jamie-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 8,
                     "baseLayerMD5": "90f9166fe6500d0c0caad8b1964d6b74.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 82,
@@ -6688,7 +6741,7 @@
                 },
                 {
                     "costumeName": "jamie-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 9,
                     "baseLayerMD5": "c3d96ef7e99440c2fa76effce1235d3f.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 82,
@@ -6696,7 +6749,7 @@
                 },
                 {
                     "costumeName": "jamie-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 10,
                     "baseLayerMD5": "1fb8b9ca79f2c0a327913bd647b53fe5.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 82,
@@ -6704,7 +6757,7 @@
                 },
                 {
                     "costumeName": "jamie-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 11,
                     "baseLayerMD5": "4adb87e6123161fcaf02f7ac022a5757.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 82,
@@ -6724,6 +6777,7 @@
     },
     {
         "name": "Jar",
+        "baseLayerID": -1,
         "md5": "73784b267083733e08bcf06aa7d6536a.svg",
         "type": "sprite",
         "tags": [
@@ -6751,7 +6805,7 @@
             "costumes": [
                 {
                     "costumeName": "jar-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 33,
                     "baseLayerMD5": "73784b267083733e08bcf06aa7d6536a.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 20,
@@ -6759,7 +6813,7 @@
                 },
                 {
                     "costumeName": "jar-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 34,
                     "baseLayerMD5": "a37eb72115966a75bc1bf521deeccc0c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 20,
@@ -6779,6 +6833,7 @@
     },
     {
         "name": "Jeans",
+        "baseLayerID": -1,
         "md5": "4e283da8c59bcbb9803bdc0016b14c21.svg",
         "type": "sprite",
         "tags": [
@@ -6804,7 +6859,7 @@
             "costumes": [
                 {
                     "costumeName": "jeans-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 55,
                     "baseLayerMD5": "4e283da8c59bcbb9803bdc0016b14c21.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -6812,7 +6867,7 @@
                 },
                 {
                     "costumeName": "jeans-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 56,
                     "baseLayerMD5": "01732aa03a48482093fbed3ea402c4a9.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -6832,6 +6887,7 @@
     },
     {
         "name": "Jellyfish",
+        "baseLayerID": -1,
         "md5": "9e6563e417350af3094c2ed02b9b0bbd.svg",
         "type": "sprite",
         "tags": [
@@ -6862,7 +6918,7 @@
             "costumes": [
                 {
                     "costumeName": "jellyfish-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 0,
                     "baseLayerMD5": "9e6563e417350af3094c2ed02b9b0bbd.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 99,
@@ -6870,7 +6926,7 @@
                 },
                 {
                     "costumeName": "jellyfish-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 1,
                     "baseLayerMD5": "31a42fad0891f1298c522a6d5008930a.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 99,
@@ -6878,7 +6934,7 @@
                 },
                 {
                     "costumeName": "jellyfish-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 2,
                     "baseLayerMD5": "697262d9ed04467bae52cca786c36bd3.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 99,
@@ -6886,7 +6942,7 @@
                 },
                 {
                     "costumeName": "jellyfish-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 3,
                     "baseLayerMD5": "6a949493aaf62954f1c74f8369d494c4.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 99,
@@ -6906,6 +6962,7 @@
     },
     {
         "name": "Jordyn",
+        "baseLayerID": -1,
         "md5": "8dd2a2abbb8e639da8576b6e72ef9e59.svg",
         "type": "sprite",
         "tags": [
@@ -6935,7 +6992,7 @@
             "costumes": [
                 {
                     "costumeName": "jordyn-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 5,
                     "baseLayerMD5": "8dd2a2abbb8e639da8576b6e72ef9e59.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 76,
@@ -6943,7 +7000,7 @@
                 },
                 {
                     "costumeName": "jordyn-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 6,
                     "baseLayerMD5": "9665f543147961551d8dc6f612d9cc41.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 76,
@@ -6951,7 +7008,7 @@
                 },
                 {
                     "costumeName": "jordyn-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 7,
                     "baseLayerMD5": "ec8c2286070c77ebd9dd40c96eaae3fc.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 76,
@@ -6959,7 +7016,7 @@
                 },
                 {
                     "costumeName": "jordyn-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 8,
                     "baseLayerMD5": "1f9ed7f29800f31ce2ee53196143a3c8.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 76,
@@ -6978,7 +7035,8 @@
         }
     },
     {
-        "name": "Ke",
+        "name": "Key",
+        "baseLayerID": -1,
         "md5": "af35300cef35803e11f4ed744dc5e818.svg",
         "type": "sprite",
         "tags": [
@@ -6991,7 +7049,7 @@
             1
         ],
         "json": {
-            "objName": "Ke",
+            "objName": "Key",
             "sounds": [
                 {
                     "soundName": "pop",
@@ -7005,7 +7063,7 @@
             "costumes": [
                 {
                     "costumeName": "key",
-                    "baseLayerID": -1,
+                    "baseLayerID": 57,
                     "baseLayerMD5": "af35300cef35803e11f4ed744dc5e818.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 42,
@@ -7025,6 +7083,7 @@
     },
     {
         "name": "Keyboard",
+        "baseLayerID": -1,
         "md5": "c67d180e964926b6393ac14781541b39.svg",
         "type": "sprite",
         "tags": [
@@ -7041,7 +7100,7 @@
             "sounds": [
                 {
                     "soundName": "C elec piano",
-                    "soundID": -1,
+                    "soundID": 54,
                     "md5": "8366ee963cc57ad24a8a35a26f722c2b.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -7049,7 +7108,7 @@
                 },
                 {
                     "soundName": "D elec piano",
-                    "soundID": -1,
+                    "soundID": 55,
                     "md5": "835f136ca8d346a17b4d4baf8405be37.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -7057,7 +7116,7 @@
                 },
                 {
                     "soundName": "E elec piano",
-                    "soundID": -1,
+                    "soundID": 56,
                     "md5": "ab3c198f8e36efff14f0a5bad35fa3cd.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -7065,7 +7124,7 @@
                 },
                 {
                     "soundName": "F elec piano",
-                    "soundID": -1,
+                    "soundID": 57,
                     "md5": "dc5e368fc0d0dad1da609bfc3e29aa15.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -7073,7 +7132,7 @@
                 },
                 {
                     "soundName": "G elec piano",
-                    "soundID": -1,
+                    "soundID": 58,
                     "md5": "39525f6545d62a95d05153f92d63301a.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -7081,7 +7140,7 @@
                 },
                 {
                     "soundName": "A elec piano",
-                    "soundID": -1,
+                    "soundID": 59,
                     "md5": "0cfa8e84d6a5cd63afa31d541625a9ef.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -7089,7 +7148,7 @@
                 },
                 {
                     "soundName": "B elec piano",
-                    "soundID": -1,
+                    "soundID": 60,
                     "md5": "9cc77167419f228503dd57fddaa5b2a6.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -7097,7 +7156,7 @@
                 },
                 {
                     "soundName": "C2 elec piano",
-                    "soundID": -1,
+                    "soundID": 61,
                     "md5": "366c7edbd4dd5cca68bf62902999bd66.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -7107,7 +7166,7 @@
             "costumes": [
                 {
                     "costumeName": "keyboard-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 22,
                     "baseLayerMD5": "c67d180e964926b6393ac14781541b39.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 72,
@@ -7115,7 +7174,7 @@
                 },
                 {
                     "costumeName": "keyboard-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 23,
                     "baseLayerMD5": "dbaf62b33de45093c3c7d13b5d49d637.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 72,
@@ -7135,6 +7194,7 @@
     },
     {
         "name": "Kiran",
+        "baseLayerID": -1,
         "md5": "9de23c4a7a7fbb67136b539241346854.svg",
         "type": "sprite",
         "tags": [
@@ -7162,7 +7222,7 @@
             "costumes": [
                 {
                     "costumeName": "kiran-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 11,
                     "baseLayerMD5": "9de23c4a7a7fbb67136b539241346854.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 67,
@@ -7170,7 +7230,7 @@
                 },
                 {
                     "costumeName": "kiran-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 12,
                     "baseLayerMD5": "f1e74f3c02333e9e2068e8baf4e77aa0.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 67,
@@ -7178,7 +7238,7 @@
                 },
                 {
                     "costumeName": "kiran-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 13,
                     "baseLayerMD5": "e2482cf509c312935f08be0e2e2c9d84.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 67,
@@ -7186,7 +7246,7 @@
                 },
                 {
                     "costumeName": "kiran-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 14,
                     "baseLayerMD5": "569e736b519199efddfbae2572f7e92b.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 67,
@@ -7194,7 +7254,7 @@
                 },
                 {
                     "costumeName": "kiran-e",
-                    "baseLayerID": -1,
+                    "baseLayerID": 15,
                     "baseLayerMD5": "2261bed0f2cc819def17969158297b4f.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 77,
@@ -7202,7 +7262,7 @@
                 },
                 {
                     "costumeName": "kiran-f",
-                    "baseLayerID": -1,
+                    "baseLayerID": 16,
                     "baseLayerMD5": "d7f44adb3dc7906b9dfb3599a028e0d6.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 62,
@@ -7222,6 +7282,7 @@
     },
     {
         "name": "Knight",
+        "baseLayerID": -1,
         "md5": "f2c5e8bc24d001b81566879dbf2f1a13.svg",
         "type": "sprite",
         "tags": [
@@ -7249,7 +7310,7 @@
             "costumes": [
                 {
                     "costumeName": "knight",
-                    "baseLayerID": -1,
+                    "baseLayerID": 46,
                     "baseLayerMD5": "f2c5e8bc24d001b81566879dbf2f1a13.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -7269,6 +7330,7 @@
     },
     {
         "name": "Ladybug1",
+        "baseLayerID": -1,
         "md5": "f16a1ccc69a4a8190a927f1595aa7bfa.svg",
         "type": "sprite",
         "tags": [
@@ -7297,7 +7359,7 @@
             "costumes": [
                 {
                     "costumeName": "ladybug2",
-                    "baseLayerID": -1,
+                    "baseLayerID": 47,
                     "baseLayerMD5": "f16a1ccc69a4a8190a927f1595aa7bfa.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 41,
@@ -7317,6 +7379,7 @@
     },
     {
         "name": "Ladybug2",
+        "baseLayerID": -1,
         "md5": "c018a3eed966d5f92c69f2188dfd2aae.svg",
         "type": "sprite",
         "tags": [
@@ -7346,7 +7409,7 @@
             "costumes": [
                 {
                     "costumeName": "ladybug2-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 58,
                     "baseLayerMD5": "c018a3eed966d5f92c69f2188dfd2aae.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 49,
@@ -7354,7 +7417,7 @@
                 },
                 {
                     "costumeName": "ladybug2-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 59,
                     "baseLayerMD5": "a2bb15ace808e070a2b815502952b292.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 49,
@@ -7374,6 +7437,7 @@
     },
     {
         "name": "Laptop",
+        "baseLayerID": -1,
         "md5": "76f456b30b98eeefd7c942b27b524e31.svg",
         "type": "sprite",
         "tags": [
@@ -7400,7 +7464,7 @@
             "costumes": [
                 {
                     "costumeName": "laptop",
-                    "baseLayerID": -1,
+                    "baseLayerID": 60,
                     "baseLayerMD5": "76f456b30b98eeefd7c942b27b524e31.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -7420,6 +7484,7 @@
     },
     {
         "name": "Lightning",
+        "baseLayerID": -1,
         "md5": "c2d636ab2b491e591536afc3d49cbecd.svg",
         "type": "sprite",
         "tags": [
@@ -7449,7 +7514,7 @@
             "costumes": [
                 {
                     "costumeName": "lightning",
-                    "baseLayerID": -1,
+                    "baseLayerID": 61,
                     "baseLayerMD5": "c2d636ab2b491e591536afc3d49cbecd.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 21,
@@ -7469,6 +7534,7 @@
     },
     {
         "name": "Line",
+        "baseLayerID": -1,
         "md5": "1b2cfb4d4746522aeb84e16a62820299.svg",
         "type": "sprite",
         "tags": [
@@ -7496,7 +7562,7 @@
             "costumes": [
                 {
                     "costumeName": "line",
-                    "baseLayerID": -1,
+                    "baseLayerID": 62,
                     "baseLayerMD5": "1b2cfb4d4746522aeb84e16a62820299.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 239,
@@ -7516,6 +7582,7 @@
     },
     {
         "name": "Lion",
+        "baseLayerID": -1,
         "md5": "692a3c84366bf8ae4d16858e20e792f5.svg",
         "type": "sprite",
         "tags": [
@@ -7547,7 +7614,7 @@
             "costumes": [
                 {
                     "costumeName": "lion-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 82,
                     "baseLayerMD5": "692a3c84366bf8ae4d16858e20e792f5.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -7555,7 +7622,7 @@
                 },
                 {
                     "costumeName": "lion-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 83,
                     "baseLayerMD5": "a519ef168a345a2846d0201bf092a6d0.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -7575,6 +7642,7 @@
     },
     {
         "name": "Llama",
+        "baseLayerID": -1,
         "md5": "07158eb6d62e309bb60a6bc36baf2300.svg",
         "type": "sprite",
         "tags": [
@@ -7602,7 +7670,7 @@
             "costumes": [
                 {
                     "costumeName": "llama",
-                    "baseLayerID": -1,
+                    "baseLayerID": 3,
                     "baseLayerMD5": "07158eb6d62e309bb60a6bc36baf2300.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 100,
@@ -7610,7 +7678,7 @@
                 },
                 {
                     "costumeName": "llama-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 4,
                     "baseLayerMD5": "2021eea71514bd2b23e96076750727ae.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 100,
@@ -7618,7 +7686,7 @@
                 },
                 {
                     "costumeName": "llama-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 5,
                     "baseLayerMD5": "7837d7247acbc4eebb793452a35aa1f5.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 100,
@@ -7638,6 +7706,7 @@
     },
     {
         "name": "Magic Wand",
+        "baseLayerID": -1,
         "md5": "3db9bfe57d561557795633c5cda44e8c.svg",
         "type": "sprite",
         "tags": [
@@ -7665,7 +7734,7 @@
             "costumes": [
                 {
                     "costumeName": "magicwand",
-                    "baseLayerID": -1,
+                    "baseLayerID": 63,
                     "baseLayerMD5": "3db9bfe57d561557795633c5cda44e8c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 41,
@@ -7685,6 +7754,7 @@
     },
     {
         "name": "Max",
+        "baseLayerID": -1,
         "md5": "e10cca3bdbc09d039c2f937574f7a6ea.svg",
         "type": "sprite",
         "tags": [
@@ -7713,7 +7783,7 @@
             "costumes": [
                 {
                     "costumeName": "max-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 12,
                     "baseLayerMD5": "e10cca3bdbc09d039c2f937574f7a6ea.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 82,
@@ -7721,7 +7791,7 @@
                 },
                 {
                     "costumeName": "max-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 13,
                     "baseLayerMD5": "6d8ee139a741cf945d600a8cef0ea2e6.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 82,
@@ -7729,7 +7799,7 @@
                 },
                 {
                     "costumeName": "max-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 14,
                     "baseLayerMD5": "aa66109994d27de02711f6a0ef6de9ec.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 82,
@@ -7737,7 +7807,7 @@
                 },
                 {
                     "costumeName": "max-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 15,
                     "baseLayerMD5": "a0dbf509d542c7eff6d2ddfc9c9410f1.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 82,
@@ -7757,6 +7827,7 @@
     },
     {
         "name": "Mermaid",
+        "baseLayerID": -1,
         "md5": "36db41c47259881c26d9b98a806d3308.svg",
         "type": "sprite",
         "tags": [
@@ -7785,7 +7856,7 @@
             "costumes": [
                 {
                     "costumeName": "mermaid-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 50,
                     "baseLayerMD5": "36db41c47259881c26d9b98a806d3308.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 92,
@@ -7793,7 +7864,7 @@
                 },
                 {
                     "costumeName": "mermaid-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 51,
                     "baseLayerMD5": "564bf3f466df3b3e8aba71eeae8255ab.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 92,
@@ -7813,6 +7884,7 @@
     },
     {
         "name": "Mermaid-swimming",
+        "baseLayerID": -1,
         "md5": "9f973b89b68f7d8147f157cbac8af341.svg",
         "type": "sprite",
         "tags": [
@@ -7841,7 +7913,7 @@
             "costumes": [
                 {
                     "costumeName": "mermaid-swim-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 54,
                     "baseLayerMD5": "9f973b89b68f7d8147f157cbac8af341.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 150,
@@ -7849,7 +7921,7 @@
                 },
                 {
                     "costumeName": "mermaid-swim-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 55,
                     "baseLayerMD5": "2295784bb8e6354bfa7676089235cb9f.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 150,
@@ -7869,6 +7941,7 @@
     },
     {
         "name": "Microphone",
+        "baseLayerID": -1,
         "md5": "9126b6362313e20578fb88d38902cd4c.svg",
         "type": "sprite",
         "tags": [
@@ -7885,7 +7958,7 @@
             "sounds": [
                 {
                     "soundName": "bass beatbox",
-                    "soundID": -1,
+                    "soundID": 41,
                     "md5": "28153621d293c86da0b246d314458faf.wav",
                     "sampleCount": 6720,
                     "rate": 22050,
@@ -7893,7 +7966,7 @@
                 },
                 {
                     "soundName": "clap beatbox",
-                    "soundID": -1,
+                    "soundID": 42,
                     "md5": "abc70bb390f8e55f22f32265500d814a.wav",
                     "sampleCount": 4224,
                     "rate": 22050,
@@ -7901,7 +7974,7 @@
                 },
                 {
                     "soundName": "hi beatbox",
-                    "soundID": -1,
+                    "soundID": 43,
                     "md5": "5a07847bf246c227204728b05a3fc8f3.wav",
                     "sampleCount": 5856,
                     "rate": 22050,
@@ -7909,7 +7982,7 @@
                 },
                 {
                     "soundName": "scratch beatbox",
-                    "soundID": -1,
+                    "soundID": 44,
                     "md5": "859249563a7b1fc0f6e92e36d1db81c7.wav",
                     "sampleCount": 11552,
                     "rate": 22050,
@@ -7917,7 +7990,7 @@
                 },
                 {
                     "soundName": "snare beatbox",
-                    "soundID": -1,
+                    "soundID": 45,
                     "md5": "c642c4c00135d890998f351faec55498.wav",
                     "sampleCount": 5630,
                     "rate": 22050,
@@ -7925,7 +7998,7 @@
                 },
                 {
                     "soundName": "snare beatbox2",
-                    "soundID": -1,
+                    "soundID": 46,
                     "md5": "7ede1382b578d8fc32850b48d082d914.wav",
                     "sampleCount": 4960,
                     "rate": 22050,
@@ -7933,7 +8006,7 @@
                 },
                 {
                     "soundName": "wah beatbox",
-                    "soundID": -1,
+                    "soundID": 47,
                     "md5": "9021b7bb06f2399f18e2db4fb87095dc.wav",
                     "sampleCount": 6624,
                     "rate": 22050,
@@ -7941,7 +8014,7 @@
                 },
                 {
                     "soundName": "crash beatbox",
-                    "soundID": -1,
+                    "soundID": 48,
                     "md5": "725e29369e9138a43f11e0e5eb3eb562.wav",
                     "sampleCount": 26883,
                     "rate": 22050,
@@ -7949,7 +8022,7 @@
                 },
                 {
                     "soundName": "wub beatbox",
-                    "soundID": -1,
+                    "soundID": 49,
                     "md5": "e1f32c057411da4237181ce72ae15d23.wav",
                     "sampleCount": 7392,
                     "rate": 22050,
@@ -7959,7 +8032,7 @@
             "costumes": [
                 {
                     "costumeName": "microphone-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 16,
                     "baseLayerMD5": "9126b6362313e20578fb88d38902cd4c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 40,
@@ -7967,7 +8040,7 @@
                 },
                 {
                     "costumeName": "microphone-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 17,
                     "baseLayerMD5": "29988ebbde49beaceb06d9eb66138b80.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 40,
@@ -7987,6 +8060,7 @@
     },
     {
         "name": "Milk",
+        "baseLayerID": -1,
         "md5": "e6a7964bc4ea38c79a5a31d6ddfb5ba9.svg",
         "type": "sprite",
         "tags": [
@@ -8014,7 +8088,7 @@
             "costumes": [
                 {
                     "costumeName": "milk-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 0,
                     "baseLayerMD5": "e6a7964bc4ea38c79a5a31d6ddfb5ba9.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 68,
@@ -8022,7 +8096,7 @@
                 },
                 {
                     "costumeName": "milk-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 1,
                     "baseLayerMD5": "82d4c1855fe0d400433c7344fb2af3b5.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 68,
@@ -8030,7 +8104,7 @@
                 },
                 {
                     "costumeName": "milk-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 2,
                     "baseLayerMD5": "50afc991b6fdad4b6547ba98ecf8a6af.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 47,
@@ -8038,7 +8112,7 @@
                 },
                 {
                     "costumeName": "milk-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 3,
                     "baseLayerMD5": "8fc7606a176149d225a541a04fa67473.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 68,
@@ -8046,7 +8120,7 @@
                 },
                 {
                     "costumeName": "milk-e",
-                    "baseLayerID": -1,
+                    "baseLayerID": 4,
                     "baseLayerMD5": "f2373d449b1226c44436dced422c2935.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 68,
@@ -8066,6 +8140,7 @@
     },
     {
         "name": "Monet",
+        "baseLayerID": -1,
         "md5": "11c46aaa5e30ad46f5c1883d6feb47b8.svg",
         "type": "sprite",
         "tags": [
@@ -8093,7 +8168,7 @@
             "costumes": [
                 {
                     "costumeName": "monet-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 6,
                     "baseLayerMD5": "11c46aaa5e30ad46f5c1883d6feb47b8.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 64,
@@ -8101,7 +8176,7 @@
                 },
                 {
                     "costumeName": "monet-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 7,
                     "baseLayerMD5": "9c8f83e39dc8ac49d57c0622ffe2063f.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 64,
@@ -8109,7 +8184,7 @@
                 },
                 {
                     "costumeName": "monet-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 8,
                     "baseLayerMD5": "4435678d26e8fbc266d647693f65f5d7.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 64,
@@ -8117,7 +8192,7 @@
                 },
                 {
                     "costumeName": "monet-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 9,
                     "baseLayerMD5": "42113ca3eca593c3a8f232a9202d6f14.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 82,
@@ -8125,7 +8200,7 @@
                 },
                 {
                     "costumeName": "monet-e",
-                    "baseLayerID": -1,
+                    "baseLayerID": 10,
                     "baseLayerMD5": "e530d0dac5290c5366af719cfb4e5953.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 65,
@@ -8145,6 +8220,7 @@
     },
     {
         "name": "Monkey",
+        "baseLayerID": -1,
         "md5": "6e4de762dbd52cd2b6356694a9668211.svg",
         "type": "sprite",
         "tags": [
@@ -8163,7 +8239,7 @@
             "sounds": [
                 {
                     "soundName": "chee chee",
-                    "soundID": -1,
+                    "soundID": 7,
                     "md5": "25f4826cdd61e0a1c623ec2324c16ca0.wav",
                     "sampleCount": 34560,
                     "rate": 22050,
@@ -8173,7 +8249,7 @@
             "costumes": [
                 {
                     "costumeName": "monkey-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 84,
                     "baseLayerMD5": "6e4de762dbd52cd2b6356694a9668211.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 68,
@@ -8181,7 +8257,7 @@
                 },
                 {
                     "costumeName": "monkey-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 85,
                     "baseLayerMD5": "7662a3a0f4c6fa21fdf2de33bd80fe5f.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 68,
@@ -8189,7 +8265,7 @@
                 },
                 {
                     "costumeName": "monkey-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 86,
                     "baseLayerMD5": "db8eb50b948047181922310bb94511fb.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 68,
@@ -8209,6 +8285,7 @@
     },
     {
         "name": "Mouse1",
+        "baseLayerID": -1,
         "md5": "e1f0c26afecbe9d4b9923d8e6bf489a8.svg",
         "type": "sprite",
         "tags": [
@@ -8236,7 +8313,7 @@
             "costumes": [
                 {
                     "costumeName": "mouse1-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 64,
                     "baseLayerMD5": "e1f0c26afecbe9d4b9923d8e6bf489a8.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 50,
@@ -8244,7 +8321,7 @@
                 },
                 {
                     "costumeName": "mouse1-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 65,
                     "baseLayerMD5": "f5e477a3f94fc98ba3cd927228405646.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 65,
@@ -8264,6 +8341,7 @@
     },
     {
         "name": "Muffin",
+        "baseLayerID": -1,
         "md5": "e00161f08c77d10e72e44b6e01243e63.svg",
         "type": "sprite",
         "tags": [
@@ -8289,7 +8367,7 @@
             "costumes": [
                 {
                     "costumeName": "muffin-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 66,
                     "baseLayerMD5": "e00161f08c77d10e72e44b6e01243e63.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 85,
@@ -8297,7 +8375,7 @@
                 },
                 {
                     "costumeName": "muffin-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 67,
                     "baseLayerMD5": "fb60c3f8d6a892813299daa33b91df23.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 85,
@@ -8317,6 +8395,7 @@
     },
     {
         "name": "Nano",
+        "baseLayerID": -1,
         "md5": "02c5433118f508038484bbc5b111e187.svg",
         "type": "sprite",
         "tags": [
@@ -8343,7 +8422,7 @@
             "costumes": [
                 {
                     "costumeName": "nano-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 87,
                     "baseLayerMD5": "02c5433118f508038484bbc5b111e187.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 61,
@@ -8351,7 +8430,7 @@
                 },
                 {
                     "costumeName": "nano-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 88,
                     "baseLayerMD5": "10d6d9130618cd092ae02158cde2e113.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 61,
@@ -8359,7 +8438,7 @@
                 },
                 {
                     "costumeName": "nano-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 89,
                     "baseLayerMD5": "85e762d45bc626ca2edb3472c7cfaa32.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 61,
@@ -8367,7 +8446,7 @@
                 },
                 {
                     "costumeName": "nano-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 90,
                     "baseLayerMD5": "b10925346da8080443f27e7dfaeff6f7.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 61,
@@ -8387,6 +8466,7 @@
     },
     {
         "name": "Neigh Pony",
+        "baseLayerID": -1,
         "md5": "176c4fb4df80df899ca28a48bd1f0edf.svg",
         "type": "sprite",
         "tags": [
@@ -8413,7 +8493,7 @@
             "costumes": [
                 {
                     "costumeName": "neigh pony",
-                    "baseLayerID": -1,
+                    "baseLayerID": 68,
                     "baseLayerMD5": "176c4fb4df80df899ca28a48bd1f0edf.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 74,
@@ -8433,6 +8513,7 @@
     },
     {
         "name": "Octopus",
+        "baseLayerID": -1,
         "md5": "038df646d2f935d2a5dd601b343fc1d9.svg",
         "type": "sprite",
         "tags": [
@@ -8462,7 +8543,7 @@
             "costumes": [
                 {
                     "costumeName": "octopus-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 4,
                     "baseLayerMD5": "038df646d2f935d2a5dd601b343fc1d9.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 88,
@@ -8470,7 +8551,7 @@
                 },
                 {
                     "costumeName": "octopus-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 5,
                     "baseLayerMD5": "31bdcbdf05688c01aace3fd94c5e82df.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 88,
@@ -8478,7 +8559,7 @@
                 },
                 {
                     "costumeName": "octopus-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 6,
                     "baseLayerMD5": "51e80c09323e36489ad452250acd827c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 88,
@@ -8486,7 +8567,7 @@
                 },
                 {
                     "costumeName": "octopus-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 7,
                     "baseLayerMD5": "b4242e6cde0392bb9a5fb43a8f232962.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 88,
@@ -8494,7 +8575,7 @@
                 },
                 {
                     "costumeName": "octopus-e",
-                    "baseLayerID": -1,
+                    "baseLayerID": 8,
                     "baseLayerMD5": "edfda0a36d9cd8482e3a8dc317107d56.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 88,
@@ -8514,6 +8595,7 @@
     },
     {
         "name": "Orange",
+        "baseLayerID": -1,
         "md5": "780ee2ef342f79a81b4c353725331138.svg",
         "type": "sprite",
         "tags": [
@@ -8540,7 +8622,7 @@
             "costumes": [
                 {
                     "costumeName": "orange",
-                    "baseLayerID": -1,
+                    "baseLayerID": 69,
                     "baseLayerMD5": "780ee2ef342f79a81b4c353725331138.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 19,
@@ -8560,6 +8642,7 @@
     },
     {
         "name": "Orange2",
+        "baseLayerID": -1,
         "md5": "89b11d2a404c3972b65743f743cc968a.svg",
         "type": "sprite",
         "tags": [
@@ -8587,7 +8670,7 @@
             "costumes": [
                 {
                     "costumeName": "orange2-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 70,
                     "baseLayerMD5": "89b11d2a404c3972b65743f743cc968a.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 49,
@@ -8595,7 +8678,7 @@
                 },
                 {
                     "costumeName": "orange2-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 71,
                     "baseLayerMD5": "5f7998e007dfa70e70bbd8d43199ebba.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 49,
@@ -8603,7 +8686,7 @@
                 },
                 {
                     "costumeName": "orange2-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 72,
                     "baseLayerMD5": "466e9e2d62ee135a2dabd5593e6f8407.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 49,
@@ -8623,6 +8706,7 @@
     },
     {
         "name": "Owl",
+        "baseLayerID": -1,
         "md5": "a312273b198fcacf68976e3cc74fadb4.svg",
         "type": "sprite",
         "tags": [
@@ -8650,7 +8734,7 @@
             "costumes": [
                 {
                     "costumeName": "owl-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 6,
                     "baseLayerMD5": "a312273b198fcacf68976e3cc74fadb4.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 113,
@@ -8658,7 +8742,7 @@
                 },
                 {
                     "costumeName": "owl-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 7,
                     "baseLayerMD5": "c9916dcfe67302367b05be7f3e5c5ddf.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 113,
@@ -8666,7 +8750,7 @@
                 },
                 {
                     "costumeName": "owl-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 8,
                     "baseLayerMD5": "8ec3a2507f1d6dc9b39f7ae5a1ebfdd3.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 113,
@@ -8686,6 +8770,7 @@
     },
     {
         "name": "Paddle",
+        "baseLayerID": -1,
         "md5": "8038149bdfe24733ea2144d37d297815.svg",
         "type": "sprite",
         "tags": [
@@ -8701,7 +8786,7 @@
             "sounds": [
                 {
                     "soundName": "boing",
-                    "soundID": -1,
+                    "soundID": 1,
                     "md5": "53a3c2e27d1fb5fdb14aaf0cb41e7889.wav",
                     "sampleCount": 6804,
                     "rate": 22050,
@@ -8711,7 +8796,7 @@
             "costumes": [
                 {
                     "costumeName": "paddle",
-                    "baseLayerID": -1,
+                    "baseLayerID": 73,
                     "baseLayerMD5": "8038149bdfe24733ea2144d37d297815.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 44,
@@ -8731,6 +8816,7 @@
     },
     {
         "name": "Panther",
+        "baseLayerID": -1,
         "md5": "04ca2c122cff11b9bc23834d6f79361e.svg",
         "type": "sprite",
         "tags": [
@@ -8759,7 +8845,7 @@
             "costumes": [
                 {
                     "costumeName": "panther-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 0,
                     "baseLayerMD5": "04ca2c122cff11b9bc23834d6f79361e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 125,
@@ -8767,7 +8853,7 @@
                 },
                 {
                     "costumeName": "panther-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 1,
                     "baseLayerMD5": "f8c33765d1105f3bb4cd145fad0f717e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 125,
@@ -8775,7 +8861,7 @@
                 },
                 {
                     "costumeName": "panther-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 2,
                     "baseLayerMD5": "096bf9cad84def12eef2b5d84736b393.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 125,
@@ -8795,6 +8881,7 @@
     },
     {
         "name": "Parrot",
+        "baseLayerID": -1,
         "md5": "098570b8e1aa85b32f9b4eb07bea3af2.svg",
         "type": "sprite",
         "tags": [
@@ -8816,7 +8903,7 @@
             "sounds": [
                 {
                     "soundName": "bird",
-                    "soundID": -1,
+                    "soundID": 8,
                     "md5": "18bd4b634a3f992a16b30344c7d810e0.wav",
                     "sampleCount": 3840,
                     "rate": 11025,
@@ -8826,7 +8913,7 @@
             "costumes": [
                 {
                     "costumeName": "parrot-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 91,
                     "baseLayerMD5": "098570b8e1aa85b32f9b4eb07bea3af2.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 86,
@@ -8834,7 +8921,7 @@
                 },
                 {
                     "costumeName": "parrot-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 92,
                     "baseLayerMD5": "721255a0733c9d8d2ba518ff09b3b7cb.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 49,
@@ -8854,6 +8941,7 @@
     },
     {
         "name": "Pencil",
+        "baseLayerID": -1,
         "md5": "4495fcb0443cebc5d43e66243a88f1ac.svg",
         "type": "sprite",
         "tags": [
@@ -8880,7 +8968,7 @@
             "costumes": [
                 {
                     "costumeName": "pencil-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 74,
                     "baseLayerMD5": "4495fcb0443cebc5d43e66243a88f1ac.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 49,
@@ -8888,7 +8976,7 @@
                 },
                 {
                     "costumeName": "pencil-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 75,
                     "baseLayerMD5": "21088922dbe127f6d2e58e2e83fb632e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 48,
@@ -8907,7 +8995,8 @@
         }
     },
     {
-        "name": "Penguin1",
+        "name": "Penguin 2",
+        "baseLayerID": -1,
         "md5": "c17d9e4bdb59c574e0c34aa70af516da.svg",
         "type": "sprite",
         "tags": [
@@ -8922,7 +9011,7 @@
             1
         ],
         "json": {
-            "objName": "Penguin1",
+            "objName": "Penguin 2",
             "sounds": [
                 {
                     "soundName": "pop",
@@ -8935,24 +9024,24 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "penguin1-a",
-                    "baseLayerID": -1,
+                    "costumeName": "penguin2-a",
+                    "baseLayerID": 48,
                     "baseLayerMD5": "c17d9e4bdb59c574e0c34aa70af516da.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 54,
                     "rotationCenterY": 61
                 },
                 {
-                    "costumeName": "penguin1-b",
-                    "baseLayerID": -1,
+                    "costumeName": "penguin2-b",
+                    "baseLayerID": 49,
                     "baseLayerMD5": "35fec7aa5f60cca945fe0615413f1f08.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 48,
                     "rotationCenterY": 62
                 },
                 {
-                    "costumeName": "penguin1-c",
-                    "baseLayerID": -1,
+                    "costumeName": "penguin2-c",
+                    "baseLayerID": 50,
                     "baseLayerMD5": "18fa51a64ebd5518f0c5c465525346e5.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 48,
@@ -8971,71 +9060,8 @@
         }
     },
     {
-        "name": "Penguin2",
-        "md5": "eaaaa7068e78a51d73ba437f1ec5763e.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "bird",
-            "winter",
-            "antarctica"
-        ],
-        "info": [
-            0,
-            3,
-            1
-        ],
-        "json": {
-            "objName": "Penguin2",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "penguin2-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "eaaaa7068e78a51d73ba437f1ec5763e.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 49,
-                    "rotationCenterY": 79
-                },
-                {
-                    "costumeName": "penguin2-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "5a80f4b2fd20d43e4f7cb4189c08d99c.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 45,
-                    "rotationCenterY": 79
-                },
-                {
-                    "costumeName": "penguin2-c",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "394e79f5f9a462064ece2a9a6606a07d.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 50,
-                    "rotationCenterY": 78
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 95,
-            "scratchY": 44,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
         "name": "Pico",
+        "baseLayerID": -1,
         "md5": "0579fe60bb3717c49dfd7743caa84ada.svg",
         "type": "sprite",
         "tags": [
@@ -9062,7 +9088,7 @@
             "costumes": [
                 {
                     "costumeName": "pico-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 101,
                     "baseLayerMD5": "0579fe60bb3717c49dfd7743caa84ada.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 55,
@@ -9070,7 +9096,7 @@
                 },
                 {
                     "costumeName": "pico-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 102,
                     "baseLayerMD5": "26c688d7544757225ff51cd2fb1519b5.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 55,
@@ -9078,7 +9104,7 @@
                 },
                 {
                     "costumeName": "pico-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 103,
                     "baseLayerMD5": "adf61e2090f8060e1e8b2b0604d03751.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 55,
@@ -9086,7 +9112,7 @@
                 },
                 {
                     "costumeName": "pico-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 104,
                     "baseLayerMD5": "594704bf12e3c4d9e83bb91661ad709a.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 55,
@@ -9106,6 +9132,7 @@
     },
     {
         "name": "Pico Walking",
+        "baseLayerID": -1,
         "md5": "8eab5fe20dd249bf22964298b1d377eb.svg",
         "type": "sprite",
         "tags": [
@@ -9132,7 +9159,7 @@
             "costumes": [
                 {
                     "costumeName": "Pico walk1",
-                    "baseLayerID": -1,
+                    "baseLayerID": 76,
                     "baseLayerMD5": "8eab5fe20dd249bf22964298b1d377eb.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 54,
@@ -9140,7 +9167,7 @@
                 },
                 {
                     "costumeName": "Pico walk2",
-                    "baseLayerID": -1,
+                    "baseLayerID": 77,
                     "baseLayerMD5": "39ecd3c38d3f2cd81e3a17ee6c25699f.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 54,
@@ -9148,7 +9175,7 @@
                 },
                 {
                     "costumeName": "Pico walk3",
-                    "baseLayerID": -1,
+                    "baseLayerID": 78,
                     "baseLayerMD5": "43f7d92dcf9eadf77c07a6fc1eb4104f.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 54,
@@ -9156,7 +9183,7 @@
                 },
                 {
                     "costumeName": "Pico walk4",
-                    "baseLayerID": -1,
+                    "baseLayerID": 79,
                     "baseLayerMD5": "2582d012d57bca59bc0315c5c5954958.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 54,
@@ -9176,6 +9203,7 @@
     },
     {
         "name": "Planet2",
+        "baseLayerID": -1,
         "md5": "978784738c1d9dd4b1d397fd18bdf406.svg",
         "type": "sprite",
         "tags": [
@@ -9201,7 +9229,7 @@
             "costumes": [
                 {
                     "costumeName": "planet2",
-                    "baseLayerID": -1,
+                    "baseLayerID": 80,
                     "baseLayerMD5": "978784738c1d9dd4b1d397fd18bdf406.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 72,
@@ -9221,6 +9249,7 @@
     },
     {
         "name": "Potion",
+        "baseLayerID": -1,
         "md5": "a317b50b255a208455a7733091adad23.svg",
         "type": "sprite",
         "tags": [
@@ -9248,7 +9277,7 @@
             "costumes": [
                 {
                     "costumeName": "potion-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 30,
                     "baseLayerMD5": "a317b50b255a208455a7733091adad23.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 15,
@@ -9256,7 +9285,7 @@
                 },
                 {
                     "costumeName": "potion-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 31,
                     "baseLayerMD5": "5f96576605c3a022df48278b630da745.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 15,
@@ -9264,7 +9293,7 @@
                 },
                 {
                     "costumeName": "potion-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 32,
                     "baseLayerMD5": "92d0184c28fac9acb0fb720ec599d61d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 15,
@@ -9284,6 +9313,7 @@
     },
     {
         "name": "Prince",
+        "baseLayerID": -1,
         "md5": "a760bed1cfc28a30b2dc7fd045c90792.svg",
         "type": "sprite",
         "tags": [
@@ -9311,7 +9341,7 @@
             "costumes": [
                 {
                     "costumeName": "prince",
-                    "baseLayerID": -1,
+                    "baseLayerID": 81,
                     "baseLayerMD5": "a760bed1cfc28a30b2dc7fd045c90792.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -9331,6 +9361,7 @@
     },
     {
         "name": "Princess",
+        "baseLayerID": -1,
         "md5": "fcbf44a543dfda884d8acbd6af66faad.svg",
         "type": "sprite",
         "tags": [
@@ -9360,7 +9391,7 @@
             "costumes": [
                 {
                     "costumeName": "princess-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 56,
                     "baseLayerMD5": "fcbf44a543dfda884d8acbd6af66faad.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -9368,7 +9399,7 @@
                 },
                 {
                     "costumeName": "princess-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 57,
                     "baseLayerMD5": "562e5eba4a598118411be3062cfbb26f.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -9376,7 +9407,7 @@
                 },
                 {
                     "costumeName": "princess-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 58,
                     "baseLayerMD5": "f3e5f466d406745cf1b6ce44b0567b9a.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -9384,7 +9415,7 @@
                 },
                 {
                     "costumeName": "princess-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 59,
                     "baseLayerMD5": "663134f64588f0c55e77767ba9039cfe.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -9392,7 +9423,7 @@
                 },
                 {
                     "costumeName": "princess-e",
-                    "baseLayerID": -1,
+                    "baseLayerID": 60,
                     "baseLayerMD5": "ad0ecbf907d132ddbb547666551ac087.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -9412,6 +9443,7 @@
     },
     {
         "name": "Pufferfish",
+        "baseLayerID": -1,
         "md5": "81d7db99142a39c9082be2c2183f2175.svg",
         "type": "sprite",
         "tags": [
@@ -9441,7 +9473,7 @@
             "costumes": [
                 {
                     "costumeName": "pufferfish-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 13,
                     "baseLayerMD5": "81d7db99142a39c9082be2c2183f2175.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 69,
@@ -9449,7 +9481,7 @@
                 },
                 {
                     "costumeName": "pufferfish-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 14,
                     "baseLayerMD5": "6ea79950db63f5ac24d6c5091df3836b.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 69,
@@ -9457,7 +9489,7 @@
                 },
                 {
                     "costumeName": "pufferfish-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 15,
                     "baseLayerMD5": "4acf5bc398c19d58acf69fce047ee8f6.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 69,
@@ -9465,7 +9497,7 @@
                 },
                 {
                     "costumeName": "pufferfish-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 16,
                     "baseLayerMD5": "c214fa8a9ceed06db03664007b8ad5c6.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 69,
@@ -9485,6 +9517,7 @@
     },
     {
         "name": "Rabbit",
+        "baseLayerID": -1,
         "md5": "2f42891c3f3d63c0e591aeabc5946533.svg",
         "type": "sprite",
         "tags": [
@@ -9515,7 +9548,7 @@
             "costumes": [
                 {
                     "costumeName": "rabbit-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 5,
                     "baseLayerMD5": "2f42891c3f3d63c0e591aeabc5946533.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 84,
@@ -9523,7 +9556,7 @@
                 },
                 {
                     "costumeName": "rabbit-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 6,
                     "baseLayerMD5": "80e05ff501040cdc9f52fa6782e06fd2.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 84,
@@ -9531,7 +9564,7 @@
                 },
                 {
                     "costumeName": "rabbit-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 7,
                     "baseLayerMD5": "88ed8b7925baa025b6c7fc628a64b9b1.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 84,
@@ -9539,7 +9572,7 @@
                 },
                 {
                     "costumeName": "rabbit-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 8,
                     "baseLayerMD5": "5f3b8df4d6ab8a72e887f89f554db0be.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 84,
@@ -9547,7 +9580,7 @@
                 },
                 {
                     "costumeName": "rabbit-e",
-                    "baseLayerID": -1,
+                    "baseLayerID": 9,
                     "baseLayerMD5": "3003f1135f4aa3b6c361734243621260.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 84,
@@ -9567,6 +9600,7 @@
     },
     {
         "name": "Rainbow",
+        "baseLayerID": -1,
         "md5": "680a806bd87a28c8b25b5f9b6347f022.svg",
         "type": "sprite",
         "tags": [
@@ -9595,7 +9629,7 @@
             "costumes": [
                 {
                     "costumeName": "rainbow",
-                    "baseLayerID": -1,
+                    "baseLayerID": 51,
                     "baseLayerMD5": "680a806bd87a28c8b25b5f9b6347f022.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 72,
@@ -9615,6 +9649,7 @@
     },
     {
         "name": "Referee",
+        "baseLayerID": -1,
         "md5": "0959403aeb134ed2932a85c77e261122.svg",
         "type": "sprite",
         "tags": [
@@ -9643,7 +9678,7 @@
             "costumes": [
                 {
                     "costumeName": "referee-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 14,
                     "baseLayerMD5": "0959403aeb134ed2932a85c77e261122.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 76,
@@ -9651,7 +9686,7 @@
                 },
                 {
                     "costumeName": "referee-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 15,
                     "baseLayerMD5": "866b9e1ad2e0584216dd45fe7d50d6f5.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 76,
@@ -9659,7 +9694,7 @@
                 },
                 {
                     "costumeName": "referee-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 16,
                     "baseLayerMD5": "21a3869435fbd470ef60960a78b06b16.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 76,
@@ -9667,7 +9702,7 @@
                 },
                 {
                     "costumeName": "referee-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 17,
                     "baseLayerMD5": "5e037aca5446a7e57093e45fe6f18c9e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 76,
@@ -9687,6 +9722,7 @@
     },
     {
         "name": "Reindeer",
+        "baseLayerID": -1,
         "md5": "0fff0b181cc4d9250b5b985cc283b049.svg",
         "type": "sprite",
         "tags": [
@@ -9714,7 +9750,7 @@
             "costumes": [
                 {
                     "costumeName": "reindeer",
-                    "baseLayerID": -1,
+                    "baseLayerID": 82,
                     "baseLayerMD5": "0fff0b181cc4d9250b5b985cc283b049.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 39,
@@ -9734,6 +9770,7 @@
     },
     {
         "name": "Ripley",
+        "baseLayerID": -1,
         "md5": "417ec9f25ad70281564e85e67c97aa08.svg",
         "type": "sprite",
         "tags": [
@@ -9761,7 +9798,7 @@
             "costumes": [
                 {
                     "costumeName": "ripley-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 0,
                     "baseLayerMD5": "417ec9f25ad70281564e85e67c97aa08.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 57,
@@ -9769,7 +9806,7 @@
                 },
                 {
                     "costumeName": "ripley-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 1,
                     "baseLayerMD5": "e40918acf5c4d1d0d42b437b6b6e965d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 57,
@@ -9777,7 +9814,7 @@
                 },
                 {
                     "costumeName": "ripley-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 2,
                     "baseLayerMD5": "5fb713effcdae17208e6e89527bf720c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 57,
@@ -9785,7 +9822,7 @@
                 },
                 {
                     "costumeName": "ripley-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 3,
                     "baseLayerMD5": "6c6597c221c9a5b46c160f537b9795a2.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 85,
@@ -9793,7 +9830,7 @@
                 },
                 {
                     "costumeName": "ripley-e",
-                    "baseLayerID": -1,
+                    "baseLayerID": 4,
                     "baseLayerMD5": "92909161afd79673c93a77d15fe8d456.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 56,
@@ -9801,7 +9838,7 @@
                 },
                 {
                     "costumeName": "ripley-f",
-                    "baseLayerID": -1,
+                    "baseLayerID": 5,
                     "baseLayerMD5": "16e31a6b510ba4e8c1215e6e3a41d9f9.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 58,
@@ -9821,6 +9858,7 @@
     },
     {
         "name": "Robot",
+        "baseLayerID": -1,
         "md5": "cb3985cd066ccbab11954709b3d54c17.svg",
         "type": "sprite",
         "tags": [
@@ -9838,7 +9876,7 @@
             "sounds": [
                 {
                     "soundName": "computer beep",
-                    "soundID": -1,
+                    "soundID": 3,
                     "md5": "28c76b6bebd04be1383fe9ba4933d263.wav",
                     "sampleCount": 9536,
                     "rate": 11025,
@@ -9846,7 +9884,7 @@
                 },
                 {
                     "soundName": "buzz whir",
-                    "soundID": -1,
+                    "soundID": 4,
                     "md5": "d4f76ded6bccd765958d15b63804de55.wav",
                     "sampleCount": 9037,
                     "rate": 11025,
@@ -9856,7 +9894,7 @@
             "costumes": [
                 {
                     "costumeName": "robot-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 22,
                     "baseLayerMD5": "cb3985cd066ccbab11954709b3d54c17.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 74,
@@ -9864,7 +9902,7 @@
                 },
                 {
                     "costumeName": "robot-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 23,
                     "baseLayerMD5": "fc9276d0909539fd31c30db7b2e08bf9.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 56,
@@ -9872,7 +9910,7 @@
                 },
                 {
                     "costumeName": "robot-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 24,
                     "baseLayerMD5": "c5e02f00d233199fea1c51b71c402ce4.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 63,
@@ -9880,7 +9918,7 @@
                 },
                 {
                     "costumeName": "robot-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 25,
                     "baseLayerMD5": "ca2cf7d6c0446fbce36621006a4b0fac.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 59,
@@ -9900,6 +9938,7 @@
     },
     {
         "name": "Rocks",
+        "baseLayerID": -1,
         "md5": "82c79fdb6a7d9c49ab7f70ee79a3d7f8.svg",
         "type": "sprite",
         "tags": [
@@ -9926,7 +9965,7 @@
             "costumes": [
                 {
                     "costumeName": "rocks",
-                    "baseLayerID": -1,
+                    "baseLayerID": 83,
                     "baseLayerMD5": "82c79fdb6a7d9c49ab7f70ee79a3d7f8.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 59,
@@ -9946,6 +9985,7 @@
     },
     {
         "name": "Saxophone",
+        "baseLayerID": -1,
         "md5": "e9e4297f5d7e630a384b1dea835ec72d.svg",
         "type": "sprite",
         "tags": [
@@ -9962,7 +10002,7 @@
             "sounds": [
                 {
                     "soundName": "C sax",
-                    "soundID": -1,
+                    "soundID": 16,
                     "md5": "4d2c939d6953b5f241a27a62cf72de64.wav",
                     "sampleCount": 9491,
                     "rate": 22050,
@@ -9970,7 +10010,7 @@
                 },
                 {
                     "soundName": "D sax",
-                    "soundID": -1,
+                    "soundID": 17,
                     "md5": "39f41954a73c0e15d842061e1a4c5e1d.wav",
                     "sampleCount": 9555,
                     "rate": 22050,
@@ -9978,7 +10018,7 @@
                 },
                 {
                     "soundName": "E sax",
-                    "soundID": -1,
+                    "soundID": 18,
                     "md5": "3568b7dfe173fab6877a9ff1dcbcf1aa.wav",
                     "sampleCount": 7489,
                     "rate": 22050,
@@ -9986,7 +10026,7 @@
                 },
                 {
                     "soundName": "F sax",
-                    "soundID": -1,
+                    "soundID": 19,
                     "md5": "2ae3083817bcd595e26ea2884b6684d5.wav",
                     "sampleCount": 7361,
                     "rate": 22050,
@@ -9994,7 +10034,7 @@
                 },
                 {
                     "soundName": "G sax",
-                    "soundID": -1,
+                    "soundID": 20,
                     "md5": "cefba5de46adfe5702485e0934bb1e13.wav",
                     "sampleCount": 7349,
                     "rate": 22050,
@@ -10002,7 +10042,7 @@
                 },
                 {
                     "soundName": "A sax",
-                    "soundID": -1,
+                    "soundID": 21,
                     "md5": "420991e0d6d99292c6d736963842536a.wav",
                     "sampleCount": 6472,
                     "rate": 22050,
@@ -10010,7 +10050,7 @@
                 },
                 {
                     "soundName": "B sax",
-                    "soundID": -1,
+                    "soundID": 22,
                     "md5": "653ebe92d491b49ad5d8101d629f567b.wav",
                     "sampleCount": 9555,
                     "rate": 22050,
@@ -10018,7 +10058,7 @@
                 },
                 {
                     "soundName": "C2 sax",
-                    "soundID": -1,
+                    "soundID": 23,
                     "md5": "ea8d34b18c3d8fe328cea201666458bf.wav",
                     "sampleCount": 7349,
                     "rate": 22050,
@@ -10028,7 +10068,7 @@
             "costumes": [
                 {
                     "costumeName": "saxophone-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 6,
                     "baseLayerMD5": "e9e4297f5d7e630a384b1dea835ec72d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 47,
@@ -10036,7 +10076,7 @@
                 },
                 {
                     "costumeName": "saxophone-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 7,
                     "baseLayerMD5": "04e5650480bfcf9190aa35bbd8d67b8e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 47,
@@ -10056,6 +10096,7 @@
     },
     {
         "name": "Scarf1",
+        "baseLayerID": -1,
         "md5": "9db18d2a2b3c9859654fc1b4832e6076.svg",
         "type": "sprite",
         "tags": [
@@ -10082,7 +10123,7 @@
             "costumes": [
                 {
                     "costumeName": "scarf1",
-                    "baseLayerID": -1,
+                    "baseLayerID": 84,
                     "baseLayerMD5": "9db18d2a2b3c9859654fc1b4832e6076.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 54,
@@ -10102,6 +10143,7 @@
     },
     {
         "name": "Scarf2",
+        "baseLayerID": -1,
         "md5": "ce66662165e2756070f1b12e0a7cb5db.svg",
         "type": "sprite",
         "tags": [
@@ -10128,7 +10170,7 @@
             "costumes": [
                 {
                     "costumeName": "scarf2",
-                    "baseLayerID": -1,
+                    "baseLayerID": 85,
                     "baseLayerMD5": "ce66662165e2756070f1b12e0a7cb5db.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 23,
@@ -10148,6 +10190,7 @@
     },
     {
         "name": "Shark",
+        "baseLayerID": -1,
         "md5": "4ca6776e9c021e8b21c3346793c9361d.svg",
         "type": "sprite",
         "tags": [
@@ -10176,7 +10219,7 @@
             "costumes": [
                 {
                     "costumeName": "shark-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 8,
                     "baseLayerMD5": "4ca6776e9c021e8b21c3346793c9361d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 150,
@@ -10184,7 +10227,7 @@
                 },
                 {
                     "costumeName": "shark-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 9,
                     "baseLayerMD5": "0bb623f0bbec53ee9667cee0b7ad6d47.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 150,
@@ -10204,6 +10247,7 @@
     },
     {
         "name": "Shirt Blouse",
+        "baseLayerID": -1,
         "md5": "918a507af6bbae9e7f36f0d949900838.svg",
         "type": "sprite",
         "tags": [
@@ -10229,7 +10273,7 @@
             "costumes": [
                 {
                     "costumeName": "shirt blouse",
-                    "baseLayerID": -1,
+                    "baseLayerID": 88,
                     "baseLayerMD5": "918a507af6bbae9e7f36f0d949900838.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 35,
@@ -10249,6 +10293,7 @@
     },
     {
         "name": "Shirt Collar",
+        "baseLayerID": -1,
         "md5": "b7ecf6503e27e9ab5c086eaf07d22b94.svg",
         "type": "sprite",
         "tags": [
@@ -10274,7 +10319,7 @@
             "costumes": [
                 {
                     "costumeName": "shirt collar-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 89,
                     "baseLayerMD5": "b7ecf6503e27e9ab5c086eaf07d22b94.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 30,
@@ -10282,7 +10327,7 @@
                 },
                 {
                     "costumeName": "shirt collar-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 90,
                     "baseLayerMD5": "f1b20c3350e8a7e92a2fb1925ad4158b.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 30,
@@ -10290,7 +10335,7 @@
                 },
                 {
                     "costumeName": "shirt collar-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 91,
                     "baseLayerMD5": "5f04b99416a794e04d0855f446780f18.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 30,
@@ -10310,6 +10355,7 @@
     },
     {
         "name": "Shirt-T",
+        "baseLayerID": -1,
         "md5": "5d7fa4f1788f03d2962f1624d6eac800.svg",
         "type": "sprite",
         "tags": [
@@ -10335,7 +10381,7 @@
             "costumes": [
                 {
                     "costumeName": "shirt-t",
-                    "baseLayerID": -1,
+                    "baseLayerID": 92,
                     "baseLayerMD5": "5d7fa4f1788f03d2962f1624d6eac800.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 39,
@@ -10355,6 +10401,7 @@
     },
     {
         "name": "Shirt2",
+        "baseLayerID": -1,
         "md5": "5946e7a1e36c6d97ae47d41dd8595a41.svg",
         "type": "sprite",
         "tags": [
@@ -10380,7 +10427,7 @@
             "costumes": [
                 {
                     "costumeName": "shirt2-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 86,
                     "baseLayerMD5": "5946e7a1e36c6d97ae47d41dd8595a41.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 39,
@@ -10388,7 +10435,7 @@
                 },
                 {
                     "costumeName": "shirt2-a2",
-                    "baseLayerID": -1,
+                    "baseLayerID": 87,
                     "baseLayerMD5": "5b78ab09592126b6bbe2d4907d203909.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 39,
@@ -10408,6 +10455,7 @@
     },
     {
         "name": "Shoes1",
+        "baseLayerID": -1,
         "md5": "ffab4cc284070b50ac317e515f59f7d8.svg",
         "type": "sprite",
         "tags": [
@@ -10433,7 +10481,7 @@
             "costumes": [
                 {
                     "costumeName": "shoes1",
-                    "baseLayerID": -1,
+                    "baseLayerID": 94,
                     "baseLayerMD5": "ffab4cc284070b50ac317e515f59f7d8.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 36,
@@ -10453,6 +10501,7 @@
     },
     {
         "name": "Shoes2",
+        "baseLayerID": -1,
         "md5": "1dc5d568d98405c370b91a230397a7f9.svg",
         "type": "sprite",
         "tags": [
@@ -10478,7 +10527,7 @@
             "costumes": [
                 {
                     "costumeName": "shoes2",
-                    "baseLayerID": -1,
+                    "baseLayerID": 93,
                     "baseLayerMD5": "1dc5d568d98405c370b91a230397a7f9.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 40,
@@ -10498,6 +10547,7 @@
     },
     {
         "name": "Singer1",
+        "baseLayerID": -1,
         "md5": "e47ef1af3b925e5ac9e3b3f809d440b3.svg",
         "type": "sprite",
         "tags": [
@@ -10524,7 +10574,7 @@
             "costumes": [
                 {
                     "costumeName": "Singer1",
-                    "baseLayerID": -1,
+                    "baseLayerID": 95,
                     "baseLayerMD5": "e47ef1af3b925e5ac9e3b3f809d440b3.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -10544,6 +10594,7 @@
     },
     {
         "name": "Skates",
+        "baseLayerID": -1,
         "md5": "00e5e173400662875a26bb7d6556346a.svg",
         "type": "sprite",
         "tags": [
@@ -10570,7 +10621,7 @@
             "costumes": [
                 {
                     "costumeName": "skates",
-                    "baseLayerID": -1,
+                    "baseLayerID": 96,
                     "baseLayerMD5": "00e5e173400662875a26bb7d6556346a.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 44,
@@ -10590,6 +10641,7 @@
     },
     {
         "name": "Snake",
+        "baseLayerID": -1,
         "md5": "4d06e12d90479461303d828f0970f2d4.svg",
         "type": "sprite",
         "tags": [
@@ -10617,7 +10669,7 @@
             "costumes": [
                 {
                     "costumeName": "snake-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 3,
                     "baseLayerMD5": "4d06e12d90479461303d828f0970f2d4.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 142,
@@ -10625,7 +10677,7 @@
                 },
                 {
                     "costumeName": "snake-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 4,
                     "baseLayerMD5": "a8546a5f9ccaa2bdb678a362c50a17ec.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 142,
@@ -10633,7 +10685,7 @@
                 },
                 {
                     "costumeName": "snake-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 5,
                     "baseLayerMD5": "d993a7d70179777c14ac91a07e711d90.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 142,
@@ -10653,6 +10705,7 @@
     },
     {
         "name": "Snowflake",
+        "baseLayerID": -1,
         "md5": "67de2af723246de37d7379b76800ee0b.svg",
         "type": "sprite",
         "tags": [
@@ -10678,7 +10731,7 @@
             "costumes": [
                 {
                     "costumeName": "snowflake",
-                    "baseLayerID": -1,
+                    "baseLayerID": 97,
                     "baseLayerMD5": "67de2af723246de37d7379b76800ee0b.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 104,
@@ -10698,6 +10751,7 @@
     },
     {
         "name": "Snowman",
+        "baseLayerID": -1,
         "md5": "56c71c31c17b9bc66a2aab0342cf94b2.svg",
         "type": "sprite",
         "tags": [
@@ -10725,7 +10779,7 @@
             "costumes": [
                 {
                     "costumeName": "snowman",
-                    "baseLayerID": -1,
+                    "baseLayerID": 52,
                     "baseLayerMD5": "56c71c31c17b9bc66a2aab0342cf94b2.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -10745,6 +10799,7 @@
     },
     {
         "name": "Soccer Ball",
+        "baseLayerID": -1,
         "md5": "81ff5ad24454e7a0f1f3ae863bb4dd25.svg",
         "type": "sprite",
         "tags": [
@@ -10773,7 +10828,7 @@
             "costumes": [
                 {
                     "costumeName": "soccer ball",
-                    "baseLayerID": -1,
+                    "baseLayerID": 13,
                     "baseLayerMD5": "81ff5ad24454e7a0f1f3ae863bb4dd25.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 26,
@@ -10793,6 +10848,7 @@
     },
     {
         "name": "Spaceship",
+        "baseLayerID": -1,
         "md5": "7d51af7c52e137ef137012595bac928d.svg",
         "type": "sprite",
         "tags": [
@@ -10809,7 +10865,7 @@
             "sounds": [
                 {
                     "soundName": "space ripple",
-                    "soundID": -1,
+                    "soundID": 0,
                     "md5": "ff8b8c3bf841a11fd5fe3afaa92be1b5.wav",
                     "sampleCount": 41149,
                     "rate": 11025,
@@ -10817,7 +10873,7 @@
                 },
                 {
                     "soundName": "laser1",
-                    "soundID": -1,
+                    "soundID": 1,
                     "md5": "46571f8ec0f2cc91666c80e312579082.wav",
                     "sampleCount": 516,
                     "rate": 11025,
@@ -10825,7 +10881,7 @@
                 },
                 {
                     "soundName": "laser2",
-                    "soundID": -1,
+                    "soundID": 2,
                     "md5": "27654ed2e3224f0a3f77c244e4fae9aa.wav",
                     "sampleCount": 755,
                     "rate": 11025,
@@ -10835,7 +10891,7 @@
             "costumes": [
                 {
                     "costumeName": "spaceship-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 17,
                     "baseLayerMD5": "7d51af7c52e137ef137012595bac928d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 66,
@@ -10843,7 +10899,7 @@
                 },
                 {
                     "costumeName": "spaceship-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 18,
                     "baseLayerMD5": "ae2634705b7a4fd31f4c1d1bb0e12545.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 53,
@@ -10851,7 +10907,7 @@
                 },
                 {
                     "costumeName": "spaceship-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 19,
                     "baseLayerMD5": "3d375cd033f1a7161cae56b114f4cfdb.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 61,
@@ -10859,7 +10915,7 @@
                 },
                 {
                     "costumeName": "spaceship-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 20,
                     "baseLayerMD5": "a456964f32cd7e7bd83fe076bf29558b.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 63,
@@ -10867,7 +10923,7 @@
                 },
                 {
                     "costumeName": "spaceship-e",
-                    "baseLayerID": -1,
+                    "baseLayerID": 21,
                     "baseLayerMD5": "5b5cc9904ba63ca2801b61a73d4dcb7e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 71,
@@ -10887,6 +10943,7 @@
     },
     {
         "name": "Speaker",
+        "baseLayerID": -1,
         "md5": "44dc3a2ec161999545914d1f77332d76.svg",
         "type": "sprite",
         "tags": [
@@ -10928,7 +10985,7 @@
             "sounds": [
                 {
                     "soundName": "drive around",
-                    "soundID": -1,
+                    "soundID": 9,
                     "md5": "a3a85fb8564b0266f50a9c091087b7aa.wav",
                     "sampleCount": 44096,
                     "rate": 22050,
@@ -10936,7 +10993,7 @@
                 },
                 {
                     "soundName": "scratchy beat",
-                    "soundID": -1,
+                    "soundID": 10,
                     "md5": "289dc558e076971e74dd1a0bd55719b1.wav",
                     "sampleCount": 44096,
                     "rate": 22050,
@@ -10944,7 +11001,7 @@
                 },
                 {
                     "soundName": "drum jam",
-                    "soundID": -1,
+                    "soundID": 11,
                     "md5": "8b5486ccc806e97e83049d25b071f7e4.wav",
                     "sampleCount": 44288,
                     "rate": 22050,
@@ -10952,7 +11009,7 @@
                 },
                 {
                     "soundName": "cymbal echo",
-                    "soundID": -1,
+                    "soundID": 12,
                     "md5": "bb243badd1201b2607bf2513df10cd97.wav",
                     "sampleCount": 44326,
                     "rate": 22050,
@@ -10960,7 +11017,7 @@
                 },
                 {
                     "soundName": "drum satellite",
-                    "soundID": -1,
+                    "soundID": 13,
                     "md5": "079067d7909f791b29f8be1c00fc2131.wav",
                     "sampleCount": 44096,
                     "rate": 22050,
@@ -10968,7 +11025,7 @@
                 },
                 {
                     "soundName": "kick back",
-                    "soundID": -1,
+                    "soundID": 14,
                     "md5": "9cd340d9d568b1479f731e69e103b3ce.wav",
                     "sampleCount": 44748,
                     "rate": 22050,
@@ -10976,7 +11033,7 @@
                 },
                 {
                     "soundName": "drum funky",
-                    "soundID": -1,
+                    "soundID": 15,
                     "md5": "fb56022366d21b299cbc3fd5e16000c2.wav",
                     "sampleCount": 44748,
                     "rate": 22050,
@@ -10986,7 +11043,7 @@
             "costumes": [
                 {
                     "costumeName": "speaker",
-                    "baseLayerID": -1,
+                    "baseLayerID": 93,
                     "baseLayerMD5": "44dc3a2ec161999545914d1f77332d76.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 53,
@@ -11006,6 +11063,7 @@
     },
     {
         "name": "Star",
+        "baseLayerID": -1,
         "md5": "ab0914e53e360477275e58b83ec4d423.svg",
         "type": "sprite",
         "tags": [
@@ -11032,7 +11090,7 @@
             "costumes": [
                 {
                     "costumeName": "star",
-                    "baseLayerID": -1,
+                    "baseLayerID": 98,
                     "baseLayerMD5": "ab0914e53e360477275e58b83ec4d423.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 21,
@@ -11052,6 +11110,7 @@
     },
     {
         "name": "Starfish",
+        "baseLayerID": -1,
         "md5": "3d1101bbc24ae292a36356af325f660c.svg",
         "type": "sprite",
         "tags": [
@@ -11081,7 +11140,7 @@
             "costumes": [
                 {
                     "costumeName": "starfish-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 99,
                     "baseLayerMD5": "3d1101bbc24ae292a36356af325f660c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -11089,7 +11148,7 @@
                 },
                 {
                     "costumeName": "starfish-b ",
-                    "baseLayerID": -1,
+                    "baseLayerID": 100,
                     "baseLayerMD5": "ad8007f4e63693984d4adc466ffa3ad2.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 53,
@@ -11109,6 +11168,7 @@
     },
     {
         "name": "Stop",
+        "baseLayerID": -1,
         "md5": "5b9e3e8edffb0bd4914113609eec5e04.svg",
         "type": "sprite",
         "tags": [
@@ -11135,7 +11195,7 @@
             "costumes": [
                 {
                     "costumeName": "stop",
-                    "baseLayerID": -1,
+                    "baseLayerID": 101,
                     "baseLayerMD5": "5b9e3e8edffb0bd4914113609eec5e04.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 25,
@@ -11155,6 +11215,7 @@
     },
     {
         "name": "Strawberry",
+        "baseLayerID": -1,
         "md5": "734556fb8e14740f2cbc971238b71d47.svg",
         "type": "sprite",
         "tags": [
@@ -11182,7 +11243,7 @@
             "costumes": [
                 {
                     "costumeName": "strawberry-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 10,
                     "baseLayerMD5": "734556fb8e14740f2cbc971238b71d47.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 57,
@@ -11190,7 +11251,7 @@
                 },
                 {
                     "costumeName": "strawberry-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 11,
                     "baseLayerMD5": "77dadaa80bc5156f655c2196f57972f7.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 57,
@@ -11198,7 +11259,7 @@
                 },
                 {
                     "costumeName": "strawberry-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 12,
                     "baseLayerMD5": "19f933b3cf3e8e150753f8fb9bb7a779.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 57,
@@ -11206,7 +11267,7 @@
                 },
                 {
                     "costumeName": "strawberry-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 13,
                     "baseLayerMD5": "8e8057da8457e6167de36b7d3d28b4bb.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 57,
@@ -11214,7 +11275,7 @@
                 },
                 {
                     "costumeName": "strawberry-e",
-                    "baseLayerID": -1,
+                    "baseLayerID": 14,
                     "baseLayerMD5": "5eb63e64b83f5aa5b75a55329a34efec.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 57,
@@ -11234,6 +11295,7 @@
     },
     {
         "name": "Sun",
+        "baseLayerID": -1,
         "md5": "55c931c65456822c0c56a2b30e3e550d.svg",
         "type": "sprite",
         "tags": [
@@ -11264,7 +11326,7 @@
             "costumes": [
                 {
                     "costumeName": "sun",
-                    "baseLayerID": -1,
+                    "baseLayerID": 102,
                     "baseLayerMD5": "55c931c65456822c0c56a2b30e3e550d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 72,
@@ -11284,6 +11346,7 @@
     },
     {
         "name": "Sunglasses1",
+        "baseLayerID": -1,
         "md5": "424393e8705aeadcfecb8559ce4dcea2.svg",
         "type": "sprite",
         "tags": [
@@ -11310,7 +11373,7 @@
             "costumes": [
                 {
                     "costumeName": "sunglasses1",
-                    "baseLayerID": -1,
+                    "baseLayerID": 103,
                     "baseLayerMD5": "424393e8705aeadcfecb8559ce4dcea2.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 37,
@@ -11330,6 +11393,7 @@
     },
     {
         "name": "Sunglasses2",
+        "baseLayerID": -1,
         "md5": "3185d2295bbf2c5ebd0688c9e4f13076.svg",
         "type": "sprite",
         "tags": [
@@ -11356,7 +11420,7 @@
             "costumes": [
                 {
                     "costumeName": "sunglasses2",
-                    "baseLayerID": -1,
+                    "baseLayerID": 104,
                     "baseLayerMD5": "3185d2295bbf2c5ebd0688c9e4f13076.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 29,
@@ -11376,6 +11440,7 @@
     },
     {
         "name": "Taco",
+        "baseLayerID": -1,
         "md5": "d224b30c54bd4d6000c935938c7f5d7e.svg",
         "type": "sprite",
         "tags": [
@@ -11404,7 +11469,7 @@
             "costumes": [
                 {
                     "costumeName": "taco-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 105,
                     "baseLayerMD5": "d224b30c54bd4d6000c935938c7f5d7e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 20,
@@ -11412,7 +11477,7 @@
                 },
                 {
                     "costumeName": "taco-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 106,
                     "baseLayerMD5": "6dee4f866d79e6475d9824ba11973037.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 56,
@@ -11432,6 +11497,7 @@
     },
     {
         "name": "Takeout",
+        "baseLayerID": -1,
         "md5": "0cfdefe0df1a032b90c8facd9f5dbe1f.svg",
         "type": "sprite",
         "tags": [
@@ -11458,7 +11524,7 @@
             "costumes": [
                 {
                     "costumeName": "takeout-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 15,
                     "baseLayerMD5": "0cfdefe0df1a032b90c8facd9f5dbe1f.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 78,
@@ -11466,7 +11532,7 @@
                 },
                 {
                     "costumeName": "takeout-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 16,
                     "baseLayerMD5": "48b19c48e32c98a35836ee40e3a7accf.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 78,
@@ -11474,7 +11540,7 @@
                 },
                 {
                     "costumeName": "takeout-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 17,
                     "baseLayerMD5": "22d33d87883f8fb26c642eccc9b339f0.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 78,
@@ -11482,7 +11548,7 @@
                 },
                 {
                     "costumeName": "takeout-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 18,
                     "baseLayerMD5": "262f1a3730d669dc9d43b3853e397361.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 78,
@@ -11490,7 +11556,7 @@
                 },
                 {
                     "costumeName": "takeout-e",
-                    "baseLayerID": -1,
+                    "baseLayerID": 19,
                     "baseLayerMD5": "528e9df8c3bd173867be4143f8563e87.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 78,
@@ -11510,6 +11576,7 @@
     },
     {
         "name": "Tera",
+        "baseLayerID": -1,
         "md5": "b54a4a9087435863ab6f6c908f1cac99.svg",
         "type": "sprite",
         "tags": [
@@ -11536,7 +11603,7 @@
             "costumes": [
                 {
                     "costumeName": "tera-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 94,
                     "baseLayerMD5": "b54a4a9087435863ab6f6c908f1cac99.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 49,
@@ -11544,7 +11611,7 @@
                 },
                 {
                     "costumeName": "tera-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 95,
                     "baseLayerMD5": "1e6b3a29351cda80d1a70a3cc0e499f2.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 49,
@@ -11552,7 +11619,7 @@
                 },
                 {
                     "costumeName": "tera-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 96,
                     "baseLayerMD5": "7edf116cbb7111292361431521ae699e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 49,
@@ -11560,7 +11627,7 @@
                 },
                 {
                     "costumeName": "tera-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 97,
                     "baseLayerMD5": "7c3c9c8b5f4ac77de2036175712a777a.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 49,
@@ -11580,6 +11647,7 @@
     },
     {
         "name": "Toucan",
+        "baseLayerID": -1,
         "md5": "6c8798e606abd728b112aecedb5dc249.svg",
         "type": "sprite",
         "tags": [
@@ -11607,7 +11675,7 @@
             "costumes": [
                 {
                     "costumeName": "toucan-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 6,
                     "baseLayerMD5": "6c8798e606abd728b112aecedb5dc249.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 80,
@@ -11615,7 +11683,7 @@
                 },
                 {
                     "costumeName": "toucan-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 7,
                     "baseLayerMD5": "a3e12be9efa0e7aa83778f6054c9c541.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 80,
@@ -11623,7 +11691,7 @@
                 },
                 {
                     "costumeName": "toucan-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 8,
                     "baseLayerMD5": "56522b58a9959fd6152060346129f7cb.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 80,
@@ -11643,6 +11711,7 @@
     },
     {
         "name": "Tree1",
+        "baseLayerID": -1,
         "md5": "8c40e2662c55d17bc384f47165ac43c1.svg",
         "type": "sprite",
         "tags": [
@@ -11670,7 +11739,7 @@
             "costumes": [
                 {
                     "costumeName": "tree1",
-                    "baseLayerID": -1,
+                    "baseLayerID": 107,
                     "baseLayerMD5": "8c40e2662c55d17bc384f47165ac43c1.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 77,
@@ -11690,6 +11759,7 @@
     },
     {
         "name": "Trees",
+        "baseLayerID": -1,
         "md5": "866ed2c2971bb04157e14e935ac8521c.svg",
         "type": "sprite",
         "tags": [
@@ -11717,7 +11787,7 @@
             "costumes": [
                 {
                     "costumeName": "trees-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 108,
                     "baseLayerMD5": "866ed2c2971bb04157e14e935ac8521c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 49,
@@ -11725,7 +11795,7 @@
                 },
                 {
                     "costumeName": "trees-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 109,
                     "baseLayerMD5": "f1393dde1bb0fc512577995b27616d86.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 36,
@@ -11745,6 +11815,7 @@
     },
     {
         "name": "Trumpet",
+        "baseLayerID": -1,
         "md5": "8fa7459ed5877bb14c6625e688be70e7.svg",
         "type": "sprite",
         "tags": [
@@ -11761,7 +11832,7 @@
             "sounds": [
                 {
                     "soundName": "C trumpet",
-                    "soundID": -1,
+                    "soundID": 24,
                     "md5": "8970afcdc4e47bb54959a81fe27522bd.wav",
                     "sampleCount": 13118,
                     "rate": 22050,
@@ -11769,7 +11840,7 @@
                 },
                 {
                     "soundName": "D trumpet",
-                    "soundID": -1,
+                    "soundID": 25,
                     "md5": "0b1345b8fe2ba3076fedb4f3ae48748a.wav",
                     "sampleCount": 12702,
                     "rate": 22050,
@@ -11777,7 +11848,7 @@
                 },
                 {
                     "soundName": "E trumpet",
-                    "soundID": -1,
+                    "soundID": 26,
                     "md5": "494295a92314cadb220945a6711c568c.wav",
                     "sampleCount": 8680,
                     "rate": 22050,
@@ -11785,7 +11856,7 @@
                 },
                 {
                     "soundName": "F trumpet",
-                    "soundID": -1,
+                    "soundID": 27,
                     "md5": "5fa3108b119ca266029b4caa340a7cd0.wav",
                     "sampleCount": 12766,
                     "rate": 22050,
@@ -11793,7 +11864,7 @@
                 },
                 {
                     "soundName": "G trumpet",
-                    "soundID": -1,
+                    "soundID": 28,
                     "md5": "e84afda25975f14b364118591538ccf4.wav",
                     "sampleCount": 14640,
                     "rate": 22050,
@@ -11801,7 +11872,7 @@
                 },
                 {
                     "soundName": "A trumpet",
-                    "soundID": -1,
+                    "soundID": 29,
                     "md5": "d2dd6b4372ca17411965dc92d52b2172.wav",
                     "sampleCount": 13911,
                     "rate": 22050,
@@ -11809,7 +11880,7 @@
                 },
                 {
                     "soundName": "B trumpet",
-                    "soundID": -1,
+                    "soundID": 30,
                     "md5": "cad2bc57729942ed9b605145fc9ea65d.wav",
                     "sampleCount": 14704,
                     "rate": 22050,
@@ -11817,7 +11888,7 @@
                 },
                 {
                     "soundName": "C2 trumpet",
-                    "soundID": -1,
+                    "soundID": 31,
                     "md5": "df08249ed5446cc5e10b7ac62faac89b.wav",
                     "sampleCount": 15849,
                     "rate": 22050,
@@ -11827,7 +11898,7 @@
             "costumes": [
                 {
                     "costumeName": "trumpet-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 8,
                     "baseLayerMD5": "8fa7459ed5877bb14c6625e688be70e7.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 37,
@@ -11835,7 +11906,7 @@
                 },
                 {
                     "costumeName": "trumpet-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 9,
                     "baseLayerMD5": "7cedda5ec925118f237094cd05381e5d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 37,
@@ -11855,6 +11926,7 @@
     },
     {
         "name": "Unicorn",
+        "baseLayerID": -1,
         "md5": "bd2cf980966c13d5ad3ab403bae4bb05.svg",
         "type": "sprite",
         "tags": [
@@ -11882,7 +11954,7 @@
             "costumes": [
                 {
                     "costumeName": "unicorn",
-                    "baseLayerID": -1,
+                    "baseLayerID": 7,
                     "baseLayerMD5": "bd2cf980966c13d5ad3ab403bae4bb05.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 100,
@@ -11901,7 +11973,57 @@
         }
     },
     {
+        "name": "Unicorn 2",
+        "baseLayerID": -1,
+        "md5": "a04def38351e7fd805226345cac4fbfe.svg",
+        "type": "sprite",
+        "tags": [
+            "fantasy",
+            "horse",
+            "horn",
+            "rainbow"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Unicorn 2",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "unicorn 2",
+                    "baseLayerID": 53,
+                    "baseLayerMD5": "a04def38351e7fd805226345cac4fbfe.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": -96,
+            "scratchY": -43,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
         "name": "Unicorn-running",
+        "baseLayerID": -1,
         "md5": "c6456df027561c74b70b8b25ab83fec9.svg",
         "type": "sprite",
         "tags": [
@@ -11929,7 +12051,7 @@
             "costumes": [
                 {
                     "costumeName": "unicorn-run-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 65,
                     "baseLayerMD5": "c6456df027561c74b70b8b25ab83fec9.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 130,
@@ -11937,7 +12059,7 @@
                 },
                 {
                     "costumeName": "unicorn-run-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 66,
                     "baseLayerMD5": "f2d6c5b62b56d0cc51598126c74e0ace.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 130,
@@ -11945,7 +12067,7 @@
                 },
                 {
                     "costumeName": "unicorn-run-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 67,
                     "baseLayerMD5": "fba367b11a710bf542333649c4d68e1e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 130,
@@ -11953,7 +12075,7 @@
                 },
                 {
                     "costumeName": "unicorn-run-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 68,
                     "baseLayerMD5": "20bad70a67e0c7ed3255c65780cdb2a8.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 130,
@@ -11961,7 +12083,7 @@
                 },
                 {
                     "costumeName": "unicorn-run-e",
-                    "baseLayerID": -1,
+                    "baseLayerID": 69,
                     "baseLayerMD5": "39db08aafdde1542e755b8ead8df7a1f.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 130,
@@ -11969,7 +12091,7 @@
                 },
                 {
                     "costumeName": "unicorn-run-f",
-                    "baseLayerID": -1,
+                    "baseLayerID": 70,
                     "baseLayerMD5": "d66d0625702433a4cbd7591e39676700.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 130,
@@ -11989,6 +12111,7 @@
     },
     {
         "name": "Vest",
+        "baseLayerID": -1,
         "md5": "f8285ca9564451c62a0e3d75b8a714e8.svg",
         "type": "sprite",
         "tags": [
@@ -12014,7 +12137,7 @@
             "costumes": [
                 {
                     "costumeName": "vest-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 110,
                     "baseLayerMD5": "f8285ca9564451c62a0e3d75b8a714e8.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 18,
@@ -12022,7 +12145,7 @@
                 },
                 {
                     "costumeName": "vest-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 111,
                     "baseLayerMD5": "77d553eea3910ab8f5bac3d2da601061.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 18,
@@ -12042,6 +12165,7 @@
     },
     {
         "name": "Wand",
+        "baseLayerID": -1,
         "md5": "1aa56e9ef7043eaf36ecfe8e330271b7.svg",
         "type": "sprite",
         "tags": [
@@ -12069,7 +12193,7 @@
             "costumes": [
                 {
                     "costumeName": "wand",
-                    "baseLayerID": -1,
+                    "baseLayerID": 29,
                     "baseLayerMD5": "1aa56e9ef7043eaf36ecfe8e330271b7.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 12,
@@ -12089,6 +12213,7 @@
     },
     {
         "name": "Wanda",
+        "baseLayerID": -1,
         "md5": "450bc8fbd5ab6bc2e83576aad58cd07c.svg",
         "type": "sprite",
         "tags": [
@@ -12114,7 +12239,7 @@
             "costumes": [
                 {
                     "costumeName": "wanda",
-                    "baseLayerID": -1,
+                    "baseLayerID": 112,
                     "baseLayerMD5": "450bc8fbd5ab6bc2e83576aad58cd07c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 49,
@@ -12134,6 +12259,7 @@
     },
     {
         "name": "Watermelon",
+        "baseLayerID": -1,
         "md5": "26fecef75cf3b6e0d98bff5c06475036.svg",
         "type": "sprite",
         "tags": [
@@ -12164,7 +12290,7 @@
             "costumes": [
                 {
                     "costumeName": "watermelon-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 98,
                     "baseLayerMD5": "26fecef75cf3b6e0d98bff5c06475036.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 40,
@@ -12172,7 +12298,7 @@
                 },
                 {
                     "costumeName": "watermelon-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 99,
                     "baseLayerMD5": "fbdaf4d1d349edd3ddf3a1c4528aa9ec.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -12180,7 +12306,7 @@
                 },
                 {
                     "costumeName": "watermelon-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 100,
                     "baseLayerMD5": "5976c10412306fc093c1d1930fa05119.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 21,
@@ -12200,6 +12326,7 @@
     },
     {
         "name": "Witch",
+        "baseLayerID": -1,
         "md5": "cbc54e15cd62f0c16369587377636099.svg",
         "type": "sprite",
         "tags": [
@@ -12230,7 +12357,7 @@
             "costumes": [
                 {
                     "costumeName": "witch-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 36,
                     "baseLayerMD5": "cbc54e15cd62f0c16369587377636099.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 65,
@@ -12238,7 +12365,7 @@
                 },
                 {
                     "costumeName": "witch-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 37,
                     "baseLayerMD5": "64d2c4c51e6cb6008cd5e93f77e6f591.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 65,
@@ -12246,7 +12373,7 @@
                 },
                 {
                     "costumeName": "witch-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 38,
                     "baseLayerMD5": "00b768c3da5b4ee3efddf05d1eb88de2.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 65,
@@ -12254,7 +12381,7 @@
                 },
                 {
                     "costumeName": "witch-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 39,
                     "baseLayerMD5": "4fe4c0ee34a9028f2c6988b7294a61c1.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 65,
@@ -12274,6 +12401,7 @@
     },
     {
         "name": "Wizard",
+        "baseLayerID": -1,
         "md5": "9632aab80fce1c5bdb58150b29cb0067.svg",
         "type": "sprite",
         "tags": [
@@ -12304,7 +12432,7 @@
             "costumes": [
                 {
                     "costumeName": "wizard-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 0,
                     "baseLayerMD5": "9632aab80fce1c5bdb58150b29cb0067.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 87,
@@ -12312,7 +12440,7 @@
                 },
                 {
                     "costumeName": "wizard-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 1,
                     "baseLayerMD5": "36c9b8b93ddb2c392b7145862fc4e8d8.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 79,
@@ -12320,7 +12448,7 @@
                 },
                 {
                     "costumeName": "wizard-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 2,
                     "baseLayerMD5": "16d4d221a2182278cfa6b0621f455cf6.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 87,
@@ -12340,6 +12468,7 @@
     },
     {
         "name": "Wizard-toad",
+        "baseLayerID": -1,
         "md5": "fd5c4cce36e866489febc227e23b21aa.svg",
         "type": "sprite",
         "tags": [
@@ -12370,7 +12499,7 @@
             "costumes": [
                 {
                     "costumeName": "wizard-toad-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 52,
                     "baseLayerMD5": "fd5c4cce36e866489febc227e23b21aa.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 87,
@@ -12378,7 +12507,7 @@
                 },
                 {
                     "costumeName": "wizard-toad-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 53,
                     "baseLayerMD5": "4c260807d4ac4c0ad39760f1efeef1de.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 87,
@@ -12397,101 +12526,8 @@
         }
     },
     {
-        "name": "Wizard1",
-        "md5": "e085c97691d16f0cc8a595ce1137e26c.svg",
-        "type": "sprite",
-        "tags": [
-            "fantasy",
-            "magic",
-            "wand"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Wizard1",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "wizard1",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "e085c97691d16f0cc8a595ce1137e26c.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 134,
-                    "rotationCenterY": 153
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": -7,
-            "scratchY": -23,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Wizard2",
-        "md5": "6db4d9e4229dc50a1b1c91c3c8311d40.svg",
-        "type": "sprite",
-        "tags": [
-            "fantasy",
-            "magic",
-            "wand"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Wizard2",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "wizard2",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "6db4d9e4229dc50a1b1c91c3c8311d40.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 69,
-                    "rotationCenterY": 93
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 82,
-            "scratchY": -8,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
         "name": "Block-A",
+        "baseLayerID": -1,
         "md5": "602a16930a8050e1298e1a0ae844363e.svg",
         "type": "sprite",
         "tags": [
@@ -12518,7 +12554,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-a",
-                    "baseLayerID": -1,
+                    "baseLayerID": 0,
                     "baseLayerMD5": "602a16930a8050e1298e1a0ae844363e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 28,
@@ -12538,6 +12574,7 @@
     },
     {
         "name": "Block-B",
+        "baseLayerID": -1,
         "md5": "f8c683cf71660e8ac1f8855599857a25.svg",
         "type": "sprite",
         "tags": [
@@ -12564,7 +12601,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-b",
-                    "baseLayerID": -1,
+                    "baseLayerID": 1,
                     "baseLayerMD5": "f8c683cf71660e8ac1f8855599857a25.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 29,
@@ -12584,6 +12621,7 @@
     },
     {
         "name": "Block-C",
+        "baseLayerID": -1,
         "md5": "f8f4cc686ffc5a4113a99f70b09abd32.svg",
         "type": "sprite",
         "tags": [
@@ -12610,7 +12648,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-c",
-                    "baseLayerID": -1,
+                    "baseLayerID": 2,
                     "baseLayerMD5": "f8f4cc686ffc5a4113a99f70b09abd32.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 35,
@@ -12630,6 +12668,7 @@
     },
     {
         "name": "Block-D",
+        "baseLayerID": -1,
         "md5": "aee2d71ef0293b33479bff9423d16b67.svg",
         "type": "sprite",
         "tags": [
@@ -12656,7 +12695,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-d",
-                    "baseLayerID": -1,
+                    "baseLayerID": 3,
                     "baseLayerMD5": "aee2d71ef0293b33479bff9423d16b67.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 31,
@@ -12676,6 +12715,7 @@
     },
     {
         "name": "Block-E",
+        "baseLayerID": -1,
         "md5": "16c6257316ff94cc7539ccdfc24e5fb8.svg",
         "type": "sprite",
         "tags": [
@@ -12702,7 +12742,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-e",
-                    "baseLayerID": -1,
+                    "baseLayerID": 4,
                     "baseLayerMD5": "16c6257316ff94cc7539ccdfc24e5fb8.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 25,
@@ -12722,6 +12762,7 @@
     },
     {
         "name": "Block-F",
+        "baseLayerID": -1,
         "md5": "34c090c1f573c569332ead68cb99b595.svg",
         "type": "sprite",
         "tags": [
@@ -12748,7 +12789,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-f",
-                    "baseLayerID": -1,
+                    "baseLayerID": 6,
                     "baseLayerMD5": "34c090c1f573c569332ead68cb99b595.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 23,
@@ -12768,6 +12809,7 @@
     },
     {
         "name": "Block-G",
+        "baseLayerID": -1,
         "md5": "8bb2382627004eb08ff10ea8171cc724.svg",
         "type": "sprite",
         "tags": [
@@ -12794,7 +12836,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-g",
-                    "baseLayerID": -1,
+                    "baseLayerID": 9,
                     "baseLayerMD5": "8bb2382627004eb08ff10ea8171cc724.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 28,
@@ -12814,6 +12856,7 @@
     },
     {
         "name": "Block-H",
+        "baseLayerID": -1,
         "md5": "f1578807d4a124fc02b639a8febeaab3.svg",
         "type": "sprite",
         "tags": [
@@ -12840,7 +12883,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-h",
-                    "baseLayerID": -1,
+                    "baseLayerID": 11,
                     "baseLayerMD5": "f1578807d4a124fc02b639a8febeaab3.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 27,
@@ -12860,6 +12903,7 @@
     },
     {
         "name": "Block-I",
+        "baseLayerID": -1,
         "md5": "341bc70442886d6fdf959f2a97a63554.svg",
         "type": "sprite",
         "tags": [
@@ -12886,7 +12930,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-i",
-                    "baseLayerID": -1,
+                    "baseLayerID": 13,
                     "baseLayerMD5": "341bc70442886d6fdf959f2a97a63554.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 19,
@@ -12906,6 +12950,7 @@
     },
     {
         "name": "Block-J",
+        "baseLayerID": -1,
         "md5": "4b420cce964beedf2c1dc43faa59fdec.svg",
         "type": "sprite",
         "tags": [
@@ -12932,7 +12977,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-j",
-                    "baseLayerID": -1,
+                    "baseLayerID": 15,
                     "baseLayerMD5": "4b420cce964beedf2c1dc43faa59fdec.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 25,
@@ -12952,6 +12997,7 @@
     },
     {
         "name": "Block-K",
+        "baseLayerID": -1,
         "md5": "19601cc33449813aa93a47c63167e5c1.svg",
         "type": "sprite",
         "tags": [
@@ -12978,7 +13024,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-k",
-                    "baseLayerID": -1,
+                    "baseLayerID": 17,
                     "baseLayerMD5": "19601cc33449813aa93a47c63167e5c1.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 24,
@@ -12998,6 +13044,7 @@
     },
     {
         "name": "Block-L",
+        "baseLayerID": -1,
         "md5": "87358e3c9b9f5be4376253ce08d0192d.svg",
         "type": "sprite",
         "tags": [
@@ -13024,7 +13071,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-l",
-                    "baseLayerID": -1,
+                    "baseLayerID": 19,
                     "baseLayerMD5": "87358e3c9b9f5be4376253ce08d0192d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 26,
@@ -13044,6 +13091,7 @@
     },
     {
         "name": "Block-M",
+        "baseLayerID": -1,
         "md5": "7ba0642be1f0080c0d273ea96e29b1e8.svg",
         "type": "sprite",
         "tags": [
@@ -13070,7 +13118,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-m",
-                    "baseLayerID": -1,
+                    "baseLayerID": 21,
                     "baseLayerMD5": "7ba0642be1f0080c0d273ea96e29b1e8.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 35,
@@ -13090,6 +13138,7 @@
     },
     {
         "name": "Block-N",
+        "baseLayerID": -1,
         "md5": "6c1fbc57821744bd9356ce9a21ed70f7.svg",
         "type": "sprite",
         "tags": [
@@ -13116,7 +13165,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-n",
-                    "baseLayerID": -1,
+                    "baseLayerID": 23,
                     "baseLayerMD5": "6c1fbc57821744bd9356ce9a21ed70f7.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 28,
@@ -13136,6 +13185,7 @@
     },
     {
         "name": "Block-O",
+        "baseLayerID": -1,
         "md5": "e88638200a73e167d0e266a343019cec.svg",
         "type": "sprite",
         "tags": [
@@ -13162,7 +13212,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-o",
-                    "baseLayerID": -1,
+                    "baseLayerID": 27,
                     "baseLayerMD5": "e88638200a73e167d0e266a343019cec.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 32,
@@ -13182,6 +13232,7 @@
     },
     {
         "name": "Block-P",
+        "baseLayerID": -1,
         "md5": "ad2fc3a1c6538678915633a11ab6ec73.svg",
         "type": "sprite",
         "tags": [
@@ -13208,7 +13259,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-p",
-                    "baseLayerID": -1,
+                    "baseLayerID": 25,
                     "baseLayerMD5": "ad2fc3a1c6538678915633a11ab6ec73.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 18,
@@ -13228,6 +13279,7 @@
     },
     {
         "name": "Block-Q",
+        "baseLayerID": -1,
         "md5": "64da9da8684c74deb567dbdb661d3a52.svg",
         "type": "sprite",
         "tags": [
@@ -13254,7 +13306,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-q",
-                    "baseLayerID": -1,
+                    "baseLayerID": 35,
                     "baseLayerMD5": "64da9da8684c74deb567dbdb661d3a52.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 26,
@@ -13274,6 +13326,7 @@
     },
     {
         "name": "Block-R",
+        "baseLayerID": -1,
         "md5": "73e8d46f7475476d8cb4cfcfc75ee50d.svg",
         "type": "sprite",
         "tags": [
@@ -13300,7 +13353,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-r",
-                    "baseLayerID": -1,
+                    "baseLayerID": 30,
                     "baseLayerMD5": "73e8d46f7475476d8cb4cfcfc75ee50d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -13320,6 +13373,7 @@
     },
     {
         "name": "Block-S",
+        "baseLayerID": -1,
         "md5": "9feb5593fed51e88dbb3128cfc290d29.svg",
         "type": "sprite",
         "tags": [
@@ -13346,7 +13400,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-s",
-                    "baseLayerID": -1,
+                    "baseLayerID": 32,
                     "baseLayerMD5": "9feb5593fed51e88dbb3128cfc290d29.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 13,
@@ -13366,6 +13420,7 @@
     },
     {
         "name": "Block-T",
+        "baseLayerID": -1,
         "md5": "d29c1caf5cf195740c38f279e82a77a4.svg",
         "type": "sprite",
         "tags": [
@@ -13392,7 +13447,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-t",
-                    "baseLayerID": -1,
+                    "baseLayerID": 37,
                     "baseLayerMD5": "d29c1caf5cf195740c38f279e82a77a4.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 25,
@@ -13412,6 +13467,7 @@
     },
     {
         "name": "Block-U",
+        "baseLayerID": -1,
         "md5": "faef46b7bf589c36300142f6f03c5d32.svg",
         "type": "sprite",
         "tags": [
@@ -13438,7 +13494,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-u",
-                    "baseLayerID": -1,
+                    "baseLayerID": 39,
                     "baseLayerMD5": "faef46b7bf589c36300142f6f03c5d32.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 28,
@@ -13458,6 +13514,7 @@
     },
     {
         "name": "Block-V",
+        "baseLayerID": -1,
         "md5": "65e2f4821ab084827e22920acb61c92b.svg",
         "type": "sprite",
         "tags": [
@@ -13484,7 +13541,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-v",
-                    "baseLayerID": -1,
+                    "baseLayerID": 42,
                     "baseLayerMD5": "65e2f4821ab084827e22920acb61c92b.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 35,
@@ -13504,6 +13561,7 @@
     },
     {
         "name": "Block-W",
+        "baseLayerID": -1,
         "md5": "5ab197b4f70b2f98a3658c7ccdc3351d.svg",
         "type": "sprite",
         "tags": [
@@ -13530,7 +13588,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-w",
-                    "baseLayerID": -1,
+                    "baseLayerID": 44,
                     "baseLayerMD5": "5ab197b4f70b2f98a3658c7ccdc3351d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 47,
@@ -13550,6 +13608,7 @@
     },
     {
         "name": "Block-X",
+        "baseLayerID": -1,
         "md5": "cb9dff35f05e823d954e47e4a717a48c.svg",
         "type": "sprite",
         "tags": [
@@ -13576,7 +13635,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-x",
-                    "baseLayerID": -1,
+                    "baseLayerID": 46,
                     "baseLayerMD5": "cb9dff35f05e823d954e47e4a717a48c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 25,
@@ -13596,6 +13655,7 @@
     },
     {
         "name": "Block-Y",
+        "baseLayerID": -1,
         "md5": "4c13c440bcb35c8c3aa6226374fced3f.svg",
         "type": "sprite",
         "tags": [
@@ -13622,7 +13682,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-y",
-                    "baseLayerID": -1,
+                    "baseLayerID": 48,
                     "baseLayerMD5": "4c13c440bcb35c8c3aa6226374fced3f.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 26,
@@ -13642,6 +13702,7 @@
     },
     {
         "name": "Block-Z",
+        "baseLayerID": -1,
         "md5": "0ccff1898f1bf1b25333d581db09fae2.svg",
         "type": "sprite",
         "tags": [
@@ -13668,7 +13729,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-z",
-                    "baseLayerID": -1,
+                    "baseLayerID": 50,
                     "baseLayerMD5": "0ccff1898f1bf1b25333d581db09fae2.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 24,
@@ -13688,6 +13749,7 @@
     },
     {
         "name": "Glow-0",
+        "baseLayerID": -1,
         "md5": "38b2b342659adc6fa289090975e0e71d.svg",
         "type": "sprite",
         "tags": [
@@ -13714,7 +13776,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-0",
-                    "baseLayerID": -1,
+                    "baseLayerID": 31,
                     "baseLayerMD5": "38b2b342659adc6fa289090975e0e71d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 29,
@@ -13734,6 +13796,7 @@
     },
     {
         "name": "Glow-1",
+        "baseLayerID": -1,
         "md5": "2c88706210672655401fe09edd8ff6a7.svg",
         "type": "sprite",
         "tags": [
@@ -13760,7 +13823,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-1",
-                    "baseLayerID": -1,
+                    "baseLayerID": 52,
                     "baseLayerMD5": "2c88706210672655401fe09edd8ff6a7.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 24,
@@ -13780,6 +13843,7 @@
     },
     {
         "name": "Glow-2",
+        "baseLayerID": -1,
         "md5": "b9faa5708a799a1607f0325a7af2561c.svg",
         "type": "sprite",
         "tags": [
@@ -13806,7 +13870,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-2",
-                    "baseLayerID": -1,
+                    "baseLayerID": 53,
                     "baseLayerMD5": "b9faa5708a799a1607f0325a7af2561c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 28,
@@ -13826,6 +13890,7 @@
     },
     {
         "name": "Glow-3",
+        "baseLayerID": -1,
         "md5": "cf42a50552ce26032ead712ac4f36c23.svg",
         "type": "sprite",
         "tags": [
@@ -13852,7 +13917,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-3",
-                    "baseLayerID": -1,
+                    "baseLayerID": 54,
                     "baseLayerMD5": "cf42a50552ce26032ead712ac4f36c23.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 33,
@@ -13872,6 +13937,7 @@
     },
     {
         "name": "Glow-4",
+        "baseLayerID": -1,
         "md5": "3ffa6aee373e28fc36b9395ac4d0467e.svg",
         "type": "sprite",
         "tags": [
@@ -13898,7 +13964,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-4",
-                    "baseLayerID": -1,
+                    "baseLayerID": 55,
                     "baseLayerMD5": "3ffa6aee373e28fc36b9395ac4d0467e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 31,
@@ -13918,6 +13984,7 @@
     },
     {
         "name": "Glow-5",
+        "baseLayerID": -1,
         "md5": "85d87d32e7e9e6be122c905b0d2e7e33.svg",
         "type": "sprite",
         "tags": [
@@ -13944,7 +14011,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-5",
-                    "baseLayerID": -1,
+                    "baseLayerID": 56,
                     "baseLayerMD5": "85d87d32e7e9e6be122c905b0d2e7e33.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 30,
@@ -13964,6 +14031,7 @@
     },
     {
         "name": "Glow-6",
+        "baseLayerID": -1,
         "md5": "62cc2a6def27f19d11ed56e86e95aac5.svg",
         "type": "sprite",
         "tags": [
@@ -13990,7 +14058,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-6",
-                    "baseLayerID": -1,
+                    "baseLayerID": 57,
                     "baseLayerMD5": "62cc2a6def27f19d11ed56e86e95aac5.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 30,
@@ -14010,6 +14078,7 @@
     },
     {
         "name": "Glow-7",
+        "baseLayerID": -1,
         "md5": "8887983eb4df2e62a2ed4770a1d98d60.svg",
         "type": "sprite",
         "tags": [
@@ -14036,7 +14105,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-7",
-                    "baseLayerID": -1,
+                    "baseLayerID": 58,
                     "baseLayerMD5": "8887983eb4df2e62a2ed4770a1d98d60.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 31,
@@ -14056,6 +14125,7 @@
     },
     {
         "name": "Glow-8",
+        "baseLayerID": -1,
         "md5": "4c42c4cb0c1e090d0f9570416d3c80c8.svg",
         "type": "sprite",
         "tags": [
@@ -14082,7 +14152,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-8",
-                    "baseLayerID": -1,
+                    "baseLayerID": 59,
                     "baseLayerMD5": "4c42c4cb0c1e090d0f9570416d3c80c8.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 31,
@@ -14102,6 +14172,7 @@
     },
     {
         "name": "Glow-9",
+        "baseLayerID": -1,
         "md5": "7bcb7e2e48f5cb770c83d4267922fec0.svg",
         "type": "sprite",
         "tags": [
@@ -14128,7 +14199,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-9",
-                    "baseLayerID": -1,
+                    "baseLayerID": 60,
                     "baseLayerMD5": "7bcb7e2e48f5cb770c83d4267922fec0.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 28,
@@ -14148,6 +14219,7 @@
     },
     {
         "name": "Glow-A",
+        "baseLayerID": -1,
         "md5": "d5aa299350c24c747200a64b63b1aa52.svg",
         "type": "sprite",
         "tags": [
@@ -14174,7 +14246,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-A",
-                    "baseLayerID": -1,
+                    "baseLayerID": 5,
                     "baseLayerMD5": "d5aa299350c24c747200a64b63b1aa52.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 36,
@@ -14194,6 +14266,7 @@
     },
     {
         "name": "Glow-B",
+        "baseLayerID": -1,
         "md5": "a2e95f268a6cab03f3e94b3b0b792d83.svg",
         "type": "sprite",
         "tags": [
@@ -14220,7 +14293,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-B",
-                    "baseLayerID": -1,
+                    "baseLayerID": 7,
                     "baseLayerMD5": "a2e95f268a6cab03f3e94b3b0b792d83.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 32,
@@ -14240,6 +14313,7 @@
     },
     {
         "name": "Glow-C",
+        "baseLayerID": -1,
         "md5": "9779a4a40934f04a4bf84920b258d7c9.svg",
         "type": "sprite",
         "tags": [
@@ -14266,7 +14340,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-C",
-                    "baseLayerID": -1,
+                    "baseLayerID": 8,
                     "baseLayerMD5": "9779a4a40934f04a4bf84920b258d7c9.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 27,
@@ -14286,6 +14360,7 @@
     },
     {
         "name": "Glow-D",
+        "baseLayerID": -1,
         "md5": "3555b8bbbbcdc00354bf6fa81ac7042f.svg",
         "type": "sprite",
         "tags": [
@@ -14312,7 +14387,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-D",
-                    "baseLayerID": -1,
+                    "baseLayerID": 10,
                     "baseLayerMD5": "3555b8bbbbcdc00354bf6fa81ac7042f.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 33,
@@ -14332,6 +14407,7 @@
     },
     {
         "name": "Glow-E",
+        "baseLayerID": -1,
         "md5": "44dbc655d5ac9f13618473848e23484e.svg",
         "type": "sprite",
         "tags": [
@@ -14358,7 +14434,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-E",
-                    "baseLayerID": -1,
+                    "baseLayerID": 12,
                     "baseLayerMD5": "44dbc655d5ac9f13618473848e23484e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 34,
@@ -14378,6 +14454,7 @@
     },
     {
         "name": "Glow-F",
+        "baseLayerID": -1,
         "md5": "dec417e749e43d7de3985155f5f5a7a0.svg",
         "type": "sprite",
         "tags": [
@@ -14404,7 +14481,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-F",
-                    "baseLayerID": -1,
+                    "baseLayerID": 14,
                     "baseLayerMD5": "dec417e749e43d7de3985155f5f5a7a0.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 35,
@@ -14424,6 +14501,7 @@
     },
     {
         "name": "Glow-G",
+        "baseLayerID": -1,
         "md5": "cf4aa465cd8fb7049cc571d7546a7eb1.svg",
         "type": "sprite",
         "tags": [
@@ -14450,7 +14528,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-G",
-                    "baseLayerID": -1,
+                    "baseLayerID": 16,
                     "baseLayerMD5": "cf4aa465cd8fb7049cc571d7546a7eb1.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 32,
@@ -14470,6 +14548,7 @@
     },
     {
         "name": "Glow-H",
+        "baseLayerID": -1,
         "md5": "8d9bd5f00ea1ac6f92d0f97ee491b0f3.svg",
         "type": "sprite",
         "tags": [
@@ -14496,7 +14575,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-H",
-                    "baseLayerID": -1,
+                    "baseLayerID": 18,
                     "baseLayerMD5": "8d9bd5f00ea1ac6f92d0f97ee491b0f3.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 35,
@@ -14516,6 +14595,7 @@
     },
     {
         "name": "Glow-I",
+        "baseLayerID": -1,
         "md5": "0e86de55840103dcd50199ab2b765de7.svg",
         "type": "sprite",
         "tags": [
@@ -14542,7 +14622,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-I",
-                    "baseLayerID": -1,
+                    "baseLayerID": 20,
                     "baseLayerMD5": "0e86de55840103dcd50199ab2b765de7.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 21,
@@ -14562,6 +14642,7 @@
     },
     {
         "name": "Glow-J",
+        "baseLayerID": -1,
         "md5": "b3832145eacc39f91bd3a9a6673fa05c.svg",
         "type": "sprite",
         "tags": [
@@ -14588,7 +14669,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-J",
-                    "baseLayerID": -1,
+                    "baseLayerID": 22,
                     "baseLayerMD5": "b3832145eacc39f91bd3a9a6673fa05c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 29,
@@ -14608,6 +14689,7 @@
     },
     {
         "name": "Glow-K",
+        "baseLayerID": -1,
         "md5": "f4e37a7552ba05e995613211a7146de5.svg",
         "type": "sprite",
         "tags": [
@@ -14634,7 +14716,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-K",
-                    "baseLayerID": -1,
+                    "baseLayerID": 24,
                     "baseLayerMD5": "f4e37a7552ba05e995613211a7146de5.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 38,
@@ -14654,6 +14736,7 @@
     },
     {
         "name": "Glow-L",
+        "baseLayerID": -1,
         "md5": "a75e45773ea6afaf8ae44f79f936fc82.svg",
         "type": "sprite",
         "tags": [
@@ -14680,7 +14763,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-L",
-                    "baseLayerID": -1,
+                    "baseLayerID": 26,
                     "baseLayerMD5": "a75e45773ea6afaf8ae44f79f936fc82.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 33,
@@ -14700,6 +14783,7 @@
     },
     {
         "name": "Glow-M",
+        "baseLayerID": -1,
         "md5": "219b06faa5b816347165450d148213b4.svg",
         "type": "sprite",
         "tags": [
@@ -14726,7 +14810,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-M",
-                    "baseLayerID": -1,
+                    "baseLayerID": 28,
                     "baseLayerMD5": "219b06faa5b816347165450d148213b4.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 42,
@@ -14746,6 +14830,7 @@
     },
     {
         "name": "Glow-N",
+        "baseLayerID": -1,
         "md5": "4b724479fb3b2184fd8be6f83fb20e54.svg",
         "type": "sprite",
         "tags": [
@@ -14772,7 +14857,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-N",
-                    "baseLayerID": -1,
+                    "baseLayerID": 29,
                     "baseLayerMD5": "4b724479fb3b2184fd8be6f83fb20e54.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 37,
@@ -14792,6 +14877,7 @@
     },
     {
         "name": "Glow-O",
+        "baseLayerID": -1,
         "md5": "38b2b342659adc6fa289090975e0e71d.svg",
         "type": "sprite",
         "tags": [
@@ -14818,7 +14904,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-O",
-                    "baseLayerID": -1,
+                    "baseLayerID": 31,
                     "baseLayerMD5": "38b2b342659adc6fa289090975e0e71d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 29,
@@ -14838,6 +14924,7 @@
     },
     {
         "name": "Glow-P",
+        "baseLayerID": -1,
         "md5": "1cfa849cc967069730b7e9d0809c9dc1.svg",
         "type": "sprite",
         "tags": [
@@ -14864,7 +14951,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-P",
-                    "baseLayerID": -1,
+                    "baseLayerID": 33,
                     "baseLayerMD5": "1cfa849cc967069730b7e9d0809c9dc1.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 32,
@@ -14884,6 +14971,7 @@
     },
     {
         "name": "Glow-Q",
+        "baseLayerID": -1,
         "md5": "9d35979e9404ac234301269fcd7de288.svg",
         "type": "sprite",
         "tags": [
@@ -14910,7 +14998,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-Q",
-                    "baseLayerID": -1,
+                    "baseLayerID": 34,
                     "baseLayerMD5": "9d35979e9404ac234301269fcd7de288.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 33,
@@ -14930,6 +15018,7 @@
     },
     {
         "name": "Glow-R",
+        "baseLayerID": -1,
         "md5": "fc067ee076ecaba8430ccd54d9414c1b.svg",
         "type": "sprite",
         "tags": [
@@ -14956,7 +15045,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-R",
-                    "baseLayerID": -1,
+                    "baseLayerID": 36,
                     "baseLayerMD5": "fc067ee076ecaba8430ccd54d9414c1b.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 35,
@@ -14976,6 +15065,7 @@
     },
     {
         "name": "Glow-S",
+        "baseLayerID": -1,
         "md5": "19a93db8a294ccaec4d6eef4020a446f.svg",
         "type": "sprite",
         "tags": [
@@ -15002,7 +15092,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-S",
-                    "baseLayerID": -1,
+                    "baseLayerID": 38,
                     "baseLayerMD5": "19a93db8a294ccaec4d6eef4020a446f.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 27,
@@ -15022,6 +15112,7 @@
     },
     {
         "name": "Glow-T",
+        "baseLayerID": -1,
         "md5": "d7bcda522a1e9504dafcf2fa0fcde39b.svg",
         "type": "sprite",
         "tags": [
@@ -15048,7 +15139,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-T",
-                    "baseLayerID": -1,
+                    "baseLayerID": 40,
                     "baseLayerMD5": "d7bcda522a1e9504dafcf2fa0fcde39b.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 35,
@@ -15068,6 +15159,7 @@
     },
     {
         "name": "Glow-U",
+        "baseLayerID": -1,
         "md5": "790482a3c3691a1e96ef34eee7303872.svg",
         "type": "sprite",
         "tags": [
@@ -15094,7 +15186,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-U",
-                    "baseLayerID": -1,
+                    "baseLayerID": 41,
                     "baseLayerMD5": "790482a3c3691a1e96ef34eee7303872.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 37,
@@ -15114,6 +15206,7 @@
     },
     {
         "name": "Glow-V",
+        "baseLayerID": -1,
         "md5": "6a00388d8dc6be645b843cef9c22681c.svg",
         "type": "sprite",
         "tags": [
@@ -15140,7 +15233,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-V",
-                    "baseLayerID": -1,
+                    "baseLayerID": 43,
                     "baseLayerMD5": "6a00388d8dc6be645b843cef9c22681c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 35,
@@ -15160,6 +15253,7 @@
     },
     {
         "name": "Glow-W",
+        "baseLayerID": -1,
         "md5": "1a9ea7305a85b271c1de79beafe16cb4.svg",
         "type": "sprite",
         "tags": [
@@ -15186,7 +15280,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-W",
-                    "baseLayerID": -1,
+                    "baseLayerID": 45,
                     "baseLayerMD5": "1a9ea7305a85b271c1de79beafe16cb4.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 45,
@@ -15206,6 +15300,7 @@
     },
     {
         "name": "Glow-X",
+        "baseLayerID": -1,
         "md5": "ec4e65b9ae475a676973128f4205df5f.svg",
         "type": "sprite",
         "tags": [
@@ -15232,7 +15327,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-X",
-                    "baseLayerID": -1,
+                    "baseLayerID": 47,
                     "baseLayerMD5": "ec4e65b9ae475a676973128f4205df5f.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 40,
@@ -15252,6 +15347,7 @@
     },
     {
         "name": "Glow-Y",
+        "baseLayerID": -1,
         "md5": "683cd093bb3b254733a15df6f843464c.svg",
         "type": "sprite",
         "tags": [
@@ -15278,7 +15374,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-Y",
-                    "baseLayerID": -1,
+                    "baseLayerID": 49,
                     "baseLayerMD5": "683cd093bb3b254733a15df6f843464c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 38,
@@ -15298,6 +15394,7 @@
     },
     {
         "name": "Glow-Z",
+        "baseLayerID": -1,
         "md5": "db89a4c9b123123542e0b7556ed3ff9f.svg",
         "type": "sprite",
         "tags": [
@@ -15324,7 +15421,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-Z",
-                    "baseLayerID": -1,
+                    "baseLayerID": 51,
                     "baseLayerMD5": "db89a4c9b123123542e0b7556ed3ff9f.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 30,
@@ -15343,1663 +15440,8 @@
         }
     },
     {
-        "name": "Pixel-0",
-        "md5": "cd1f984997b44de464bbf86fc073b280.svg",
-        "type": "sprite",
-        "tags": [
-            "numbers",
-            "digits"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Pixel-0",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "Pixel-0",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "cd1f984997b44de464bbf86fc073b280.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 13,
-                    "rotationCenterY": 18
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 9,
-            "scratchY": 1,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Pixel-1",
-        "md5": "4ec3d6c4ef14112ed7c6ba6b9549da3b.svg",
-        "type": "sprite",
-        "tags": [
-            "numbers",
-            "digits"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Pixel-1",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "Pixel-1",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "4ec3d6c4ef14112ed7c6ba6b9549da3b.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 7,
-                    "rotationCenterY": 20
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 71,
-            "scratchY": 8,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Pixel-2",
-        "md5": "d0136e77a646a3ad719aaa7f8f95a7ff.svg",
-        "type": "sprite",
-        "tags": [
-            "numbers",
-            "digits"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Pixel-2",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "Pixel-2",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "d0136e77a646a3ad719aaa7f8f95a7ff.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 14,
-                    "rotationCenterY": 17
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 37,
-            "scratchY": -16,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Pixel-3",
-        "md5": "7c1700f0dcfb418662d29ba6faa114e7.svg",
-        "type": "sprite",
-        "tags": [
-            "numbers",
-            "digits"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Pixel-3",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "Pixel-3",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "7c1700f0dcfb418662d29ba6faa114e7.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 14,
-                    "rotationCenterY": 18
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": -4,
-            "scratchY": -44,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Pixel-4",
-        "md5": "6238b9b95fad7f7aa9cef9bde5bde474.svg",
-        "type": "sprite",
-        "tags": [
-            "numbers",
-            "digits"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Pixel-4",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "Pixel-4",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "6238b9b95fad7f7aa9cef9bde5bde474.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 14,
-                    "rotationCenterY": 19
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": -32,
-            "scratchY": 42,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Pixel-5",
-        "md5": "aef915acf1d49deed46692411e6c6039.svg",
-        "type": "sprite",
-        "tags": [
-            "numbers",
-            "digits"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Pixel-5",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "Pixel-5",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "aef915acf1d49deed46692411e6c6039.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 12,
-                    "rotationCenterY": 19
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": -26,
-            "scratchY": 43,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Pixel-6",
-        "md5": "e6ad1d1fe44a1c63c8f99c0bbb893a44.svg",
-        "type": "sprite",
-        "tags": [
-            "numbers",
-            "digits"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Pixel-6",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "Pixel-6",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "e6ad1d1fe44a1c63c8f99c0bbb893a44.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 14,
-                    "rotationCenterY": 17
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": -33,
-            "scratchY": -47,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Pixel-7",
-        "md5": "469b4fb6f6f8721e2c244ae9c71a7e66.svg",
-        "type": "sprite",
-        "tags": [
-            "numbers",
-            "digits"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Pixel-7",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "Pixel-7",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "469b4fb6f6f8721e2c244ae9c71a7e66.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 12,
-                    "rotationCenterY": 19
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": -7,
-            "scratchY": -29,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Pixel-8",
-        "md5": "5bfcf2c715b81ae380ae2983bb4c5bb2.svg",
-        "type": "sprite",
-        "tags": [
-            "numbers",
-            "digits"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Pixel-8",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "Pixel-8",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "5bfcf2c715b81ae380ae2983bb4c5bb2.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 14,
-                    "rotationCenterY": 19
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": -16,
-            "scratchY": 10,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Pixel-9",
-        "md5": "8014a66c758f1bc389194c988badb382.svg",
-        "type": "sprite",
-        "tags": [
-            "numbers",
-            "digits"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Pixel-9",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "Pixel-9",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "8014a66c758f1bc389194c988badb382.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 12,
-                    "rotationCenterY": 20
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 50,
-            "scratchY": 24,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Pixel-A",
-        "md5": "a54da6be420c9e8e7cb02e2a568f3442.svg",
-        "type": "sprite",
-        "tags": [
-            "alphabet",
-            "letters"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Pixel-A",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "Pixel-A",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "a54da6be420c9e8e7cb02e2a568f3442.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 14,
-                    "rotationCenterY": 19
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": -50,
-            "scratchY": -31,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Pixel-B",
-        "md5": "e47682020873e276f550421f0d854523.svg",
-        "type": "sprite",
-        "tags": [
-            "alphabet",
-            "letters"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Pixel-B",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "Pixel-B",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "e47682020873e276f550421f0d854523.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 14,
-                    "rotationCenterY": 18
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": -15,
-            "scratchY": -36,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Pixel-C",
-        "md5": "ee1958ffbae4e0fd836622ae183b55bd.svg",
-        "type": "sprite",
-        "tags": [
-            "alphabet",
-            "letters"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Pixel-C",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "Pixel-C",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "ee1958ffbae4e0fd836622ae183b55bd.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 14,
-                    "rotationCenterY": 20
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 69,
-            "scratchY": 31,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Pixel-D",
-        "md5": "d759df99f347d9b7d59e1f703e8e1438.svg",
-        "type": "sprite",
-        "tags": [
-            "alphabet",
-            "letters"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Pixel-D",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "Pixel-D",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "d759df99f347d9b7d59e1f703e8e1438.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 14,
-                    "rotationCenterY": 20
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 50,
-            "scratchY": 12,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Pixel-E",
-        "md5": "059a64a90014dc69c510b562cdf94df7.svg",
-        "type": "sprite",
-        "tags": [
-            "alphabet",
-            "letters"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Pixel-E",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "Pixel-E",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "059a64a90014dc69c510b562cdf94df7.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 11,
-                    "rotationCenterY": 19
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": -42,
-            "scratchY": 17,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Pixel-F",
-        "md5": "ebbc6dc0f7d1a89b159aac3f76fe52f4.svg",
-        "type": "sprite",
-        "tags": [
-            "alphabet",
-            "letters"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Pixel-F",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "Pixel-F",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "ebbc6dc0f7d1a89b159aac3f76fe52f4.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 10,
-                    "rotationCenterY": 20
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 32,
-            "scratchY": 10,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Pixel-G",
-        "md5": "203dfa253635f0e52059e835c51fa6f8.svg",
-        "type": "sprite",
-        "tags": [
-            "alphabet",
-            "letters"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Pixel-G",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "Pixel-G",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "203dfa253635f0e52059e835c51fa6f8.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 15,
-                    "rotationCenterY": 22
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 37,
-            "scratchY": -2,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Pixel-H",
-        "md5": "d9a94d9b9abc9e26eb91d22d197a1556.svg",
-        "type": "sprite",
-        "tags": [
-            "alphabet",
-            "letters"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Pixel-H",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "Pixel-H",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "d9a94d9b9abc9e26eb91d22d197a1556.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 15,
-                    "rotationCenterY": 20
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": -20,
-            "scratchY": 24,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Pixel-I",
-        "md5": "aeb851adc39da9582a379af1ed6d0efe.svg",
-        "type": "sprite",
-        "tags": [
-            "alphabet",
-            "letters"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Pixel-I",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "Pixel-I",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "aeb851adc39da9582a379af1ed6d0efe.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 9,
-                    "rotationCenterY": 21
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": -48,
-            "scratchY": -38,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Pixel-J",
-        "md5": "c18906f764b2889a8fc0b3c16db28bf0.svg",
-        "type": "sprite",
-        "tags": [
-            "alphabet",
-            "letters"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Pixel-J",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "Pixel-J",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "c18906f764b2889a8fc0b3c16db28bf0.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 14,
-                    "rotationCenterY": 20
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 13,
-            "scratchY": 46,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Pixel-K",
-        "md5": "4483633d2ae26987d0efe359aaf1357b.svg",
-        "type": "sprite",
-        "tags": [
-            "alphabet",
-            "letters"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Pixel-K",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "Pixel-K",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "4483633d2ae26987d0efe359aaf1357b.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 14,
-                    "rotationCenterY": 20
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 13,
-            "scratchY": -41,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Pixel-L",
-        "md5": "0625b64705d62748c6105e969859fe0d.svg",
-        "type": "sprite",
-        "tags": [
-            "alphabet",
-            "letters"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Pixel-L",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "Pixel-L",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "0625b64705d62748c6105e969859fe0d.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 11,
-                    "rotationCenterY": 18
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": -75,
-            "scratchY": -15,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Pixel-M",
-        "md5": "46ccf731f158b9dda75f4e71a5bcd282.svg",
-        "type": "sprite",
-        "tags": [
-            "alphabet",
-            "letters"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Pixel-M",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "Pixel-M",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "46ccf731f158b9dda75f4e71a5bcd282.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 19,
-                    "rotationCenterY": 16
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 75,
-            "scratchY": -18,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Pixel-N",
-        "md5": "f9d3b49b5962ff4070fae186b8b71e39.svg",
-        "type": "sprite",
-        "tags": [
-            "alphabet",
-            "letters"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Pixel-N",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "Pixel-N",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "f9d3b49b5962ff4070fae186b8b71e39.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 14,
-                    "rotationCenterY": 19
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": -66,
-            "scratchY": -37,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Pixel-O",
-        "md5": "668b21968078f3b7b1a9ccd74407fa1e.svg",
-        "type": "sprite",
-        "tags": [
-            "alphabet",
-            "letters"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Pixel-O",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "Pixel-O",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "668b21968078f3b7b1a9ccd74407fa1e.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 13,
-                    "rotationCenterY": 19
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 20,
-            "scratchY": -37,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Pixel-P",
-        "md5": "02011265d2597175c7496da667265f4a.svg",
-        "type": "sprite",
-        "tags": [
-            "alphabet",
-            "letters"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Pixel-P",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "Pixel-P",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "02011265d2597175c7496da667265f4a.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 13,
-                    "rotationCenterY": 19
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 67,
-            "scratchY": -22,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Pixel-Q",
-        "md5": "8c77c87dd0ed2613873cff0795ffc701.svg",
-        "type": "sprite",
-        "tags": [
-            "alphabet",
-            "letters"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Pixel-Q",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "Pixel-Q",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "8c77c87dd0ed2613873cff0795ffc701.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 13,
-                    "rotationCenterY": 21
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 87,
-            "scratchY": -42,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Pixel-R",
-        "md5": "c94daea3bd1e8cec36e1aa4e0b1d3f2b.svg",
-        "type": "sprite",
-        "tags": [
-            "alphabet",
-            "letters"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Pixel-R",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "Pixel-R",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "c94daea3bd1e8cec36e1aa4e0b1d3f2b.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 13,
-                    "rotationCenterY": 19
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 16,
-            "scratchY": -10,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Pixel-S",
-        "md5": "2fedb1b52f4a4500938a3a52085344e6.svg",
-        "type": "sprite",
-        "tags": [
-            "alphabet",
-            "letters"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Pixel-S",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "Pixel-S",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "2fedb1b52f4a4500938a3a52085344e6.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 13,
-                    "rotationCenterY": 20
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 55,
-            "scratchY": 16,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Pixel-T",
-        "md5": "3f481b967f82014c7cf6dd14d438c32d.svg",
-        "type": "sprite",
-        "tags": [
-            "alphabet",
-            "letters"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Pixel-T",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "Pixel-T",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "3f481b967f82014c7cf6dd14d438c32d.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 13,
-                    "rotationCenterY": 20
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": -74,
-            "scratchY": 10,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Pixel-U",
-        "md5": "a207644e4adb613f410f80a7e123db60.svg",
-        "type": "sprite",
-        "tags": [
-            "alphabet",
-            "letters"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Pixel-U",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "Pixel-U",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "a207644e4adb613f410f80a7e123db60.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 14,
-                    "rotationCenterY": 19
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": -46,
-            "scratchY": -12,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Pixel-V",
-        "md5": "1bb20febe562fa291bea94be1e2d44ba.svg",
-        "type": "sprite",
-        "tags": [
-            "alphabet",
-            "letters"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Pixel-V",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "Pixel-V",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "1bb20febe562fa291bea94be1e2d44ba.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 14,
-                    "rotationCenterY": 20
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": -86,
-            "scratchY": 27,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Pixel-W",
-        "md5": "34b628e8c84cc551a1fa740b85afb750.svg",
-        "type": "sprite",
-        "tags": [
-            "alphabet",
-            "letters"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Pixel-W",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "Pixel-W",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "34b628e8c84cc551a1fa740b85afb750.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 13,
-                    "rotationCenterY": 19
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": -44,
-            "scratchY": 19,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Pixel-X",
-        "md5": "4cc2d68ceb08176481e882ed39e4f5d5.svg",
-        "type": "sprite",
-        "tags": [
-            "alphabet",
-            "letters"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Pixel-X",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "Pixel-X",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "4cc2d68ceb08176481e882ed39e4f5d5.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 14,
-                    "rotationCenterY": 19
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 12,
-            "scratchY": 15,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Pixel-Y",
-        "md5": "e6c377982c023761796eaed1047169e6.svg",
-        "type": "sprite",
-        "tags": [
-            "alphabet",
-            "letters"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Pixel-Y",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "Pixel-Y",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "e6c377982c023761796eaed1047169e6.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 13,
-                    "rotationCenterY": 18
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 14,
-            "scratchY": -15,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Pixel-Z",
-        "md5": "ecadc3a562c9aa963717fcdf07ec96b4.svg",
-        "type": "sprite",
-        "tags": [
-            "alphabet",
-            "letters"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Pixel-Z",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "Pixel-Z",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "ecadc3a562c9aa963717fcdf07ec96b4.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 12,
-                    "rotationCenterY": 18
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 97,
-            "scratchY": 0,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
         "name": "Story-A",
+        "baseLayerID": -1,
         "md5": "5406b37278d819d4787a588b9c91f68e.svg",
         "type": "sprite",
         "tags": [
@@ -17026,7 +15468,7 @@
             "costumes": [
                 {
                     "costumeName": "story-A-1",
-                    "baseLayerID": -1,
+                    "baseLayerID": 61,
                     "baseLayerMD5": "5406b37278d819d4787a588b9c91f68e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 23,
@@ -17034,7 +15476,7 @@
                 },
                 {
                     "costumeName": "story-A-2",
-                    "baseLayerID": -1,
+                    "baseLayerID": 62,
                     "baseLayerMD5": "f277943adf8d79b41b9b568321a786ee.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 23,
@@ -17042,7 +15484,7 @@
                 },
                 {
                     "costumeName": "story-A-3",
-                    "baseLayerID": -1,
+                    "baseLayerID": 63,
                     "baseLayerMD5": "cc0cc7ae3240eab7d040e148cc663325.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -17062,6 +15504,7 @@
     },
     {
         "name": "Story-B",
+        "baseLayerID": -1,
         "md5": "2a8fac3c82d95f13203843a597b5757b.svg",
         "type": "sprite",
         "tags": [
@@ -17088,7 +15531,7 @@
             "costumes": [
                 {
                     "costumeName": "story-B-1",
-                    "baseLayerID": -1,
+                    "baseLayerID": 64,
                     "baseLayerMD5": "2a8fac3c82d95f13203843a597b5757b.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 20,
@@ -17096,7 +15539,7 @@
                 },
                 {
                     "costumeName": "story-B-2",
-                    "baseLayerID": -1,
+                    "baseLayerID": 65,
                     "baseLayerMD5": "07fa4ebc421d84743b6ced189dd2f9cf.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 19,
@@ -17104,7 +15547,7 @@
                 },
                 {
                     "costumeName": "story-B-3",
-                    "baseLayerID": -1,
+                    "baseLayerID": 66,
                     "baseLayerMD5": "6c9a9203155f93f24f31b30e3bd76b6d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 18,
@@ -17124,6 +15567,7 @@
     },
     {
         "name": "Story-C",
+        "baseLayerID": -1,
         "md5": "144845715016910e88e2a223ed4d3df1.svg",
         "type": "sprite",
         "tags": [
@@ -17150,7 +15594,7 @@
             "costumes": [
                 {
                     "costumeName": "story-C-1",
-                    "baseLayerID": -1,
+                    "baseLayerID": 67,
                     "baseLayerMD5": "144845715016910e88e2a223ed4d3df1.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -17158,7 +15602,7 @@
                 },
                 {
                     "costumeName": "story-C-2",
-                    "baseLayerID": -1,
+                    "baseLayerID": 68,
                     "baseLayerMD5": "1045c56c4be3d8d0650579864417fbc7.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -17166,7 +15610,7 @@
                 },
                 {
                     "costumeName": "story-C-3",
-                    "baseLayerID": -1,
+                    "baseLayerID": 69,
                     "baseLayerMD5": "c8fd35294d17a369fecb6d6e4725d04a.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 20,
@@ -17186,6 +15630,7 @@
     },
     {
         "name": "Story-D",
+        "baseLayerID": -1,
         "md5": "dfd362f2da975c20aa7849a8fa2fb4df.svg",
         "type": "sprite",
         "tags": [
@@ -17212,7 +15657,7 @@
             "costumes": [
                 {
                     "costumeName": "story-D-1",
-                    "baseLayerID": -1,
+                    "baseLayerID": 70,
                     "baseLayerMD5": "dfd362f2da975c20aa7849a8fa2fb4df.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 25,
@@ -17220,7 +15665,7 @@
                 },
                 {
                     "costumeName": "story-D-2",
-                    "baseLayerID": -1,
+                    "baseLayerID": 71,
                     "baseLayerMD5": "3e4cc4cff08bb42bc690eff66dffbbe9.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 25,
@@ -17228,7 +15673,7 @@
                 },
                 {
                     "costumeName": "story-D-3",
-                    "baseLayerID": -1,
+                    "baseLayerID": 72,
                     "baseLayerMD5": "bd7f984fe82d9d0fdcff0a87b3c0f9e0.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -17248,6 +15693,7 @@
     },
     {
         "name": "Story-E",
+        "baseLayerID": -1,
         "md5": "56473bacbdf6f0dbca1afb04e5aebaf7.svg",
         "type": "sprite",
         "tags": [
@@ -17274,7 +15720,7 @@
             "costumes": [
                 {
                     "costumeName": "story-E-1",
-                    "baseLayerID": -1,
+                    "baseLayerID": 73,
                     "baseLayerMD5": "56473bacbdf6f0dbca1afb04e5aebaf7.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 20,
@@ -17282,7 +15728,7 @@
                 },
                 {
                     "costumeName": "story-E-2",
-                    "baseLayerID": -1,
+                    "baseLayerID": 74,
                     "baseLayerMD5": "8bba14966fe35f0dccb66ef06a9843ca.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 20,
@@ -17290,7 +15736,7 @@
                 },
                 {
                     "costumeName": "story-E-3",
-                    "baseLayerID": -1,
+                    "baseLayerID": 75,
                     "baseLayerMD5": "e8cfc63375f6d6c2a580823489427f38.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 18,
@@ -17310,6 +15756,7 @@
     },
     {
         "name": "Story-F",
+        "baseLayerID": -1,
         "md5": "5844ff29fc8663c8613f12169d2f07ef.svg",
         "type": "sprite",
         "tags": [
@@ -17336,7 +15783,7 @@
             "costumes": [
                 {
                     "costumeName": "story-F-1",
-                    "baseLayerID": -1,
+                    "baseLayerID": 76,
                     "baseLayerMD5": "5844ff29fc8663c8613f12169d2f07ef.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 18,
@@ -17344,7 +15791,7 @@
                 },
                 {
                     "costumeName": "story-F-2",
-                    "baseLayerID": -1,
+                    "baseLayerID": 77,
                     "baseLayerMD5": "0dbe4a064abea1a9a3bc0d2732643e6b.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 18,
@@ -17352,7 +15799,7 @@
                 },
                 {
                     "costumeName": "story-F-3",
-                    "baseLayerID": -1,
+                    "baseLayerID": 78,
                     "baseLayerMD5": "3db373f4482e391e66d1b06335a96144.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 16,
@@ -17372,6 +15819,7 @@
     },
     {
         "name": "Story-G",
+        "baseLayerID": -1,
         "md5": "ee6454d15fbbe93e908a2ebbfad483a0.svg",
         "type": "sprite",
         "tags": [
@@ -17398,7 +15846,7 @@
             "costumes": [
                 {
                     "costumeName": "story-G-1",
-                    "baseLayerID": -1,
+                    "baseLayerID": 79,
                     "baseLayerMD5": "ee6454d15fbbe93e908a2ebbfad483a0.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 23,
@@ -17406,7 +15854,7 @@
                 },
                 {
                     "costumeName": "story-G-2",
-                    "baseLayerID": -1,
+                    "baseLayerID": 80,
                     "baseLayerMD5": "991023d303f79ce092f070392ffbd69f.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 23,
@@ -17414,7 +15862,7 @@
                 },
                 {
                     "costumeName": "story-G-3",
-                    "baseLayerID": -1,
+                    "baseLayerID": 81,
                     "baseLayerMD5": "38f22c0d8dbe541bde409ba1f241d4c1.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 21,
@@ -17434,6 +15882,7 @@
     },
     {
         "name": "Story-H",
+        "baseLayerID": -1,
         "md5": "2a0e1308d6cb806818af696a89b21863.svg",
         "type": "sprite",
         "tags": [
@@ -17460,7 +15909,7 @@
             "costumes": [
                 {
                     "costumeName": "story-H-1",
-                    "baseLayerID": -1,
+                    "baseLayerID": 82,
                     "baseLayerMD5": "2a0e1308d6cb806818af696a89b21863.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 24,
@@ -17468,7 +15917,7 @@
                 },
                 {
                     "costumeName": "story-H-2",
-                    "baseLayerID": -1,
+                    "baseLayerID": 83,
                     "baseLayerMD5": "ca33be5270308a695c9b88af73f590dc.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 24,
@@ -17476,7 +15925,7 @@
                 },
                 {
                     "costumeName": "story-H-3",
-                    "baseLayerID": -1,
+                    "baseLayerID": 84,
                     "baseLayerMD5": "668ba2b891f82ce78d8590f0287632b1.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -17496,6 +15945,7 @@
     },
     {
         "name": "Story-I",
+        "baseLayerID": -1,
         "md5": "705297637ea83af5b94b6fe2e34aeef4.svg",
         "type": "sprite",
         "tags": [
@@ -17522,7 +15972,7 @@
             "costumes": [
                 {
                     "costumeName": "story-I-1",
-                    "baseLayerID": -1,
+                    "baseLayerID": 85,
                     "baseLayerMD5": "705297637ea83af5b94b6fe2e34aeef4.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 9,
@@ -17530,7 +15980,7 @@
                 },
                 {
                     "costumeName": "story-I-2",
-                    "baseLayerID": -1,
+                    "baseLayerID": 86,
                     "baseLayerMD5": "7b3ae96764795727fa1cb0be68a9ca5e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 9,
@@ -17538,7 +15988,7 @@
                 },
                 {
                     "costumeName": "story-I-3",
-                    "baseLayerID": -1,
+                    "baseLayerID": 87,
                     "baseLayerMD5": "3475aa570304accb7e6dbd2516234135.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 7,
@@ -17558,6 +16008,7 @@
     },
     {
         "name": "Story-J",
+        "baseLayerID": -1,
         "md5": "ac2e7eaecb80c5501e5e56802d03af00.svg",
         "type": "sprite",
         "tags": [
@@ -17584,7 +16035,7 @@
             "costumes": [
                 {
                     "costumeName": "story-J-1",
-                    "baseLayerID": -1,
+                    "baseLayerID": 88,
                     "baseLayerMD5": "ac2e7eaecb80c5501e5e56802d03af00.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 14,
@@ -17592,7 +16043,7 @@
                 },
                 {
                     "costumeName": "story-J-2",
-                    "baseLayerID": -1,
+                    "baseLayerID": 89,
                     "baseLayerMD5": "0ab9a94fc2e32160efc113a8e5ffb984.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 14,
@@ -17600,7 +16051,7 @@
                 },
                 {
                     "costumeName": "story-J-3",
-                    "baseLayerID": -1,
+                    "baseLayerID": 90,
                     "baseLayerMD5": "c9356a022cfbc25be6c484e9781e4637.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 12,
@@ -17620,6 +16071,7 @@
     },
     {
         "name": "Story-K",
+        "baseLayerID": -1,
         "md5": "62dcc92dc3c6cb0271244190320c4f71.svg",
         "type": "sprite",
         "tags": [
@@ -17646,7 +16098,7 @@
             "costumes": [
                 {
                     "costumeName": "story-K-1",
-                    "baseLayerID": -1,
+                    "baseLayerID": 91,
                     "baseLayerMD5": "62dcc92dc3c6cb0271244190320c4f71.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 24,
@@ -17654,7 +16106,7 @@
                 },
                 {
                     "costumeName": "story-K-2",
-                    "baseLayerID": -1,
+                    "baseLayerID": 92,
                     "baseLayerMD5": "ef02339e8a0382367f0b5a414915b885.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 24,
@@ -17662,7 +16114,7 @@
                 },
                 {
                     "costumeName": "story-K-3",
-                    "baseLayerID": -1,
+                    "baseLayerID": 93,
                     "baseLayerMD5": "07977708617d12381b22d1ee0f4926a3.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 21,
@@ -17682,6 +16134,7 @@
     },
     {
         "name": "Story-L",
+        "baseLayerID": -1,
         "md5": "7ce306e9c9c0dd0a24279606301f1d05.svg",
         "type": "sprite",
         "tags": [
@@ -17708,7 +16161,7 @@
             "costumes": [
                 {
                     "costumeName": "story-L-1",
-                    "baseLayerID": -1,
+                    "baseLayerID": 94,
                     "baseLayerMD5": "7ce306e9c9c0dd0a24279606301f1d05.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 19,
@@ -17716,7 +16169,7 @@
                 },
                 {
                     "costumeName": "story-L-2",
-                    "baseLayerID": -1,
+                    "baseLayerID": 95,
                     "baseLayerMD5": "067c21a9b2f91ed33e07131ce5a59210.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 19,
@@ -17724,7 +16177,7 @@
                 },
                 {
                     "costumeName": "story-L-3",
-                    "baseLayerID": -1,
+                    "baseLayerID": 96,
                     "baseLayerMD5": "488d66f17c0089a7796d44cfc70792e8.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 17,
@@ -17744,6 +16197,7 @@
     },
     {
         "name": "Story-M",
+        "baseLayerID": -1,
         "md5": "b27f166f9ab4a3fb93a50a77c58c3df3.svg",
         "type": "sprite",
         "tags": [
@@ -17770,7 +16224,7 @@
             "costumes": [
                 {
                     "costumeName": "story-M-1",
-                    "baseLayerID": -1,
+                    "baseLayerID": 97,
                     "baseLayerMD5": "b27f166f9ab4a3fb93a50a77c58c3df3.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 30,
@@ -17778,7 +16232,7 @@
                 },
                 {
                     "costumeName": "story-M-2",
-                    "baseLayerID": -1,
+                    "baseLayerID": 98,
                     "baseLayerMD5": "55f00a23d0f5cc57be9533f126a7ac8c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 30,
@@ -17786,7 +16240,7 @@
                 },
                 {
                     "costumeName": "story-M-3",
-                    "baseLayerID": -1,
+                    "baseLayerID": 99,
                     "baseLayerMD5": "613df2bd97784a239ab992f7a95458a0.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 27,
@@ -17806,6 +16260,7 @@
     },
     {
         "name": "Story-N",
+        "baseLayerID": -1,
         "md5": "293589fd5bbc358a20c165ab49c19833.svg",
         "type": "sprite",
         "tags": [
@@ -17832,7 +16287,7 @@
             "costumes": [
                 {
                     "costumeName": "story-N-1",
-                    "baseLayerID": -1,
+                    "baseLayerID": 100,
                     "baseLayerMD5": "293589fd5bbc358a20c165ab49c19833.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 26,
@@ -17840,7 +16295,7 @@
                 },
                 {
                     "costumeName": "story-N-2",
-                    "baseLayerID": -1,
+                    "baseLayerID": 101,
                     "baseLayerMD5": "5e07ee61cb20bc575720774584dfec53.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 26,
@@ -17848,7 +16303,7 @@
                 },
                 {
                     "costumeName": "story-N-3",
-                    "baseLayerID": -1,
+                    "baseLayerID": 102,
                     "baseLayerMD5": "435697335345f946d943c1d89fdb459a.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 24,
@@ -17868,6 +16323,7 @@
     },
     {
         "name": "Story-O",
+        "baseLayerID": -1,
         "md5": "088beed7ce0dff554da06f54d0558bc0.svg",
         "type": "sprite",
         "tags": [
@@ -17894,7 +16350,7 @@
             "costumes": [
                 {
                     "costumeName": "story-O-1",
-                    "baseLayerID": -1,
+                    "baseLayerID": 103,
                     "baseLayerMD5": "088beed7ce0dff554da06f54d0558bc0.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 25,
@@ -17902,7 +16358,7 @@
                 },
                 {
                     "costumeName": "story-O-2",
-                    "baseLayerID": -1,
+                    "baseLayerID": 104,
                     "baseLayerMD5": "e8fa671bb1ca53c044bfb27225321c25.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 24,
@@ -17910,7 +16366,7 @@
                 },
                 {
                     "costumeName": "story-O-3",
-                    "baseLayerID": -1,
+                    "baseLayerID": 105,
                     "baseLayerMD5": "a132bf3d4084ef8ca9e0797f64c0f082.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -17930,6 +16386,7 @@
     },
     {
         "name": "Story-P",
+        "baseLayerID": -1,
         "md5": "ad4a101b83f28ced16849be3e393caa9.svg",
         "type": "sprite",
         "tags": [
@@ -17956,7 +16413,7 @@
             "costumes": [
                 {
                     "costumeName": "story-P-1",
-                    "baseLayerID": -1,
+                    "baseLayerID": 106,
                     "baseLayerMD5": "ad4a101b83f28ced16849be3e393caa9.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 20,
@@ -17964,7 +16421,7 @@
                 },
                 {
                     "costumeName": "story-P-2",
-                    "baseLayerID": -1,
+                    "baseLayerID": 107,
                     "baseLayerMD5": "781c42f9da36bbc0ee3775f18ac98124.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 20,
@@ -17972,7 +16429,7 @@
                 },
                 {
                     "costumeName": "story-P-3",
-                    "baseLayerID": -1,
+                    "baseLayerID": 108,
                     "baseLayerMD5": "bcaec7c778920d8d74c275c1aff634fe.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 17,
@@ -17992,6 +16449,7 @@
     },
     {
         "name": "Story-Q",
+        "baseLayerID": -1,
         "md5": "484e44f908e84d795c87cf994364e722.svg",
         "type": "sprite",
         "tags": [
@@ -18018,7 +16476,7 @@
             "costumes": [
                 {
                     "costumeName": "story-Q-1",
-                    "baseLayerID": -1,
+                    "baseLayerID": 109,
                     "baseLayerMD5": "484e44f908e84d795c87cf994364e722.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 25,
@@ -18026,7 +16484,7 @@
                 },
                 {
                     "costumeName": "story-Q-2",
-                    "baseLayerID": -1,
+                    "baseLayerID": 110,
                     "baseLayerMD5": "31f28be74dc7de42a5c4a38504d666ca.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 25,
@@ -18034,7 +16492,7 @@
                 },
                 {
                     "costumeName": "story-Q-3",
-                    "baseLayerID": -1,
+                    "baseLayerID": 111,
                     "baseLayerMD5": "aef19097378515308e934a79f147032e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -18054,6 +16512,7 @@
     },
     {
         "name": "Story-R",
+        "baseLayerID": -1,
         "md5": "55999cb6783ef8351d841294d75af942.svg",
         "type": "sprite",
         "tags": [
@@ -18080,7 +16539,7 @@
             "costumes": [
                 {
                     "costumeName": "story-R-1",
-                    "baseLayerID": -1,
+                    "baseLayerID": 112,
                     "baseLayerMD5": "55999cb6783ef8351d841294d75af942.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -18088,7 +16547,7 @@
                 },
                 {
                     "costumeName": "story-R-2",
-                    "baseLayerID": -1,
+                    "baseLayerID": 113,
                     "baseLayerMD5": "926f8ff770cb15b42b12f209fd02d98c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -18096,7 +16555,7 @@
                 },
                 {
                     "costumeName": "story-R-3",
-                    "baseLayerID": -1,
+                    "baseLayerID": 114,
                     "baseLayerMD5": "a66d8f0ba6d40c624873edc8df58c014.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 20,
@@ -18116,6 +16575,7 @@
     },
     {
         "name": "Story-S",
+        "baseLayerID": -1,
         "md5": "fca1555f335392f1c4ef620bf098c0de.svg",
         "type": "sprite",
         "tags": [
@@ -18142,7 +16602,7 @@
             "costumes": [
                 {
                     "costumeName": "story-S-1",
-                    "baseLayerID": -1,
+                    "baseLayerID": 115,
                     "baseLayerMD5": "fca1555f335392f1c4ef620bf098c0de.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 16,
@@ -18150,7 +16610,7 @@
                 },
                 {
                     "costumeName": "story-S-2",
-                    "baseLayerID": -1,
+                    "baseLayerID": 116,
                     "baseLayerMD5": "c529ed7b40f4a949539f8f454e3fe475.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 16,
@@ -18158,7 +16618,7 @@
                 },
                 {
                     "costumeName": "story-S-3",
-                    "baseLayerID": -1,
+                    "baseLayerID": 117,
                     "baseLayerMD5": "e96388c9197733bdadbad3ce014c0e59.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 14,
@@ -18178,6 +16638,7 @@
     },
     {
         "name": "Story-T",
+        "baseLayerID": -1,
         "md5": "d3b342c795a620b69639c02a419e8535.svg",
         "type": "sprite",
         "tags": [
@@ -18204,7 +16665,7 @@
             "costumes": [
                 {
                     "costumeName": "story-T-1",
-                    "baseLayerID": -1,
+                    "baseLayerID": 118,
                     "baseLayerMD5": "d3b342c795a620b69639c02a419e8535.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -18212,7 +16673,7 @@
                 },
                 {
                     "costumeName": "story-T-2",
-                    "baseLayerID": -1,
+                    "baseLayerID": 119,
                     "baseLayerMD5": "eeb0fd25c9273747ac38766d1959ba2b.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -18220,7 +16681,7 @@
                 },
                 {
                     "costumeName": "story-T-3",
-                    "baseLayerID": -1,
+                    "baseLayerID": 120,
                     "baseLayerMD5": "a9683d4946b08a76864a51bd21d811cb.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 20,
@@ -18240,6 +16701,7 @@
     },
     {
         "name": "Story-U",
+        "baseLayerID": -1,
         "md5": "fcf99b6e8aeb2d504e1e9b2194640916.svg",
         "type": "sprite",
         "tags": [
@@ -18266,7 +16728,7 @@
             "costumes": [
                 {
                     "costumeName": "story-U-1",
-                    "baseLayerID": -1,
+                    "baseLayerID": 121,
                     "baseLayerMD5": "fcf99b6e8aeb2d504e1e9b2194640916.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 24,
@@ -18274,7 +16736,7 @@
                 },
                 {
                     "costumeName": "story-U-2",
-                    "baseLayerID": -1,
+                    "baseLayerID": 122,
                     "baseLayerMD5": "f442802f17225d6506ac9718810f179e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 24,
@@ -18282,7 +16744,7 @@
                 },
                 {
                     "costumeName": "story-U-3",
-                    "baseLayerID": -1,
+                    "baseLayerID": 123,
                     "baseLayerMD5": "0779f03a6589c60352b1d4806a4a61c0.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 21,
@@ -18302,6 +16764,7 @@
     },
     {
         "name": "Story-V",
+        "baseLayerID": -1,
         "md5": "750b47f1de2143f76354239b27e1e5f0.svg",
         "type": "sprite",
         "tags": [
@@ -18328,7 +16791,7 @@
             "costumes": [
                 {
                     "costumeName": "story-V-1",
-                    "baseLayerID": -1,
+                    "baseLayerID": 124,
                     "baseLayerMD5": "750b47f1de2143f76354239b27e1e5f0.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 25,
@@ -18336,7 +16799,7 @@
                 },
                 {
                     "costumeName": "story-V-2",
-                    "baseLayerID": -1,
+                    "baseLayerID": 125,
                     "baseLayerMD5": "03de7add77e31799ca568a9c671012b4.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 25,
@@ -18344,7 +16807,7 @@
                 },
                 {
                     "costumeName": "story-V-3",
-                    "baseLayerID": -1,
+                    "baseLayerID": 126,
                     "baseLayerMD5": "29befe20b105b69471f5507d025ec3e0.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -18364,6 +16827,7 @@
     },
     {
         "name": "Story-W",
+        "baseLayerID": -1,
         "md5": "7d9d4c0da9bd1a3ddf253d1bea26f4e9.svg",
         "type": "sprite",
         "tags": [
@@ -18390,7 +16854,7 @@
             "costumes": [
                 {
                     "costumeName": "story-W-1",
-                    "baseLayerID": -1,
+                    "baseLayerID": 127,
                     "baseLayerMD5": "7d9d4c0da9bd1a3ddf253d1bea26f4e9.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 37,
@@ -18398,7 +16862,7 @@
                 },
                 {
                     "costumeName": "story-W-2",
-                    "baseLayerID": -1,
+                    "baseLayerID": 128,
                     "baseLayerMD5": "c0f48eb69cae4a611d3e7b7e06b0d1c1.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 37,
@@ -18406,7 +16870,7 @@
                 },
                 {
                     "costumeName": "story-W-3",
-                    "baseLayerID": -1,
+                    "baseLayerID": 129,
                     "baseLayerMD5": "d1c922c9e9d53d2f6f36ca637e85de6b.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 34,
@@ -18426,6 +16890,7 @@
     },
     {
         "name": "Story-X",
+        "baseLayerID": -1,
         "md5": "92c452555b3d5a4993f107810043ea03.svg",
         "type": "sprite",
         "tags": [
@@ -18452,7 +16917,7 @@
             "costumes": [
                 {
                     "costumeName": "story-X-1",
-                    "baseLayerID": -1,
+                    "baseLayerID": 130,
                     "baseLayerMD5": "92c452555b3d5a4993f107810043ea03.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -18460,7 +16925,7 @@
                 },
                 {
                     "costumeName": "story-X-2",
-                    "baseLayerID": -1,
+                    "baseLayerID": 131,
                     "baseLayerMD5": "f688425da41c2b7f80d4b8752de69bc9.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -18468,7 +16933,7 @@
                 },
                 {
                     "costumeName": "story-X-3",
-                    "baseLayerID": -1,
+                    "baseLayerID": 132,
                     "baseLayerMD5": "ec90479a0ce3c7706f1916daef0f3c67.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 20,
@@ -18488,6 +16953,7 @@
     },
     {
         "name": "Story-Y",
+        "baseLayerID": -1,
         "md5": "b3c252450d413fc75be0eafdbe4490dc.svg",
         "type": "sprite",
         "tags": [
@@ -18514,7 +16980,7 @@
             "costumes": [
                 {
                     "costumeName": "story-Y-1",
-                    "baseLayerID": -1,
+                    "baseLayerID": 133,
                     "baseLayerMD5": "b3c252450d413fc75be0eafdbe4490dc.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -18522,7 +16988,7 @@
                 },
                 {
                     "costumeName": "story-Y-2",
-                    "baseLayerID": -1,
+                    "baseLayerID": 134,
                     "baseLayerMD5": "1cfa161ae5d60ea163e4e0aa34d08f02.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -18530,7 +16996,7 @@
                 },
                 {
                     "costumeName": "story-Y-3",
-                    "baseLayerID": -1,
+                    "baseLayerID": 135,
                     "baseLayerMD5": "a1fc3c0fa304255364c0f98547e0e448.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 20,
@@ -18550,6 +17016,7 @@
     },
     {
         "name": "Story-Z",
+        "baseLayerID": -1,
         "md5": "86326c9180c485b557a075f4794939d7.svg",
         "type": "sprite",
         "tags": [
@@ -18576,7 +17043,7 @@
             "costumes": [
                 {
                     "costumeName": "story-Z-1",
-                    "baseLayerID": -1,
+                    "baseLayerID": 136,
                     "baseLayerMD5": "86326c9180c485b557a075f4794939d7.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 19,
@@ -18584,7 +17051,7 @@
                 },
                 {
                     "costumeName": "story-Z-2",
-                    "baseLayerID": -1,
+                    "baseLayerID": 137,
                     "baseLayerMD5": "e10b203e47bbb41edab78be59e628449.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 19,
@@ -18592,7 +17059,7 @@
                 },
                 {
                     "costumeName": "story-Z-3",
-                    "baseLayerID": -1,
+                    "baseLayerID": 138,
                     "baseLayerMD5": "0788df7b1d9cf02dfdebc021d4f30ce4.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 17,


### PR DESCRIPTION
### Proposed Changes

- Resolves issue where costume tags were being dropped on export from `libgen`
- Add some (for now) bitmap backdrops for testing
- Add second (legacy) unicorn
- Remove "pixel" font sprites / costumes
- Update to new "beta.txt" project list

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [x] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
