### PR TITLE
Change "browser is not supported" message

### DIFF
--- a/src/components/browser-modal/browser-modal.jsx
+++ b/src/components/browser-modal/browser-modal.jsx
@@ -31,7 +31,7 @@ const BrowserModal = ({intl, ...props}) => (
             <p>
                 { /* eslint-disable max-len */ }
                 <FormattedMessage
-                    defaultMessage="We're very sorry, but Scratch 3.0 does not support Internet Explorer, Vivaldi, Opera or Silk. We recommend trying a newer browser such as Google Chrome, Mozilla Firefox, or Microsoft Edge."
+                    defaultMessage="We're very sorry, but Scratch 3.0 does not support Internet Explorer, Vivaldi, Opera or Silk because of many crash reports with them. We recommend trying a newer browser such as Google Chrome, Mozilla Firefox, or Microsoft Edge."
                     description="Unsupported browser description"
                     id="gui.unsupportedBrowser.description"
                 />


### PR DESCRIPTION
### Resolves

#2308 

### Proposed Changes

Add a clause to the "browser is not supported" message like this:

We're very sorry, but Scratch 3.0 does not support Internet Explorer, Vivaldi, Opera or Silk **because of many crash reports with them**. We recommend trying a newer browser such as Google Chrome, Mozilla Firefox, or Microsoft Edge.

### Browser Coverage

A simple text change is obviously going to work in all the browsers.