### PR TITLE
use new SoundPlayer in SoundLibrary

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "redux-mock-store": "^1.2.3",
     "redux-throttle": "0.1.1",
     "rimraf": "^2.6.1",
-    "scratch-audio": "0.1.0-prerelease.1528394075",
+    "scratch-audio": "0.1.0-prerelease.1528996828",
     "scratch-blocks": "0.1.0-prerelease.1528907522",
     "scratch-l10n": "3.0.20180611175036",
     "scratch-paint": "0.2.0-prerelease.20180614161221",


### PR DESCRIPTION
Depends on llk/scratch-audio#88

### Resolves

- Stopping sounds in SoundLibrary fades them out avoiding potential audio clipping

### Proposed Changes

Use new `AudioEngine.decodeSoundPlayer` to decode sounds in SoundLibrary and have a promise resolving to a SoundPlayer instance returned. This SoundPlayer can control playback on its own and fades out when told to stop playback.

### Reason for Changes

`scratch-audio` is being rewritten to help resolve vm bugs like `deleting a clone stops sprite sounds`. SoundLibrary depends on a small part of `scratch-audio` so that is being updated to use the slightly different new API.

