### PR TITLE
Add Amazon Polly extension to the extensions library

### DIFF
--- a/src/lib/libraries/extensions/index.js
+++ b/src/lib/libraries/extensions/index.js
@@ -31,6 +31,13 @@ export default [
         featured: true
     },
     {
+        name: 'Amazon Polly',
+        extensionId: 'speak',
+        iconURL: speechImage,
+        description: 'Make your projects talk.',
+        featured: true
+    },
+    {
         name: 'Video Motion',
         extensionId: 'videoSensing',
         iconURL: videoImage,


### PR DESCRIPTION
Adds the "Amazon Polly" (Text-to-Speech) extension to the library. Still lots of work to do on the extension itself, but this is far enough for testing / feedback.