### PR TITLE
Better project loading analytics and errors

### DIFF
--- a/src/containers/gui.jsx
+++ b/src/containers/gui.jsx
@@ -65,7 +65,10 @@ class GUI extends React.Component {
         this.props.vm.stopAll();
     }
     render () {
-        if (this.state.loadingError) throw new Error(`Failed to load project: ${this.state.errorMessage}`);
+        if (this.state.loadingError) {
+            throw new Error(
+                `Failed to load project from server [id=${window.location.hash}]: ${this.state.errorMessage}`);
+        }
         const {
             children,
             fetchingProject,

--- a/src/containers/project-loader.jsx
+++ b/src/containers/project-loader.jsx
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
 
+import analytics from '../lib/analytics';
+
 import {
     openLoadingProject,
     closeLoadingProject
@@ -45,6 +47,11 @@ class ProjectLoader extends React.Component {
         const thisFileInput = e.target;
         reader.onload = () => this.props.vm.loadProject(reader.result)
             .then(() => {
+                analytics.event({
+                    category: 'project',
+                    action: 'Import Project File',
+                    nonInteraction: true
+                });
                 this.props.closeLoadingState();
                 // Reset the file input after project is loaded
                 // This is necessary in case the user wants to reload a project

--- a/src/containers/project-loader.jsx
+++ b/src/containers/project-loader.jsx
@@ -76,7 +76,10 @@ class ProjectLoader extends React.Component {
         );
     }
     render () {
-        if (this.state.loadingError) throw new Error(`Failed to load project: ${this.state.errorMessage}`);
+        if (this.state.loadingError) {
+            throw new Error(
+                `Failed to load project from file: ${this.state.errorMessage}`);
+        }
         const {
             /* eslint-disable no-unused-vars */
             children,

--- a/src/lib/project-loader-hoc.jsx
+++ b/src/lib/project-loader-hoc.jsx
@@ -44,7 +44,7 @@ const ProjectLoaderHOC = function (WrappedComponent) {
                         analytics.event({
                             category: 'project',
                             action: 'Load Project',
-                            value: projectId,
+                            label: projectId,
                             nonInteraction: true
                         });
                     }


### PR DESCRIPTION
Fixes an issue where we can't see which projects are giving us errors, and which modes projects are being brought in by (file vs. server)

Making the project load analytics use `label` instead of `value` makes it possible to see which projects are getting loaded, making it easier to see those projects for users with errors.

Including the window.location.hash in the project loader error message also creates a more direct way to see where load errors are coming from.
