### PR TITLE
Fix sharing assets ordering

### DIFF
--- a/src/lib/sortable-hoc.jsx
+++ b/src/lib/sortable-hoc.jsx
@@ -33,8 +33,10 @@ const SortableHOC = function (WrappedComponent) {
                 }
                 this.containerBox = this.ref.getBoundingClientRect();
             } else if (!newProps.dragInfo.dragging && this.props.dragInfo.dragging) {
-                this.props.onDrop(Object.assign({},
-                    this.props.dragInfo, {newIndex: this.getMouseOverIndex()}));
+                const newIndex = this.getMouseOverIndex();
+                if (newIndex !== null) {
+                    this.props.onDrop(Object.assign({}, this.props.dragInfo, {newIndex}));
+                }
             }
         }
 


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/LLK/scratch-gui/issues/2401

### Proposed Changes

_Describe what this Pull Request does_

Make sure not to call onDrop unless the newIndex is an actual value. This makes sure that the sorting onDrop from the costume tab does not get called before the onDrop from the sprite selector, which was leading to the appearance that the wrong costume was being shared in #2401 

Tested by going through the same process as listed in #2401 
