### PR TITLE
GH-1500: Fix Firefox-specific bug with add sprite, backdrop buttons

### DIFF
--- a/src/components/gui/gui.css
+++ b/src/components/gui/gui.css
@@ -171,6 +171,7 @@
     display: flex;
     flex-grow: 1;
     flex-basis: 0;
+    min-height: 0px;
 
     padding-top: $space;
     padding-left: $space;

--- a/src/components/gui/gui.css
+++ b/src/components/gui/gui.css
@@ -171,7 +171,7 @@
     display: flex;
     flex-grow: 1;
     flex-basis: 0;
-    min-height: 0px;
+    min-height: 0;
 
     padding-top: $space;
     padding-left: $space;


### PR DESCRIPTION
### Resolves
This PR fixes #1500. 

### Proposed Changes
This PR adds a `min-height` of 0 to the `target-wrapper` element.

### Reason for Changes
Firefox treats flex elements slightly differently than Chrome and Safari do, which means that the elements the add sprite and backdrop buttons were positioned against were not shrinking smaller than the minimum height required to contain all thumbnails. This change forces Firefox to allow those container elements to shrink to match the behavior of Chrome and Safari.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [x] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
