### PR TITLE
Npm preview channel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,19 +9,21 @@ env:
   global:
   - NODE_ENV=production
   - SMOKE_URL=https://llk.github.io/scratch-gui/$TRAVIS_PULL_REQUEST_BRANCH
+  - NPM_TAG=preview
 cache:
   directories:
   - node_modules
 install:
 - npm --production=false install
 - npm --production=false update
-before_deploy:
-- npm --no-git-tag-version version 0.1.0-prerelease.$(date +%Y%m%d%H%M%S)
-- git config --global user.email $(git log --pretty=format:"%ae" -n1)
-- git config --global user.name $(git log --pretty=format:"%an" -n1)
 script:
 - npm test
 - if [ "$TRAVIS_EVENT_TYPE" == "pull_request" ] && [ "$TRAVIS_BRANCH" == "master" ]; then  npm run test:smoke; fi
+before_deploy:
+- npm --no-git-tag-version version 0.1.0-prerelease.$(date +%Y%m%d%H%M%S)
+- if [ "$TRAVIS_BRANCH" == "develop" ]; then export NPM_TAG=latest; fi
+- git config --global user.email $(git log --pretty=format:"%ae" -n1)
+- git config --global user.name $(git log --pretty=format:"%an" -n1)
 deploy:
 - provider: script
   on:
@@ -39,9 +41,12 @@ deploy:
     branch:
     - master
     - develop
+    - smoke
+    - npm-preview-channel
   skip_cleanup: true
   email: $NPM_EMAIL
   api_key: $NPM_TOKEN
+  tag: $NPM_TAG
 - provider: s3
   on:
     branch:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
   global:
   - NODE_ENV=production
   - SMOKE_URL=https://llk.github.io/scratch-gui/$TRAVIS_PULL_REQUEST_BRANCH
-  - NPM_TAG=preview
+  - NPM_TAG=latest
 cache:
   directories:
   - node_modules
@@ -21,7 +21,7 @@ script:
 - if [ "$TRAVIS_EVENT_TYPE" == "pull_request" ] && [ "$TRAVIS_BRANCH" == "master" ]; then  npm run test:smoke; fi
 before_deploy:
 - npm --no-git-tag-version version 0.1.0-prerelease.$(date +%Y%m%d%H%M%S)
-- if [ "$TRAVIS_BRANCH" == "develop" ]; then export NPM_TAG=latest; fi
+- if [ "$TRAVIS_BRANCH" == "develop" ]; then export NPM_TAG=develop; fi
 - git config --global user.email $(git log --pretty=format:"%ae" -n1)
 - git config --global user.name $(git log --pretty=format:"%an" -n1)
 deploy:
@@ -42,7 +42,6 @@ deploy:
     - master
     - develop
     - smoke
-    - npm-preview-channel
   skip_cleanup: true
   email: $NPM_EMAIL
   api_key: $NPM_TOKEN


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_
Resolves #2262 

### Proposed Changes

_Describe what this Pull Request does_
Start publishing develop builds to a separate release channel from `latest` called `develop`. I also moved the `before_deploy` section in the .travis.yml to ...before the ...deploy section for readability (although this looks like I moved the script section).

### Reason for Changes

_Explain why these changes should be made_
This allows us to pin scratch-www to `scratch-gui@latest`, and ensure that it will be up to date with the most recent smoke-tested (or smoke-testable) build. If need be, we still have the ability to pin it to a specific develop version on the `scratch-gui@develop` channel.

### Test Coverage

_Please show how you have added tests to cover your changes_
I tested that pushing to the smoke branch still publishes to the latest channel. On the first commit, I also tested publishing to a `preview` channel separate from `latest`, so I am confident this will work correctly when it gets merged to develop.
