### PR TITLE
Fix target area max-width problem

### DIFF
--- a/src/components/gui/gui.css
+++ b/src/components/gui/gui.css
@@ -163,9 +163,21 @@
     */
     display: flex;
     flex-direction: column;
+}
 
-    /* Fix the max width to max stage size (defined in layout_constants.js) + gutter size */
+.stage-and-target-wrapper.large {
+    /* Fix the max width to max large stage size (defined in layout_constants.js) + gutter size */
     max-width: calc(480px + calc($space * 2));
+}
+
+.stage-and-target-wrapper.large-constrained {
+    /* Fix the max width to max largeConstrained stage size (defined in layout_constants.js) + gutter size */
+    max-width: calc(408px + calc($space * 2));
+}
+
+.stage-and-target-wrapper.small {
+    /* Fix the max width to max small stage size (defined in layout_constants.js) + gutter size */
+    max-width: calc(240px + calc($space * 2));
 }
 
 .target-wrapper {

--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -240,7 +240,7 @@ const GUIComponent = props => {
                             ) : null}
                         </Box>
 
-                        <Box className={styles.stageAndTargetWrapper}>
+                        <Box className={classNames(styles.stageAndTargetWrapper, styles[stageSize])}>
                             <StageWrapper
                                 isRendererSupported={isRendererSupported}
                                 stageSize={stageSize}


### PR DESCRIPTION
I don't love this solution, but I remember not being able to figure out a way to not specify the max width because it is needed in order for the flowing to work. Without the max-width, the sprite tiles try to be in a row, pushing over everything else.

### Resolves

_What Github issue does this resolve (please include link)?_


Fixes the small-stage (and constrained stage) sizes when you have multiple sprites.

### Proposed Changes

_Describe what this Pull Request does_

Adjust the max-width depending on the stage-size

![image](https://user-images.githubusercontent.com/654102/41434947-5e895e4c-6feb-11e8-9596-f54c6b67d5be.png)
![image](https://user-images.githubusercontent.com/654102/41434951-60744834-6feb-11e8-8dcc-2819aba6b527.png)
![image](https://user-images.githubusercontent.com/654102/41434958-6259eee2-6feb-11e8-9084-7535a4d13fe4.png)

There seems to be an unrelated issue, I think introduced by me in the reordering PR, that makes the sprite tiles sometimes take up too much space, you can see the empty space in the small stage pic above. That is definitely unrelated to this though.

I'd love to figure out a non-hard-coded way to do this, btw, but I haven't been able to figure it out yet.