### PR TITLE
Only run before_deploy phase once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,14 @@ script:
 - npm test
 - if [ "$TRAVIS_EVENT_TYPE" == "pull_request" ] && [ "$TRAVIS_BRANCH" == "master" ]; then  npm run test:smoke; fi
 before_deploy:
-- npm --no-git-tag-version version 0.1.0-prerelease.$(date +%Y%m%d%H%M%S)
-- if [ "$TRAVIS_BRANCH" == "develop" ]; then export NPM_TAG=develop; fi
-- git config --global user.email $(git log --pretty=format:"%ae" -n1)
-- git config --global user.name $(git log --pretty=format:"%an" -n1)
+- >
+  if [ -z "$BEFORE_DEPLOY_RAN" ]; then
+    npm --no-git-tag-version version 0.1.0-prerelease.$(date +%Y%m%d%H%M%S)
+    if [ "$TRAVIS_BRANCH" == "develop" ]; then export NPM_TAG=develop; fi
+    git config --global user.email $(git log --pretty=format:"%ae" -n1)
+    git config --global user.name $(git log --pretty=format:"%an" -n1)
+    export BEFORE_DEPLOY_RAN=true
+  fi
 deploy:
 - provider: script
   on:


### PR DESCRIPTION
Our deploys are complaining about how many times we set `user.name` and are failing.
