### PR TITLE
Add optional prop to listen for EXTENSION_ADDED events

### DIFF
--- a/src/containers/gui.jsx
+++ b/src/containers/gui.jsx
@@ -37,6 +37,8 @@ class GUI extends React.Component {
         if (this.props.vm.initialized) return;
         this.audioEngine = new AudioEngine();
         this.props.vm.attachAudioEngine(this.audioEngine);
+        // If given an extension callback function (for the project page),
+        // add listener for EXTENSION_ADDED events from the VM
         if (this.props.extensionCallback) {
             this.props.vm.addListener('EXTENSION_ADDED', this.props.extensionCallback);
         }

--- a/src/containers/gui.jsx
+++ b/src/containers/gui.jsx
@@ -37,7 +37,9 @@ class GUI extends React.Component {
         if (this.props.vm.initialized) return;
         this.audioEngine = new AudioEngine();
         this.props.vm.attachAudioEngine(this.audioEngine);
-        this.props.vm.addListener('EXTENSION_ADDED', this.props.extensionCallback);
+        if (this.props.extensionCallback) {
+            this.props.vm.addListener('EXTENSION_ADDED', this.props.extensionCallback);
+        }
         this.props.vm.loadProject(this.props.projectData)
             .then(() => {
                 this.setState({loading: false}, () => {

--- a/src/containers/gui.jsx
+++ b/src/containers/gui.jsx
@@ -37,6 +37,7 @@ class GUI extends React.Component {
         if (this.props.vm.initialized) return;
         this.audioEngine = new AudioEngine();
         this.props.vm.attachAudioEngine(this.audioEngine);
+        this.props.vm.addListener('EXTENSION_ADDED', this.props.extensionCallback);
         this.props.vm.loadProject(this.props.projectData)
             .then(() => {
                 this.setState({loading: false}, () => {
@@ -96,6 +97,7 @@ class GUI extends React.Component {
 
 GUI.propTypes = {
     ...GUIComponent.propTypes,
+    extensionCallback: PropTypes.func,
     fetchingProject: PropTypes.bool,
     importInfoVisible: PropTypes.bool,
     loadingStateVisible: PropTypes.bool,


### PR DESCRIPTION
### Proposed Changes
This PR adds an optional prop to the GUI component that allows a page using it to respond to EXTENSION_ADDED events from the VM. If this prop is provided, a listener for the EXTENSION_ADDED event is added to the VM. If it is not provided, no listener is added and the component behaves as it did before.

### Reason for Changes
The project page needs to know what extensions are loaded in a project to display a list of those extensions, and the cleanest way to do it (that I found) was to listen for EXTENSION_ADDED events from the VM. However, since scratch-www can't directly interact with the VM, there needed to be a way to pass a callback for this event to the GUI.