### PR TITLE
Fix sprite selector scroll bar

### DIFF
--- a/src/components/gui/gui.css
+++ b/src/components/gui/gui.css
@@ -176,6 +176,8 @@
     padding-left: $space;
     padding-right: $space;
 
+    min-height: 0; /* this makes it work in Firefox */
+    
     /*
         For making the sprite-selector a scrollable pane
         @todo: Not working in Safari

--- a/src/components/sprite-selector/sprite-selector.css
+++ b/src/components/sprite-selector/sprite-selector.css
@@ -47,7 +47,7 @@
               then back up, introduces white space in the outside the page container.
     */
     height: calc(100% - $sprite-info-height);
-    overflow-y: scroll;
+    overflow-y: auto;
 }
 
 .items-wrapper {


### PR DESCRIPTION
### Resolves

#2295 

### Proposed Changes

The scroll bar in the sprite selector area shows up if and only if it is needed.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
