### PR TITLE
Move context menus for monitors outside of the document flow.

### DIFF
--- a/src/components/monitor/monitor.jsx
+++ b/src/components/monitor/monitor.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import Draggable from 'react-draggable';
 import {FormattedMessage} from 'react-intl';
@@ -52,7 +53,11 @@ const MonitorComponent = props => (
                 })}
             </Box>
         </Draggable>
-        {props.mode === 'list' ? null : (
+        {props.mode === 'list' ? null : ReactDOM.createPortal((
+            // Use a portal to render the context menu outside the flow to avoid
+            // positioning conflicts between the monitors `transform: scale` and
+            // the context menus `position: fixed`. For more details, see
+            // http://meyerweb.com/eric/thoughts/2011/09/12/un-fixing-fixed-elements-with-css-transforms/
             <ContextMenu id={`monitor-${props.label}`}>
                 <MenuItem onClick={props.onSetModeToDefault}>
                     <FormattedMessage
@@ -78,7 +83,7 @@ const MonitorComponent = props => (
                     </MenuItem>
                 ) : null}
             </ContextMenu>
-        )}
+        ), document.body)}
     </ContextMenuTrigger>
 
 );

--- a/test/integration/blocks.test.js
+++ b/test/integration/blocks.test.js
@@ -56,8 +56,7 @@ describe('Working with the blocks', () => {
         await expect(logs).toEqual([]);
     });
 
-    // TODO: why is this test failing?
-    test.skip('Creating variables', async () => {
+    test('Creating variables', async () => {
         await loadUri(uri);
         await clickXpath('//button[@title="tryit"]');
         await clickText('Code');


### PR DESCRIPTION

### Resolves

_What Github issue does this resolve (please include link)?_
Fixes integration test which was failing trying to use the context menu
Fixes https://github.com/LLK/scratch-gui/issues/2329

### Proposed Changes

_Describe what this Pull Request does_

Use React.createPortal to put the `position: fixed` context menu at the end of the document, instead of within the `transform`ed viewport of the monitor container.

![image](https://user-images.githubusercontent.com/654102/41372611-d1f2d14a-6f1b-11e8-8a0c-b8bd1c8af80b.png)
![image](https://user-images.githubusercontent.com/654102/41372613-d33588e0-6f1b-11e8-9cd3-aaf6e6b0c737.png)


### Reason for Changes

_Explain why these changes should be made_

`react-contextmenu` does not work when used within a parent that has `transform`s https://github.com/vkbansal/react-contextmenu/issues/147. The "create variable" smoke test was doing exactly what it is supposed to do, it was failing because there was no context menu to change to "slider" type. I didn't catch that when testing manually because I forget the integration tests all use the small screen size. 

### Test Coverage

_Please show how you have added tests to cover your changes_

Re-enabled the working test! If this passes, it is working!
