### PR TITLE
Hide category scrollbar for blocks for webkit/edge browsers

### DIFF
--- a/src/components/blocks/blocks.css
+++ b/src/components/blocks/blocks.css
@@ -21,6 +21,18 @@
     border-bottom: 1px solid $ui-black-transparent;
     box-sizing: content-box;
     height: calc(100% - 3.25rem) !important;
+
+    /*
+        For now, the layout cannot support scrollbars in the category menu.
+        The line below works for Edge, the `::-webkit-scrollbar` line
+        below that is for webkit browsers. It isn't possible to do the
+        same for Firefox, so a different solution may be needed for them.
+    */
+    -ms-overflow-style: none;
+}
+
+.blocks :global(.blocklyToolboxDiv::-webkit-scrollbar) {
+    display: none;
 }
 
 .blocks :global(.blocklyFlyout) {


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Partial solution for https://github.com/LLK/scratch-gui/issues/2396

### Proposed Changes

_Describe what this Pull Request does_

Do not hide the scrollbar for blocks categories. Only works for chrome, safari and edge. Firefox will need a separate fix.

### Reason for Changes

_Explain why these changes should be made_

https://github.com/LLK/scratch-gui/issues/2396

### Test Coverage

_Please show how you have added tests to cover your changes_

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [x] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [x] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
