### PR TITLE
Prune gh-pages to match our branch list after each build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,10 +36,8 @@ deploy:
     branch: master
   skip_cleanup: true
   script: npm run --silent deploy -- -x -a -r https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
-# - provider: script
-#   on:
-#     branch: greenkeeper/*
-#   script: ./clean_greenkeeper
+    all_branches: true
+  script: npm run prune -- https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
 - provider: npm
   on:
     branch:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,10 +36,10 @@ deploy:
     branch: master
   skip_cleanup: true
   script: npm run --silent deploy -- -x -a -r https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
-- provider: script
-  on:
-    branch: greenkeeper/*
-  script: ./clean_greenkeeper
+# - provider: script
+#   on:
+#     branch: greenkeeper/*
+#   script: ./clean_greenkeeper
 - provider: npm
   on:
     branch:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,10 @@ deploy:
     branch: master
   skip_cleanup: true
   script: npm run --silent deploy -- -x -a -r https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
+- provider: script
+  on:
+    branch: greenkeeper/*
+  script: ./clean_greenkeeper
 - provider: npm
   on:
     branch:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,14 +28,10 @@ deploy:
 - provider: script
   on:
     all_branches: true
-    condition: $TRAVIS_BRANCH != master
   skip_cleanup: true
   script: npm run deploy -- -x -e $TRAVIS_BRANCH -r https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
 - provider: script
   on:
-    branch: master
-  skip_cleanup: true
-  script: npm run --silent deploy -- -x -a -r https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
     all_branches: true
   script: npm run prune -- https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
 - provider: npm

--- a/clean_greenkeeper.sh
+++ b/clean_greenkeeper.sh
@@ -1,19 +1,51 @@
 #!/bin/bash
-
 # gh-pages cleanup script: Switches to gh-pages branch, and removes all
 # directories that aren't listed as remote branches
 
+function deslash () {
+    # Recursively build a string of a directory's parents. E.g.,
+    # deslashed "feature/test/branch" returns feature/test feature
+    deslashed=$(dirname $1)
+    if [[ $deslashed =~ .*/.* ]]
+    then
+        echo $deslashed $(deslash $deslashed)
+    else
+        echo $deslashed
+    fi
+}
 
+# Cache current branch
 current=$(git rev-parse --abbrev-ref HEAD)
