### PR TITLE
Change CSS

### DIFF
--- a/src/components/library-item/library-item.css
+++ b/src/components/library-item/library-item.css
@@ -5,7 +5,7 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    justify-content: center;
+    justify-content: flex-start;
     flex-basis: 160px;
     max-width: 160px;
     height: 160px;

--- a/src/components/library/library.css
+++ b/src/components/library/library.css
@@ -5,6 +5,7 @@
     display: flex;
     justify-content: flex-start;
     align-content: flex-start;
+    align-items: flex-start;
     background: $ui-secondary;
     flex-grow: 1;
     flex-wrap: wrap;


### PR DESCRIPTION
### Resolves

#2266, #2267

### Proposed Changes

Change the following in the extension library:
* Each item's image is now flush with the top of the card.
* The library now functions correctly when zoomed out enough for all the items to fit on one row.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