-git fetch origin
-branches=$(git branch -r --list origin/*)
-git checkout -f gh-pages
 
-# Remove all directories that aren't remote branch names
-find * -type d \( -path ./.git $(printf " -o -path ./%s" "${branches[@]//origin\//}") \) -prune -o -type d -exec rm -rfvi "$0" {} \;
+# Checkout most recent gh-pages
+git fetch upstream
+git fetch origin
+git checkout -f gh-pages-empty-history
+git reset --hard origin/gh-pages-empty-history
+
+# Make an array of directories to not delete, from the list of remote branches
+branches=$(git branch -r --list upstream/*)
+
+# Strip off the remote name prefix
+branches="${branches[@]//upstream\//}"
+
+# Add parent directories of branches to the exclusion list (e.g. greenkeeper/)
+for branch in $branches; do
+    if [[ $branch =~ .*/.* ]]; then
+        branches+=" $(deslash $branch)"
+    fi
+done
+
+# Dedupe all the greenkeepers
+branches=$(echo "${branches[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' ')
+
+# Remove all directories that don't have corresponding branches
+find . -type d \( -path ./.git $(printf " -o -path ./%s" $branches) \) -prune -o -type d -mindepth 1 -exec rm -rfv {} \;
+
+# Push
 git add -u
 git commit -m "Remove stale directories"
-git push origin
+# git push origin gh-pages
 
 # Return to where we were
 git checkout -f $current

--- a/clean_greenkeeper.sh
+++ b/clean_greenkeeper.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# gh-pages cleanup script: Switches to gh-pages branch, and removes all
+# greenkeeper/* directories that aren't listed as remote branches
+
+# Join list of remote greenkeeper/* branches for GLOBIGNORE
+# Turns origin/greenkeeper/package-x.x.x, ..., into
+# greenkeeper/package-x.x.x:greenkeeper/package:...:
+function join { local IFS=":"; shift; echo "${*#origin/}"; }
+
+current=$(git rev-parse --abbrev-ref HEAD)
+git fetch origin
+greenkeeper=$(git branch -r --list origin/greenkeeper/*)
+git checkout -f gh-pages
+
+# Remove all greenkeeper/* directories that aren't remote branch names
+GLOBIGNORE=$(join $greenkeeper)
+rm -rf greenkeeper/*
+git add -u
+git commit -m "Remove old greenkeeper directories"
+git push origin
+
+# Return to where we were
+git checkout -f $current
+exit

--- a/clean_greenkeeper.sh
+++ b/clean_greenkeeper.sh
@@ -1,23 +1,18 @@
 #!/bin/bash
 
 # gh-pages cleanup script: Switches to gh-pages branch, and removes all
-# greenkeeper/* directories that aren't listed as remote branches
+# directories that aren't listed as remote branches
 
-# Join list of remote greenkeeper/* branches for GLOBIGNORE
-# Turns origin/greenkeeper/package-x.x.x, ..., into
-# greenkeeper/package-x.x.x:greenkeeper/package:...:
-function join { local IFS=":"; shift; echo "${*#origin/}"; }
 
 current=$(git rev-parse --abbrev-ref HEAD)
 git fetch origin
-greenkeeper=$(git branch -r --list origin/greenkeeper/*)
+branches=$(git branch -r --list origin/*)
 git checkout -f gh-pages
 
-# Remove all greenkeeper/* directories that aren't remote branch names
-GLOBIGNORE=$(join $greenkeeper)
-rm -rf greenkeeper/*
+# Remove all directories that aren't remote branch names
+find * -type d \( -path ./.git $(printf " -o -path ./%s" "${branches[@]//origin\//}") \) -prune -o -type d -exec rm -rfvi "$0" {} \;
 git add -u
-git commit -m "Remove old greenkeeper directories"
+git commit -m "Remove stale directories"
 git push origin
 
 # Return to where we were

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "npm run clean && webpack --progress --colors --bail",
     "clean": "rimraf ./build && mkdirp build && rimraf ./dist && mkdirp dist",
     "deploy": "touch build/.nojekyll && gh-pages -t -d build -m \"Build for $(git log --pretty=format:%H -n1)\"",
+    "prune": "./prune-gh-pages.sh",
     "i18n:src": "babel src > tmp.js && rimraf tmp.js && build-i18n-src ./translations/messages/ ./translations/",
     "start": "webpack-dev-server",
     "test": "npm run test:lint && npm run test:unit && npm run build && npm run test:integration",

--- a/prune-gh-pages.sh
+++ b/prune-gh-pages.sh
@@ -14,20 +14,26 @@ function deslash () {
     fi
 }
 
+repository=origin
+
+if [[ $1 != "" ]]
+then
+    repository=$1
+fi
+
 # Cache current branch
 current=$(git rev-parse --abbrev-ref HEAD)
 
 # Checkout most recent gh-pages
-git fetch upstream
 git fetch origin
-git checkout -f gh-pages-empty-history
-git reset --hard origin/gh-pages-empty-history
+git checkout -f gh-pages
+git reset --hard origin/gh-pages
 
 # Make an array of directories to not delete, from the list of remote branches
-branches=$(git branch -r --list upstream/*)
+branches=$(git branch -r --list origin/*)
 
 # Strip off the remote name prefix
-branches="${branches[@]//upstream\//}"
+branches="${branches[@]//origin\//}"
 
 # Add parent directories of branches to the exclusion list (e.g. greenkeeper/)
 for branch in $branches; do
@@ -45,7 +51,7 @@ find . -type d \( -path ./.git $(printf " -o -path ./%s" $branches) \) -prune -o
 # Push
 git add -u
 git commit -m "Remove stale directories"
-# git push origin gh-pages
+git push $repository gh-pages
 
 # Return to where we were
 git checkout -f $current

--- a/prune-gh-pages.sh
+++ b/prune-gh-pages.sh
@@ -43,7 +43,16 @@ done
 branches=$(echo "${branches[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' ')
 
 # Remove all directories that don't have corresponding branches
-find . -type d \( -path ./.git $(printf " -o -path ./%s" $branches) \) -prune -o -type d -mindepth 1 -exec rm -rfv {} \;
+# It would be nice if we could exclude everything in .gitignore, but we're
+# not on the branch with the .gitignore anymore... so we can't.
+find . -type d \
+    \( \
+        -path ./.git -o \
+        -path ./node_modules \
+        $(printf " -o -path ./%s" $branches) \
+    \) -prune \
+    -o -mindepth 1 -type d \
+    -exec rm -rfv {} \;
 
 # Push
 git add -u

--- a/prune-gh-pages.sh
+++ b/prune-gh-pages.sh
@@ -25,15 +25,12 @@ fi
 current=$(git rev-parse --abbrev-ref HEAD)
 
 # Checkout most recent gh-pages
-git fetch origin
-git checkout -f gh-pages
-git reset --hard origin/gh-pages
+git fetch --force $repository gh-pages:gh-pages
+git checkout gh-pages
+git clean -fdx
 
 # Make an array of directories to not delete, from the list of remote branches
-branches=$(git branch -r --list origin/*)
-
-# Strip off the remote name prefix
-branches="${branches[@]//origin\//}"
+branches=$(git ls-remote --refs --quiet $repository | awk '{print $2}' | sed -e 's/refs\/heads\///')
 
 # Add parent directories of branches to the exclusion list (e.g. greenkeeper/)
 for branch in $branches; do
@@ -42,7 +39,7 @@ for branch in $branches; do
     fi
 done
 
-# Dedupe all the greenkeepers
+# Dedupe all the greenkeepers (or other duplicate parent directories)
 branches=$(echo "${branches[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' ')
 
 # Remove all directories that don't have corresponding branches


### PR DESCRIPTION
### Proposed Changes

_Describe what this Pull Request does_
Trim the directories in gh-pages after each build to match our active branches. It also begins building all branches, including master into a subdirectory on gh-pages, and due to this change, redirects llk.github.io/scratch-gui/ to llk.github.io/scratch-gui/master/. We should land #2334 first so the gh-pages branch is already set up for this change.

### Reason for Changes

_Explain why these changes should be made_
Right now there is no cleaning up of directories in gh-pages when branches are deleted. This means that our gh-pages branch is continually growing, and occasionally gets to the point where GitHub fails to build the gh-pages site after successful pushes to the gh-pages branch.  This in turn causes confusion by developers when changes from a successful build aren't seen.

### Test Coverage

I've tested this out on my own fork. It does what I expect.