### PR TITLE
Various fixes & additions for library assets

### DIFF
--- a/src/lib/libraries/backdrops.json
+++ b/src/lib/libraries/backdrops.json
@@ -1,5 +1,37 @@
 [
     {
+        "name": "Baseball",
+        "md5": "5d3a62635eacfbbe264fbba043207afe.svg",
+        "type": "backdrop",
+        "tags": [
+            "baseball",
+            "sports",
+            "outdoors",
+            "alex eben meyer"
+        ],
+        "info": [
+            480,
+            360,
+            1
+        ]
+    },
+    {
+        "name": "Baseball 2",
+        "md5": "069f8901194ff75609689b4a0de10b4e.svg",
+        "type": "backdrop",
+        "tags": [
+            "baseball",
+            "sports",
+            "outdoors",
+            "alex eben meyer"
+        ],
+        "info": [
+            480,
+            360,
+            1
+        ]
+    },
+    {
         "name": "Basketball",
         "md5": "e494c4f44897d94e0541f7036a302449.svg",
         "type": "backdrop",

--- a/src/lib/libraries/backdrops.json
+++ b/src/lib/libraries/backdrops.json
@@ -595,5 +595,24 @@
             360,
             1
         ]
+    },
+    {
+        "name": "Woods",
+        "md5": "3f3005b76e278b66dbeb9a982d68c555.svg",
+        "type": "backdrop",
+        "tags": [
+            "fantasy",
+            "spooky",
+            "holloween",
+            "outdoors",
+            "haunted",
+            "forest",
+            "alex eben meyer"
+        ],
+        "info": [
+            480,
+            360,
+            1
+        ]
     }
 ]

--- a/src/lib/libraries/backdrops.json
+++ b/src/lib/libraries/backdrops.json
@@ -174,7 +174,7 @@
     },
     {
         "name": "Hearts1",
-        "md5": "4bfd6a761ff985e342acbf2e07f63526.svg",
+        "md5": "26d3418b2fbc1af2c5fea82e1c3df1db.svg",
         "type": "backdrop",
         "tags": [
             "patterns"
@@ -187,7 +187,7 @@
     },
     {
         "name": "Hearts2",
-        "md5": "b6602e32d55ed75eaea1b646f61b6c17.svg",
+        "md5": "83745a26bbe0801312dfb553b422bf69.svg",
         "type": "backdrop",
         "tags": [
             "patterns"
@@ -215,7 +215,7 @@
     },
     {
         "name": "Jurassic ",
-        "md5": "73fd0531a1aaca5dff2d1c67202ff5bd.svg",
+        "md5": "2d59bed41204445ae9dbcb963b8da14f.svg",
         "type": "backdrop",
         "tags": [
             "outdoors",
@@ -519,7 +519,7 @@
         ]
     },
     {
-        "name": "Theatre",
+        "name": "Theater",
         "md5": "c2b097bc5cdb6a14ef5485202bc5ee76.png",
         "type": "backdrop",
         "tags": [

--- a/src/lib/libraries/backdrops.json
+++ b/src/lib/libraries/backdrops.json
@@ -246,8 +246,8 @@
         ]
     },
     {
-        "name": "Jurassic ",
-        "md5": "2d59bed41204445ae9dbcb963b8da14f.svg",
+        "name": "Jurassic",
+        "md5": "ad5bd6c10d2afb79d298817ec24a47fd.svg",
         "type": "backdrop",
         "tags": [
             "outdoors",
@@ -603,7 +603,7 @@
         "tags": [
             "fantasy",
             "spooky",
-            "holloween",
+            "halloween",
             "outdoors",
             "haunted",
             "forest",

--- a/src/lib/libraries/costumes.json
+++ b/src/lib/libraries/costumes.json
@@ -432,17 +432,17 @@
     },
     {
         "name": "Baseball",
-        "md5": "ae05a2a1fc22ce5929b8a67f695bfc9c.svg",
+        "md5": "6e13ef53885d2cfca9a54cc5c3f6c20f.svg",
         "type": "costume",
         "tags": [
-            "baseball",
             "sports",
-            "ball",
-            "alex eben meyer"
+            "round",
+            "summer",
+            "things"
         ],
         "info": [
-            28,
-            28,
+            34,
+            31,
             1
         ]
     },
@@ -462,70 +462,74 @@
         ]
     },
     {
-        "name": "Bat1-a",
-        "md5": "7ad915f8e0884f497a24d5bb61ea8a4a.svg",
+        "name": "Bat-a",
+        "md5": "a68f7a0b2af7514c729bb083d04dbbde.svg",
         "type": "costume",
         "tags": [
+            "fantasy",
+            "spooky",
+            "holloween",
+            "bat",
             "animals",
-            "flying",
-            "holiday",
-            "nature",
-            "castle"
+            "alex eben meyer"
         ],
         "info": [
-            75,
-            75,
+            51,
+            47,
             1
         ]
     },
     {
-        "name": "Bat1-b",
-        "md5": "f127434672b872a902346ef3c1af45f2.svg",
+        "name": "Bat-b",
+        "md5": "4ea5bb61370e189d2eba763312680201.svg",
         "type": "costume",
         "tags": [
+            "fantasy",
+            "spooky",
+            "holloween",
+            "bat",
             "animals",
-            "flying",
-            "holiday",
-            "nature",
-            "castle"
+            "alex eben meyer"
         ],
         "info": [
-            75,
-            75,
+            51,
+            47,
             1
         ]
     },
     {
-        "name": "Bat2-a",
-        "md5": "647d4bd53163f94a7dabf623ccab7fd3.svg",
+        "name": "Bat-c",
+        "md5": "9ed4deead22db511202f38abadf508c4.svg",
         "type": "costume",
         "tags": [
+            "fantasy",
+            "spooky",
+            "holloween",
+            "bat",
             "animals",
-            "flying",
-            "holiday",
-            "nature",
-            "castle"
+            "alex eben meyer"
         ],
         "info": [
-            75,
-            75,
+            51,
+            47,
             1
         ]
     },
     {
-        "name": "Bat2-b",
-        "md5": "8aa1d20e4f7761becbe9bafa75290465.svg",
+        "name": "Bat-d",
+        "md5": "293a7b03badd2f3b49e50acfb9c242ec.svg",
         "type": "costume",
         "tags": [
+            "fantasy",
+            "spooky",
+            "holloween",
+            "bat",
             "animals",
-            "flying",
-            "holiday",
-            "nature",
-            "castle"
+            "alex eben meyer"
         ],
         "info": [
-            75,
-            75,
+            51,
+            47,
             1
         ]
     },
@@ -1510,17 +1514,20 @@
     },
     {
         "name": "Cat2",
-        "md5": "01ae57fd339529445cb890978ef8a054.svg",
+        "md5": "3696356a03a8d938318876a593572843.svg",
         "type": "costume",
         "tags": [
-            "kitty",
-            "kitten",
             "animals",
-            "mammal"
+            "cat",
+            "kitten",
+            "kitty",
+            "mammal",
+            "orange",
+            "scratch cat"
         ],
         "info": [
-            87,
-            39,
+            47,
+            55,
             1
         ]
     },
@@ -3243,6 +3250,78 @@
         ]
     },
     {
+        "name": "Frank-a",
+        "md5": "19a09a005d7199d2e681e53a761bfe11.svg",
+        "type": "costume",
+        "tags": [
+            "fantasy",
+            "spooky",
+            "holloween",
+            "frankenstein",
+            "monster",
+            "alex eben meyer"
+        ],
+        "info": [
+            154,
+            107,
+            1
+        ]
+    },
+    {
+        "name": "Frank-b",
+        "md5": "a03102442ee197a39083fba24e852792.svg",
+        "type": "costume",
+        "tags": [
+            "fantasy",
+            "spooky",
+            "holloween",
+            "frankenstein",
+            "monster",
+            "alex eben meyer"
+        ],
+        "info": [
+            154,
+            107,
+            1
+        ]
+    },
+    {
+        "name": "Frank-c",
+        "md5": "b456d8dc4b7895d61c90dbc909d8a4c6.svg",
+        "type": "costume",
+        "tags": [
+            "fantasy",
+            "spooky",
+            "holloween",
+            "frankenstein",
+            "monster",
+            "alex eben meyer"
+        ],
+        "info": [
+            154,
+            107,
+            1
+        ]
+    },
+    {
+        "name": "Frank-d",
+        "md5": "8743c01814fed4190a582ba1520e8f6a.svg",
+        "type": "costume",
+        "tags": [
+            "fantasy",
+            "spooky",
+            "holloween",
+            "frankenstein",
+            "monster",
+            "alex eben meyer"
+        ],
+        "info": [
+            154,
+            107,
+            1
+        ]
+    },
+    {
         "name": "Frog",
         "md5": "285483a688eed2ff8010c65112f99c41.svg",
         "type": "costume",
@@ -3275,50 +3354,74 @@
         ]
     },
     {
-        "name": "Ghost1 ",
-        "md5": "c88579c578f2d171de78612f2ff9c9d9.svg",
-        "type": "costume",
-        "tags": [
-            "fantasy",
-            "castle",
-            "spirit",
-            "spooky"
-        ],
-        "info": [
-            60,
-            63,
-            1
-        ]
-    },
-    {
-        "name": "Ghost2-a",
-        "md5": "607be245da950af1a4e4d79acfda46e3.svg",
+        "name": "Ghost-a",
+        "md5": "23c317a22dec95421f2532090cc8de48.svg",
         "type": "costume",
         "tags": [
             "fantasy",
             "spooky",
-            "spirit",
-            "castle"
+            "holloween",
+            "ghoul",
+            "monster",
+            "alex eben meyer"
         ],
         "info": [
-            75,
-            75,
+            98,
+            73,
             1
         ]
     },
     {
-        "name": "Ghost2-b",
-        "md5": "b9e2ebbe17c617ac182abd8bc1627693.svg",
+        "name": "Ghost-b",
+        "md5": "e86a742d091370950f3353e1e430cdb2.svg",
         "type": "costume",
         "tags": [
             "fantasy",
             "spooky",
-            "spirit",
-            "castle"
+            "holloween",
+            "ghoul",
+            "monster",
+            "alex eben meyer"
         ],
         "info": [
-            75,
-            75,
+            98,
+            73,
+            1
+        ]
+    },
+    {
+        "name": "Ghost-c",
+        "md5": "24a8b71b780bc665c3e6d37c11221137.svg",
+        "type": "costume",
+        "tags": [
+            "fantasy",
+            "spooky",
+            "holloween",
+            "ghoul",
+            "monster",
+            "alex eben meyer"
+        ],
+        "info": [
+            98,
+            73,
+            1
+        ]
+    },
+    {
+        "name": "Ghost-d",
+        "md5": "221b794cad3d045008299e3c8440170c.svg",
+        "type": "costume",
+        "tags": [
+            "fantasy",
+            "spooky",
+            "holloween",
+            "ghoul",
+            "monster",
+            "alex eben meyer"
+        ],
+        "info": [
+            98,
+            73,
             1
         ]
     },
@@ -6510,33 +6613,39 @@
     },
     {
         "name": "Shark-a",
-        "md5": "4ca6776e9c021e8b21c3346793c9361d.svg",
+        "md5": "7c0a907eae79462f69f8e2af8e7df828.svg",
         "type": "costume",
         "tags": [
             "animals",
-            "underwater",
-            "ipzy",
-            "fish"
+            "ocean",
+            "sea",
+            "fish",
+            "teeth",
+            "carnivore",
+            "chomp"
         ],
         "info": [
-            150,
-            60,
+            75,
+            75,
             1
         ]
     },
     {
         "name": "Shark-b",
-        "md5": "0bb623f0bbec53ee9667cee0b7ad6d47.svg",
+        "md5": "cff9ae87a93294693a0650b38a7a33d2.svg",
         "type": "costume",
         "tags": [
             "animals",
-            "underwater",
-            "ipzy",
-            "fish"
+            "ocean",
+            "sea",
+            "fish",
+            "teeth",
+            "carnivore",
+            "chomp"
         ],
         "info": [
-            150,
-            60,
+            75,
+            75,
             1
         ]
     },
@@ -6698,6 +6807,96 @@
         "info": [
             44,
             -21,
+            1
+        ]
+    },
+    {
+        "name": "Skeleton-a",
+        "md5": "b6ddeecf18e40b99bde7e466759d5a5b.svg",
+        "type": "costume",
+        "tags": [
+            "fantasy",
+            "spooky",
+            "holloween",
+            "bones",
+            "monster",
+            "alex eben meyer"
+        ],
+        "info": [
+            75,
+            90,
+            1
+        ]
+    },
+    {
+        "name": "Skeleton-b",
+        "md5": "ba3f455026f5d7778af229ddddf83206.svg",
+        "type": "costume",
+        "tags": [
+            "fantasy",
+            "spooky",
+            "holloween",
+            "bones",
+            "monster",
+            "alex eben meyer"
+        ],
+        "info": [
+            75,
+            90,
+            1
+        ]
+    },
+    {
+        "name": "Skeleton-c",
+        "md5": "af8fb44231f7891d52db5b4ad5c0f58b.svg",
+        "type": "costume",
+        "tags": [
+            "fantasy",
+            "spooky",
+            "holloween",
+            "bones",
+            "monster",
+            "alex eben meyer"
+        ],
+        "info": [
+            75,
+            90,
+            1
+        ]
+    },
+    {
+        "name": "Skeleton-d",
+        "md5": "355eb1591be72ea1117b6a4e153010b1.svg",
+        "type": "costume",
+        "tags": [
+            "fantasy",
+            "spooky",
+            "holloween",
+            "bones",
+            "monster",
+            "alex eben meyer"
+        ],
+        "info": [
+            75,
+            90,
+            1
+        ]
+    },
+    {
+        "name": "Skeleton-e",
+        "md5": "d3497858a3b5ad938e41a34bb8103c77.svg",
+        "type": "costume",
+        "tags": [
+            "fantasy",
+            "spooky",
+            "holloween",
+            "bones",
+            "monster",
+            "alex eben meyer"
+        ],
+        "info": [
+            75,
+            90,
             1
         ]
     },

--- a/src/lib/libraries/costumes.json
+++ b/src/lib/libraries/costumes.json
@@ -432,17 +432,17 @@
     },
     {
         "name": "Baseball",
-        "md5": "6e13ef53885d2cfca9a54cc5c3f6c20f.svg",
+        "md5": "ae05a2a1fc22ce5929b8a67f695bfc9c.svg",
         "type": "costume",
         "tags": [
+            "baseball",
             "sports",
-            "round",
-            "summer",
-            "things"
+            "ball",
+            "alex eben meyer"
         ],
         "info": [
-            34,
-            31,
+            28,
+            28,
             1
         ]
     },
@@ -526,6 +526,70 @@
         "info": [
             75,
             75,
+            1
+        ]
+    },
+    {
+        "name": "Batter-a",
+        "md5": "cc7510ea0a0e2f6eaf232f8ca73e3b53.svg",
+        "type": "costume",
+        "tags": [
+            "baseball",
+            "sports",
+            "people",
+            "alex eben meyer"
+        ],
+        "info": [
+            44,
+            71,
+            1
+        ]
+    },
+    {
+        "name": "Batter-b",
+        "md5": "7e7f9ce18fd84e0e95a96ad30fb58c8c.svg",
+        "type": "costume",
+        "tags": [
+            "baseball",
+            "sports",
+            "people",
+            "alex eben meyer"
+        ],
+        "info": [
+            14,
+            58,
+            1
+        ]
+    },
+    {
+        "name": "Batter-c",
+        "md5": "05cc730290919069b8d08447214c7293.svg",
+        "type": "costume",
+        "tags": [
+            "baseball",
+            "sports",
+            "people",
+            "alex eben meyer"
+        ],
+        "info": [
+            92,
+            57,
+            1
+        ]
+    },
+    {
+        "name": "Batter-d",
+        "md5": "24c32bf9bf066e36e49beb03ccd3db8f.svg",
+        "type": "costume",
+        "tags": [
+            "baseball",
+            "sports",
+            "people",
+            "alex eben meyer"
+        ],
+        "info": [
+            64,
+            95,
             1
         ]
     },
@@ -1457,6 +1521,70 @@
         "info": [
             87,
             39,
+            1
+        ]
+    },
+    {
+        "name": "Catcher-a",
+        "md5": "6700cf1d4d653283161d2bad20f74d39.svg",
+        "type": "costume",
+        "tags": [
+            "baseball",
+            "sports",
+            "people",
+            "alex eben meyer"
+        ],
+        "info": [
+            34,
+            33,
+            1
+        ]
+    },
+    {
+        "name": "Catcher-b",
+        "md5": "d59c293e6fb4e15aa6bcfca5b1d0f2a6.svg",
+        "type": "costume",
+        "tags": [
+            "baseball",
+            "sports",
+            "people",
+            "alex eben meyer"
+        ],
+        "info": [
+            34,
+            29,
+            1
+        ]
+    },
+    {
+        "name": "Catcher-c",
+        "md5": "55a2b54e5e414c9e2a17caf73ad06b87.svg",
+        "type": "costume",
+        "tags": [
+            "baseball",
+            "sports",
+            "people",
+            "alex eben meyer"
+        ],
+        "info": [
+            53,
+            69,
+            1
+        ]
+    },
+    {
+        "name": "Catcher-d",
+        "md5": "d8943c5c2700e49f26f77826b9a3c238.svg",
+        "type": "costume",
+        "tags": [
+            "baseball",
+            "sports",
+            "people",
+            "alex eben meyer"
+        ],
+        "info": [
+            79,
+            28,
             1
         ]
     },
@@ -5279,6 +5407,70 @@
         ]
     },
     {
+        "name": "Outfielder-a",
+        "md5": "fab7218666ba49eae992664acab53159.svg",
+        "type": "costume",
+        "tags": [
+            "baseball",
+            "sports",
+            "people",
+            "alex eben meyer"
+        ],
+        "info": [
+            38,
+            61,
+            1
+        ]
+    },
+    {
+        "name": "Outfielder-b",
+        "md5": "a86813067f26947adb68897b870b1b7e.svg",
+        "type": "costume",
+        "tags": [
+            "baseball",
+            "sports",
+            "people",
+            "alex eben meyer"
+        ],
+        "info": [
+            38,
+            57,
+            1
+        ]
+    },
+    {
+        "name": "Outfielder-c",
+        "md5": "f6f1d2b7c6b50cbdac8cdbb55c872114.svg",
+        "type": "costume",
+        "tags": [
+            "baseball",
+            "sports",
+            "people",
+            "alex eben meyer"
+        ],
+        "info": [
+            46,
+            80,
+            1
+        ]
+    },
+    {
+        "name": "Outfielder-d",
+        "md5": "c6fb3a8079bce9630ab9499926c16de9.svg",
+        "type": "costume",
+        "tags": [
+            "baseball",
+            "sports",
+            "people",
+            "alex eben meyer"
+        ],
+        "info": [
+            79,
+            96,
+            1
+        ]
+    },
+    {
         "name": "Owl-a",
         "md5": "a312273b198fcacf68976e3cc74fadb4.svg",
         "type": "costume",
@@ -5622,6 +5814,70 @@
         "info": [
             55,
             66,
+            1
+        ]
+    },
+    {
+        "name": "Pitcher-a",
+        "md5": "a8694f8f7867d95c62121e60cb8b4812.svg",
+        "type": "costume",
+        "tags": [
+            "baseball",
+            "sports",
+            "people",
+            "alex eben meyer"
+        ],
+        "info": [
+            42,
+            63,
+            1
+        ]
+    },
+    {
+        "name": "Pitcher-b",
+        "md5": "13f363056c706870ede82798e6a8bcf6.svg",
+        "type": "costume",
+        "tags": [
+            "baseball",
+            "sports",
+            "people",
+            "alex eben meyer"
+        ],
+        "info": [
+            70,
+            86,
+            1
+        ]
+    },
+    {
+        "name": "Pitcher-c",
+        "md5": "6e26bd644ecd8d1f1606261d1b8f6a75.svg",
+        "type": "costume",
+        "tags": [
+            "baseball",
+            "sports",
+            "people",
+            "alex eben meyer"
+        ],
+        "info": [
+            62,
+            87,
+            1
+        ]
+    },
+    {
+        "name": "Pitcher-d",
+        "md5": "120d823290171ad83b6b328a5ffaf60e.svg",
+        "type": "costume",
+        "tags": [
+            "baseball",
+            "sports",
+            "people",
+            "alex eben meyer"
+        ],
+        "info": [
+            82,
+            46,
             1
         ]
     },

--- a/src/lib/libraries/costumes.json
+++ b/src/lib/libraries/costumes.json
@@ -432,17 +432,17 @@
     },
     {
         "name": "Baseball",
-        "md5": "6e13ef53885d2cfca9a54cc5c3f6c20f.svg",
+        "md5": "ae05a2a1fc22ce5929b8a67f695bfc9c.svg",
         "type": "costume",
         "tags": [
+            "baseball",
             "sports",
-            "round",
-            "summer",
-            "things"
+            "ball",
+            "alex eben meyer"
         ],
         "info": [
-            34,
-            31,
+            28,
+            28,
             1
         ]
     },
@@ -468,7 +468,7 @@
         "tags": [
             "fantasy",
             "spooky",
-            "holloween",
+            "halloween",
             "bat",
             "animals",
             "alex eben meyer"
@@ -486,7 +486,7 @@
         "tags": [
             "fantasy",
             "spooky",
-            "holloween",
+            "halloween",
             "bat",
             "animals",
             "alex eben meyer"
@@ -504,7 +504,7 @@
         "tags": [
             "fantasy",
             "spooky",
-            "holloween",
+            "halloween",
             "bat",
             "animals",
             "alex eben meyer"
@@ -522,7 +522,7 @@
         "tags": [
             "fantasy",
             "spooky",
-            "holloween",
+            "halloween",
             "bat",
             "animals",
             "alex eben meyer"
@@ -1514,20 +1514,17 @@
     },
     {
         "name": "Cat2",
-        "md5": "3696356a03a8d938318876a593572843.svg",
+        "md5": "01ae57fd339529445cb890978ef8a054.svg",
         "type": "costume",
         "tags": [
-            "animals",
-            "cat",
-            "kitten",
             "kitty",
-            "mammal",
-            "orange",
-            "scratch cat"
+            "kitten",
+            "animals",
+            "mammal"
         ],
         "info": [
-            47,
-            55,
+            87,
+            39,
             1
         ]
     },
@@ -3256,7 +3253,7 @@
         "tags": [
             "fantasy",
             "spooky",
-            "holloween",
+            "halloween",
             "frankenstein",
             "monster",
             "alex eben meyer"
@@ -3274,7 +3271,7 @@
         "tags": [
             "fantasy",
             "spooky",
-            "holloween",
+            "halloween",
             "frankenstein",
             "monster",
             "alex eben meyer"
@@ -3292,7 +3289,7 @@
         "tags": [
             "fantasy",
             "spooky",
-            "holloween",
+            "halloween",
             "frankenstein",
             "monster",
             "alex eben meyer"
@@ -3310,7 +3307,7 @@
         "tags": [
             "fantasy",
             "spooky",
-            "holloween",
+            "halloween",
             "frankenstein",
             "monster",
             "alex eben meyer"
@@ -3360,7 +3357,7 @@
         "tags": [
             "fantasy",
             "spooky",
-            "holloween",
+            "halloween",
             "ghoul",
             "monster",
             "alex eben meyer"
@@ -3378,7 +3375,7 @@
         "tags": [
             "fantasy",
             "spooky",
-            "holloween",
+            "halloween",
             "ghoul",
             "monster",
             "alex eben meyer"
@@ -3396,7 +3393,7 @@
         "tags": [
             "fantasy",
             "spooky",
-            "holloween",
+            "halloween",
             "ghoul",
             "monster",
             "alex eben meyer"
@@ -3414,7 +3411,7 @@
         "tags": [
             "fantasy",
             "spooky",
-            "holloween",
+            "halloween",
             "ghoul",
             "monster",
             "alex eben meyer"
@@ -6613,6 +6610,38 @@
     },
     {
         "name": "Shark-a",
+        "md5": "4ca6776e9c021e8b21c3346793c9361d.svg",
+        "type": "costume",
+        "tags": [
+            "animals",
+            "underwater",
+            "ipzy",
+            "fish"
+        ],
+        "info": [
+            150,
+            60,
+            1
+        ]
+    },
+    {
+        "name": "Shark-b",
+        "md5": "0bb623f0bbec53ee9667cee0b7ad6d47.svg",
+        "type": "costume",
+        "tags": [
+            "animals",
+            "underwater",
+            "ipzy",
+            "fish"
+        ],
+        "info": [
+            150,
+            60,
+            1
+        ]
+    },
+    {
+        "name": "Shark2-a",
         "md5": "7c0a907eae79462f69f8e2af8e7df828.svg",
         "type": "costume",
         "tags": [
@@ -6631,7 +6660,7 @@
         ]
     },
     {
-        "name": "Shark-b",
+        "name": "Shark2-b",
         "md5": "cff9ae87a93294693a0650b38a7a33d2.svg",
         "type": "costume",
         "tags": [
@@ -6650,7 +6679,7 @@
         ]
     },
     {
-        "name": "Shark-c",
+        "name": "Shark2-c",
         "md5": "afeae3f998598424f7c50918507f6ce6.svg",
         "type": "costume",
         "tags": [
@@ -6817,7 +6846,7 @@
         "tags": [
             "fantasy",
             "spooky",
-            "holloween",
+            "halloween",
             "bones",
             "monster",
             "alex eben meyer"
@@ -6835,7 +6864,7 @@
         "tags": [
             "fantasy",
             "spooky",
-            "holloween",
+            "halloween",
             "bones",
             "monster",
             "alex eben meyer"
@@ -6853,7 +6882,7 @@
         "tags": [
             "fantasy",
             "spooky",
-            "holloween",
+            "halloween",
             "bones",
             "monster",
             "alex eben meyer"
@@ -6871,7 +6900,7 @@
         "tags": [
             "fantasy",
             "spooky",
-            "holloween",
+            "halloween",
             "bones",
             "monster",
             "alex eben meyer"
@@ -6889,7 +6918,7 @@
         "tags": [
             "fantasy",
             "spooky",
-            "holloween",
+            "halloween",
             "bones",
             "monster",
             "alex eben meyer"

--- a/src/lib/libraries/costumes.json
+++ b/src/lib/libraries/costumes.json
@@ -1446,20 +1446,17 @@
     },
     {
         "name": "Cat2",
-        "md5": "3696356a03a8d938318876a593572843.svg",
+        "md5": "01ae57fd339529445cb890978ef8a054.svg",
         "type": "costume",
         "tags": [
-            "animals",
-            "cat",
-            "kitten",
             "kitty",
-            "mammal",
-            "orange",
-            "scratch cat"
+            "kitten",
+            "animals",
+            "mammal"
         ],
         "info": [
-            47,
-            55,
+            87,
+            39,
             1
         ]
     },
@@ -6229,7 +6226,7 @@
     },
     {
         "name": "Scarf1",
-        "md5": "9db18d2a2b3c9859654fc1b4832e6076.svg",
+        "md5": "0c03668b4e26eba969ad803a4e810c78.svg",
         "type": "costume",
         "tags": [
             "fashion",
@@ -6237,7 +6234,7 @@
         ],
         "info": [
             54,
-            36,
+            23,
             1
         ]
     },
@@ -6439,7 +6436,8 @@
         "type": "costume",
         "tags": [
             "fashion",
-            "winter"
+            "winter",
+            "sports"
         ],
         "info": [
             44,
@@ -6625,15 +6623,15 @@
     },
     {
         "name": "Star",
-        "md5": "ab0914e53e360477275e58b83ec4d423.svg",
+        "md5": "e929c1274c379b6b6fed12e6dec63368.svg",
         "type": "costume",
         "tags": [
             "shapes",
             "space"
         ],
         "info": [
-            21,
-            19,
+            22,
+            23,
             1
         ]
     },

--- a/src/lib/libraries/sprites.json
+++ b/src/lib/libraries/sprites.json
@@ -539,13 +539,13 @@
     },
     {
         "name": "Baseball",
-        "md5": "6e13ef53885d2cfca9a54cc5c3f6c20f.svg",
+        "md5": "ae05a2a1fc22ce5929b8a67f695bfc9c.svg",
         "type": "sprite",
         "tags": [
+            "baseball",
             "sports",
-            "round",
-            "summer",
-            "things"
+            "ball",
+            "alex eben meyer"
         ],
         "info": [
             0,
@@ -568,15 +568,15 @@
                 {
                     "costumeName": "baseball",
                     "baseLayerID": -1,
-                    "baseLayerMD5": "6e13ef53885d2cfca9a54cc5c3f6c20f.svg",
+                    "baseLayerMD5": "ae05a2a1fc22ce5929b8a67f695bfc9c.svg",
                     "bitmapResolution": 1,
-                    "rotationCenterX": 34,
-                    "rotationCenterY": 31
+                    "rotationCenterX": 28,
+                    "rotationCenterY": 28
                 }
             ],
             "currentCostumeIndex": 0,
-            "scratchX": 49,
-            "scratchY": -23,
+            "scratchX": 173,
+            "scratchY": -89,
             "scale": 1,
             "direction": 90,
             "rotationStyle": "normal",
@@ -740,6 +740,78 @@
             "currentCostumeIndex": 0,
             "scratchX": -3,
             "scratchY": 38,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Batter",
+        "md5": "cc7510ea0a0e2f6eaf232f8ca73e3b53.svg",
+        "type": "sprite",
+        "tags": [
+            "baseball",
+            "sports",
+            "people",
+            "alex eben meyer"
+        ],
+        "info": [
+            0,
+            4,
+            1
+        ],
+        "json": {
+            "objName": "Batter",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "batter-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "cc7510ea0a0e2f6eaf232f8ca73e3b53.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 44,
+                    "rotationCenterY": 71
+                },
+                {
+                    "costumeName": "batter-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "7e7f9ce18fd84e0e95a96ad30fb58c8c.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 14,
+                    "rotationCenterY": 58
+                },
+                {
+                    "costumeName": "batter-c",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "05cc730290919069b8d08447214c7293.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 92,
+                    "rotationCenterY": 57
+                },
+                {
+                    "costumeName": "batter-d",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "24c32bf9bf066e36e49beb03ccd3db8f.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 64,
+                    "rotationCenterY": 95
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 68,
+            "scratchY": 75,
             "scale": 1,
             "direction": 90,
             "rotationStyle": "normal",
@@ -2271,6 +2343,78 @@
             "currentCostumeIndex": 0,
             "scratchX": -71,
             "scratchY": 1,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Catcher",
+        "md5": "6700cf1d4d653283161d2bad20f74d39.svg",
+        "type": "sprite",
+        "tags": [
+            "baseball",
+            "sports",
+            "people",
+            "alex eben meyer"
+        ],
+        "info": [
+            0,
+            4,
+            1
+        ],
+        "json": {
+            "objName": "Catcher",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "catcher-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "6700cf1d4d653283161d2bad20f74d39.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 34,
+                    "rotationCenterY": 33
+                },
+                {
+                    "costumeName": "catcher-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "d59c293e6fb4e15aa6bcfca5b1d0f2a6.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 34,
+                    "rotationCenterY": 29
+                },
+                {
+                    "costumeName": "catcher-c",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "55a2b54e5e414c9e2a17caf73ad06b87.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 53,
+                    "rotationCenterY": 69
+                },
+                {
+                    "costumeName": "catcher-d",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "d8943c5c2700e49f26f77826b9a3c238.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 79,
+                    "rotationCenterY": 28
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": -6,
+            "scratchY": 70,
             "scale": 1,
             "direction": 90,
             "rotationStyle": "normal",
@@ -8567,6 +8711,78 @@
         }
     },
     {
+        "name": "Outfielder",
+        "md5": "fab7218666ba49eae992664acab53159.svg",
+        "type": "sprite",
+        "tags": [
+            "baseball",
+            "sports",
+            "people",
+            "alex eben meyer"
+        ],
+        "info": [
+            0,
+            4,
+            1
+        ],
+        "json": {
+            "objName": "Outfielder",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "outfielder-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "fab7218666ba49eae992664acab53159.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 38,
+                    "rotationCenterY": 61
+                },
+                {
+                    "costumeName": "outfielder-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "a86813067f26947adb68897b870b1b7e.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 38,
+                    "rotationCenterY": 57
+                },
+                {
+                    "costumeName": "outfielder-c",
+                    "baseLayerID": 0,
+                    "baseLayerMD5": "f6f1d2b7c6b50cbdac8cdbb55c872114.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 46,
+                    "rotationCenterY": 80
+                },
+                {
+                    "costumeName": "outfielder-d",
+                    "baseLayerID": 1,
+                    "baseLayerMD5": "c6fb3a8079bce9630ab9499926c16de9.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 79,
+                    "rotationCenterY": 96
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": -173,
+            "scratchY": -28,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
         "name": "Owl",
         "md5": "a312273b198fcacf68976e3cc74fadb4.svg",
         "type": "sprite",
@@ -9047,6 +9263,78 @@
             "currentCostumeIndex": 0,
             "scratchX": 98,
             "scratchY": -32,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Pitcher",
+        "md5": "a8694f8f7867d95c62121e60cb8b4812.svg",
+        "type": "sprite",
+        "tags": [
+            "baseball",
+            "sports",
+            "people",
+            "alex eben meyer"
+        ],
+        "info": [
+            0,
+            4,
+            1
+        ],
+        "json": {
+            "objName": "Pitcher",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "pitcher-a",
+                    "baseLayerID": 2,
+                    "baseLayerMD5": "a8694f8f7867d95c62121e60cb8b4812.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 42,
+                    "rotationCenterY": 63
+                },
+                {
+                    "costumeName": "pitcher-b",
+                    "baseLayerID": 3,
+                    "baseLayerMD5": "13f363056c706870ede82798e6a8bcf6.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 70,
+                    "rotationCenterY": 86
+                },
+                {
+                    "costumeName": "pitcher-c",
+                    "baseLayerID": 4,
+                    "baseLayerMD5": "6e26bd644ecd8d1f1606261d1b8f6a75.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 62,
+                    "rotationCenterY": 87
+                },
+                {
+                    "costumeName": "pitcher-d",
+                    "baseLayerID": 5,
+                    "baseLayerMD5": "120d823290171ad83b6b328a5ffaf60e.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 82,
+                    "rotationCenterY": 46
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": -5,
+            "scratchY": -79,
             "scale": 1,
             "direction": 90,
             "rotationStyle": "normal",

--- a/src/lib/libraries/sprites.json
+++ b/src/lib/libraries/sprites.json
@@ -539,13 +539,13 @@
     },
     {
         "name": "Baseball",
-        "md5": "ae05a2a1fc22ce5929b8a67f695bfc9c.svg",
+        "md5": "6e13ef53885d2cfca9a54cc5c3f6c20f.svg",
         "type": "sprite",
         "tags": [
-            "baseball",
             "sports",
-            "ball",
-            "alex eben meyer"
+            "round",
+            "summer",
+            "things"
         ],
         "info": [
             0,
@@ -568,15 +568,15 @@
                 {
                     "costumeName": "baseball",
                     "baseLayerID": -1,
-                    "baseLayerMD5": "ae05a2a1fc22ce5929b8a67f695bfc9c.svg",
+                    "baseLayerMD5": "6e13ef53885d2cfca9a54cc5c3f6c20f.svg",
                     "bitmapResolution": 1,
-                    "rotationCenterX": 28,
-                    "rotationCenterY": 28
+                    "rotationCenterX": 34,
+                    "rotationCenterY": 31
                 }
             ],
             "currentCostumeIndex": 0,
-            "scratchX": 173,
-            "scratchY": -89,
+            "scratchX": 49,
+            "scratchY": -23,
             "scale": 1,
             "direction": 90,
             "rotationStyle": "normal",
@@ -633,24 +633,24 @@
         }
     },
     {
-        "name": "Bat1",
-        "md5": "7ad915f8e0884f497a24d5bb61ea8a4a.svg",
+        "name": "Bat",
+        "md5": "a68f7a0b2af7514c729bb083d04dbbde.svg",
         "type": "sprite",
         "tags": [
+            "fantasy",
+            "spooky",
+            "holloween",
+            "bat",
             "animals",
-            "flying",
-            "holiday",
-            "nature",
-            "castle",
-            "flappers"
+            "alex eben meyer"
         ],
         "info": [
             0,
-            2,
+            4,
             1
         ],
         "json": {
-            "objName": "Bat1",
+            "objName": "Bat",
             "sounds": [
                 {
                     "soundName": "pop",
@@ -663,83 +663,41 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "bat1-a",
+                    "costumeName": "bat-a",
                     "baseLayerID": -1,
-                    "baseLayerMD5": "7ad915f8e0884f497a24d5bb61ea8a4a.svg",
+                    "baseLayerMD5": "a68f7a0b2af7514c729bb083d04dbbde.svg",
                     "bitmapResolution": 1,
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
+                    "rotationCenterX": 51,
+                    "rotationCenterY": 47
                 },
                 {
-                    "costumeName": "bat1-b",
+                    "costumeName": "bat-b",
                     "baseLayerID": -1,
-                    "baseLayerMD5": "f127434672b872a902346ef3c1af45f2.svg",
+                    "baseLayerMD5": "4ea5bb61370e189d2eba763312680201.svg",
                     "bitmapResolution": 1,
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
+                    "rotationCenterX": 51,
+                    "rotationCenterY": 47
+                },
+                {
+                    "costumeName": "bat-c",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "9ed4deead22db511202f38abadf508c4.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 51,
+                    "rotationCenterY": 47
+                },
+                {
+                    "costumeName": "bat-d",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "293a7b03badd2f3b49e50acfb9c242ec.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 51,
+                    "rotationCenterY": 47
                 }
             ],
             "currentCostumeIndex": 0,
-            "scratchX": 40,
-            "scratchY": 2,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Bat2",
-        "md5": "647d4bd53163f94a7dabf623ccab7fd3.svg",
-        "type": "sprite",
-        "tags": [
-            "animals",
-            "flying",
-            "holiday",
-            "nature",
-            "castle",
-            "flappers"
-        ],
-        "info": [
-            0,
-            2,
-            1
-        ],
-        "json": {
-            "objName": "Bat2",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "bat2-a",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "647d4bd53163f94a7dabf623ccab7fd3.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                },
-                {
-                    "costumeName": "bat2-b",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "8aa1d20e4f7761becbe9bafa75290465.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": -3,
-            "scratchY": 38,
+            "scratchX": -39,
+            "scratchY": 121,
             "scale": 1,
             "direction": 90,
             "rotationStyle": "normal",
@@ -4800,6 +4758,80 @@
         }
     },
     {
+        "name": "Frank",
+        "md5": "19a09a005d7199d2e681e53a761bfe11.svg",
+        "type": "sprite",
+        "tags": [
+            "fantasy",
+            "spooky",
+            "holloween",
+            "frankenstein",
+            "monster",
+            "alex eben meyer"
+        ],
+        "info": [
+            0,
+            4,
+            1
+        ],
+        "json": {
+            "objName": "Frank",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "frank-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "19a09a005d7199d2e681e53a761bfe11.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 154,
+                    "rotationCenterY": 107
+                },
+                {
+                    "costumeName": "frank-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "a03102442ee197a39083fba24e852792.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 154,
+                    "rotationCenterY": 107
+                },
+                {
+                    "costumeName": "frank-c",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "b456d8dc4b7895d61c90dbc909d8a4c6.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 154,
+                    "rotationCenterY": 107
+                },
+                {
+                    "costumeName": "frank-d",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "8743c01814fed4190a582ba1520e8f6a.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 154,
+                    "rotationCenterY": 107
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": -110,
+            "scratchY": -24,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
         "name": "Frog",
         "md5": "285483a688eed2ff8010c65112f99c41.svg",
         "type": "sprite",
@@ -4896,70 +4928,24 @@
         }
     },
     {
-        "name": "Ghost1",
-        "md5": "c88579c578f2d171de78612f2ff9c9d9.svg",
-        "type": "sprite",
-        "tags": [
-            "fantasy",
-            "castle",
-            "spirit",
-            "spooky"
-        ],
-        "info": [
-            0,
-            1,
-            1
-        ],
-        "json": {
-            "objName": "Ghost1",
-            "sounds": [
-                {
-                    "soundName": "pop",
-                    "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
-                }
-            ],
-            "costumes": [
-                {
-                    "costumeName": "ghost1 ",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "c88579c578f2d171de78612f2ff9c9d9.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 60,
-                    "rotationCenterY": 63
-                }
-            ],
-            "currentCostumeIndex": 0,
-            "scratchX": 90,
-            "scratchY": 38,
-            "scale": 1,
-            "direction": 90,
-            "rotationStyle": "normal",
-            "isDraggable": false,
-            "visible": true,
-            "spriteInfo": {}
-        }
-    },
-    {
-        "name": "Ghost2",
-        "md5": "607be245da950af1a4e4d79acfda46e3.svg",
+        "name": "Ghost",
+        "md5": "23c317a22dec95421f2532090cc8de48.svg",
         "type": "sprite",
         "tags": [
             "fantasy",
             "spooky",
-            "spirit",
-            "castle"
+            "holloween",
+            "ghoul",
+            "monster",
+            "alex eben meyer"
         ],
         "info": [
             0,
-            2,
+            4,
             1
         ],
         "json": {
-            "objName": "Ghost2",
+            "objName": "Ghost",
             "sounds": [
                 {
                     "soundName": "pop",
@@ -4972,25 +4958,41 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "ghost2-a",
+                    "costumeName": "ghost-a",
                     "baseLayerID": -1,
-                    "baseLayerMD5": "607be245da950af1a4e4d79acfda46e3.svg",
+                    "baseLayerMD5": "23c317a22dec95421f2532090cc8de48.svg",
                     "bitmapResolution": 1,
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
+                    "rotationCenterX": 98,
+                    "rotationCenterY": 73
                 },
                 {
-                    "costumeName": "ghost2-b",
+                    "costumeName": "ghost-b",
                     "baseLayerID": -1,
-                    "baseLayerMD5": "b9e2ebbe17c617ac182abd8bc1627693.svg",
+                    "baseLayerMD5": "e86a742d091370950f3353e1e430cdb2.svg",
                     "bitmapResolution": 1,
-                    "rotationCenterX": 75,
-                    "rotationCenterY": 75
+                    "rotationCenterX": 98,
+                    "rotationCenterY": 73
+                },
+                {
+                    "costumeName": "ghost-c",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "24a8b71b780bc665c3e6d37c11221137.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 98,
+                    "rotationCenterY": 73
+                },
+                {
+                    "costumeName": "ghost-d",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "221b794cad3d045008299e3c8440170c.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 98,
+                    "rotationCenterY": 73
                 }
             ],
             "currentCostumeIndex": 0,
-            "scratchX": 39,
-            "scratchY": -22,
+            "scratchX": 42,
+            "scratchY": 27,
             "scale": 1,
             "direction": 90,
             "rotationStyle": "normal",
@@ -10317,17 +10319,20 @@
     },
     {
         "name": "Shark",
-        "md5": "4ca6776e9c021e8b21c3346793c9361d.svg",
+        "md5": "7c0a907eae79462f69f8e2af8e7df828.svg",
         "type": "sprite",
         "tags": [
             "animals",
-            "underwater",
-            "ipzy",
-            "fish"
+            "ocean",
+            "sea",
+            "fish",
+            "teeth",
+            "carnivore",
+            "chomp"
         ],
         "info": [
             0,
-            2,
+            3,
             1
         ],
         "json": {
@@ -10345,24 +10350,32 @@
             "costumes": [
                 {
                     "costumeName": "shark-a",
-                    "baseLayerID": 8,
-                    "baseLayerMD5": "4ca6776e9c021e8b21c3346793c9361d.svg",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "7c0a907eae79462f69f8e2af8e7df828.svg",
                     "bitmapResolution": 1,
-                    "rotationCenterX": 150,
-                    "rotationCenterY": 60
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
                 },
                 {
                     "costumeName": "shark-b",
-                    "baseLayerID": 9,
-                    "baseLayerMD5": "0bb623f0bbec53ee9667cee0b7ad6d47.svg",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "cff9ae87a93294693a0650b38a7a33d2.svg",
                     "bitmapResolution": 1,
-                    "rotationCenterX": 150,
-                    "rotationCenterY": 60
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 75
+                },
+                {
+                    "costumeName": "shark-c",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "afeae3f998598424f7c50918507f6ce6.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 77,
+                    "rotationCenterY": 37
                 }
             ],
             "currentCostumeIndex": 0,
-            "scratchX": -5,
-            "scratchY": 54,
+            "scratchX": 41,
+            "scratchY": -15,
             "scale": 1,
             "direction": 90,
             "rotationStyle": "normal",
@@ -10750,6 +10763,88 @@
             "currentCostumeIndex": 0,
             "scratchX": -21,
             "scratchY": 22,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Skeleton",
+        "md5": "b6ddeecf18e40b99bde7e466759d5a5b.svg",
+        "type": "sprite",
+        "tags": [
+            "fantasy",
+            "spooky",
+            "holloween",
+            "bones",
+            "monster",
+            "alex eben meyer"
+        ],
+        "info": [
+            0,
+            5,
+            1
+        ],
+        "json": {
+            "objName": "Skeleton",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "skeleton-a",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "b6ddeecf18e40b99bde7e466759d5a5b.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 90
+                },
+                {
+                    "costumeName": "skeleton-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "ba3f455026f5d7778af229ddddf83206.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 90
+                },
+                {
+                    "costumeName": "skeleton-c",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "af8fb44231f7891d52db5b4ad5c0f58b.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 90
+                },
+                {
+                    "costumeName": "skeleton-d",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "355eb1591be72ea1117b6a4e153010b1.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 90
+                },
+                {
+                    "costumeName": "skeleton-e",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "d3497858a3b5ad938e41a34bb8103c77.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 75,
+                    "rotationCenterY": 90
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 148,
+            "scratchY": -34,
             "scale": 1,
             "direction": 90,
             "rotationStyle": "normal",
@@ -12418,19 +12513,19 @@
     },
     {
         "name": "Witch",
-        "md5": "cbc54e15cd62f0c16369587377636099.svg",
+        "md5": "c991196a708294535a1dbdce7189c23c.svg",
         "type": "sprite",
         "tags": [
             "fantasy",
-            "people",
-            "ipzy",
-            "castle",
-            "emotions",
+            "broom",
+            "wart",
+            "flying",
+            "hat",
             "magic"
         ],
         "info": [
             0,
-            4,
+            1,
             1
         ],
         "json": {
@@ -12447,41 +12542,17 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "witch-a",
-                    "baseLayerID": 36,
-                    "baseLayerMD5": "cbc54e15cd62f0c16369587377636099.svg",
+                    "costumeName": "witch",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "c991196a708294535a1dbdce7189c23c.svg",
                     "bitmapResolution": 1,
-                    "rotationCenterX": 65,
-                    "rotationCenterY": 140
-                },
-                {
-                    "costumeName": "witch-b",
-                    "baseLayerID": 37,
-                    "baseLayerMD5": "64d2c4c51e6cb6008cd5e93f77e6f591.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 65,
-                    "rotationCenterY": 140
-                },
-                {
-                    "costumeName": "witch-c",
-                    "baseLayerID": 38,
-                    "baseLayerMD5": "00b768c3da5b4ee3efddf05d1eb88de2.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 65,
-                    "rotationCenterY": 140
-                },
-                {
-                    "costumeName": "witch-d",
-                    "baseLayerID": 39,
-                    "baseLayerMD5": "4fe4c0ee34a9028f2c6988b7294a61c1.svg",
-                    "bitmapResolution": 1,
-                    "rotationCenterX": 65,
-                    "rotationCenterY": 140
+                    "rotationCenterX": 74,
+                    "rotationCenterY": 59
                 }
             ],
             "currentCostumeIndex": 0,
-            "scratchX": -47,
-            "scratchY": 33,
+            "scratchX": -86,
+            "scratchY": -49,
             "scale": 1,
             "direction": 90,
             "rotationStyle": "normal",

--- a/src/lib/libraries/sprites.json
+++ b/src/lib/libraries/sprites.json
@@ -539,13 +539,13 @@
     },
     {
         "name": "Baseball",
-        "md5": "6e13ef53885d2cfca9a54cc5c3f6c20f.svg",
+        "md5": "ae05a2a1fc22ce5929b8a67f695bfc9c.svg",
         "type": "sprite",
         "tags": [
+            "baseball",
             "sports",
-            "round",
-            "summer",
-            "things"
+            "ball",
+            "alex eben meyer"
         ],
         "info": [
             0,
@@ -568,15 +568,15 @@
                 {
                     "costumeName": "baseball",
                     "baseLayerID": -1,
-                    "baseLayerMD5": "6e13ef53885d2cfca9a54cc5c3f6c20f.svg",
+                    "baseLayerMD5": "ae05a2a1fc22ce5929b8a67f695bfc9c.svg",
                     "bitmapResolution": 1,
-                    "rotationCenterX": 34,
-                    "rotationCenterY": 31
+                    "rotationCenterX": 28,
+                    "rotationCenterY": 28
                 }
             ],
             "currentCostumeIndex": 0,
-            "scratchX": 49,
-            "scratchY": -23,
+            "scratchX": 173,
+            "scratchY": -89,
             "scale": 1,
             "direction": 90,
             "rotationStyle": "normal",
@@ -639,7 +639,7 @@
         "tags": [
             "fantasy",
             "spooky",
-            "holloween",
+            "halloween",
             "bat",
             "animals",
             "alex eben meyer"
@@ -4764,7 +4764,7 @@
         "tags": [
             "fantasy",
             "spooky",
-            "holloween",
+            "halloween",
             "frankenstein",
             "monster",
             "alex eben meyer"
@@ -4934,7 +4934,7 @@
         "tags": [
             "fantasy",
             "spooky",
-            "holloween",
+            "halloween",
             "ghoul",
             "monster",
             "alex eben meyer"
@@ -10319,20 +10319,17 @@
     },
     {
         "name": "Shark",
-        "md5": "7c0a907eae79462f69f8e2af8e7df828.svg",
+        "md5": "4ca6776e9c021e8b21c3346793c9361d.svg",
         "type": "sprite",
         "tags": [
             "animals",
-            "ocean",
-            "sea",
-            "fish",
-            "teeth",
-            "carnivore",
-            "chomp"
+            "underwater",
+            "ipzy",
+            "fish"
         ],
         "info": [
             0,
-            3,
+            2,
             1
         ],
         "json": {
@@ -10350,6 +10347,65 @@
             "costumes": [
                 {
                     "costumeName": "shark-a",
+                    "baseLayerID": 8,
+                    "baseLayerMD5": "4ca6776e9c021e8b21c3346793c9361d.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 150,
+                    "rotationCenterY": 60
+                },
+                {
+                    "costumeName": "shark-b",
+                    "baseLayerID": 9,
+                    "baseLayerMD5": "0bb623f0bbec53ee9667cee0b7ad6d47.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 150,
+                    "rotationCenterY": 60
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": -5,
+            "scratchY": 54,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Shark 2",
+        "md5": "7c0a907eae79462f69f8e2af8e7df828.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "ocean",
+            "sea",
+            "fish",
+            "teeth",
+            "carnivore",
+            "chomp"
+        ],
+        "info": [
+            0,
+            3,
+            1
+        ],
+        "json": {
+            "objName": "Shark 2",
+            "sounds": [
+                {
+                    "soundName": "pop",
+                    "soundID": -1,
+                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
+                    "sampleCount": 258,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "shark2-a",
                     "baseLayerID": -1,
                     "baseLayerMD5": "7c0a907eae79462f69f8e2af8e7df828.svg",
                     "bitmapResolution": 1,
@@ -10357,7 +10413,7 @@
                     "rotationCenterY": 75
                 },
                 {
-                    "costumeName": "shark-b",
+                    "costumeName": "shark2-b",
                     "baseLayerID": -1,
                     "baseLayerMD5": "cff9ae87a93294693a0650b38a7a33d2.svg",
                     "bitmapResolution": 1,
@@ -10365,7 +10421,7 @@
                     "rotationCenterY": 75
                 },
                 {
-                    "costumeName": "shark-c",
+                    "costumeName": "shark2-c",
                     "baseLayerID": -1,
                     "baseLayerMD5": "afeae3f998598424f7c50918507f6ce6.svg",
                     "bitmapResolution": 1,
@@ -10778,7 +10834,7 @@
         "tags": [
             "fantasy",
             "spooky",
-            "holloween",
+            "halloween",
             "bones",
             "monster",
             "alex eben meyer"
@@ -12513,19 +12569,19 @@
     },
     {
         "name": "Witch",
-        "md5": "c991196a708294535a1dbdce7189c23c.svg",
+        "md5": "cbc54e15cd62f0c16369587377636099.svg",
         "type": "sprite",
         "tags": [
             "fantasy",
-            "broom",
-            "wart",
-            "flying",
-            "hat",
+            "people",
+            "ipzy",
+            "castle",
+            "emotions",
             "magic"
         ],
         "info": [
             0,
-            1,
+            4,
             1
         ],
         "json": {
@@ -12542,17 +12598,41 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "witch",
-                    "baseLayerID": -1,
-                    "baseLayerMD5": "c991196a708294535a1dbdce7189c23c.svg",
+                    "costumeName": "witch-a",
+                    "baseLayerID": 36,
+                    "baseLayerMD5": "cbc54e15cd62f0c16369587377636099.svg",
                     "bitmapResolution": 1,
-                    "rotationCenterX": 74,
-                    "rotationCenterY": 59
+                    "rotationCenterX": 65,
+                    "rotationCenterY": 140
+                },
+                {
+                    "costumeName": "witch-b",
+                    "baseLayerID": 37,
+                    "baseLayerMD5": "64d2c4c51e6cb6008cd5e93f77e6f591.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 65,
+                    "rotationCenterY": 140
+                },
+                {
+                    "costumeName": "witch-c",
+                    "baseLayerID": 38,
+                    "baseLayerMD5": "00b768c3da5b4ee3efddf05d1eb88de2.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 65,
+                    "rotationCenterY": 140
+                },
+                {
+                    "costumeName": "witch-d",
+                    "baseLayerID": 39,
+                    "baseLayerMD5": "4fe4c0ee34a9028f2c6988b7294a61c1.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 65,
+                    "rotationCenterY": 140
                 }
             ],
             "currentCostumeIndex": 0,
-            "scratchX": -86,
-            "scratchY": -49,
+            "scratchX": -47,
+            "scratchY": 33,
             "scale": 1,
             "direction": 90,
             "rotationStyle": "normal",

--- a/src/lib/libraries/sprites.json
+++ b/src/lib/libraries/sprites.json
@@ -1,7 +1,6 @@
 [
     {
         "name": "Abby",
-        "baseLayerID": -1,
         "md5": "afab2d2141e9811bd89e385e9628cb5f.svg",
         "type": "sprite",
         "tags": [
@@ -29,7 +28,7 @@
             "costumes": [
                 {
                     "costumeName": "abby-a",
-                    "baseLayerID": 17,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "afab2d2141e9811bd89e385e9628cb5f.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 31,
@@ -37,7 +36,7 @@
                 },
                 {
                     "costumeName": "abby-b",
-                    "baseLayerID": 18,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "1e0116c7c2e5e80c679d0b33f1f5cfb7.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 31,
@@ -45,7 +44,7 @@
                 },
                 {
                     "costumeName": "abby-c",
-                    "baseLayerID": 19,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "b6e23922f23b49ddc6f62f675e77417c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 32,
@@ -53,7 +52,7 @@
                 },
                 {
                     "costumeName": "abby-d",
-                    "baseLayerID": 20,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "2193cf08f74b8354f7c4fac37a06ea24.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 31,
@@ -73,7 +72,6 @@
     },
     {
         "name": "Apple",
-        "baseLayerID": -1,
         "md5": "831ccd4741a7a56d85f6698a21f4ca69.svg",
         "type": "sprite",
         "tags": [
@@ -102,7 +100,7 @@
             "costumes": [
                 {
                     "costumeName": "apple",
-                    "baseLayerID": 1,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "831ccd4741a7a56d85f6698a21f4ca69.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 31,
@@ -122,7 +120,6 @@
     },
     {
         "name": "Arrow1",
-        "baseLayerID": -1,
         "md5": "62f8794dd120e9b4ead4d098d50fc64b.svg",
         "type": "sprite",
         "tags": [
@@ -151,7 +148,7 @@
             "costumes": [
                 {
                     "costumeName": "arrow1-a",
-                    "baseLayerID": 3,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "62f8794dd120e9b4ead4d098d50fc64b.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 28,
@@ -159,7 +156,7 @@
                 },
                 {
                     "costumeName": "arrow1-b",
-                    "baseLayerID": 4,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "a157dc7e33d7c7a048af933de999e397.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 28,
@@ -167,7 +164,7 @@
                 },
                 {
                     "costumeName": "arrow1-c",
-                    "baseLayerID": 5,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "d3b389e91f7beb22b2b1a80af09990ee.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 23,
@@ -175,7 +172,7 @@
                 },
                 {
                     "costumeName": "arrow1-d",
-                    "baseLayerID": 6,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "412717ff731e9f19003a5840054057eb.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 23,
@@ -195,7 +192,6 @@
     },
     {
         "name": "Avery",
-        "baseLayerID": -1,
         "md5": "21393c9114c7d34b1df7ccd12c793672.svg",
         "type": "sprite",
         "tags": [
@@ -221,7 +217,7 @@
             "costumes": [
                 {
                     "costumeName": "avery-a",
-                    "baseLayerID": 117,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "21393c9114c7d34b1df7ccd12c793672.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 39,
@@ -229,7 +225,7 @@
                 },
                 {
                     "costumeName": "avery-b",
-                    "baseLayerID": 118,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "cc55f2f09599edc4ae0876e8b3d187d0.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 39,
@@ -249,7 +245,6 @@
     },
     {
         "name": "Avery Walking",
-        "baseLayerID": -1,
         "md5": "ed334e546806dfbf26d2591d7ddb12d0.svg",
         "type": "sprite",
         "tags": [
@@ -276,7 +271,7 @@
             "costumes": [
                 {
                     "costumeName": "avery walking-a",
-                    "baseLayerID": 113,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "ed334e546806dfbf26d2591d7ddb12d0.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 50,
@@ -284,7 +279,7 @@
                 },
                 {
                     "costumeName": "avery walking-b",
-                    "baseLayerID": 114,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "c295731e8666ad2e1575fb4b4f82988d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 50,
@@ -292,7 +287,7 @@
                 },
                 {
                     "costumeName": "avery walking-c",
-                    "baseLayerID": 115,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "597a834225c9949e419dff7db1bc2453.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 48,
@@ -300,7 +295,7 @@
                 },
                 {
                     "costumeName": "avery walking-d",
-                    "baseLayerID": 116,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "ce9622d11d24607eec7988196b38c3c6.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 50,
@@ -320,7 +315,6 @@
     },
     {
         "name": "Ball",
-        "baseLayerID": -1,
         "md5": "10117ddaefa98d819f2b1df93805622f.svg",
         "type": "sprite",
         "tags": [
@@ -355,7 +349,7 @@
             "costumes": [
                 {
                     "costumeName": "ball-a",
-                    "baseLayerID": 7,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "10117ddaefa98d819f2b1df93805622f.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -363,7 +357,7 @@
                 },
                 {
                     "costumeName": "ball-b",
-                    "baseLayerID": 8,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "6e6330cad7750ea7e9dc88402661deb8.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -371,7 +365,7 @@
                 },
                 {
                     "costumeName": "ball-c",
-                    "baseLayerID": 9,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "bb45ed5db278f15c17c012c34a6b160f.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -379,7 +373,7 @@
                 },
                 {
                     "costumeName": "ball-d",
-                    "baseLayerID": 10,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "5d494659deae5c0de06b5885f5524276.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -387,7 +381,7 @@
                 },
                 {
                     "costumeName": "ball-e",
-                    "baseLayerID": 11,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "e80c98bc62fd32e8df81642af11ffb1a.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -407,7 +401,6 @@
     },
     {
         "name": "Ballerina",
-        "baseLayerID": -1,
         "md5": "6051bb7008cf17c8853a6f81f04c8a0f.svg",
         "type": "sprite",
         "tags": [
@@ -434,7 +427,7 @@
             "costumes": [
                 {
                     "costumeName": "ballerina-a",
-                    "baseLayerID": 0,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "6051bb7008cf17c8853a6f81f04c8a0f.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -442,7 +435,7 @@
                 },
                 {
                     "costumeName": "ballerina-b",
-                    "baseLayerID": 1,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "8bc5e47fb1439e29e11e9e3f2e20c6de.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -450,7 +443,7 @@
                 },
                 {
                     "costumeName": "ballerina-c",
-                    "baseLayerID": 2,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "6d3a07761b294f705987b0af58f8e335.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -458,7 +451,7 @@
                 },
                 {
                     "costumeName": "ballerina-d",
-                    "baseLayerID": 3,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "c3164795edf39e436272f425b4f5e487.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -478,7 +471,6 @@
     },
     {
         "name": "Balloon1",
-        "baseLayerID": -1,
         "md5": "bc96a1fb5fe794377acd44807e421ce2.svg",
         "type": "sprite",
         "tags": [
@@ -511,7 +503,7 @@
             "costumes": [
                 {
                     "costumeName": "balloon1-a",
-                    "baseLayerID": 12,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "bc96a1fb5fe794377acd44807e421ce2.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 32,
@@ -519,7 +511,7 @@
                 },
                 {
                     "costumeName": "balloon1-b",
-                    "baseLayerID": 13,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "d7bb51d9c38af6314bd2b4058d2a592d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 31,
@@ -527,7 +519,7 @@
                 },
                 {
                     "costumeName": "balloon1-c",
-                    "baseLayerID": 14,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "247cef27b665d77d9efaca69327cae77.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 31,
@@ -547,7 +539,6 @@
     },
     {
         "name": "Baseball",
-        "baseLayerID": -1,
         "md5": "6e13ef53885d2cfca9a54cc5c3f6c20f.svg",
         "type": "sprite",
         "tags": [
@@ -576,7 +567,7 @@
             "costumes": [
                 {
                     "costumeName": "baseball",
-                    "baseLayerID": 2,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "6e13ef53885d2cfca9a54cc5c3f6c20f.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 34,
@@ -596,7 +587,6 @@
     },
     {
         "name": "Basketball",
-        "baseLayerID": -1,
         "md5": "b15c425f3eef68e7d095ee91321cb52a.svg",
         "type": "sprite",
         "tags": [
@@ -644,7 +634,6 @@
     },
     {
         "name": "Bat1",
-        "baseLayerID": -1,
         "md5": "7ad915f8e0884f497a24d5bb61ea8a4a.svg",
         "type": "sprite",
         "tags": [
@@ -675,7 +664,7 @@
             "costumes": [
                 {
                     "costumeName": "bat1-a",
-                    "baseLayerID": 15,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "7ad915f8e0884f497a24d5bb61ea8a4a.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -683,7 +672,7 @@
                 },
                 {
                     "costumeName": "bat1-b",
-                    "baseLayerID": 16,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "f127434672b872a902346ef3c1af45f2.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -703,7 +692,6 @@
     },
     {
         "name": "Bat2",
-        "baseLayerID": -1,
         "md5": "647d4bd53163f94a7dabf623ccab7fd3.svg",
         "type": "sprite",
         "tags": [
@@ -734,7 +722,7 @@
             "costumes": [
                 {
                     "costumeName": "bat2-a",
-                    "baseLayerID": 22,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "647d4bd53163f94a7dabf623ccab7fd3.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -742,7 +730,7 @@
                 },
                 {
                     "costumeName": "bat2-b",
-                    "baseLayerID": 23,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "8aa1d20e4f7761becbe9bafa75290465.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -762,7 +750,6 @@
     },
     {
         "name": "Beachball",
-        "baseLayerID": -1,
         "md5": "87d64cab74c64b31498cc85f07510ee4.svg",
         "type": "sprite",
         "tags": [
@@ -791,7 +778,7 @@
             "costumes": [
                 {
                     "costumeName": "beachball",
-                    "baseLayerID": 21,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "87d64cab74c64b31498cc85f07510ee4.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 34,
@@ -811,7 +798,6 @@
     },
     {
         "name": "Bear",
-        "baseLayerID": -1,
         "md5": "5a4148d7684fc95f38c58a1672062c9e.svg",
         "type": "sprite",
         "tags": [
@@ -867,7 +853,6 @@
     },
     {
         "name": "Bear-walking",
-        "baseLayerID": -1,
         "md5": "d15eddb1a0f0ff0fa867bc006b46685d.svg",
         "type": "sprite",
         "tags": [
@@ -971,7 +956,6 @@
     },
     {
         "name": "Bear1",
-        "baseLayerID": -1,
         "md5": "598722f70e86e6f9b23ef97680baaa9c.svg",
         "type": "sprite",
         "tags": [
@@ -998,7 +982,7 @@
             "costumes": [
                 {
                     "costumeName": "bear1-a",
-                    "baseLayerID": 4,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "598722f70e86e6f9b23ef97680baaa9c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 56,
@@ -1006,7 +990,7 @@
                 },
                 {
                     "costumeName": "bear1-b",
-                    "baseLayerID": 5,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "76ceb0de4409f42713b50cbc1fb45af5.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 56,
@@ -1026,7 +1010,6 @@
     },
     {
         "name": "Bear2",
-        "baseLayerID": -1,
         "md5": "3eb8e16a983ff23c418374389c81bd30.svg",
         "type": "sprite",
         "tags": [
@@ -1053,7 +1036,7 @@
             "costumes": [
                 {
                     "costumeName": "bear2-a",
-                    "baseLayerID": 6,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "3eb8e16a983ff23c418374389c81bd30.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 37,
@@ -1061,7 +1044,7 @@
                 },
                 {
                     "costumeName": "bear2-b",
-                    "baseLayerID": 7,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "12bb6960ac01b65ae9b5e5e7f79700ac.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 51,
@@ -1081,7 +1064,6 @@
     },
     {
         "name": "Beetle",
-        "baseLayerID": -1,
         "md5": "e1ce8f153f011fdd52486c91c6ed594d.svg",
         "type": "sprite",
         "tags": [
@@ -1110,7 +1092,7 @@
             "costumes": [
                 {
                     "costumeName": "beetle",
-                    "baseLayerID": 24,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "e1ce8f153f011fdd52486c91c6ed594d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 43,
@@ -1130,7 +1112,6 @@
     },
     {
         "name": "Bell",
-        "baseLayerID": -1,
         "md5": "f35056c772395455d703773657e1da6e.svg",
         "type": "sprite",
         "tags": [
@@ -1149,7 +1130,7 @@
             "sounds": [
                 {
                     "soundName": "xylo1",
-                    "soundID": 0,
+                    "soundID": -1,
                     "md5": "6ac484e97c1c1fe1384642e26a125e70.wav",
                     "sampleCount": 238232,
                     "rate": 22050,
@@ -1157,7 +1138,7 @@
                 },
                 {
                     "soundName": "bell toll",
-                    "soundID": 1,
+                    "soundID": -1,
                     "md5": "25d61e79cbeba4041eebeaebd7bf9598.wav",
                     "sampleCount": 45168,
                     "rate": 11025,
@@ -1167,7 +1148,7 @@
             "costumes": [
                 {
                     "costumeName": "bell1",
-                    "baseLayerID": 25,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "f35056c772395455d703773657e1da6e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 59,
@@ -1187,7 +1168,6 @@
     },
     {
         "name": "Ben",
-        "baseLayerID": -1,
         "md5": "7f32d8d78ad64f50c018b7b578de2e18.svg",
         "type": "sprite",
         "tags": [
@@ -1217,7 +1197,7 @@
             "costumes": [
                 {
                     "costumeName": "ben-a",
-                    "baseLayerID": 9,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "7f32d8d78ad64f50c018b7b578de2e18.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 76,
@@ -1225,7 +1205,7 @@
                 },
                 {
                     "costumeName": "ben-b",
-                    "baseLayerID": 10,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "fb012e5d1baf80d33ae95fba3511151a.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 76,
@@ -1233,7 +1213,7 @@
                 },
                 {
                     "costumeName": "ben-c",
-                    "baseLayerID": 11,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "be0b1397965cf8ff2c4cecb84795138a.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 76,
@@ -1241,7 +1221,7 @@
                 },
                 {
                     "costumeName": "ben-d",
-                    "baseLayerID": 12,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "e2aefdb538ebbb24e1ab1464f75ef134.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 76,
@@ -1261,7 +1241,6 @@
     },
     {
         "name": "Bowl",
-        "baseLayerID": -1,
         "md5": "86f616639846f06fef29931e6b9b59de.svg",
         "type": "sprite",
         "tags": [
@@ -1288,7 +1267,7 @@
             "costumes": [
                 {
                     "costumeName": "bowl-a",
-                    "baseLayerID": 8,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "86f616639846f06fef29931e6b9b59de.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 30,
@@ -1308,7 +1287,6 @@
     },
     {
         "name": "Bowtie",
-        "baseLayerID": -1,
         "md5": "534d9924d2f9bfe240f041e3ce55ccf5.svg",
         "type": "sprite",
         "tags": [
@@ -1334,7 +1312,7 @@
             "costumes": [
                 {
                     "costumeName": "bowtie-a",
-                    "baseLayerID": 9,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "534d9924d2f9bfe240f041e3ce55ccf5.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 11,
@@ -1342,7 +1320,7 @@
                 },
                 {
                     "costumeName": "bowtie-b",
-                    "baseLayerID": 10,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "8be1e90e19cd1faced8a2e83c2b5c90d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 11,
@@ -1362,7 +1340,6 @@
     },
     {
         "name": "Bread",
-        "baseLayerID": -1,
         "md5": "68366160ce0ac1221cdde4455eca9cba.svg",
         "type": "sprite",
         "tags": [
@@ -1409,7 +1386,6 @@
     },
     {
         "name": "Broom",
-        "baseLayerID": -1,
         "md5": "836197f784bc4c4decfb1a5a60ca6c56.svg",
         "type": "sprite",
         "tags": [
@@ -1458,7 +1434,6 @@
     },
     {
         "name": "Buildings",
-        "baseLayerID": -1,
         "md5": "d713270e235851e5962becd73a951771.svg",
         "type": "sprite",
         "tags": [
@@ -1487,7 +1462,7 @@
             "costumes": [
                 {
                     "costumeName": "building-a",
-                    "baseLayerID": 106,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "d713270e235851e5962becd73a951771.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 40,
@@ -1495,7 +1470,7 @@
                 },
                 {
                     "costumeName": "building-b",
-                    "baseLayerID": 107,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "8c2d59c50a97d33b096f629258f02be6.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 46,
@@ -1503,7 +1478,7 @@
                 },
                 {
                     "costumeName": "building-c",
-                    "baseLayerID": 108,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "7f3f51f495c39809bed95991dfa1f80d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 25,
@@ -1511,7 +1486,7 @@
                 },
                 {
                     "costumeName": "building-d",
-                    "baseLayerID": 109,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "bbe68ab80b36e4c71f4e28414c7f781e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 59,
@@ -1519,7 +1494,7 @@
                 },
                 {
                     "costumeName": "building-e",
-                    "baseLayerID": 110,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "1beeb8f034a1128c9a799297b0b7fc26.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 36,
@@ -1527,7 +1502,7 @@
                 },
                 {
                     "costumeName": "building-f",
-                    "baseLayerID": 111,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "451e0a565e95d945fe2addfe609ee9df.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 41,
@@ -1535,7 +1510,7 @@
                 },
                 {
                     "costumeName": "building-g",
-                    "baseLayerID": 112,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "58b3c9b7a41dde698fa2b427b502c1fa.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 64,
@@ -1543,7 +1518,7 @@
                 },
                 {
                     "costumeName": "building-h",
-                    "baseLayerID": 113,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "e952c8b14eeac894302d07d37a45ed99.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 33,
@@ -1551,7 +1526,7 @@
                 },
                 {
                     "costumeName": "building-i",
-                    "baseLayerID": 114,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "b00b1123e3bfcb600242528d059ffcfb.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 31,
@@ -1559,7 +1534,7 @@
                 },
                 {
                     "costumeName": "building-j",
-                    "baseLayerID": 115,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "e08fd1a7397efcfe0e3691f945693cb4.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 29,
@@ -1579,7 +1554,6 @@
     },
     {
         "name": "Butterfly1",
-        "baseLayerID": -1,
         "md5": "836d4cc7889f4a1cbcb0303934f31f79.svg",
         "type": "sprite",
         "tags": [
@@ -1611,7 +1585,7 @@
             "costumes": [
                 {
                     "costumeName": "butterfly1-a",
-                    "baseLayerID": 26,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "836d4cc7889f4a1cbcb0303934f31f79.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -1619,7 +1593,7 @@
                 },
                 {
                     "costumeName": "butterfly1-b",
-                    "baseLayerID": 27,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "55dd0671a359d7c35f7b78f4176660e8.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -1639,7 +1613,6 @@
     },
     {
         "name": "Butterfly2",
-        "baseLayerID": -1,
         "md5": "a0216895beade6afc6d42bd5bb43faea.svg",
         "type": "sprite",
         "tags": [
@@ -1671,7 +1644,7 @@
             "costumes": [
                 {
                     "costumeName": "butterfly2",
-                    "baseLayerID": 28,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "a0216895beade6afc6d42bd5bb43faea.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -1691,7 +1664,6 @@
     },
     {
         "name": "Butterfly3",
-        "baseLayerID": -1,
         "md5": "8907a43cf08b0a9134969023be2074c5.svg",
         "type": "sprite",
         "tags": [
@@ -1723,7 +1695,7 @@
             "costumes": [
                 {
                     "costumeName": "butterfly3",
-                    "baseLayerID": 29,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "8907a43cf08b0a9134969023be2074c5.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -1743,7 +1715,6 @@
     },
     {
         "name": "Button1",
-        "baseLayerID": -1,
         "md5": "7ef67c5bc8cf7df64fdb3b1d6b250f71.svg",
         "type": "sprite",
         "tags": [
@@ -1772,7 +1743,7 @@
             "costumes": [
                 {
                     "costumeName": "button1",
-                    "baseLayerID": 30,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "7ef67c5bc8cf7df64fdb3b1d6b250f71.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 72,
@@ -1792,7 +1763,6 @@
     },
     {
         "name": "Button2",
-        "baseLayerID": -1,
         "md5": "c0051ff23e9aae78295964206793c1e3.svg",
         "type": "sprite",
         "tags": [
@@ -1820,7 +1790,7 @@
             "costumes": [
                 {
                     "costumeName": "button2-a",
-                    "baseLayerID": 31,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "c0051ff23e9aae78295964206793c1e3.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 72,
@@ -1828,7 +1798,7 @@
                 },
                 {
                     "costumeName": "button2-b",
-                    "baseLayerID": 32,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "712a561dc0ad66e348b8247e566b50ef.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 72,
@@ -1848,7 +1818,6 @@
     },
     {
         "name": "Button3",
-        "baseLayerID": -1,
         "md5": "ffb2a9c21084c58fdb677c8d12a97519.svg",
         "type": "sprite",
         "tags": [
@@ -1877,7 +1846,7 @@
             "costumes": [
                 {
                     "costumeName": "button3-a",
-                    "baseLayerID": 33,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "ffb2a9c21084c58fdb677c8d12a97519.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 72,
@@ -1885,7 +1854,7 @@
                 },
                 {
                     "costumeName": "button3-b",
-                    "baseLayerID": 34,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "7a9ccb55e4da36f48811ab125d2492e0.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 72,
@@ -1905,7 +1874,6 @@
     },
     {
         "name": "Button4",
-        "baseLayerID": -1,
         "md5": "ecfe263bc256349777e571eaf39761d4.svg",
         "type": "sprite",
         "tags": [
@@ -1932,7 +1900,7 @@
             "costumes": [
                 {
                     "costumeName": "button4-a",
-                    "baseLayerID": 35,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "ecfe263bc256349777e571eaf39761d4.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 35,
@@ -1940,7 +1908,7 @@
                 },
                 {
                     "costumeName": "button4-b",
-                    "baseLayerID": 36,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "9c49edde00b80cd22d636a0577a9b1c9.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 35,
@@ -1960,7 +1928,6 @@
     },
     {
         "name": "Button5",
-        "baseLayerID": -1,
         "md5": "71e97245b7be4fd6fe3ba8cdeecadaf1.svg",
         "type": "sprite",
         "tags": [
@@ -1990,7 +1957,7 @@
             "costumes": [
                 {
                     "costumeName": "button5-a",
-                    "baseLayerID": 37,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "71e97245b7be4fd6fe3ba8cdeecadaf1.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 72,
@@ -1998,7 +1965,7 @@
                 },
                 {
                     "costumeName": "button5-b",
-                    "baseLayerID": 38,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "54cd55512f7571060e6e64168e541222.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 72,
@@ -2018,7 +1985,6 @@
     },
     {
         "name": "Cake",
-        "baseLayerID": -1,
         "md5": "97ab3596dc06510e963fa29795e663bf.svg",
         "type": "sprite",
         "tags": [
@@ -2041,7 +2007,7 @@
             "sounds": [
                 {
                     "soundName": "birthday",
-                    "soundID": 4,
+                    "soundID": -1,
                     "md5": "89691587a169d935a58c48c3d4e78534.wav",
                     "sampleCount": 161408,
                     "rate": 22050,
@@ -2051,7 +2017,7 @@
             "costumes": [
                 {
                     "costumeName": "cake-a",
-                    "baseLayerID": 69,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "97ab3596dc06510e963fa29795e663bf.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 64,
@@ -2059,7 +2025,7 @@
                 },
                 {
                     "costumeName": "cake-b",
-                    "baseLayerID": 70,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "61d5481955a2f42cb843d09506f6744e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 64,
@@ -2079,7 +2045,6 @@
     },
     {
         "name": "Casey",
-        "baseLayerID": -1,
         "md5": "30a4dafa852311b2a07d72e1bb060326.svg",
         "type": "sprite",
         "tags": [
@@ -2152,7 +2117,6 @@
     },
     {
         "name": "Cat",
-        "baseLayerID": -1,
         "md5": "09dc888b0b7df19f70d81588ae73420e.svg",
         "type": "sprite",
         "tags": [
@@ -2212,7 +2176,6 @@
     },
     {
         "name": "Cat1 Flying",
-        "baseLayerID": -1,
         "md5": "1e81725d2d2c7de4a2dd4a145198a43c.svg",
         "type": "sprite",
         "tags": [
@@ -2241,7 +2204,7 @@
             "costumes": [
                 {
                     "costumeName": "cat1 flying-a",
-                    "baseLayerID": 55,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "1e81725d2d2c7de4a2dd4a145198a43c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 67,
@@ -2249,7 +2212,7 @@
                 },
                 {
                     "costumeName": "cat1 flying-b",
-                    "baseLayerID": 56,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "0d192725870ef0eda50d91cab0e3c9c5.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 42,
@@ -2269,7 +2232,6 @@
     },
     {
         "name": "Cat2",
-        "baseLayerID": -1,
         "md5": "01ae57fd339529445cb890978ef8a054.svg",
         "type": "sprite",
         "tags": [
@@ -2289,7 +2251,7 @@
             "sounds": [
                 {
                     "soundName": "meow2",
-                    "soundID": 0,
+                    "soundID": -1,
                     "md5": "cf51a0c4088942d95bcc20af13202710.wav",
                     "sampleCount": 6512,
                     "rate": 11025,
@@ -2299,7 +2261,7 @@
             "costumes": [
                 {
                     "costumeName": "cat2",
-                    "baseLayerID": 11,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "01ae57fd339529445cb890978ef8a054.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 87,
@@ -2319,7 +2281,6 @@
     },
     {
         "name": "Centaur",
-        "baseLayerID": -1,
         "md5": "45c1890ae0ab41f24f67ea74bec006c9.svg",
         "type": "sprite",
         "tags": [
@@ -2392,7 +2353,6 @@
     },
     {
         "name": "Cloud",
-        "baseLayerID": -1,
         "md5": "47005a1f20309f577a03a67abbb6b94e.svg",
         "type": "sprite",
         "tags": [
@@ -2420,7 +2380,7 @@
             "costumes": [
                 {
                     "costumeName": "cloud",
-                    "baseLayerID": 12,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "47005a1f20309f577a03a67abbb6b94e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 71,
@@ -2440,7 +2400,6 @@
     },
     {
         "name": "Clouds",
-        "baseLayerID": -1,
         "md5": "c7d7de8e29179407f03b054fa640f4d0.svg",
         "type": "sprite",
         "tags": [
@@ -2469,7 +2428,7 @@
             "costumes": [
                 {
                     "costumeName": "cloud-a",
-                    "baseLayerID": 116,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "c7d7de8e29179407f03b054fa640f4d0.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 76,
@@ -2477,7 +2436,7 @@
                 },
                 {
                     "costumeName": "cloud-b",
-                    "baseLayerID": 117,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "d8595350ebb460494c9189dabb968336.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 101,
@@ -2485,7 +2444,7 @@
                 },
                 {
                     "costumeName": "cloud-c",
-                    "baseLayerID": 118,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "395fc991e64ac0a4aa46758ab4bc65cb.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 97,
@@ -2493,7 +2452,7 @@
                 },
                 {
                     "costumeName": "cloud-d",
-                    "baseLayerID": 119,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "1767e704acb11ffa409f77cc79ba7e86.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 87,
@@ -2513,7 +2472,6 @@
     },
     {
         "name": "Convertible3",
-        "baseLayerID": -1,
         "md5": "b6ac3c9e1789cba2302d2ef82d62d019.svg",
         "type": "sprite",
         "tags": [
@@ -2540,7 +2498,7 @@
             "costumes": [
                 {
                     "costumeName": "convertible3",
-                    "baseLayerID": 13,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "b6ac3c9e1789cba2302d2ef82d62d019.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -2560,7 +2518,6 @@
     },
     {
         "name": "Crab",
-        "baseLayerID": -1,
         "md5": "114249a5660f7948663d95de575cfd8d.svg",
         "type": "sprite",
         "tags": [
@@ -2595,7 +2552,7 @@
             "costumes": [
                 {
                     "costumeName": "crab-a",
-                    "baseLayerID": 39,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "114249a5660f7948663d95de575cfd8d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -2603,7 +2560,7 @@
                 },
                 {
                     "costumeName": "crab-b",
-                    "baseLayerID": 40,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "9bf050664e68c10d2616e85f2873be09.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -2623,7 +2580,6 @@
     },
     {
         "name": "Creature1",
-        "baseLayerID": -1,
         "md5": "a560c6eab2e1de2462bdaeb1d698736c.svg",
         "type": "sprite",
         "tags": [
@@ -2653,7 +2609,7 @@
             "costumes": [
                 {
                     "costumeName": "creature1-a",
-                    "baseLayerID": 119,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "a560c6eab2e1de2462bdaeb1d698736c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 54,
@@ -2661,7 +2617,7 @@
                 },
                 {
                     "costumeName": "creature1-b",
-                    "baseLayerID": 120,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "8042b71fc2ae322151c0a3a163701333.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 60,
@@ -2669,7 +2625,7 @@
                 },
                 {
                     "costumeName": "creature1-c",
-                    "baseLayerID": 121,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "e12a83c8f1c0545b59fe8673e9fac79c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 63,
@@ -2689,7 +2645,6 @@
     },
     {
         "name": "Crystal",
-        "baseLayerID": -1,
         "md5": "8520264d48537bea17b7f6d18e9bb558.svg",
         "type": "sprite",
         "tags": [
@@ -2745,7 +2700,6 @@
     },
     {
         "name": "Dani",
-        "baseLayerID": -1,
         "md5": "f3038fb0f4a00806b02081c6789dd8cf.svg",
         "type": "sprite",
         "tags": [
@@ -2772,7 +2726,7 @@
             "costumes": [
                 {
                     "costumeName": "dani-a",
-                    "baseLayerID": 14,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "f3038fb0f4a00806b02081c6789dd8cf.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 49,
@@ -2780,7 +2734,7 @@
                 },
                 {
                     "costumeName": "dani-b",
-                    "baseLayerID": 15,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "e5c7dd4905a78e1d54087b7165dd1e8c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 82,
@@ -2788,7 +2742,7 @@
                 },
                 {
                     "costumeName": "dani-c",
-                    "baseLayerID": 16,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "cbc5f9c67022af201d498bc9b35608b8.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 49,
@@ -2808,7 +2762,6 @@
     },
     {
         "name": "Dee",
-        "baseLayerID": -1,
         "md5": "aa239b7ccdce6bddf06900c709525764.svg",
         "type": "sprite",
         "tags": [
@@ -2834,7 +2787,7 @@
             "costumes": [
                 {
                     "costumeName": "dee-a",
-                    "baseLayerID": 17,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "aa239b7ccdce6bddf06900c709525764.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 52,
@@ -2842,7 +2795,7 @@
                 },
                 {
                     "costumeName": "dee-b",
-                    "baseLayerID": 18,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "62b4ac1b735599e21af77c390b178095.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 33,
@@ -2850,7 +2803,7 @@
                 },
                 {
                     "costumeName": "dee-c",
-                    "baseLayerID": 19,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "6aa6196ce3245e93b8d1299f33adffcd.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 36,
@@ -2858,7 +2811,7 @@
                 },
                 {
                     "costumeName": "dee-d",
-                    "baseLayerID": 20,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "2159a6be8f7ff450d0b5e938ca34a3f4.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 33,
@@ -2866,7 +2819,7 @@
                 },
                 {
                     "costumeName": "dee-e",
-                    "baseLayerID": 21,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "e358d2a7e3a0a680928657161ce81a0a.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 32,
@@ -2886,7 +2839,6 @@
     },
     {
         "name": "Devin",
-        "baseLayerID": -1,
         "md5": "b1897e56265470b55fa65fabe2423c55.svg",
         "type": "sprite",
         "tags": [
@@ -2912,7 +2864,7 @@
             "costumes": [
                 {
                     "costumeName": "devin-a",
-                    "baseLayerID": 22,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "b1897e56265470b55fa65fabe2423c55.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 39,
@@ -2920,7 +2872,7 @@
                 },
                 {
                     "costumeName": "devin-b",
-                    "baseLayerID": 23,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "873fbd641768c8f753a6568da97633e7.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 40,
@@ -2928,7 +2880,7 @@
                 },
                 {
                     "costumeName": "devin-c",
-                    "baseLayerID": 24,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "eac3c03d86cebb42c8f30e373cb7f623.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 32,
@@ -2936,7 +2888,7 @@
                 },
                 {
                     "costumeName": "devin-d",
-                    "baseLayerID": 25,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "fa6a75afb0e4b822b91d8bb20d40c68f.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 41,
@@ -2956,7 +2908,6 @@
     },
     {
         "name": "Dinosaur1",
-        "baseLayerID": -1,
         "md5": "75d367961807fff8e81f556da81dec24.svg",
         "type": "sprite",
         "tags": [
@@ -2984,7 +2935,7 @@
             "costumes": [
                 {
                     "costumeName": "dinosaur1-a",
-                    "baseLayerID": 0,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "75d367961807fff8e81f556da81dec24.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 98,
@@ -2992,7 +2943,7 @@
                 },
                 {
                     "costumeName": "dinosaur1-b",
-                    "baseLayerID": 1,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "ecdaee9c08ae68fd7a67f81302f00a97.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 98,
@@ -3000,7 +2951,7 @@
                 },
                 {
                     "costumeName": "dinosaur1-c",
-                    "baseLayerID": 2,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "02078a81abd2e10cb62ebcc853a40c92.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 81,
@@ -3008,7 +2959,7 @@
                 },
                 {
                     "costumeName": "dinosaur1-d",
-                    "baseLayerID": 3,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "c9ed031bc9bf11416142880f89436be9.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 98,
@@ -3028,7 +2979,6 @@
     },
     {
         "name": "Dinosaur2",
-        "baseLayerID": -1,
         "md5": "5493f5deffe7aed451cd8b255740de4a.svg",
         "type": "sprite",
         "tags": [
@@ -3057,7 +3007,7 @@
             "costumes": [
                 {
                     "costumeName": "dinosaur2-a",
-                    "baseLayerID": 9,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "5493f5deffe7aed451cd8b255740de4a.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 115,
@@ -3065,7 +3015,7 @@
                 },
                 {
                     "costumeName": "dinosaur2-b",
-                    "baseLayerID": 10,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "70bba739b7df0bd08abb31026d078ee7.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 74,
@@ -3073,7 +3023,7 @@
                 },
                 {
                     "costumeName": "dinosaur2-c",
-                    "baseLayerID": 11,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "4a51679d86aafcc9cee1c010fc141288.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 62,
@@ -3081,7 +3031,7 @@
                 },
                 {
                     "costumeName": "dinosaur2-d",
-                    "baseLayerID": 12,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "47053664449b24749aaf199925b19f8e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 71,
@@ -3101,7 +3051,6 @@
     },
     {
         "name": "Dinosaur3",
-        "baseLayerID": -1,
         "md5": "17636db6f607c14a03a36e18abfea86a.svg",
         "type": "sprite",
         "tags": [
@@ -3131,7 +3080,7 @@
             "costumes": [
                 {
                     "costumeName": "dinosaur3-a",
-                    "baseLayerID": 4,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "17636db6f607c14a03a36e18abfea86a.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 115,
@@ -3139,7 +3088,7 @@
                 },
                 {
                     "costumeName": "dinosaur3-b",
-                    "baseLayerID": 5,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "1b20afc713b04ca5d01b25d050aa35ac.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 115,
@@ -3147,7 +3096,7 @@
                 },
                 {
                     "costumeName": "dinosaur3-c",
-                    "baseLayerID": 6,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "4700613077afa7c62659b3fd7d7c748e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 115,
@@ -3155,7 +3104,7 @@
                 },
                 {
                     "costumeName": "dinosaur3-d",
-                    "baseLayerID": 7,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "a03f110ed12b73acc9bd84037fd6ae96.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 115,
@@ -3163,7 +3112,7 @@
                 },
                 {
                     "costumeName": "dinosaur3-e",
-                    "baseLayerID": 8,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "00e24e40535a1a621fee0f70895b2b61.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 115,
@@ -3183,7 +3132,6 @@
     },
     {
         "name": "Dinosaur4",
-        "baseLayerID": -1,
         "md5": "9da591f8a6da251c800adb12a02c43cb.svg",
         "type": "sprite",
         "tags": [
@@ -3214,7 +3162,7 @@
             "costumes": [
                 {
                     "costumeName": "dinosaur4-a",
-                    "baseLayerID": 13,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "9da591f8a6da251c800adb12a02c43cb.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 59,
@@ -3222,7 +3170,7 @@
                 },
                 {
                     "costumeName": "dinosaur4-b",
-                    "baseLayerID": 14,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "a3028e87caeb8338f50b2c6dec9f23d2.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 86,
@@ -3230,7 +3178,7 @@
                 },
                 {
                     "costumeName": "dinosaur4-c",
-                    "baseLayerID": 15,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "9a4bbc1b104c8112be82c252a6ecfd11.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 59,
@@ -3238,7 +3186,7 @@
                 },
                 {
                     "costumeName": "dinosaur4-d",
-                    "baseLayerID": 16,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "45061ff84a25723625d04f0476687633.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 89,
@@ -3258,7 +3206,6 @@
     },
     {
         "name": "Diver1",
-        "baseLayerID": -1,
         "md5": "853803d5600b66538474909c5438c8ee.svg",
         "type": "sprite",
         "tags": [
@@ -3289,7 +3236,7 @@
             "costumes": [
                 {
                     "costumeName": "diver1",
-                    "baseLayerID": 41,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "853803d5600b66538474909c5438c8ee.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -3309,7 +3256,6 @@
     },
     {
         "name": "Diver2",
-        "baseLayerID": -1,
         "md5": "248d3e69ada69a64b1077149ef6a931a.svg",
         "type": "sprite",
         "tags": [
@@ -3340,7 +3286,7 @@
             "costumes": [
                 {
                     "costumeName": "diver2",
-                    "baseLayerID": 42,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "248d3e69ada69a64b1077149ef6a931a.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -3360,7 +3306,6 @@
     },
     {
         "name": "Dog1",
-        "baseLayerID": -1,
         "md5": "39ddefa0cc58f3b1b06474d63d81ef56.svg",
         "type": "sprite",
         "tags": [
@@ -3379,7 +3324,7 @@
             "sounds": [
                 {
                     "soundName": "dog1",
-                    "soundID": 2,
+                    "soundID": -1,
                     "md5": "b15adefc3c12f758b6dc6a045362532f.wav",
                     "sampleCount": 3672,
                     "rate": 22050,
@@ -3389,7 +3334,7 @@
             "costumes": [
                 {
                     "costumeName": "dog1-a",
-                    "baseLayerID": 57,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "39ddefa0cc58f3b1b06474d63d81ef56.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 83,
@@ -3397,7 +3342,7 @@
                 },
                 {
                     "costumeName": "dog1-b",
-                    "baseLayerID": 58,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "598f4aa3d8f671375d1d2b3acf753416.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 83,
@@ -3417,7 +3362,6 @@
     },
     {
         "name": "Dog2",
-        "baseLayerID": -1,
         "md5": "e921f865b19b27cd99e16a341dbf09c2.svg",
         "type": "sprite",
         "tags": [
@@ -3436,7 +3380,7 @@
             "sounds": [
                 {
                     "soundName": "dog1",
-                    "soundID": 2,
+                    "soundID": -1,
                     "md5": "b15adefc3c12f758b6dc6a045362532f.wav",
                     "sampleCount": 3672,
                     "rate": 22050,
@@ -3446,7 +3390,7 @@
             "costumes": [
                 {
                     "costumeName": "dog2-a",
-                    "baseLayerID": 59,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "e921f865b19b27cd99e16a341dbf09c2.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -3454,7 +3398,7 @@
                 },
                 {
                     "costumeName": "dog2-b",
-                    "baseLayerID": 60,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "891f2fb7daf79ba8b224a9173eeb0a63.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -3462,7 +3406,7 @@
                 },
                 {
                     "costumeName": "dog2-c",
-                    "baseLayerID": 61,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "cd236d5eef4431dea82983ac9eec406b.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -3482,7 +3426,6 @@
     },
     {
         "name": "Donut",
-        "baseLayerID": -1,
         "md5": "9e7b4d153421dae04a24571d7e079e85.svg",
         "type": "sprite",
         "tags": [
@@ -3515,7 +3458,7 @@
             "costumes": [
                 {
                     "costumeName": "donut",
-                    "baseLayerID": 43,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "9e7b4d153421dae04a24571d7e079e85.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 73,
@@ -3535,7 +3478,6 @@
     },
     {
         "name": "Dorian",
-        "baseLayerID": -1,
         "md5": "b042b1a5fde03dd5abbc2f3f78d11a2c.svg",
         "type": "sprite",
         "tags": [
@@ -3608,7 +3550,6 @@
     },
     {
         "name": "Dot",
-        "baseLayerID": -1,
         "md5": "47c975e37f9a89c01d0d4d6fd17ef847.svg",
         "type": "sprite",
         "tags": [
@@ -3680,7 +3621,6 @@
     },
     {
         "name": "Dove",
-        "baseLayerID": -1,
         "md5": "6dde2b880ad6ddeaea2a53821befb86d.svg",
         "type": "sprite",
         "tags": [
@@ -3708,7 +3648,7 @@
             "costumes": [
                 {
                     "costumeName": "dove-a",
-                    "baseLayerID": 26,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "6dde2b880ad6ddeaea2a53821befb86d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 86,
@@ -3716,7 +3656,7 @@
                 },
                 {
                     "costumeName": "dove-b",
-                    "baseLayerID": 27,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "1c0bc118044d7f6033bc9cd1ef555590.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 88,
@@ -3736,7 +3676,6 @@
     },
     {
         "name": "Dragon",
-        "baseLayerID": -1,
         "md5": "8aed65cee4cfe22b4f4b8e749092dbbb.svg",
         "type": "sprite",
         "tags": [
@@ -3801,7 +3740,6 @@
     },
     {
         "name": "Drum",
-        "baseLayerID": -1,
         "md5": "dd66742bc2a3cfe5a6f9f540afd2e15c.svg",
         "type": "sprite",
         "tags": [
@@ -3818,7 +3756,7 @@
             "sounds": [
                 {
                     "soundName": "high tom",
-                    "soundID": 32,
+                    "soundID": -1,
                     "md5": "d623f99b3c8d33932eb2c6c9cfd817c5.wav",
                     "sampleCount": 12320,
                     "rate": 22050,
@@ -3826,7 +3764,7 @@
                 },
                 {
                     "soundName": "low tom",
-                    "soundID": 33,
+                    "soundID": -1,
                     "md5": "1569bbbd8952b0575e5a5cb5aefb50ba.wav",
                     "sampleCount": 20000,
                     "rate": 22050,
@@ -3836,7 +3774,7 @@
             "costumes": [
                 {
                     "costumeName": "drum-a",
-                    "baseLayerID": 10,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "dd66742bc2a3cfe5a6f9f540afd2e15c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 43,
@@ -3844,7 +3782,7 @@
                 },
                 {
                     "costumeName": "drum-b",
-                    "baseLayerID": 11,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "9c9d371da382c227e43f09b1a748c554.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 43,
@@ -3864,7 +3802,6 @@
     },
     {
         "name": "Drum Kit",
-        "baseLayerID": -1,
         "md5": "131d040d86ecea62ccd175a8709c7866.svg",
         "type": "sprite",
         "tags": [
@@ -3881,7 +3818,7 @@
             "sounds": [
                 {
                     "soundName": "drum bass1",
-                    "soundID": 51,
+                    "soundID": -1,
                     "md5": "48328c874353617451e4c7902cc82817.wav",
                     "sampleCount": 6528,
                     "rate": 22050,
@@ -3889,7 +3826,7 @@
                 },
                 {
                     "soundName": "drum bass2",
-                    "soundID": 52,
+                    "soundID": -1,
                     "md5": "711a1270d1cf2e5de9b145ee539213e4.wav",
                     "sampleCount": 3791,
                     "rate": 22050,
@@ -3897,7 +3834,7 @@
                 },
                 {
                     "soundName": "drum bass3",
-                    "soundID": 53,
+                    "soundID": -1,
                     "md5": "c21704337b16359ea631b5f8eb48f765.wav",
                     "sampleCount": 8576,
                     "rate": 22050,
@@ -3905,7 +3842,7 @@
                 },
                 {
                     "soundName": "high tom",
-                    "soundID": 32,
+                    "soundID": -1,
                     "md5": "d623f99b3c8d33932eb2c6c9cfd817c5.wav",
                     "sampleCount": 12320,
                     "rate": 22050,
@@ -3913,7 +3850,7 @@
                 },
                 {
                     "soundName": "low tom",
-                    "soundID": 33,
+                    "soundID": -1,
                     "md5": "1569bbbd8952b0575e5a5cb5aefb50ba.wav",
                     "sampleCount": 20000,
                     "rate": 22050,
@@ -3923,7 +3860,7 @@
             "costumes": [
                 {
                     "costumeName": "drum-kit",
-                    "baseLayerID": 20,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "131d040d86ecea62ccd175a8709c7866.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 58,
@@ -3931,7 +3868,7 @@
                 },
                 {
                     "costumeName": "drum-kit-b",
-                    "baseLayerID": 21,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "ff14be049146cf9ab142e0951cb9b735.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 58,
@@ -3951,7 +3888,6 @@
     },
     {
         "name": "Drum-cymbal",
-        "baseLayerID": -1,
         "md5": "d6d41862fda966df1455d2dbff5e1988.svg",
         "type": "sprite",
         "tags": [
@@ -3968,7 +3904,7 @@
             "sounds": [
                 {
                     "soundName": "crash cymbal",
-                    "soundID": 37,
+                    "soundID": -1,
                     "md5": "f2c47a46f614f467a7ac802ed9ec3d8e.wav",
                     "sampleCount": 25220,
                     "rate": 22050,
@@ -3976,7 +3912,7 @@
                 },
                 {
                     "soundName": "splash cymbal",
-                    "soundID": 38,
+                    "soundID": -1,
                     "md5": "9d63ed5be96c43b06492e8b4a9cea8d8.wav",
                     "sampleCount": 9600,
                     "rate": 22050,
@@ -3984,7 +3920,7 @@
                 },
                 {
                     "soundName": "bell cymbal",
-                    "soundID": 39,
+                    "soundID": -1,
                     "md5": "efddec047de95492f775a1b5b2e8d19e.wav",
                     "sampleCount": 19328,
                     "rate": 22050,
@@ -3992,7 +3928,7 @@
                 },
                 {
                     "soundName": "roll cymbal",
-                    "soundID": 40,
+                    "soundID": -1,
                     "md5": "da8355d753cd2a5ddd19cb2bb41c1547.wav",
                     "sampleCount": 26432,
                     "rate": 22050,
@@ -4002,7 +3938,7 @@
             "costumes": [
                 {
                     "costumeName": "drum-cymbal-a",
-                    "baseLayerID": 14,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "d6d41862fda966df1455d2dbff5e1988.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 30,
@@ -4010,7 +3946,7 @@
                 },
                 {
                     "costumeName": "drum-cymbal-b",
-                    "baseLayerID": 15,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "e6b7d7d8874bc4b7be58afe927157554.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 30,
@@ -4030,7 +3966,6 @@
     },
     {
         "name": "Drum-highhat",
-        "baseLayerID": -1,
         "md5": "81fb79151a63cb096258607451cc2cf5.svg",
         "type": "sprite",
         "tags": [
@@ -4047,7 +3982,7 @@
             "sounds": [
                 {
                     "soundName": "hihat cymbal",
-                    "soundID": 50,
+                    "soundID": -1,
                     "md5": "2d01f60d0f20ab39facbf707899c6b2a.wav",
                     "sampleCount": 2752,
                     "rate": 22050,
@@ -4057,7 +3992,7 @@
             "costumes": [
                 {
                     "costumeName": "drum-highhat-a",
-                    "baseLayerID": 18,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "81fb79151a63cb096258607451cc2cf5.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 33,
@@ -4065,7 +4000,7 @@
                 },
                 {
                     "costumeName": "drum-highhat-b",
-                    "baseLayerID": 19,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "e3c273e4ad1a24583064f9b61fcd753a.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 33,
@@ -4085,7 +4020,6 @@
     },
     {
         "name": "Drum-snare",
-        "baseLayerID": -1,
         "md5": "b0255be93e3c8be6ac687f4199a25c4b.svg",
         "type": "sprite",
         "tags": [
@@ -4102,7 +4036,7 @@
             "sounds": [
                 {
                     "soundName": "tap snare",
-                    "soundID": 34,
+                    "soundID": -1,
                     "md5": "d55b3954d72c6275917f375e49b502f3.wav",
                     "sampleCount": 3296,
                     "rate": 22050,
@@ -4110,7 +4044,7 @@
                 },
                 {
                     "soundName": "flam snare",
-                    "soundID": 35,
+                    "soundID": -1,
                     "md5": "3b6cce9f8c56c0537ca61eee3945cd1d.wav",
                     "sampleCount": 4416,
                     "rate": 22050,
@@ -4118,7 +4052,7 @@
                 },
                 {
                     "soundName": "sidestick snare",
-                    "soundID": 36,
+                    "soundID": -1,
                     "md5": "f6868ee5cf626fc4ef3ca1119dc95592.wav",
                     "sampleCount": 2336,
                     "rate": 22050,
@@ -4128,7 +4062,7 @@
             "costumes": [
                 {
                     "costumeName": "drum-snare-a",
-                    "baseLayerID": 12,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "b0255be93e3c8be6ac687f4199a25c4b.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 23,
@@ -4136,7 +4070,7 @@
                 },
                 {
                     "costumeName": "drum-snare-b",
-                    "baseLayerID": 13,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "f6d2f2a6e1055dab6262336625ddf652.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 36,
@@ -4156,7 +4090,6 @@
     },
     {
         "name": "Duck",
-        "baseLayerID": -1,
         "md5": "c3baf7eedfbdac8cd1e4f1f1f779dc0c.svg",
         "type": "sprite",
         "tags": [
@@ -4176,7 +4109,7 @@
             "sounds": [
                 {
                     "soundName": "duck",
-                    "soundID": 3,
+                    "soundID": -1,
                     "md5": "af5b039e1b05e0ccb12944f648a8884e.wav",
                     "sampleCount": 5792,
                     "rate": 22050,
@@ -4186,7 +4119,7 @@
             "costumes": [
                 {
                     "costumeName": "duck",
-                    "baseLayerID": 64,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "c3baf7eedfbdac8cd1e4f1f1f779dc0c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 61,
@@ -4206,7 +4139,6 @@
     },
     {
         "name": "Earth",
-        "baseLayerID": -1,
         "md5": "814197522984a302972998b1a7f92d91.svg",
         "type": "sprite",
         "tags": [
@@ -4232,7 +4164,7 @@
             "costumes": [
                 {
                     "costumeName": "earth",
-                    "baseLayerID": 28,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "814197522984a302972998b1a7f92d91.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 72,
@@ -4252,7 +4184,6 @@
     },
     {
         "name": "Egg",
-        "baseLayerID": -1,
         "md5": "bc723738dfe626c5c3bb90970d985961.svg",
         "type": "sprite",
         "tags": [
@@ -4332,7 +4263,6 @@
     },
     {
         "name": "Elephant",
-        "baseLayerID": -1,
         "md5": "b3515b3805938b0fae4e527aa0b4524e.svg",
         "type": "sprite",
         "tags": [
@@ -4360,7 +4290,7 @@
             "costumes": [
                 {
                     "costumeName": "elephant-a",
-                    "baseLayerID": 65,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "b3515b3805938b0fae4e527aa0b4524e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 107,
@@ -4368,7 +4298,7 @@
                 },
                 {
                     "costumeName": "elephant-b",
-                    "baseLayerID": 66,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "bce91fa266220d3679a4c19c4e38b1f7.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 95,
@@ -4388,7 +4318,6 @@
     },
     {
         "name": "Elf",
-        "baseLayerID": -1,
         "md5": "00748a750dc4fd754ce4debb5e3595c0.svg",
         "type": "sprite",
         "tags": [
@@ -4469,7 +4398,6 @@
     },
     {
         "name": "Empty",
-        "baseLayerID": -1,
         "md5": "cd21514d0531fdffb22204e0ec5ed84a.svg",
         "type": "sprite",
         "tags": [],
@@ -4493,7 +4421,7 @@
             "costumes": [
                 {
                     "costumeName": "empty",
-                    "baseLayerID": 105,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "cd21514d0531fdffb22204e0ec5ed84a.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 0,
@@ -4513,7 +4441,6 @@
     },
     {
         "name": "Fairy",
-        "baseLayerID": -1,
         "md5": "fe97687c7f1b747bb6f41c252cc5926a.svg",
         "type": "sprite",
         "tags": [
@@ -4594,7 +4521,6 @@
     },
     {
         "name": "Fish",
-        "baseLayerID": -1,
         "md5": "8598752b1b7b9892c23817c4ed848e7d.svg",
         "type": "sprite",
         "tags": [
@@ -4624,7 +4550,7 @@
             "costumes": [
                 {
                     "costumeName": "fish-a",
-                    "baseLayerID": 9,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "8598752b1b7b9892c23817c4ed848e7d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 63,
@@ -4632,7 +4558,7 @@
                 },
                 {
                     "costumeName": "fish-b",
-                    "baseLayerID": 10,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "52032e4310f9855b89f873b528a5e928.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 63,
@@ -4640,7 +4566,7 @@
                 },
                 {
                     "costumeName": "fish-c",
-                    "baseLayerID": 11,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "06c139dcfe45bf31ef45e7030b77dc36.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 63,
@@ -4648,7 +4574,7 @@
                 },
                 {
                     "costumeName": "fish-d",
-                    "baseLayerID": 12,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "6a3a2c97374c157e0dbc0a03c2079284.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 63,
@@ -4668,7 +4594,6 @@
     },
     {
         "name": "Fox",
-        "baseLayerID": -1,
         "md5": "fab5488e600e81565f0fc285fc7050f8.svg",
         "type": "sprite",
         "tags": [
@@ -4696,7 +4621,7 @@
             "costumes": [
                 {
                     "costumeName": "fox-a",
-                    "baseLayerID": 0,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "fab5488e600e81565f0fc285fc7050f8.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 94,
@@ -4704,7 +4629,7 @@
                 },
                 {
                     "costumeName": "fox-b",
-                    "baseLayerID": 1,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "afb192ae250a74dfac18bfc52d1d6266.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 94,
@@ -4712,7 +4637,7 @@
                 },
                 {
                     "costumeName": "fox-c",
-                    "baseLayerID": 2,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "29f858d384db7998c0e5183f6a31a3b4.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 94,
@@ -4732,7 +4657,6 @@
     },
     {
         "name": "Frog",
-        "baseLayerID": -1,
         "md5": "285483a688eed2ff8010c65112f99c41.svg",
         "type": "sprite",
         "tags": [
@@ -4763,7 +4687,7 @@
             "costumes": [
                 {
                     "costumeName": "frog",
-                    "baseLayerID": 44,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "285483a688eed2ff8010c65112f99c41.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 48,
@@ -4783,7 +4707,6 @@
     },
     {
         "name": "Fruit Salad",
-        "baseLayerID": -1,
         "md5": "dbf8cc34f7ca18b4a008d2890dba56b7.svg",
         "type": "sprite",
         "tags": [
@@ -4810,7 +4733,7 @@
             "costumes": [
                 {
                     "costumeName": "fruitsalad",
-                    "baseLayerID": 29,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "dbf8cc34f7ca18b4a008d2890dba56b7.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 30,
@@ -4830,7 +4753,6 @@
     },
     {
         "name": "Ghost1",
-        "baseLayerID": -1,
         "md5": "c88579c578f2d171de78612f2ff9c9d9.svg",
         "type": "sprite",
         "tags": [
@@ -4859,7 +4781,7 @@
             "costumes": [
                 {
                     "costumeName": "ghost1 ",
-                    "baseLayerID": 45,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "c88579c578f2d171de78612f2ff9c9d9.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 60,
@@ -4879,7 +4801,6 @@
     },
     {
         "name": "Ghost2",
-        "baseLayerID": -1,
         "md5": "607be245da950af1a4e4d79acfda46e3.svg",
         "type": "sprite",
         "tags": [
@@ -4908,7 +4829,7 @@
             "costumes": [
                 {
                     "costumeName": "ghost2-a",
-                    "baseLayerID": 67,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "607be245da950af1a4e4d79acfda46e3.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -4916,7 +4837,7 @@
                 },
                 {
                     "costumeName": "ghost2-b",
-                    "baseLayerID": 68,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "b9e2ebbe17c617ac182abd8bc1627693.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -4936,7 +4857,6 @@
     },
     {
         "name": "Gift",
-        "baseLayerID": -1,
         "md5": "abeae2217b3ce67b1ff761cd7a89274d.svg",
         "type": "sprite",
         "tags": [
@@ -4963,7 +4883,7 @@
             "costumes": [
                 {
                     "costumeName": "gift-a",
-                    "baseLayerID": 30,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "abeae2217b3ce67b1ff761cd7a89274d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 33,
@@ -4971,7 +4891,7 @@
                 },
                 {
                     "costumeName": "gift-b",
-                    "baseLayerID": 31,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "5cae973c98f2d98b51e6c6b3c9602f8c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 33,
@@ -4991,7 +4911,6 @@
     },
     {
         "name": "Giga",
-        "baseLayerID": -1,
         "md5": "93cb048a1d199f92424b9c097fa5fa38.svg",
         "type": "sprite",
         "tags": [
@@ -5018,7 +4937,7 @@
             "costumes": [
                 {
                     "costumeName": "giga-a",
-                    "baseLayerID": 74,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "93cb048a1d199f92424b9c097fa5fa38.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 72,
@@ -5026,7 +4945,7 @@
                 },
                 {
                     "costumeName": "giga-b",
-                    "baseLayerID": 75,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "528613711a7eae3a929025be04db081c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 72,
@@ -5034,7 +4953,7 @@
                 },
                 {
                     "costumeName": "giga-c",
-                    "baseLayerID": 76,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "ee4dd21d7ca6d1b889ee25d245cbcc66.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 73,
@@ -5042,7 +4961,7 @@
                 },
                 {
                     "costumeName": "giga-d",
-                    "baseLayerID": 77,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "7708e2d9f83a01476ee6d17aa540ddf1.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 73,
@@ -5062,7 +4981,6 @@
     },
     {
         "name": "Giga Walking",
-        "baseLayerID": -1,
         "md5": "f76bc420011db2cdb2de378c1536f6da.svg",
         "type": "sprite",
         "tags": [
@@ -5089,7 +5007,7 @@
             "costumes": [
                 {
                     "costumeName": "Giga walk1",
-                    "baseLayerID": 32,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "f76bc420011db2cdb2de378c1536f6da.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 70,
@@ -5097,7 +5015,7 @@
                 },
                 {
                     "costumeName": "Giga walk2",
-                    "baseLayerID": 33,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "43b5874e8a54f93bd02727f0abf6905b.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 71,
@@ -5105,7 +5023,7 @@
                 },
                 {
                     "costumeName": "Giga walk3",
-                    "baseLayerID": 34,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "9aab3bbb375765391978be4f6d478ab3.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 71,
@@ -5113,7 +5031,7 @@
                 },
                 {
                     "costumeName": "Giga walk4",
-                    "baseLayerID": 35,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "22e4ae40919cf0fe6b4d7649d14a6e71.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 73,
@@ -5133,7 +5051,6 @@
     },
     {
         "name": "Glass Water",
-        "baseLayerID": -1,
         "md5": "c364b9e1f4bcdc61705032d89eaaa0a1.svg",
         "type": "sprite",
         "tags": [
@@ -5161,7 +5078,7 @@
             "costumes": [
                 {
                     "costumeName": "glass water-a",
-                    "baseLayerID": 36,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "c364b9e1f4bcdc61705032d89eaaa0a1.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 39,
@@ -5169,7 +5086,7 @@
                 },
                 {
                     "costumeName": "glass water-b",
-                    "baseLayerID": 37,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "bc07ce6a2004ac91ce704531a1c526e5.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 39,
@@ -5189,7 +5106,6 @@
     },
     {
         "name": "Glasses",
-        "baseLayerID": -1,
         "md5": "5fcf716b53f223bc86b10ab0eca3e162.svg",
         "type": "sprite",
         "tags": [
@@ -5216,7 +5132,7 @@
             "costumes": [
                 {
                     "costumeName": "glasses",
-                    "baseLayerID": 38,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "5fcf716b53f223bc86b10ab0eca3e162.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 16,
@@ -5236,7 +5152,6 @@
     },
     {
         "name": "Goalie",
-        "baseLayerID": -1,
         "md5": "86b0610ea21fdecb99795c5e6d52768c.svg",
         "type": "sprite",
         "tags": [
@@ -5265,7 +5180,7 @@
             "costumes": [
                 {
                     "costumeName": "goalie-a",
-                    "baseLayerID": 0,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "86b0610ea21fdecb99795c5e6d52768c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 76,
@@ -5273,7 +5188,7 @@
                 },
                 {
                     "costumeName": "goalie-b",
-                    "baseLayerID": 1,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "af3ef5125d187772240a1120e7eb67ac.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 76,
@@ -5281,7 +5196,7 @@
                 },
                 {
                     "costumeName": "goalie-c",
-                    "baseLayerID": 2,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "7c9377cedae11a094d2e77bed3edb884.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 76,
@@ -5289,7 +5204,7 @@
                 },
                 {
                     "costumeName": "goalie-d",
-                    "baseLayerID": 3,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "bd628034d356d30b0e9b563447471290.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 76,
@@ -5297,7 +5212,7 @@
                 },
                 {
                     "costumeName": "goalie-e",
-                    "baseLayerID": 4,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "b3f6c4c0be9a0f71e9486dea51e513c3.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 76,
@@ -5317,7 +5232,6 @@
     },
     {
         "name": "Goblin",
-        "baseLayerID": -1,
         "md5": "f10eaedff51f50f0809a7b4b310337fa.svg",
         "type": "sprite",
         "tags": [
@@ -5389,7 +5303,6 @@
     },
     {
         "name": "Gobo",
-        "baseLayerID": -1,
         "md5": "1f5ea0d12f85aed2e471cdd21b0bd6d7.svg",
         "type": "sprite",
         "tags": [
@@ -5418,7 +5331,7 @@
             "costumes": [
                 {
                     "costumeName": "gobo-a",
-                    "baseLayerID": 71,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "1f5ea0d12f85aed2e471cdd21b0bd6d7.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 47,
@@ -5426,7 +5339,7 @@
                 },
                 {
                     "costumeName": "gobo-b",
-                    "baseLayerID": 72,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "73e493e4abd5d0954b677b97abcb7116.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 47,
@@ -5434,7 +5347,7 @@
                 },
                 {
                     "costumeName": "gobo-c",
-                    "baseLayerID": 73,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "bc68a6bdf300df7b53d73b38f74c844e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 47,
@@ -5454,7 +5367,6 @@
     },
     {
         "name": "Green Flag",
-        "baseLayerID": -1,
         "md5": "173e20ac537d2c278ed621be3db3fc87.svg",
         "type": "sprite",
         "tags": [
@@ -5480,7 +5392,7 @@
             "costumes": [
                 {
                     "costumeName": "green flag",
-                    "baseLayerID": 39,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "173e20ac537d2c278ed621be3db3fc87.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 70,
@@ -5500,7 +5412,6 @@
     },
     {
         "name": "Griffin",
-        "baseLayerID": -1,
         "md5": "d2ddc25b224ad72240f92e632afc7c69.svg",
         "type": "sprite",
         "tags": [
@@ -5557,7 +5468,6 @@
     },
     {
         "name": "Griffin-flying",
-        "baseLayerID": -1,
         "md5": "03d75e0c7c34e8618545a5f4913db4ea.svg",
         "type": "sprite",
         "tags": [
@@ -5614,7 +5524,6 @@
     },
     {
         "name": "Guitar",
-        "baseLayerID": -1,
         "md5": "cb8c2a5e69da7538e1dd73cb7ff4a666.svg",
         "type": "sprite",
         "tags": [
@@ -5631,7 +5540,7 @@
             "sounds": [
                 {
                     "soundName": "C guitar",
-                    "soundID": 0,
+                    "soundID": -1,
                     "md5": "22baa07795a9a524614075cdea543793.wav",
                     "sampleCount": 44864,
                     "rate": 22050,
@@ -5639,7 +5548,7 @@
                 },
                 {
                     "soundName": "D guitar",
-                    "soundID": 1,
+                    "soundID": -1,
                     "md5": "2dbcfae6a55738f94bbb40aa5fcbf7ce.wav",
                     "sampleCount": 41120,
                     "rate": 22050,
@@ -5647,7 +5556,7 @@
                 },
                 {
                     "soundName": "E guitar",
-                    "soundID": 2,
+                    "soundID": -1,
                     "md5": "4b5d1da83e59bf35578324573c991666.wav",
                     "sampleCount": 38400,
                     "rate": 22050,
@@ -5655,7 +5564,7 @@
                 },
                 {
                     "soundName": "F guitar",
-                    "soundID": 3,
+                    "soundID": -1,
                     "md5": "b51d086aeb1921ec405561df52ecbc50.wav",
                     "sampleCount": 36416,
                     "rate": 22050,
@@ -5663,7 +5572,7 @@
                 },
                 {
                     "soundName": "G guitar",
-                    "soundID": 4,
+                    "soundID": -1,
                     "md5": "98a835713ecea2f3ef9f4f442d52ad20.wav",
                     "sampleCount": 33600,
                     "rate": 22050,
@@ -5671,7 +5580,7 @@
                 },
                 {
                     "soundName": "A guitar",
-                    "soundID": 5,
+                    "soundID": -1,
                     "md5": "ee753e87d212d4b2fb650ca660f1e839.wav",
                     "sampleCount": 31872,
                     "rate": 22050,
@@ -5679,7 +5588,7 @@
                 },
                 {
                     "soundName": "B guitar",
-                    "soundID": 6,
+                    "soundID": -1,
                     "md5": "2ae2d67de62df8ca54d638b4ad2466c3.wav",
                     "sampleCount": 29504,
                     "rate": 22050,
@@ -5687,7 +5596,7 @@
                 },
                 {
                     "soundName": "C2 guitar",
-                    "soundID": 7,
+                    "soundID": -1,
                     "md5": "c8d2851bd99d8e0ce6c1f05e4acc7f34.wav",
                     "sampleCount": 27712,
                     "rate": 22050,
@@ -5697,7 +5606,7 @@
             "costumes": [
                 {
                     "costumeName": "guitar-a",
-                    "baseLayerID": 0,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "cb8c2a5e69da7538e1dd73cb7ff4a666.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 47,
@@ -5705,7 +5614,7 @@
                 },
                 {
                     "costumeName": "guitar-b",
-                    "baseLayerID": 1,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "fed44bd1091628c060f45060a84f2885.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 47,
@@ -5725,7 +5634,6 @@
     },
     {
         "name": "Guitar-electric2",
-        "baseLayerID": -1,
         "md5": "1fc433b89038f9e16092c9f4d7514cca.svg",
         "type": "sprite",
         "tags": [
@@ -5742,7 +5650,7 @@
             "sounds": [
                 {
                     "soundName": "C elec guitar",
-                    "soundID": 8,
+                    "soundID": -1,
                     "md5": "0d340de02e14bebaf8dfa0e43eb3f1f9.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -5750,7 +5658,7 @@
                 },
                 {
                     "soundName": "D elec guitar",
-                    "soundID": 9,
+                    "soundID": -1,
                     "md5": "1b5de9866801eb2f9d4f57c7c3b473f5.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -5758,7 +5666,7 @@
                 },
                 {
                     "soundName": "E elec guitar",
-                    "soundID": 10,
+                    "soundID": -1,
                     "md5": "2e6a6ae3e0f72bf78c74def8130f459a.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -5766,7 +5674,7 @@
                 },
                 {
                     "soundName": "F elec guitar",
-                    "soundID": 11,
+                    "soundID": -1,
                     "md5": "5eb00f15f21f734986aa45156d44478d.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -5774,7 +5682,7 @@
                 },
                 {
                     "soundName": "G elec guitar",
-                    "soundID": 12,
+                    "soundID": -1,
                     "md5": "cd0d0e7dad415b2ffa2ba7a61860eaf8.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -5782,7 +5690,7 @@
                 },
                 {
                     "soundName": "A elec guitar",
-                    "soundID": 13,
+                    "soundID": -1,
                     "md5": "fa5f7fea601e9368dd68449d9a54c995.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -5790,7 +5698,7 @@
                 },
                 {
                     "soundName": "B elec guitar",
-                    "soundID": 14,
+                    "soundID": -1,
                     "md5": "81f142d0b00189703d7fe9b1f13f6f87.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -5798,7 +5706,7 @@
                 },
                 {
                     "soundName": "C2 elec guitar",
-                    "soundID": 15,
+                    "soundID": -1,
                     "md5": "3a8ed3129f22cba5b0810bc030d16b5f.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -5808,7 +5716,7 @@
             "costumes": [
                 {
                     "costumeName": "guitar-electric2-a",
-                    "baseLayerID": 2,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "1fc433b89038f9e16092c9f4d7514cca.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 38,
@@ -5816,7 +5724,7 @@
                 },
                 {
                     "costumeName": "guitar-electric2-b",
-                    "baseLayerID": 3,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "7b843dbc93d4b2ea31fa67cca3d5077c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 38,
@@ -5836,7 +5744,6 @@
     },
     {
         "name": "Gutar-electric1",
-        "baseLayerID": -1,
         "md5": "b2b469b9d11fd23bdd671eab94dc58ff.svg",
         "type": "sprite",
         "tags": [
@@ -5853,7 +5760,7 @@
             "sounds": [
                 {
                     "soundName": "C elec guitar",
-                    "soundID": 8,
+                    "soundID": -1,
                     "md5": "0d340de02e14bebaf8dfa0e43eb3f1f9.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -5861,7 +5768,7 @@
                 },
                 {
                     "soundName": "D elec guitar",
-                    "soundID": 9,
+                    "soundID": -1,
                     "md5": "1b5de9866801eb2f9d4f57c7c3b473f5.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -5869,7 +5776,7 @@
                 },
                 {
                     "soundName": "E elec guitar",
-                    "soundID": 10,
+                    "soundID": -1,
                     "md5": "2e6a6ae3e0f72bf78c74def8130f459a.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -5877,7 +5784,7 @@
                 },
                 {
                     "soundName": "F elec guitar",
-                    "soundID": 11,
+                    "soundID": -1,
                     "md5": "5eb00f15f21f734986aa45156d44478d.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -5885,7 +5792,7 @@
                 },
                 {
                     "soundName": "G elec guitar",
-                    "soundID": 12,
+                    "soundID": -1,
                     "md5": "cd0d0e7dad415b2ffa2ba7a61860eaf8.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -5893,7 +5800,7 @@
                 },
                 {
                     "soundName": "A elec guitar",
-                    "soundID": 13,
+                    "soundID": -1,
                     "md5": "fa5f7fea601e9368dd68449d9a54c995.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -5901,7 +5808,7 @@
                 },
                 {
                     "soundName": "B elec guitar",
-                    "soundID": 14,
+                    "soundID": -1,
                     "md5": "81f142d0b00189703d7fe9b1f13f6f87.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -5909,7 +5816,7 @@
                 },
                 {
                     "soundName": "C2 elec guitar",
-                    "soundID": 15,
+                    "soundID": -1,
                     "md5": "3a8ed3129f22cba5b0810bc030d16b5f.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -5919,7 +5826,7 @@
             "costumes": [
                 {
                     "costumeName": "guitar-electric1-a",
-                    "baseLayerID": 4,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "b2b469b9d11fd23bdd671eab94dc58ff.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 42,
@@ -5927,7 +5834,7 @@
                 },
                 {
                     "costumeName": "guitar-electric1-b",
-                    "baseLayerID": 5,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "3632184c19c66a088a99568570d61b13.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 42,
@@ -5947,7 +5854,6 @@
     },
     {
         "name": "Hat",
-        "baseLayerID": -1,
         "md5": "b3beb1f52d371428d70b65a0c4c5c001.svg",
         "type": "sprite",
         "tags": [
@@ -5973,7 +5879,7 @@
             "costumes": [
                 {
                     "costumeName": "Hat",
-                    "baseLayerID": 40,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "b3beb1f52d371428d70b65a0c4c5c001.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 52,
@@ -5993,7 +5899,6 @@
     },
     {
         "name": "Hat Beanie",
-        "baseLayerID": -1,
         "md5": "3271da33e4108ed08a303c2244739fbf.svg",
         "type": "sprite",
         "tags": [
@@ -6019,7 +5924,7 @@
             "costumes": [
                 {
                     "costumeName": "hat beanie",
-                    "baseLayerID": 41,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "3271da33e4108ed08a303c2244739fbf.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 28,
@@ -6039,7 +5944,6 @@
     },
     {
         "name": "Hat Party1",
-        "baseLayerID": -1,
         "md5": "70a7f535d8857cf9175492415361c361.svg",
         "type": "sprite",
         "tags": [
@@ -6066,7 +5970,7 @@
             "costumes": [
                 {
                     "costumeName": "partyhat1",
-                    "baseLayerID": 42,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "70a7f535d8857cf9175492415361c361.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -6086,7 +5990,6 @@
     },
     {
         "name": "Hat Party2",
-        "baseLayerID": -1,
         "md5": "9b7a84fe3e50621752917e4e484a1e2f.svg",
         "type": "sprite",
         "tags": [
@@ -6113,7 +6016,7 @@
             "costumes": [
                 {
                     "costumeName": "hat party2-a",
-                    "baseLayerID": 43,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "9b7a84fe3e50621752917e4e484a1e2f.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -6133,7 +6036,6 @@
     },
     {
         "name": "Hat Winter",
-        "baseLayerID": -1,
         "md5": "6c2ee1b97f6ec2b3457a25a3975a2009.svg",
         "type": "sprite",
         "tags": [
@@ -6160,7 +6062,7 @@
             "costumes": [
                 {
                     "costumeName": "hat winter",
-                    "baseLayerID": 44,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "6c2ee1b97f6ec2b3457a25a3975a2009.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 26,
@@ -6180,7 +6082,6 @@
     },
     {
         "name": "Hat Wizard",
-        "baseLayerID": -1,
         "md5": "581571e8c8f5adeb01565e12b1b77b58.svg",
         "type": "sprite",
         "tags": [
@@ -6207,7 +6108,7 @@
             "costumes": [
                 {
                     "costumeName": "hat wizard",
-                    "baseLayerID": 45,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "581571e8c8f5adeb01565e12b1b77b58.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 76,
@@ -6227,7 +6128,6 @@
     },
     {
         "name": "Headband",
-        "baseLayerID": -1,
         "md5": "961148d1605a1bd8ce80ed8d39e831c2.svg",
         "type": "sprite",
         "tags": [
@@ -6254,7 +6154,7 @@
             "costumes": [
                 {
                     "costumeName": "headband",
-                    "baseLayerID": 46,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "961148d1605a1bd8ce80ed8d39e831c2.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 53,
@@ -6274,7 +6174,6 @@
     },
     {
         "name": "Heart",
-        "baseLayerID": -1,
         "md5": "6e79e087c866a016f99ee482e1aeba47.svg",
         "type": "sprite",
         "tags": [
@@ -6304,7 +6203,7 @@
             "costumes": [
                 {
                     "costumeName": "heart red",
-                    "baseLayerID": 47,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "6e79e087c866a016f99ee482e1aeba47.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 65,
@@ -6312,7 +6211,7 @@
                 },
                 {
                     "costumeName": "heart purple",
-                    "baseLayerID": 48,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "b15362bb6b02a59e364db9081ccf19aa.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 66,
@@ -6332,7 +6231,6 @@
     },
     {
         "name": "Heart Candy",
-        "baseLayerID": -1,
         "md5": "d448acd247f10f32bef7823cd433f928.svg",
         "type": "sprite",
         "tags": [
@@ -6358,7 +6256,7 @@
             "costumes": [
                 {
                     "costumeName": "heart love it",
-                    "baseLayerID": 49,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "d448acd247f10f32bef7823cd433f928.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 58,
@@ -6366,7 +6264,7 @@
                 },
                 {
                     "costumeName": "heart code",
-                    "baseLayerID": 50,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "497c5df9e02467202ff93096dccaf91f.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 58,
@@ -6374,7 +6272,7 @@
                 },
                 {
                     "costumeName": "heart sweet",
-                    "baseLayerID": 51,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "a39d78d33b051e8b12a4b2a10d77b249.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 58,
@@ -6382,7 +6280,7 @@
                 },
                 {
                     "costumeName": "heart smile",
-                    "baseLayerID": 52,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "74a8f75d139d330b715787edbbacd83d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 58,
@@ -6402,7 +6300,6 @@
     },
     {
         "name": "Heart Face",
-        "baseLayerID": -1,
         "md5": "4ab84263da32069cf97cc0fa52729a0d.svg",
         "type": "sprite",
         "tags": [
@@ -6428,7 +6325,7 @@
             "costumes": [
                 {
                     "costumeName": "heart face",
-                    "baseLayerID": 53,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "4ab84263da32069cf97cc0fa52729a0d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 59,
@@ -6448,7 +6345,6 @@
     },
     {
         "name": "Hedgehog",
-        "baseLayerID": -1,
         "md5": "32416e6b2ef8e45fb5fd10778c1b9a9f.svg",
         "type": "sprite",
         "tags": [
@@ -6529,7 +6425,6 @@
     },
     {
         "name": "Hippo1",
-        "baseLayerID": -1,
         "md5": "c1353c4a5eec5e6f32ed053e6f6e8f99.svg",
         "type": "sprite",
         "tags": [
@@ -6562,7 +6457,7 @@
             "costumes": [
                 {
                     "costumeName": "hippo1-a",
-                    "baseLayerID": 78,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "c1353c4a5eec5e6f32ed053e6f6e8f99.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 69,
@@ -6570,7 +6465,7 @@
                 },
                 {
                     "costumeName": "hippo1-b",
-                    "baseLayerID": 79,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "e65ed93bbb9cccf698fc7e774ab609a6.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 69,
@@ -6590,7 +6485,6 @@
     },
     {
         "name": "Home Button",
-        "baseLayerID": -1,
         "md5": "1bac530a0701a8fc88bb0802ae6787a3.svg",
         "type": "sprite",
         "tags": [
@@ -6617,7 +6511,7 @@
             "costumes": [
                 {
                     "costumeName": "home button",
-                    "baseLayerID": 54,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "1bac530a0701a8fc88bb0802ae6787a3.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 72,
@@ -6637,7 +6531,6 @@
     },
     {
         "name": "Horse1",
-        "baseLayerID": -1,
         "md5": "32f4d80477cd070cb0848e555d374060.svg",
         "type": "sprite",
         "tags": [
@@ -6658,7 +6551,7 @@
             "sounds": [
                 {
                     "soundName": "horse",
-                    "soundID": 5,
+                    "soundID": -1,
                     "md5": "45ffcf97ee2edca0199ff5aa71a5b72e.wav",
                     "sampleCount": 14464,
                     "rate": 11025,
@@ -6666,7 +6559,7 @@
                 },
                 {
                     "soundName": "horse gallop",
-                    "soundID": 6,
+                    "soundID": -1,
                     "md5": "058a34b5fb8b57178b5322d994b6b8c8.wav",
                     "sampleCount": 38336,
                     "rate": 11025,
@@ -6676,7 +6569,7 @@
             "costumes": [
                 {
                     "costumeName": "horse1-a",
-                    "baseLayerID": 80,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "32f4d80477cd070cb0848e555d374060.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 119,
@@ -6684,7 +6577,7 @@
                 },
                 {
                     "costumeName": "horse1-b",
-                    "baseLayerID": 81,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "ffa6431c5ef2a4e975ecffacdb0efea7.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 103,
@@ -6704,7 +6597,6 @@
     },
     {
         "name": "Jamie",
-        "baseLayerID": -1,
         "md5": "90f9166fe6500d0c0caad8b1964d6b74.svg",
         "type": "sprite",
         "tags": [
@@ -6777,7 +6669,6 @@
     },
     {
         "name": "Jar",
-        "baseLayerID": -1,
         "md5": "73784b267083733e08bcf06aa7d6536a.svg",
         "type": "sprite",
         "tags": [
@@ -6833,7 +6724,6 @@
     },
     {
         "name": "Jeans",
-        "baseLayerID": -1,
         "md5": "4e283da8c59bcbb9803bdc0016b14c21.svg",
         "type": "sprite",
         "tags": [
@@ -6859,7 +6749,7 @@
             "costumes": [
                 {
                     "costumeName": "jeans-a",
-                    "baseLayerID": 55,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "4e283da8c59bcbb9803bdc0016b14c21.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -6867,7 +6757,7 @@
                 },
                 {
                     "costumeName": "jeans-b",
-                    "baseLayerID": 56,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "01732aa03a48482093fbed3ea402c4a9.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -6887,7 +6777,6 @@
     },
     {
         "name": "Jellyfish",
-        "baseLayerID": -1,
         "md5": "9e6563e417350af3094c2ed02b9b0bbd.svg",
         "type": "sprite",
         "tags": [
@@ -6918,7 +6807,7 @@
             "costumes": [
                 {
                     "costumeName": "jellyfish-a",
-                    "baseLayerID": 0,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "9e6563e417350af3094c2ed02b9b0bbd.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 99,
@@ -6926,7 +6815,7 @@
                 },
                 {
                     "costumeName": "jellyfish-b",
-                    "baseLayerID": 1,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "31a42fad0891f1298c522a6d5008930a.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 99,
@@ -6934,7 +6823,7 @@
                 },
                 {
                     "costumeName": "jellyfish-c",
-                    "baseLayerID": 2,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "697262d9ed04467bae52cca786c36bd3.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 99,
@@ -6942,7 +6831,7 @@
                 },
                 {
                     "costumeName": "jellyfish-d",
-                    "baseLayerID": 3,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "6a949493aaf62954f1c74f8369d494c4.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 99,
@@ -6962,7 +6851,6 @@
     },
     {
         "name": "Jordyn",
-        "baseLayerID": -1,
         "md5": "8dd2a2abbb8e639da8576b6e72ef9e59.svg",
         "type": "sprite",
         "tags": [
@@ -6992,7 +6880,7 @@
             "costumes": [
                 {
                     "costumeName": "jordyn-a",
-                    "baseLayerID": 5,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "8dd2a2abbb8e639da8576b6e72ef9e59.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 76,
@@ -7000,7 +6888,7 @@
                 },
                 {
                     "costumeName": "jordyn-b",
-                    "baseLayerID": 6,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "9665f543147961551d8dc6f612d9cc41.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 76,
@@ -7008,7 +6896,7 @@
                 },
                 {
                     "costumeName": "jordyn-c",
-                    "baseLayerID": 7,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "ec8c2286070c77ebd9dd40c96eaae3fc.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 76,
@@ -7016,7 +6904,7 @@
                 },
                 {
                     "costumeName": "jordyn-d",
-                    "baseLayerID": 8,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "1f9ed7f29800f31ce2ee53196143a3c8.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 76,
@@ -7036,7 +6924,6 @@
     },
     {
         "name": "Key",
-        "baseLayerID": -1,
         "md5": "af35300cef35803e11f4ed744dc5e818.svg",
         "type": "sprite",
         "tags": [
@@ -7063,7 +6950,7 @@
             "costumes": [
                 {
                     "costumeName": "key",
-                    "baseLayerID": 57,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "af35300cef35803e11f4ed744dc5e818.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 42,
@@ -7083,7 +6970,6 @@
     },
     {
         "name": "Keyboard",
-        "baseLayerID": -1,
         "md5": "c67d180e964926b6393ac14781541b39.svg",
         "type": "sprite",
         "tags": [
@@ -7100,7 +6986,7 @@
             "sounds": [
                 {
                     "soundName": "C elec piano",
-                    "soundID": 54,
+                    "soundID": -1,
                     "md5": "8366ee963cc57ad24a8a35a26f722c2b.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -7108,7 +6994,7 @@
                 },
                 {
                     "soundName": "D elec piano",
-                    "soundID": 55,
+                    "soundID": -1,
                     "md5": "835f136ca8d346a17b4d4baf8405be37.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -7116,7 +7002,7 @@
                 },
                 {
                     "soundName": "E elec piano",
-                    "soundID": 56,
+                    "soundID": -1,
                     "md5": "ab3c198f8e36efff14f0a5bad35fa3cd.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -7124,7 +7010,7 @@
                 },
                 {
                     "soundName": "F elec piano",
-                    "soundID": 57,
+                    "soundID": -1,
                     "md5": "dc5e368fc0d0dad1da609bfc3e29aa15.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -7132,7 +7018,7 @@
                 },
                 {
                     "soundName": "G elec piano",
-                    "soundID": 58,
+                    "soundID": -1,
                     "md5": "39525f6545d62a95d05153f92d63301a.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -7140,7 +7026,7 @@
                 },
                 {
                     "soundName": "A elec piano",
-                    "soundID": 59,
+                    "soundID": -1,
                     "md5": "0cfa8e84d6a5cd63afa31d541625a9ef.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -7148,7 +7034,7 @@
                 },
                 {
                     "soundName": "B elec piano",
-                    "soundID": 60,
+                    "soundID": -1,
                     "md5": "9cc77167419f228503dd57fddaa5b2a6.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -7156,7 +7042,7 @@
                 },
                 {
                     "soundName": "C2 elec piano",
-                    "soundID": 61,
+                    "soundID": -1,
                     "md5": "366c7edbd4dd5cca68bf62902999bd66.wav",
                     "sampleCount": 44100,
                     "rate": 22050,
@@ -7166,7 +7052,7 @@
             "costumes": [
                 {
                     "costumeName": "keyboard-a",
-                    "baseLayerID": 22,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "c67d180e964926b6393ac14781541b39.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 72,
@@ -7174,7 +7060,7 @@
                 },
                 {
                     "costumeName": "keyboard-b",
-                    "baseLayerID": 23,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "dbaf62b33de45093c3c7d13b5d49d637.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 72,
@@ -7194,7 +7080,6 @@
     },
     {
         "name": "Kiran",
-        "baseLayerID": -1,
         "md5": "9de23c4a7a7fbb67136b539241346854.svg",
         "type": "sprite",
         "tags": [
@@ -7282,7 +7167,6 @@
     },
     {
         "name": "Knight",
-        "baseLayerID": -1,
         "md5": "f2c5e8bc24d001b81566879dbf2f1a13.svg",
         "type": "sprite",
         "tags": [
@@ -7310,7 +7194,7 @@
             "costumes": [
                 {
                     "costumeName": "knight",
-                    "baseLayerID": 46,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "f2c5e8bc24d001b81566879dbf2f1a13.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -7330,7 +7214,6 @@
     },
     {
         "name": "Ladybug1",
-        "baseLayerID": -1,
         "md5": "f16a1ccc69a4a8190a927f1595aa7bfa.svg",
         "type": "sprite",
         "tags": [
@@ -7359,7 +7242,7 @@
             "costumes": [
                 {
                     "costumeName": "ladybug2",
-                    "baseLayerID": 47,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "f16a1ccc69a4a8190a927f1595aa7bfa.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 41,
@@ -7379,7 +7262,6 @@
     },
     {
         "name": "Ladybug2",
-        "baseLayerID": -1,
         "md5": "c018a3eed966d5f92c69f2188dfd2aae.svg",
         "type": "sprite",
         "tags": [
@@ -7409,7 +7291,7 @@
             "costumes": [
                 {
                     "costumeName": "ladybug2-a",
-                    "baseLayerID": 58,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "c018a3eed966d5f92c69f2188dfd2aae.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 49,
@@ -7417,7 +7299,7 @@
                 },
                 {
                     "costumeName": "ladybug2-b",
-                    "baseLayerID": 59,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "a2bb15ace808e070a2b815502952b292.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 49,
@@ -7437,7 +7319,6 @@
     },
     {
         "name": "Laptop",
-        "baseLayerID": -1,
         "md5": "76f456b30b98eeefd7c942b27b524e31.svg",
         "type": "sprite",
         "tags": [
@@ -7464,7 +7345,7 @@
             "costumes": [
                 {
                     "costumeName": "laptop",
-                    "baseLayerID": 60,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "76f456b30b98eeefd7c942b27b524e31.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -7484,7 +7365,6 @@
     },
     {
         "name": "Lightning",
-        "baseLayerID": -1,
         "md5": "c2d636ab2b491e591536afc3d49cbecd.svg",
         "type": "sprite",
         "tags": [
@@ -7514,7 +7394,7 @@
             "costumes": [
                 {
                     "costumeName": "lightning",
-                    "baseLayerID": 61,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "c2d636ab2b491e591536afc3d49cbecd.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 21,
@@ -7534,7 +7414,6 @@
     },
     {
         "name": "Line",
-        "baseLayerID": -1,
         "md5": "1b2cfb4d4746522aeb84e16a62820299.svg",
         "type": "sprite",
         "tags": [
@@ -7562,7 +7441,7 @@
             "costumes": [
                 {
                     "costumeName": "line",
-                    "baseLayerID": 62,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "1b2cfb4d4746522aeb84e16a62820299.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 239,
@@ -7582,7 +7461,6 @@
     },
     {
         "name": "Lion",
-        "baseLayerID": -1,
         "md5": "692a3c84366bf8ae4d16858e20e792f5.svg",
         "type": "sprite",
         "tags": [
@@ -7614,7 +7492,7 @@
             "costumes": [
                 {
                     "costumeName": "lion-a",
-                    "baseLayerID": 82,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "692a3c84366bf8ae4d16858e20e792f5.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -7622,7 +7500,7 @@
                 },
                 {
                     "costumeName": "lion-b",
-                    "baseLayerID": 83,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "a519ef168a345a2846d0201bf092a6d0.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -7642,7 +7520,6 @@
     },
     {
         "name": "Llama",
-        "baseLayerID": -1,
         "md5": "07158eb6d62e309bb60a6bc36baf2300.svg",
         "type": "sprite",
         "tags": [
@@ -7670,7 +7547,7 @@
             "costumes": [
                 {
                     "costumeName": "llama",
-                    "baseLayerID": 3,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "07158eb6d62e309bb60a6bc36baf2300.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 100,
@@ -7678,7 +7555,7 @@
                 },
                 {
                     "costumeName": "llama-b",
-                    "baseLayerID": 4,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "2021eea71514bd2b23e96076750727ae.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 100,
@@ -7686,7 +7563,7 @@
                 },
                 {
                     "costumeName": "llama-c",
-                    "baseLayerID": 5,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "7837d7247acbc4eebb793452a35aa1f5.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 100,
@@ -7706,7 +7583,6 @@
     },
     {
         "name": "Magic Wand",
-        "baseLayerID": -1,
         "md5": "3db9bfe57d561557795633c5cda44e8c.svg",
         "type": "sprite",
         "tags": [
@@ -7734,7 +7610,7 @@
             "costumes": [
                 {
                     "costumeName": "magicwand",
-                    "baseLayerID": 63,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "3db9bfe57d561557795633c5cda44e8c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 41,
@@ -7754,7 +7630,6 @@
     },
     {
         "name": "Max",
-        "baseLayerID": -1,
         "md5": "e10cca3bdbc09d039c2f937574f7a6ea.svg",
         "type": "sprite",
         "tags": [
@@ -7827,7 +7702,6 @@
     },
     {
         "name": "Mermaid",
-        "baseLayerID": -1,
         "md5": "36db41c47259881c26d9b98a806d3308.svg",
         "type": "sprite",
         "tags": [
@@ -7884,7 +7758,6 @@
     },
     {
         "name": "Mermaid-swimming",
-        "baseLayerID": -1,
         "md5": "9f973b89b68f7d8147f157cbac8af341.svg",
         "type": "sprite",
         "tags": [
@@ -7941,7 +7814,6 @@
     },
     {
         "name": "Microphone",
-        "baseLayerID": -1,
         "md5": "9126b6362313e20578fb88d38902cd4c.svg",
         "type": "sprite",
         "tags": [
@@ -7958,7 +7830,7 @@
             "sounds": [
                 {
                     "soundName": "bass beatbox",
-                    "soundID": 41,
+                    "soundID": -1,
                     "md5": "28153621d293c86da0b246d314458faf.wav",
                     "sampleCount": 6720,
                     "rate": 22050,
@@ -7966,7 +7838,7 @@
                 },
                 {
                     "soundName": "clap beatbox",
-                    "soundID": 42,
+                    "soundID": -1,
                     "md5": "abc70bb390f8e55f22f32265500d814a.wav",
                     "sampleCount": 4224,
                     "rate": 22050,
@@ -7974,7 +7846,7 @@
                 },
                 {
                     "soundName": "hi beatbox",
-                    "soundID": 43,
+                    "soundID": -1,
                     "md5": "5a07847bf246c227204728b05a3fc8f3.wav",
                     "sampleCount": 5856,
                     "rate": 22050,
@@ -7982,7 +7854,7 @@
                 },
                 {
                     "soundName": "scratch beatbox",
-                    "soundID": 44,
+                    "soundID": -1,
                     "md5": "859249563a7b1fc0f6e92e36d1db81c7.wav",
                     "sampleCount": 11552,
                     "rate": 22050,
@@ -7990,7 +7862,7 @@
                 },
                 {
                     "soundName": "snare beatbox",
-                    "soundID": 45,
+                    "soundID": -1,
                     "md5": "c642c4c00135d890998f351faec55498.wav",
                     "sampleCount": 5630,
                     "rate": 22050,
@@ -7998,7 +7870,7 @@
                 },
                 {
                     "soundName": "snare beatbox2",
-                    "soundID": 46,
+                    "soundID": -1,
                     "md5": "7ede1382b578d8fc32850b48d082d914.wav",
                     "sampleCount": 4960,
                     "rate": 22050,
@@ -8006,7 +7878,7 @@
                 },
                 {
                     "soundName": "wah beatbox",
-                    "soundID": 47,
+                    "soundID": -1,
                     "md5": "9021b7bb06f2399f18e2db4fb87095dc.wav",
                     "sampleCount": 6624,
                     "rate": 22050,
@@ -8014,7 +7886,7 @@
                 },
                 {
                     "soundName": "crash beatbox",
-                    "soundID": 48,
+                    "soundID": -1,
                     "md5": "725e29369e9138a43f11e0e5eb3eb562.wav",
                     "sampleCount": 26883,
                     "rate": 22050,
@@ -8022,7 +7894,7 @@
                 },
                 {
                     "soundName": "wub beatbox",
-                    "soundID": 49,
+                    "soundID": -1,
                     "md5": "e1f32c057411da4237181ce72ae15d23.wav",
                     "sampleCount": 7392,
                     "rate": 22050,
@@ -8032,7 +7904,7 @@
             "costumes": [
                 {
                     "costumeName": "microphone-a",
-                    "baseLayerID": 16,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "9126b6362313e20578fb88d38902cd4c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 40,
@@ -8040,7 +7912,7 @@
                 },
                 {
                     "costumeName": "microphone-b",
-                    "baseLayerID": 17,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "29988ebbde49beaceb06d9eb66138b80.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 40,
@@ -8060,7 +7932,6 @@
     },
     {
         "name": "Milk",
-        "baseLayerID": -1,
         "md5": "e6a7964bc4ea38c79a5a31d6ddfb5ba9.svg",
         "type": "sprite",
         "tags": [
@@ -8140,7 +8011,6 @@
     },
     {
         "name": "Monet",
-        "baseLayerID": -1,
         "md5": "11c46aaa5e30ad46f5c1883d6feb47b8.svg",
         "type": "sprite",
         "tags": [
@@ -8220,7 +8090,6 @@
     },
     {
         "name": "Monkey",
-        "baseLayerID": -1,
         "md5": "6e4de762dbd52cd2b6356694a9668211.svg",
         "type": "sprite",
         "tags": [
@@ -8239,7 +8108,7 @@
             "sounds": [
                 {
                     "soundName": "chee chee",
-                    "soundID": 7,
+                    "soundID": -1,
                     "md5": "25f4826cdd61e0a1c623ec2324c16ca0.wav",
                     "sampleCount": 34560,
                     "rate": 22050,
@@ -8249,7 +8118,7 @@
             "costumes": [
                 {
                     "costumeName": "monkey-a",
-                    "baseLayerID": 84,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "6e4de762dbd52cd2b6356694a9668211.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 68,
@@ -8257,7 +8126,7 @@
                 },
                 {
                     "costumeName": "monkey-b",
-                    "baseLayerID": 85,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "7662a3a0f4c6fa21fdf2de33bd80fe5f.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 68,
@@ -8265,7 +8134,7 @@
                 },
                 {
                     "costumeName": "monkey-c",
-                    "baseLayerID": 86,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "db8eb50b948047181922310bb94511fb.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 68,
@@ -8285,7 +8154,6 @@
     },
     {
         "name": "Mouse1",
-        "baseLayerID": -1,
         "md5": "e1f0c26afecbe9d4b9923d8e6bf489a8.svg",
         "type": "sprite",
         "tags": [
@@ -8313,7 +8181,7 @@
             "costumes": [
                 {
                     "costumeName": "mouse1-a",
-                    "baseLayerID": 64,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "e1f0c26afecbe9d4b9923d8e6bf489a8.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 50,
@@ -8321,7 +8189,7 @@
                 },
                 {
                     "costumeName": "mouse1-b",
-                    "baseLayerID": 65,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "f5e477a3f94fc98ba3cd927228405646.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 65,
@@ -8341,7 +8209,6 @@
     },
     {
         "name": "Muffin",
-        "baseLayerID": -1,
         "md5": "e00161f08c77d10e72e44b6e01243e63.svg",
         "type": "sprite",
         "tags": [
@@ -8367,7 +8234,7 @@
             "costumes": [
                 {
                     "costumeName": "muffin-a",
-                    "baseLayerID": 66,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "e00161f08c77d10e72e44b6e01243e63.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 85,
@@ -8375,7 +8242,7 @@
                 },
                 {
                     "costumeName": "muffin-b",
-                    "baseLayerID": 67,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "fb60c3f8d6a892813299daa33b91df23.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 85,
@@ -8395,7 +8262,6 @@
     },
     {
         "name": "Nano",
-        "baseLayerID": -1,
         "md5": "02c5433118f508038484bbc5b111e187.svg",
         "type": "sprite",
         "tags": [
@@ -8422,7 +8288,7 @@
             "costumes": [
                 {
                     "costumeName": "nano-a",
-                    "baseLayerID": 87,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "02c5433118f508038484bbc5b111e187.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 61,
@@ -8430,7 +8296,7 @@
                 },
                 {
                     "costumeName": "nano-b",
-                    "baseLayerID": 88,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "10d6d9130618cd092ae02158cde2e113.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 61,
@@ -8438,7 +8304,7 @@
                 },
                 {
                     "costumeName": "nano-c",
-                    "baseLayerID": 89,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "85e762d45bc626ca2edb3472c7cfaa32.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 61,
@@ -8446,7 +8312,7 @@
                 },
                 {
                     "costumeName": "nano-d",
-                    "baseLayerID": 90,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "b10925346da8080443f27e7dfaeff6f7.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 61,
@@ -8466,7 +8332,6 @@
     },
     {
         "name": "Neigh Pony",
-        "baseLayerID": -1,
         "md5": "176c4fb4df80df899ca28a48bd1f0edf.svg",
         "type": "sprite",
         "tags": [
@@ -8493,7 +8358,7 @@
             "costumes": [
                 {
                     "costumeName": "neigh pony",
-                    "baseLayerID": 68,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "176c4fb4df80df899ca28a48bd1f0edf.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 74,
@@ -8513,7 +8378,6 @@
     },
     {
         "name": "Octopus",
-        "baseLayerID": -1,
         "md5": "038df646d2f935d2a5dd601b343fc1d9.svg",
         "type": "sprite",
         "tags": [
@@ -8543,7 +8407,7 @@
             "costumes": [
                 {
                     "costumeName": "octopus-a",
-                    "baseLayerID": 4,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "038df646d2f935d2a5dd601b343fc1d9.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 88,
@@ -8551,7 +8415,7 @@
                 },
                 {
                     "costumeName": "octopus-b",
-                    "baseLayerID": 5,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "31bdcbdf05688c01aace3fd94c5e82df.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 88,
@@ -8559,7 +8423,7 @@
                 },
                 {
                     "costumeName": "octopus-c",
-                    "baseLayerID": 6,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "51e80c09323e36489ad452250acd827c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 88,
@@ -8567,7 +8431,7 @@
                 },
                 {
                     "costumeName": "octopus-d",
-                    "baseLayerID": 7,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "b4242e6cde0392bb9a5fb43a8f232962.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 88,
@@ -8575,7 +8439,7 @@
                 },
                 {
                     "costumeName": "octopus-e",
-                    "baseLayerID": 8,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "edfda0a36d9cd8482e3a8dc317107d56.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 88,
@@ -8595,7 +8459,6 @@
     },
     {
         "name": "Orange",
-        "baseLayerID": -1,
         "md5": "780ee2ef342f79a81b4c353725331138.svg",
         "type": "sprite",
         "tags": [
@@ -8622,7 +8485,7 @@
             "costumes": [
                 {
                     "costumeName": "orange",
-                    "baseLayerID": 69,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "780ee2ef342f79a81b4c353725331138.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 19,
@@ -8642,7 +8505,6 @@
     },
     {
         "name": "Orange2",
-        "baseLayerID": -1,
         "md5": "89b11d2a404c3972b65743f743cc968a.svg",
         "type": "sprite",
         "tags": [
@@ -8670,7 +8532,7 @@
             "costumes": [
                 {
                     "costumeName": "orange2-a",
-                    "baseLayerID": 70,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "89b11d2a404c3972b65743f743cc968a.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 49,
@@ -8678,7 +8540,7 @@
                 },
                 {
                     "costumeName": "orange2-b",
-                    "baseLayerID": 71,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "5f7998e007dfa70e70bbd8d43199ebba.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 49,
@@ -8686,7 +8548,7 @@
                 },
                 {
                     "costumeName": "orange2-c",
-                    "baseLayerID": 72,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "466e9e2d62ee135a2dabd5593e6f8407.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 49,
@@ -8706,7 +8568,6 @@
     },
     {
         "name": "Owl",
-        "baseLayerID": -1,
         "md5": "a312273b198fcacf68976e3cc74fadb4.svg",
         "type": "sprite",
         "tags": [
@@ -8734,7 +8595,7 @@
             "costumes": [
                 {
                     "costumeName": "owl-a",
-                    "baseLayerID": 6,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "a312273b198fcacf68976e3cc74fadb4.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 113,
@@ -8742,7 +8603,7 @@
                 },
                 {
                     "costumeName": "owl-b",
-                    "baseLayerID": 7,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "c9916dcfe67302367b05be7f3e5c5ddf.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 113,
@@ -8750,7 +8611,7 @@
                 },
                 {
                     "costumeName": "owl-c",
-                    "baseLayerID": 8,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "8ec3a2507f1d6dc9b39f7ae5a1ebfdd3.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 113,
@@ -8770,7 +8631,6 @@
     },
     {
         "name": "Paddle",
-        "baseLayerID": -1,
         "md5": "8038149bdfe24733ea2144d37d297815.svg",
         "type": "sprite",
         "tags": [
@@ -8786,7 +8646,7 @@
             "sounds": [
                 {
                     "soundName": "boing",
-                    "soundID": 1,
+                    "soundID": -1,
                     "md5": "53a3c2e27d1fb5fdb14aaf0cb41e7889.wav",
                     "sampleCount": 6804,
                     "rate": 22050,
@@ -8796,7 +8656,7 @@
             "costumes": [
                 {
                     "costumeName": "paddle",
-                    "baseLayerID": 73,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "8038149bdfe24733ea2144d37d297815.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 44,
@@ -8816,7 +8676,6 @@
     },
     {
         "name": "Panther",
-        "baseLayerID": -1,
         "md5": "04ca2c122cff11b9bc23834d6f79361e.svg",
         "type": "sprite",
         "tags": [
@@ -8881,7 +8740,6 @@
     },
     {
         "name": "Parrot",
-        "baseLayerID": -1,
         "md5": "098570b8e1aa85b32f9b4eb07bea3af2.svg",
         "type": "sprite",
         "tags": [
@@ -8903,7 +8761,7 @@
             "sounds": [
                 {
                     "soundName": "bird",
-                    "soundID": 8,
+                    "soundID": -1,
                     "md5": "18bd4b634a3f992a16b30344c7d810e0.wav",
                     "sampleCount": 3840,
                     "rate": 11025,
@@ -8913,7 +8771,7 @@
             "costumes": [
                 {
                     "costumeName": "parrot-a",
-                    "baseLayerID": 91,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "098570b8e1aa85b32f9b4eb07bea3af2.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 86,
@@ -8921,7 +8779,7 @@
                 },
                 {
                     "costumeName": "parrot-b",
-                    "baseLayerID": 92,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "721255a0733c9d8d2ba518ff09b3b7cb.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 49,
@@ -8941,7 +8799,6 @@
     },
     {
         "name": "Pencil",
-        "baseLayerID": -1,
         "md5": "4495fcb0443cebc5d43e66243a88f1ac.svg",
         "type": "sprite",
         "tags": [
@@ -8968,7 +8825,7 @@
             "costumes": [
                 {
                     "costumeName": "pencil-a",
-                    "baseLayerID": 74,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "4495fcb0443cebc5d43e66243a88f1ac.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 49,
@@ -8976,7 +8833,7 @@
                 },
                 {
                     "costumeName": "pencil-b",
-                    "baseLayerID": 75,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "21088922dbe127f6d2e58e2e83fb632e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 48,
@@ -8996,7 +8853,6 @@
     },
     {
         "name": "Penguin 2",
-        "baseLayerID": -1,
         "md5": "c17d9e4bdb59c574e0c34aa70af516da.svg",
         "type": "sprite",
         "tags": [
@@ -9025,7 +8881,7 @@
             "costumes": [
                 {
                     "costumeName": "penguin2-a",
-                    "baseLayerID": 48,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "c17d9e4bdb59c574e0c34aa70af516da.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 54,
@@ -9033,7 +8889,7 @@
                 },
                 {
                     "costumeName": "penguin2-b",
-                    "baseLayerID": 49,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "35fec7aa5f60cca945fe0615413f1f08.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 48,
@@ -9041,7 +8897,7 @@
                 },
                 {
                     "costumeName": "penguin2-c",
-                    "baseLayerID": 50,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "18fa51a64ebd5518f0c5c465525346e5.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 48,
@@ -9061,7 +8917,6 @@
     },
     {
         "name": "Pico",
-        "baseLayerID": -1,
         "md5": "0579fe60bb3717c49dfd7743caa84ada.svg",
         "type": "sprite",
         "tags": [
@@ -9088,7 +8943,7 @@
             "costumes": [
                 {
                     "costumeName": "pico-a",
-                    "baseLayerID": 101,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "0579fe60bb3717c49dfd7743caa84ada.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 55,
@@ -9096,7 +8951,7 @@
                 },
                 {
                     "costumeName": "pico-b",
-                    "baseLayerID": 102,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "26c688d7544757225ff51cd2fb1519b5.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 55,
@@ -9104,7 +8959,7 @@
                 },
                 {
                     "costumeName": "pico-c",
-                    "baseLayerID": 103,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "adf61e2090f8060e1e8b2b0604d03751.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 55,
@@ -9112,7 +8967,7 @@
                 },
                 {
                     "costumeName": "pico-d",
-                    "baseLayerID": 104,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "594704bf12e3c4d9e83bb91661ad709a.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 55,
@@ -9132,7 +8987,6 @@
     },
     {
         "name": "Pico Walking",
-        "baseLayerID": -1,
         "md5": "8eab5fe20dd249bf22964298b1d377eb.svg",
         "type": "sprite",
         "tags": [
@@ -9159,7 +9013,7 @@
             "costumes": [
                 {
                     "costumeName": "Pico walk1",
-                    "baseLayerID": 76,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "8eab5fe20dd249bf22964298b1d377eb.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 54,
@@ -9167,7 +9021,7 @@
                 },
                 {
                     "costumeName": "Pico walk2",
-                    "baseLayerID": 77,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "39ecd3c38d3f2cd81e3a17ee6c25699f.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 54,
@@ -9175,7 +9029,7 @@
                 },
                 {
                     "costumeName": "Pico walk3",
-                    "baseLayerID": 78,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "43f7d92dcf9eadf77c07a6fc1eb4104f.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 54,
@@ -9183,7 +9037,7 @@
                 },
                 {
                     "costumeName": "Pico walk4",
-                    "baseLayerID": 79,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "2582d012d57bca59bc0315c5c5954958.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 54,
@@ -9203,7 +9057,6 @@
     },
     {
         "name": "Planet2",
-        "baseLayerID": -1,
         "md5": "978784738c1d9dd4b1d397fd18bdf406.svg",
         "type": "sprite",
         "tags": [
@@ -9229,7 +9082,7 @@
             "costumes": [
                 {
                     "costumeName": "planet2",
-                    "baseLayerID": 80,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "978784738c1d9dd4b1d397fd18bdf406.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 72,
@@ -9249,7 +9102,6 @@
     },
     {
         "name": "Potion",
-        "baseLayerID": -1,
         "md5": "a317b50b255a208455a7733091adad23.svg",
         "type": "sprite",
         "tags": [
@@ -9313,7 +9165,6 @@
     },
     {
         "name": "Prince",
-        "baseLayerID": -1,
         "md5": "a760bed1cfc28a30b2dc7fd045c90792.svg",
         "type": "sprite",
         "tags": [
@@ -9341,7 +9192,7 @@
             "costumes": [
                 {
                     "costumeName": "prince",
-                    "baseLayerID": 81,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "a760bed1cfc28a30b2dc7fd045c90792.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -9361,7 +9212,6 @@
     },
     {
         "name": "Princess",
-        "baseLayerID": -1,
         "md5": "fcbf44a543dfda884d8acbd6af66faad.svg",
         "type": "sprite",
         "tags": [
@@ -9443,7 +9293,6 @@
     },
     {
         "name": "Pufferfish",
-        "baseLayerID": -1,
         "md5": "81d7db99142a39c9082be2c2183f2175.svg",
         "type": "sprite",
         "tags": [
@@ -9473,7 +9322,7 @@
             "costumes": [
                 {
                     "costumeName": "pufferfish-a",
-                    "baseLayerID": 13,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "81d7db99142a39c9082be2c2183f2175.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 69,
@@ -9481,7 +9330,7 @@
                 },
                 {
                     "costumeName": "pufferfish-b",
-                    "baseLayerID": 14,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "6ea79950db63f5ac24d6c5091df3836b.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 69,
@@ -9489,7 +9338,7 @@
                 },
                 {
                     "costumeName": "pufferfish-c",
-                    "baseLayerID": 15,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "4acf5bc398c19d58acf69fce047ee8f6.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 69,
@@ -9497,7 +9346,7 @@
                 },
                 {
                     "costumeName": "pufferfish-d",
-                    "baseLayerID": 16,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "c214fa8a9ceed06db03664007b8ad5c6.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 69,
@@ -9517,7 +9366,6 @@
     },
     {
         "name": "Rabbit",
-        "baseLayerID": -1,
         "md5": "2f42891c3f3d63c0e591aeabc5946533.svg",
         "type": "sprite",
         "tags": [
@@ -9600,7 +9448,6 @@
     },
     {
         "name": "Rainbow",
-        "baseLayerID": -1,
         "md5": "680a806bd87a28c8b25b5f9b6347f022.svg",
         "type": "sprite",
         "tags": [
@@ -9629,7 +9476,7 @@
             "costumes": [
                 {
                     "costumeName": "rainbow",
-                    "baseLayerID": 51,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "680a806bd87a28c8b25b5f9b6347f022.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 72,
@@ -9649,7 +9496,6 @@
     },
     {
         "name": "Referee",
-        "baseLayerID": -1,
         "md5": "0959403aeb134ed2932a85c77e261122.svg",
         "type": "sprite",
         "tags": [
@@ -9678,7 +9524,7 @@
             "costumes": [
                 {
                     "costumeName": "referee-a",
-                    "baseLayerID": 14,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "0959403aeb134ed2932a85c77e261122.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 76,
@@ -9686,7 +9532,7 @@
                 },
                 {
                     "costumeName": "referee-b",
-                    "baseLayerID": 15,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "866b9e1ad2e0584216dd45fe7d50d6f5.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 76,
@@ -9694,7 +9540,7 @@
                 },
                 {
                     "costumeName": "referee-c",
-                    "baseLayerID": 16,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "21a3869435fbd470ef60960a78b06b16.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 76,
@@ -9702,7 +9548,7 @@
                 },
                 {
                     "costumeName": "referee-d",
-                    "baseLayerID": 17,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "5e037aca5446a7e57093e45fe6f18c9e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 76,
@@ -9722,7 +9568,6 @@
     },
     {
         "name": "Reindeer",
-        "baseLayerID": -1,
         "md5": "0fff0b181cc4d9250b5b985cc283b049.svg",
         "type": "sprite",
         "tags": [
@@ -9750,7 +9595,7 @@
             "costumes": [
                 {
                     "costumeName": "reindeer",
-                    "baseLayerID": 82,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "0fff0b181cc4d9250b5b985cc283b049.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 39,
@@ -9770,7 +9615,6 @@
     },
     {
         "name": "Ripley",
-        "baseLayerID": -1,
         "md5": "417ec9f25ad70281564e85e67c97aa08.svg",
         "type": "sprite",
         "tags": [
@@ -9858,7 +9702,6 @@
     },
     {
         "name": "Robot",
-        "baseLayerID": -1,
         "md5": "cb3985cd066ccbab11954709b3d54c17.svg",
         "type": "sprite",
         "tags": [
@@ -9938,7 +9781,6 @@
     },
     {
         "name": "Rocks",
-        "baseLayerID": -1,
         "md5": "82c79fdb6a7d9c49ab7f70ee79a3d7f8.svg",
         "type": "sprite",
         "tags": [
@@ -9965,7 +9807,7 @@
             "costumes": [
                 {
                     "costumeName": "rocks",
-                    "baseLayerID": 83,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "82c79fdb6a7d9c49ab7f70ee79a3d7f8.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 59,
@@ -9985,7 +9827,6 @@
     },
     {
         "name": "Saxophone",
-        "baseLayerID": -1,
         "md5": "e9e4297f5d7e630a384b1dea835ec72d.svg",
         "type": "sprite",
         "tags": [
@@ -10002,7 +9843,7 @@
             "sounds": [
                 {
                     "soundName": "C sax",
-                    "soundID": 16,
+                    "soundID": -1,
                     "md5": "4d2c939d6953b5f241a27a62cf72de64.wav",
                     "sampleCount": 9491,
                     "rate": 22050,
@@ -10010,7 +9851,7 @@
                 },
                 {
                     "soundName": "D sax",
-                    "soundID": 17,
+                    "soundID": -1,
                     "md5": "39f41954a73c0e15d842061e1a4c5e1d.wav",
                     "sampleCount": 9555,
                     "rate": 22050,
@@ -10018,7 +9859,7 @@
                 },
                 {
                     "soundName": "E sax",
-                    "soundID": 18,
+                    "soundID": -1,
                     "md5": "3568b7dfe173fab6877a9ff1dcbcf1aa.wav",
                     "sampleCount": 7489,
                     "rate": 22050,
@@ -10026,7 +9867,7 @@
                 },
                 {
                     "soundName": "F sax",
-                    "soundID": 19,
+                    "soundID": -1,
                     "md5": "2ae3083817bcd595e26ea2884b6684d5.wav",
                     "sampleCount": 7361,
                     "rate": 22050,
@@ -10034,7 +9875,7 @@
                 },
                 {
                     "soundName": "G sax",
-                    "soundID": 20,
+                    "soundID": -1,
                     "md5": "cefba5de46adfe5702485e0934bb1e13.wav",
                     "sampleCount": 7349,
                     "rate": 22050,
@@ -10042,7 +9883,7 @@
                 },
                 {
                     "soundName": "A sax",
-                    "soundID": 21,
+                    "soundID": -1,
                     "md5": "420991e0d6d99292c6d736963842536a.wav",
                     "sampleCount": 6472,
                     "rate": 22050,
@@ -10050,7 +9891,7 @@
                 },
                 {
                     "soundName": "B sax",
-                    "soundID": 22,
+                    "soundID": -1,
                     "md5": "653ebe92d491b49ad5d8101d629f567b.wav",
                     "sampleCount": 9555,
                     "rate": 22050,
@@ -10058,7 +9899,7 @@
                 },
                 {
                     "soundName": "C2 sax",
-                    "soundID": 23,
+                    "soundID": -1,
                     "md5": "ea8d34b18c3d8fe328cea201666458bf.wav",
                     "sampleCount": 7349,
                     "rate": 22050,
@@ -10068,7 +9909,7 @@
             "costumes": [
                 {
                     "costumeName": "saxophone-a",
-                    "baseLayerID": 6,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "e9e4297f5d7e630a384b1dea835ec72d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 47,
@@ -10076,7 +9917,7 @@
                 },
                 {
                     "costumeName": "saxophone-b",
-                    "baseLayerID": 7,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "04e5650480bfcf9190aa35bbd8d67b8e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 47,
@@ -10096,8 +9937,7 @@
     },
     {
         "name": "Scarf1",
-        "baseLayerID": -1,
-        "md5": "9db18d2a2b3c9859654fc1b4832e6076.svg",
+        "md5": "0c03668b4e26eba969ad803a4e810c78.svg",
         "type": "sprite",
         "tags": [
             "fashion",
@@ -10123,11 +9963,11 @@
             "costumes": [
                 {
                     "costumeName": "scarf1",
-                    "baseLayerID": 84,
-                    "baseLayerMD5": "9db18d2a2b3c9859654fc1b4832e6076.svg",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "0c03668b4e26eba969ad803a4e810c78.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 54,
-                    "rotationCenterY": 36
+                    "rotationCenterY": 23
                 }
             ],
             "currentCostumeIndex": 0,
@@ -10143,7 +9983,6 @@
     },
     {
         "name": "Scarf2",
-        "baseLayerID": -1,
         "md5": "ce66662165e2756070f1b12e0a7cb5db.svg",
         "type": "sprite",
         "tags": [
@@ -10170,7 +10009,7 @@
             "costumes": [
                 {
                     "costumeName": "scarf2",
-                    "baseLayerID": 85,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "ce66662165e2756070f1b12e0a7cb5db.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 23,
@@ -10190,7 +10029,6 @@
     },
     {
         "name": "Shark",
-        "baseLayerID": -1,
         "md5": "4ca6776e9c021e8b21c3346793c9361d.svg",
         "type": "sprite",
         "tags": [
@@ -10247,7 +10085,6 @@
     },
     {
         "name": "Shirt Blouse",
-        "baseLayerID": -1,
         "md5": "918a507af6bbae9e7f36f0d949900838.svg",
         "type": "sprite",
         "tags": [
@@ -10273,7 +10110,7 @@
             "costumes": [
                 {
                     "costumeName": "shirt blouse",
-                    "baseLayerID": 88,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "918a507af6bbae9e7f36f0d949900838.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 35,
@@ -10293,7 +10130,6 @@
     },
     {
         "name": "Shirt Collar",
-        "baseLayerID": -1,
         "md5": "b7ecf6503e27e9ab5c086eaf07d22b94.svg",
         "type": "sprite",
         "tags": [
@@ -10319,7 +10155,7 @@
             "costumes": [
                 {
                     "costumeName": "shirt collar-a",
-                    "baseLayerID": 89,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "b7ecf6503e27e9ab5c086eaf07d22b94.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 30,
@@ -10327,7 +10163,7 @@
                 },
                 {
                     "costumeName": "shirt collar-b",
-                    "baseLayerID": 90,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "f1b20c3350e8a7e92a2fb1925ad4158b.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 30,
@@ -10335,7 +10171,7 @@
                 },
                 {
                     "costumeName": "shirt collar-c",
-                    "baseLayerID": 91,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "5f04b99416a794e04d0855f446780f18.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 30,
@@ -10355,7 +10191,6 @@
     },
     {
         "name": "Shirt-T",
-        "baseLayerID": -1,
         "md5": "5d7fa4f1788f03d2962f1624d6eac800.svg",
         "type": "sprite",
         "tags": [
@@ -10381,7 +10216,7 @@
             "costumes": [
                 {
                     "costumeName": "shirt-t",
-                    "baseLayerID": 92,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "5d7fa4f1788f03d2962f1624d6eac800.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 39,
@@ -10401,7 +10236,6 @@
     },
     {
         "name": "Shirt2",
-        "baseLayerID": -1,
         "md5": "5946e7a1e36c6d97ae47d41dd8595a41.svg",
         "type": "sprite",
         "tags": [
@@ -10427,7 +10261,7 @@
             "costumes": [
                 {
                     "costumeName": "shirt2-a",
-                    "baseLayerID": 86,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "5946e7a1e36c6d97ae47d41dd8595a41.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 39,
@@ -10435,7 +10269,7 @@
                 },
                 {
                     "costumeName": "shirt2-a2",
-                    "baseLayerID": 87,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "5b78ab09592126b6bbe2d4907d203909.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 39,
@@ -10455,7 +10289,6 @@
     },
     {
         "name": "Shoes1",
-        "baseLayerID": -1,
         "md5": "ffab4cc284070b50ac317e515f59f7d8.svg",
         "type": "sprite",
         "tags": [
@@ -10481,7 +10314,7 @@
             "costumes": [
                 {
                     "costumeName": "shoes1",
-                    "baseLayerID": 94,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "ffab4cc284070b50ac317e515f59f7d8.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 36,
@@ -10501,7 +10334,6 @@
     },
     {
         "name": "Shoes2",
-        "baseLayerID": -1,
         "md5": "1dc5d568d98405c370b91a230397a7f9.svg",
         "type": "sprite",
         "tags": [
@@ -10527,7 +10359,7 @@
             "costumes": [
                 {
                     "costumeName": "shoes2",
-                    "baseLayerID": 93,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "1dc5d568d98405c370b91a230397a7f9.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 40,
@@ -10547,7 +10379,6 @@
     },
     {
         "name": "Singer1",
-        "baseLayerID": -1,
         "md5": "e47ef1af3b925e5ac9e3b3f809d440b3.svg",
         "type": "sprite",
         "tags": [
@@ -10574,7 +10405,7 @@
             "costumes": [
                 {
                     "costumeName": "Singer1",
-                    "baseLayerID": 95,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "e47ef1af3b925e5ac9e3b3f809d440b3.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -10594,12 +10425,12 @@
     },
     {
         "name": "Skates",
-        "baseLayerID": -1,
         "md5": "00e5e173400662875a26bb7d6556346a.svg",
         "type": "sprite",
         "tags": [
             "fashion",
-            "winter"
+            "winter",
+            "sports"
         ],
         "info": [
             0,
@@ -10621,7 +10452,7 @@
             "costumes": [
                 {
                     "costumeName": "skates",
-                    "baseLayerID": 96,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "00e5e173400662875a26bb7d6556346a.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 44,
@@ -10641,7 +10472,6 @@
     },
     {
         "name": "Snake",
-        "baseLayerID": -1,
         "md5": "4d06e12d90479461303d828f0970f2d4.svg",
         "type": "sprite",
         "tags": [
@@ -10705,7 +10535,6 @@
     },
     {
         "name": "Snowflake",
-        "baseLayerID": -1,
         "md5": "67de2af723246de37d7379b76800ee0b.svg",
         "type": "sprite",
         "tags": [
@@ -10731,7 +10560,7 @@
             "costumes": [
                 {
                     "costumeName": "snowflake",
-                    "baseLayerID": 97,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "67de2af723246de37d7379b76800ee0b.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 104,
@@ -10751,7 +10580,6 @@
     },
     {
         "name": "Snowman",
-        "baseLayerID": -1,
         "md5": "56c71c31c17b9bc66a2aab0342cf94b2.svg",
         "type": "sprite",
         "tags": [
@@ -10779,7 +10607,7 @@
             "costumes": [
                 {
                     "costumeName": "snowman",
-                    "baseLayerID": 52,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "56c71c31c17b9bc66a2aab0342cf94b2.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -10799,7 +10627,6 @@
     },
     {
         "name": "Soccer Ball",
-        "baseLayerID": -1,
         "md5": "81ff5ad24454e7a0f1f3ae863bb4dd25.svg",
         "type": "sprite",
         "tags": [
@@ -10828,7 +10655,7 @@
             "costumes": [
                 {
                     "costumeName": "soccer ball",
-                    "baseLayerID": 13,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "81ff5ad24454e7a0f1f3ae863bb4dd25.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 26,
@@ -10848,7 +10675,6 @@
     },
     {
         "name": "Spaceship",
-        "baseLayerID": -1,
         "md5": "7d51af7c52e137ef137012595bac928d.svg",
         "type": "sprite",
         "tags": [
@@ -10943,7 +10769,6 @@
     },
     {
         "name": "Speaker",
-        "baseLayerID": -1,
         "md5": "44dc3a2ec161999545914d1f77332d76.svg",
         "type": "sprite",
         "tags": [
@@ -10985,7 +10810,7 @@
             "sounds": [
                 {
                     "soundName": "drive around",
-                    "soundID": 9,
+                    "soundID": -1,
                     "md5": "a3a85fb8564b0266f50a9c091087b7aa.wav",
                     "sampleCount": 44096,
                     "rate": 22050,
@@ -10993,7 +10818,7 @@
                 },
                 {
                     "soundName": "scratchy beat",
-                    "soundID": 10,
+                    "soundID": -1,
                     "md5": "289dc558e076971e74dd1a0bd55719b1.wav",
                     "sampleCount": 44096,
                     "rate": 22050,
@@ -11001,7 +10826,7 @@
                 },
                 {
                     "soundName": "drum jam",
-                    "soundID": 11,
+                    "soundID": -1,
                     "md5": "8b5486ccc806e97e83049d25b071f7e4.wav",
                     "sampleCount": 44288,
                     "rate": 22050,
@@ -11009,7 +10834,7 @@
                 },
                 {
                     "soundName": "cymbal echo",
-                    "soundID": 12,
+                    "soundID": -1,
                     "md5": "bb243badd1201b2607bf2513df10cd97.wav",
                     "sampleCount": 44326,
                     "rate": 22050,
@@ -11017,7 +10842,7 @@
                 },
                 {
                     "soundName": "drum satellite",
-                    "soundID": 13,
+                    "soundID": -1,
                     "md5": "079067d7909f791b29f8be1c00fc2131.wav",
                     "sampleCount": 44096,
                     "rate": 22050,
@@ -11025,7 +10850,7 @@
                 },
                 {
                     "soundName": "kick back",
-                    "soundID": 14,
+                    "soundID": -1,
                     "md5": "9cd340d9d568b1479f731e69e103b3ce.wav",
                     "sampleCount": 44748,
                     "rate": 22050,
@@ -11033,7 +10858,7 @@
                 },
                 {
                     "soundName": "drum funky",
-                    "soundID": 15,
+                    "soundID": -1,
                     "md5": "fb56022366d21b299cbc3fd5e16000c2.wav",
                     "sampleCount": 44748,
                     "rate": 22050,
@@ -11043,7 +10868,7 @@
             "costumes": [
                 {
                     "costumeName": "speaker",
-                    "baseLayerID": 93,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "44dc3a2ec161999545914d1f77332d76.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 53,
@@ -11063,8 +10888,7 @@
     },
     {
         "name": "Star",
-        "baseLayerID": -1,
-        "md5": "ab0914e53e360477275e58b83ec4d423.svg",
+        "md5": "e929c1274c379b6b6fed12e6dec63368.svg",
         "type": "sprite",
         "tags": [
             "shapes",
@@ -11090,11 +10914,11 @@
             "costumes": [
                 {
                     "costumeName": "star",
-                    "baseLayerID": 98,
-                    "baseLayerMD5": "ab0914e53e360477275e58b83ec4d423.svg",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "e929c1274c379b6b6fed12e6dec63368.svg",
                     "bitmapResolution": 1,
-                    "rotationCenterX": 21,
-                    "rotationCenterY": 19
+                    "rotationCenterX": 22,
+                    "rotationCenterY": 23
                 }
             ],
             "currentCostumeIndex": 0,
@@ -11110,7 +10934,6 @@
     },
     {
         "name": "Starfish",
-        "baseLayerID": -1,
         "md5": "3d1101bbc24ae292a36356af325f660c.svg",
         "type": "sprite",
         "tags": [
@@ -11140,7 +10963,7 @@
             "costumes": [
                 {
                     "costumeName": "starfish-a",
-                    "baseLayerID": 99,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "3d1101bbc24ae292a36356af325f660c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -11148,7 +10971,7 @@
                 },
                 {
                     "costumeName": "starfish-b ",
-                    "baseLayerID": 100,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "ad8007f4e63693984d4adc466ffa3ad2.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 53,
@@ -11168,7 +10991,6 @@
     },
     {
         "name": "Stop",
-        "baseLayerID": -1,
         "md5": "5b9e3e8edffb0bd4914113609eec5e04.svg",
         "type": "sprite",
         "tags": [
@@ -11195,7 +11017,7 @@
             "costumes": [
                 {
                     "costumeName": "stop",
-                    "baseLayerID": 101,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "5b9e3e8edffb0bd4914113609eec5e04.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 25,
@@ -11215,7 +11037,6 @@
     },
     {
         "name": "Strawberry",
-        "baseLayerID": -1,
         "md5": "734556fb8e14740f2cbc971238b71d47.svg",
         "type": "sprite",
         "tags": [
@@ -11295,7 +11116,6 @@
     },
     {
         "name": "Sun",
-        "baseLayerID": -1,
         "md5": "55c931c65456822c0c56a2b30e3e550d.svg",
         "type": "sprite",
         "tags": [
@@ -11326,7 +11146,7 @@
             "costumes": [
                 {
                     "costumeName": "sun",
-                    "baseLayerID": 102,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "55c931c65456822c0c56a2b30e3e550d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 72,
@@ -11346,7 +11166,6 @@
     },
     {
         "name": "Sunglasses1",
-        "baseLayerID": -1,
         "md5": "424393e8705aeadcfecb8559ce4dcea2.svg",
         "type": "sprite",
         "tags": [
@@ -11373,7 +11192,7 @@
             "costumes": [
                 {
                     "costumeName": "sunglasses1",
-                    "baseLayerID": 103,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "424393e8705aeadcfecb8559ce4dcea2.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 37,
@@ -11393,7 +11212,6 @@
     },
     {
         "name": "Sunglasses2",
-        "baseLayerID": -1,
         "md5": "3185d2295bbf2c5ebd0688c9e4f13076.svg",
         "type": "sprite",
         "tags": [
@@ -11420,7 +11238,7 @@
             "costumes": [
                 {
                     "costumeName": "sunglasses2",
-                    "baseLayerID": 104,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "3185d2295bbf2c5ebd0688c9e4f13076.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 29,
@@ -11440,7 +11258,6 @@
     },
     {
         "name": "Taco",
-        "baseLayerID": -1,
         "md5": "d224b30c54bd4d6000c935938c7f5d7e.svg",
         "type": "sprite",
         "tags": [
@@ -11469,7 +11286,7 @@
             "costumes": [
                 {
                     "costumeName": "taco-a",
-                    "baseLayerID": 105,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "d224b30c54bd4d6000c935938c7f5d7e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 20,
@@ -11477,7 +11294,7 @@
                 },
                 {
                     "costumeName": "taco-b",
-                    "baseLayerID": 106,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "6dee4f866d79e6475d9824ba11973037.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 56,
@@ -11497,7 +11314,6 @@
     },
     {
         "name": "Takeout",
-        "baseLayerID": -1,
         "md5": "0cfdefe0df1a032b90c8facd9f5dbe1f.svg",
         "type": "sprite",
         "tags": [
@@ -11576,7 +11392,6 @@
     },
     {
         "name": "Tera",
-        "baseLayerID": -1,
         "md5": "b54a4a9087435863ab6f6c908f1cac99.svg",
         "type": "sprite",
         "tags": [
@@ -11603,7 +11418,7 @@
             "costumes": [
                 {
                     "costumeName": "tera-a",
-                    "baseLayerID": 94,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "b54a4a9087435863ab6f6c908f1cac99.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 49,
@@ -11611,7 +11426,7 @@
                 },
                 {
                     "costumeName": "tera-b",
-                    "baseLayerID": 95,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "1e6b3a29351cda80d1a70a3cc0e499f2.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 49,
@@ -11619,7 +11434,7 @@
                 },
                 {
                     "costumeName": "tera-c",
-                    "baseLayerID": 96,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "7edf116cbb7111292361431521ae699e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 49,
@@ -11627,7 +11442,7 @@
                 },
                 {
                     "costumeName": "tera-d",
-                    "baseLayerID": 97,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "7c3c9c8b5f4ac77de2036175712a777a.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 49,
@@ -11647,7 +11462,6 @@
     },
     {
         "name": "Toucan",
-        "baseLayerID": -1,
         "md5": "6c8798e606abd728b112aecedb5dc249.svg",
         "type": "sprite",
         "tags": [
@@ -11711,7 +11525,6 @@
     },
     {
         "name": "Tree1",
-        "baseLayerID": -1,
         "md5": "8c40e2662c55d17bc384f47165ac43c1.svg",
         "type": "sprite",
         "tags": [
@@ -11739,7 +11552,7 @@
             "costumes": [
                 {
                     "costumeName": "tree1",
-                    "baseLayerID": 107,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "8c40e2662c55d17bc384f47165ac43c1.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 77,
@@ -11759,7 +11572,6 @@
     },
     {
         "name": "Trees",
-        "baseLayerID": -1,
         "md5": "866ed2c2971bb04157e14e935ac8521c.svg",
         "type": "sprite",
         "tags": [
@@ -11787,7 +11599,7 @@
             "costumes": [
                 {
                     "costumeName": "trees-a",
-                    "baseLayerID": 108,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "866ed2c2971bb04157e14e935ac8521c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 49,
@@ -11795,7 +11607,7 @@
                 },
                 {
                     "costumeName": "trees-b",
-                    "baseLayerID": 109,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "f1393dde1bb0fc512577995b27616d86.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 36,
@@ -11815,7 +11627,6 @@
     },
     {
         "name": "Trumpet",
-        "baseLayerID": -1,
         "md5": "8fa7459ed5877bb14c6625e688be70e7.svg",
         "type": "sprite",
         "tags": [
@@ -11832,7 +11643,7 @@
             "sounds": [
                 {
                     "soundName": "C trumpet",
-                    "soundID": 24,
+                    "soundID": -1,
                     "md5": "8970afcdc4e47bb54959a81fe27522bd.wav",
                     "sampleCount": 13118,
                     "rate": 22050,
@@ -11840,7 +11651,7 @@
                 },
                 {
                     "soundName": "D trumpet",
-                    "soundID": 25,
+                    "soundID": -1,
                     "md5": "0b1345b8fe2ba3076fedb4f3ae48748a.wav",
                     "sampleCount": 12702,
                     "rate": 22050,
@@ -11848,7 +11659,7 @@
                 },
                 {
                     "soundName": "E trumpet",
-                    "soundID": 26,
+                    "soundID": -1,
                     "md5": "494295a92314cadb220945a6711c568c.wav",
                     "sampleCount": 8680,
                     "rate": 22050,
@@ -11856,7 +11667,7 @@
                 },
                 {
                     "soundName": "F trumpet",
-                    "soundID": 27,
+                    "soundID": -1,
                     "md5": "5fa3108b119ca266029b4caa340a7cd0.wav",
                     "sampleCount": 12766,
                     "rate": 22050,
@@ -11864,7 +11675,7 @@
                 },
                 {
                     "soundName": "G trumpet",
-                    "soundID": 28,
+                    "soundID": -1,
                     "md5": "e84afda25975f14b364118591538ccf4.wav",
                     "sampleCount": 14640,
                     "rate": 22050,
@@ -11872,7 +11683,7 @@
                 },
                 {
                     "soundName": "A trumpet",
-                    "soundID": 29,
+                    "soundID": -1,
                     "md5": "d2dd6b4372ca17411965dc92d52b2172.wav",
                     "sampleCount": 13911,
                     "rate": 22050,
@@ -11880,7 +11691,7 @@
                 },
                 {
                     "soundName": "B trumpet",
-                    "soundID": 30,
+                    "soundID": -1,
                     "md5": "cad2bc57729942ed9b605145fc9ea65d.wav",
                     "sampleCount": 14704,
                     "rate": 22050,
@@ -11888,7 +11699,7 @@
                 },
                 {
                     "soundName": "C2 trumpet",
-                    "soundID": 31,
+                    "soundID": -1,
                     "md5": "df08249ed5446cc5e10b7ac62faac89b.wav",
                     "sampleCount": 15849,
                     "rate": 22050,
@@ -11898,7 +11709,7 @@
             "costumes": [
                 {
                     "costumeName": "trumpet-a",
-                    "baseLayerID": 8,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "8fa7459ed5877bb14c6625e688be70e7.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 37,
@@ -11906,7 +11717,7 @@
                 },
                 {
                     "costumeName": "trumpet-b",
-                    "baseLayerID": 9,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "7cedda5ec925118f237094cd05381e5d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 37,
@@ -11926,7 +11737,6 @@
     },
     {
         "name": "Unicorn",
-        "baseLayerID": -1,
         "md5": "bd2cf980966c13d5ad3ab403bae4bb05.svg",
         "type": "sprite",
         "tags": [
@@ -11974,7 +11784,6 @@
     },
     {
         "name": "Unicorn 2",
-        "baseLayerID": -1,
         "md5": "a04def38351e7fd805226345cac4fbfe.svg",
         "type": "sprite",
         "tags": [
@@ -12003,7 +11812,7 @@
             "costumes": [
                 {
                     "costumeName": "unicorn 2",
-                    "baseLayerID": 53,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "a04def38351e7fd805226345cac4fbfe.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 75,
@@ -12023,7 +11832,6 @@
     },
     {
         "name": "Unicorn-running",
-        "baseLayerID": -1,
         "md5": "c6456df027561c74b70b8b25ab83fec9.svg",
         "type": "sprite",
         "tags": [
@@ -12111,7 +11919,6 @@
     },
     {
         "name": "Vest",
-        "baseLayerID": -1,
         "md5": "f8285ca9564451c62a0e3d75b8a714e8.svg",
         "type": "sprite",
         "tags": [
@@ -12137,7 +11944,7 @@
             "costumes": [
                 {
                     "costumeName": "vest-a",
-                    "baseLayerID": 110,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "f8285ca9564451c62a0e3d75b8a714e8.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 18,
@@ -12145,7 +11952,7 @@
                 },
                 {
                     "costumeName": "vest-b",
-                    "baseLayerID": 111,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "77d553eea3910ab8f5bac3d2da601061.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 18,
@@ -12165,7 +11972,6 @@
     },
     {
         "name": "Wand",
-        "baseLayerID": -1,
         "md5": "1aa56e9ef7043eaf36ecfe8e330271b7.svg",
         "type": "sprite",
         "tags": [
@@ -12213,7 +12019,6 @@
     },
     {
         "name": "Wanda",
-        "baseLayerID": -1,
         "md5": "450bc8fbd5ab6bc2e83576aad58cd07c.svg",
         "type": "sprite",
         "tags": [
@@ -12239,7 +12044,7 @@
             "costumes": [
                 {
                     "costumeName": "wanda",
-                    "baseLayerID": 112,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "450bc8fbd5ab6bc2e83576aad58cd07c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 49,
@@ -12259,7 +12064,6 @@
     },
     {
         "name": "Watermelon",
-        "baseLayerID": -1,
         "md5": "26fecef75cf3b6e0d98bff5c06475036.svg",
         "type": "sprite",
         "tags": [
@@ -12290,7 +12094,7 @@
             "costumes": [
                 {
                     "costumeName": "watermelon-a",
-                    "baseLayerID": 98,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "26fecef75cf3b6e0d98bff5c06475036.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 40,
@@ -12298,7 +12102,7 @@
                 },
                 {
                     "costumeName": "watermelon-b",
-                    "baseLayerID": 99,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "fbdaf4d1d349edd3ddf3a1c4528aa9ec.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -12306,7 +12110,7 @@
                 },
                 {
                     "costumeName": "watermelon-c",
-                    "baseLayerID": 100,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "5976c10412306fc093c1d1930fa05119.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 21,
@@ -12326,7 +12130,6 @@
     },
     {
         "name": "Witch",
-        "baseLayerID": -1,
         "md5": "cbc54e15cd62f0c16369587377636099.svg",
         "type": "sprite",
         "tags": [
@@ -12401,7 +12204,6 @@
     },
     {
         "name": "Wizard",
-        "baseLayerID": -1,
         "md5": "9632aab80fce1c5bdb58150b29cb0067.svg",
         "type": "sprite",
         "tags": [
@@ -12468,7 +12270,6 @@
     },
     {
         "name": "Wizard-toad",
-        "baseLayerID": -1,
         "md5": "fd5c4cce36e866489febc227e23b21aa.svg",
         "type": "sprite",
         "tags": [
@@ -12527,7 +12328,6 @@
     },
     {
         "name": "Block-A",
-        "baseLayerID": -1,
         "md5": "602a16930a8050e1298e1a0ae844363e.svg",
         "type": "sprite",
         "tags": [
@@ -12554,7 +12354,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-a",
-                    "baseLayerID": 0,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "602a16930a8050e1298e1a0ae844363e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 28,
@@ -12574,7 +12374,6 @@
     },
     {
         "name": "Block-B",
-        "baseLayerID": -1,
         "md5": "f8c683cf71660e8ac1f8855599857a25.svg",
         "type": "sprite",
         "tags": [
@@ -12601,7 +12400,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-b",
-                    "baseLayerID": 1,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "f8c683cf71660e8ac1f8855599857a25.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 29,
@@ -12621,7 +12420,6 @@
     },
     {
         "name": "Block-C",
-        "baseLayerID": -1,
         "md5": "f8f4cc686ffc5a4113a99f70b09abd32.svg",
         "type": "sprite",
         "tags": [
@@ -12648,7 +12446,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-c",
-                    "baseLayerID": 2,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "f8f4cc686ffc5a4113a99f70b09abd32.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 35,
@@ -12668,7 +12466,6 @@
     },
     {
         "name": "Block-D",
-        "baseLayerID": -1,
         "md5": "aee2d71ef0293b33479bff9423d16b67.svg",
         "type": "sprite",
         "tags": [
@@ -12695,7 +12492,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-d",
-                    "baseLayerID": 3,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "aee2d71ef0293b33479bff9423d16b67.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 31,
@@ -12715,7 +12512,6 @@
     },
     {
         "name": "Block-E",
-        "baseLayerID": -1,
         "md5": "16c6257316ff94cc7539ccdfc24e5fb8.svg",
         "type": "sprite",
         "tags": [
@@ -12742,7 +12538,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-e",
-                    "baseLayerID": 4,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "16c6257316ff94cc7539ccdfc24e5fb8.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 25,
@@ -12762,7 +12558,6 @@
     },
     {
         "name": "Block-F",
-        "baseLayerID": -1,
         "md5": "34c090c1f573c569332ead68cb99b595.svg",
         "type": "sprite",
         "tags": [
@@ -12789,7 +12584,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-f",
-                    "baseLayerID": 6,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "34c090c1f573c569332ead68cb99b595.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 23,
@@ -12809,7 +12604,6 @@
     },
     {
         "name": "Block-G",
-        "baseLayerID": -1,
         "md5": "8bb2382627004eb08ff10ea8171cc724.svg",
         "type": "sprite",
         "tags": [
@@ -12836,7 +12630,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-g",
-                    "baseLayerID": 9,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "8bb2382627004eb08ff10ea8171cc724.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 28,
@@ -12856,7 +12650,6 @@
     },
     {
         "name": "Block-H",
-        "baseLayerID": -1,
         "md5": "f1578807d4a124fc02b639a8febeaab3.svg",
         "type": "sprite",
         "tags": [
@@ -12883,7 +12676,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-h",
-                    "baseLayerID": 11,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "f1578807d4a124fc02b639a8febeaab3.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 27,
@@ -12903,7 +12696,6 @@
     },
     {
         "name": "Block-I",
-        "baseLayerID": -1,
         "md5": "341bc70442886d6fdf959f2a97a63554.svg",
         "type": "sprite",
         "tags": [
@@ -12930,7 +12722,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-i",
-                    "baseLayerID": 13,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "341bc70442886d6fdf959f2a97a63554.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 19,
@@ -12950,7 +12742,6 @@
     },
     {
         "name": "Block-J",
-        "baseLayerID": -1,
         "md5": "4b420cce964beedf2c1dc43faa59fdec.svg",
         "type": "sprite",
         "tags": [
@@ -12977,7 +12768,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-j",
-                    "baseLayerID": 15,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "4b420cce964beedf2c1dc43faa59fdec.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 25,
@@ -12997,7 +12788,6 @@
     },
     {
         "name": "Block-K",
-        "baseLayerID": -1,
         "md5": "19601cc33449813aa93a47c63167e5c1.svg",
         "type": "sprite",
         "tags": [
@@ -13024,7 +12814,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-k",
-                    "baseLayerID": 17,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "19601cc33449813aa93a47c63167e5c1.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 24,
@@ -13044,7 +12834,6 @@
     },
     {
         "name": "Block-L",
-        "baseLayerID": -1,
         "md5": "87358e3c9b9f5be4376253ce08d0192d.svg",
         "type": "sprite",
         "tags": [
@@ -13071,7 +12860,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-l",
-                    "baseLayerID": 19,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "87358e3c9b9f5be4376253ce08d0192d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 26,
@@ -13091,7 +12880,6 @@
     },
     {
         "name": "Block-M",
-        "baseLayerID": -1,
         "md5": "7ba0642be1f0080c0d273ea96e29b1e8.svg",
         "type": "sprite",
         "tags": [
@@ -13118,7 +12906,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-m",
-                    "baseLayerID": 21,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "7ba0642be1f0080c0d273ea96e29b1e8.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 35,
@@ -13138,7 +12926,6 @@
     },
     {
         "name": "Block-N",
-        "baseLayerID": -1,
         "md5": "6c1fbc57821744bd9356ce9a21ed70f7.svg",
         "type": "sprite",
         "tags": [
@@ -13165,7 +12952,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-n",
-                    "baseLayerID": 23,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "6c1fbc57821744bd9356ce9a21ed70f7.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 28,
@@ -13185,7 +12972,6 @@
     },
     {
         "name": "Block-O",
-        "baseLayerID": -1,
         "md5": "e88638200a73e167d0e266a343019cec.svg",
         "type": "sprite",
         "tags": [
@@ -13212,7 +12998,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-o",
-                    "baseLayerID": 27,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "e88638200a73e167d0e266a343019cec.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 32,
@@ -13232,7 +13018,6 @@
     },
     {
         "name": "Block-P",
-        "baseLayerID": -1,
         "md5": "ad2fc3a1c6538678915633a11ab6ec73.svg",
         "type": "sprite",
         "tags": [
@@ -13259,7 +13044,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-p",
-                    "baseLayerID": 25,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "ad2fc3a1c6538678915633a11ab6ec73.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 18,
@@ -13279,7 +13064,6 @@
     },
     {
         "name": "Block-Q",
-        "baseLayerID": -1,
         "md5": "64da9da8684c74deb567dbdb661d3a52.svg",
         "type": "sprite",
         "tags": [
@@ -13306,7 +13090,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-q",
-                    "baseLayerID": 35,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "64da9da8684c74deb567dbdb661d3a52.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 26,
@@ -13326,7 +13110,6 @@
     },
     {
         "name": "Block-R",
-        "baseLayerID": -1,
         "md5": "73e8d46f7475476d8cb4cfcfc75ee50d.svg",
         "type": "sprite",
         "tags": [
@@ -13353,7 +13136,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-r",
-                    "baseLayerID": 30,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "73e8d46f7475476d8cb4cfcfc75ee50d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -13373,7 +13156,6 @@
     },
     {
         "name": "Block-S",
-        "baseLayerID": -1,
         "md5": "9feb5593fed51e88dbb3128cfc290d29.svg",
         "type": "sprite",
         "tags": [
@@ -13400,7 +13182,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-s",
-                    "baseLayerID": 32,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "9feb5593fed51e88dbb3128cfc290d29.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 13,
@@ -13420,7 +13202,6 @@
     },
     {
         "name": "Block-T",
-        "baseLayerID": -1,
         "md5": "d29c1caf5cf195740c38f279e82a77a4.svg",
         "type": "sprite",
         "tags": [
@@ -13447,7 +13228,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-t",
-                    "baseLayerID": 37,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "d29c1caf5cf195740c38f279e82a77a4.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 25,
@@ -13467,7 +13248,6 @@
     },
     {
         "name": "Block-U",
-        "baseLayerID": -1,
         "md5": "faef46b7bf589c36300142f6f03c5d32.svg",
         "type": "sprite",
         "tags": [
@@ -13494,7 +13274,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-u",
-                    "baseLayerID": 39,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "faef46b7bf589c36300142f6f03c5d32.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 28,
@@ -13514,7 +13294,6 @@
     },
     {
         "name": "Block-V",
-        "baseLayerID": -1,
         "md5": "65e2f4821ab084827e22920acb61c92b.svg",
         "type": "sprite",
         "tags": [
@@ -13541,7 +13320,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-v",
-                    "baseLayerID": 42,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "65e2f4821ab084827e22920acb61c92b.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 35,
@@ -13561,7 +13340,6 @@
     },
     {
         "name": "Block-W",
-        "baseLayerID": -1,
         "md5": "5ab197b4f70b2f98a3658c7ccdc3351d.svg",
         "type": "sprite",
         "tags": [
@@ -13588,7 +13366,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-w",
-                    "baseLayerID": 44,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "5ab197b4f70b2f98a3658c7ccdc3351d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 47,
@@ -13608,7 +13386,6 @@
     },
     {
         "name": "Block-X",
-        "baseLayerID": -1,
         "md5": "cb9dff35f05e823d954e47e4a717a48c.svg",
         "type": "sprite",
         "tags": [
@@ -13635,7 +13412,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-x",
-                    "baseLayerID": 46,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "cb9dff35f05e823d954e47e4a717a48c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 25,
@@ -13655,7 +13432,6 @@
     },
     {
         "name": "Block-Y",
-        "baseLayerID": -1,
         "md5": "4c13c440bcb35c8c3aa6226374fced3f.svg",
         "type": "sprite",
         "tags": [
@@ -13682,7 +13458,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-y",
-                    "baseLayerID": 48,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "4c13c440bcb35c8c3aa6226374fced3f.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 26,
@@ -13702,7 +13478,6 @@
     },
     {
         "name": "Block-Z",
-        "baseLayerID": -1,
         "md5": "0ccff1898f1bf1b25333d581db09fae2.svg",
         "type": "sprite",
         "tags": [
@@ -13729,7 +13504,7 @@
             "costumes": [
                 {
                     "costumeName": "Block-z",
-                    "baseLayerID": 50,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "0ccff1898f1bf1b25333d581db09fae2.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 24,
@@ -13749,7 +13524,6 @@
     },
     {
         "name": "Glow-0",
-        "baseLayerID": -1,
         "md5": "38b2b342659adc6fa289090975e0e71d.svg",
         "type": "sprite",
         "tags": [
@@ -13776,7 +13550,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-0",
-                    "baseLayerID": 31,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "38b2b342659adc6fa289090975e0e71d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 29,
@@ -13796,7 +13570,6 @@
     },
     {
         "name": "Glow-1",
-        "baseLayerID": -1,
         "md5": "2c88706210672655401fe09edd8ff6a7.svg",
         "type": "sprite",
         "tags": [
@@ -13823,7 +13596,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-1",
-                    "baseLayerID": 52,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "2c88706210672655401fe09edd8ff6a7.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 24,
@@ -13843,7 +13616,6 @@
     },
     {
         "name": "Glow-2",
-        "baseLayerID": -1,
         "md5": "b9faa5708a799a1607f0325a7af2561c.svg",
         "type": "sprite",
         "tags": [
@@ -13870,7 +13642,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-2",
-                    "baseLayerID": 53,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "b9faa5708a799a1607f0325a7af2561c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 28,
@@ -13890,7 +13662,6 @@
     },
     {
         "name": "Glow-3",
-        "baseLayerID": -1,
         "md5": "cf42a50552ce26032ead712ac4f36c23.svg",
         "type": "sprite",
         "tags": [
@@ -13917,7 +13688,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-3",
-                    "baseLayerID": 54,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "cf42a50552ce26032ead712ac4f36c23.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 33,
@@ -13937,7 +13708,6 @@
     },
     {
         "name": "Glow-4",
-        "baseLayerID": -1,
         "md5": "3ffa6aee373e28fc36b9395ac4d0467e.svg",
         "type": "sprite",
         "tags": [
@@ -13964,7 +13734,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-4",
-                    "baseLayerID": 55,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "3ffa6aee373e28fc36b9395ac4d0467e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 31,
@@ -13984,7 +13754,6 @@
     },
     {
         "name": "Glow-5",
-        "baseLayerID": -1,
         "md5": "85d87d32e7e9e6be122c905b0d2e7e33.svg",
         "type": "sprite",
         "tags": [
@@ -14011,7 +13780,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-5",
-                    "baseLayerID": 56,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "85d87d32e7e9e6be122c905b0d2e7e33.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 30,
@@ -14031,7 +13800,6 @@
     },
     {
         "name": "Glow-6",
-        "baseLayerID": -1,
         "md5": "62cc2a6def27f19d11ed56e86e95aac5.svg",
         "type": "sprite",
         "tags": [
@@ -14058,7 +13826,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-6",
-                    "baseLayerID": 57,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "62cc2a6def27f19d11ed56e86e95aac5.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 30,
@@ -14078,7 +13846,6 @@
     },
     {
         "name": "Glow-7",
-        "baseLayerID": -1,
         "md5": "8887983eb4df2e62a2ed4770a1d98d60.svg",
         "type": "sprite",
         "tags": [
@@ -14105,7 +13872,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-7",
-                    "baseLayerID": 58,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "8887983eb4df2e62a2ed4770a1d98d60.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 31,
@@ -14125,7 +13892,6 @@
     },
     {
         "name": "Glow-8",
-        "baseLayerID": -1,
         "md5": "4c42c4cb0c1e090d0f9570416d3c80c8.svg",
         "type": "sprite",
         "tags": [
@@ -14152,7 +13918,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-8",
-                    "baseLayerID": 59,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "4c42c4cb0c1e090d0f9570416d3c80c8.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 31,
@@ -14172,7 +13938,6 @@
     },
     {
         "name": "Glow-9",
-        "baseLayerID": -1,
         "md5": "7bcb7e2e48f5cb770c83d4267922fec0.svg",
         "type": "sprite",
         "tags": [
@@ -14199,7 +13964,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-9",
-                    "baseLayerID": 60,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "7bcb7e2e48f5cb770c83d4267922fec0.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 28,
@@ -14219,7 +13984,6 @@
     },
     {
         "name": "Glow-A",
-        "baseLayerID": -1,
         "md5": "d5aa299350c24c747200a64b63b1aa52.svg",
         "type": "sprite",
         "tags": [
@@ -14246,7 +14010,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-A",
-                    "baseLayerID": 5,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "d5aa299350c24c747200a64b63b1aa52.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 36,
@@ -14266,7 +14030,6 @@
     },
     {
         "name": "Glow-B",
-        "baseLayerID": -1,
         "md5": "a2e95f268a6cab03f3e94b3b0b792d83.svg",
         "type": "sprite",
         "tags": [
@@ -14293,7 +14056,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-B",
-                    "baseLayerID": 7,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "a2e95f268a6cab03f3e94b3b0b792d83.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 32,
@@ -14313,7 +14076,6 @@
     },
     {
         "name": "Glow-C",
-        "baseLayerID": -1,
         "md5": "9779a4a40934f04a4bf84920b258d7c9.svg",
         "type": "sprite",
         "tags": [
@@ -14340,7 +14102,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-C",
-                    "baseLayerID": 8,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "9779a4a40934f04a4bf84920b258d7c9.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 27,
@@ -14360,7 +14122,6 @@
     },
     {
         "name": "Glow-D",
-        "baseLayerID": -1,
         "md5": "3555b8bbbbcdc00354bf6fa81ac7042f.svg",
         "type": "sprite",
         "tags": [
@@ -14387,7 +14148,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-D",
-                    "baseLayerID": 10,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "3555b8bbbbcdc00354bf6fa81ac7042f.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 33,
@@ -14407,7 +14168,6 @@
     },
     {
         "name": "Glow-E",
-        "baseLayerID": -1,
         "md5": "44dbc655d5ac9f13618473848e23484e.svg",
         "type": "sprite",
         "tags": [
@@ -14434,7 +14194,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-E",
-                    "baseLayerID": 12,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "44dbc655d5ac9f13618473848e23484e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 34,
@@ -14454,7 +14214,6 @@
     },
     {
         "name": "Glow-F",
-        "baseLayerID": -1,
         "md5": "dec417e749e43d7de3985155f5f5a7a0.svg",
         "type": "sprite",
         "tags": [
@@ -14481,7 +14240,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-F",
-                    "baseLayerID": 14,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "dec417e749e43d7de3985155f5f5a7a0.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 35,
@@ -14501,7 +14260,6 @@
     },
     {
         "name": "Glow-G",
-        "baseLayerID": -1,
         "md5": "cf4aa465cd8fb7049cc571d7546a7eb1.svg",
         "type": "sprite",
         "tags": [
@@ -14528,7 +14286,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-G",
-                    "baseLayerID": 16,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "cf4aa465cd8fb7049cc571d7546a7eb1.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 32,
@@ -14548,7 +14306,6 @@
     },
     {
         "name": "Glow-H",
-        "baseLayerID": -1,
         "md5": "8d9bd5f00ea1ac6f92d0f97ee491b0f3.svg",
         "type": "sprite",
         "tags": [
@@ -14575,7 +14332,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-H",
-                    "baseLayerID": 18,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "8d9bd5f00ea1ac6f92d0f97ee491b0f3.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 35,
@@ -14595,7 +14352,6 @@
     },
     {
         "name": "Glow-I",
-        "baseLayerID": -1,
         "md5": "0e86de55840103dcd50199ab2b765de7.svg",
         "type": "sprite",
         "tags": [
@@ -14622,7 +14378,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-I",
-                    "baseLayerID": 20,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "0e86de55840103dcd50199ab2b765de7.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 21,
@@ -14642,7 +14398,6 @@
     },
     {
         "name": "Glow-J",
-        "baseLayerID": -1,
         "md5": "b3832145eacc39f91bd3a9a6673fa05c.svg",
         "type": "sprite",
         "tags": [
@@ -14669,7 +14424,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-J",
-                    "baseLayerID": 22,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "b3832145eacc39f91bd3a9a6673fa05c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 29,
@@ -14689,7 +14444,6 @@
     },
     {
         "name": "Glow-K",
-        "baseLayerID": -1,
         "md5": "f4e37a7552ba05e995613211a7146de5.svg",
         "type": "sprite",
         "tags": [
@@ -14716,7 +14470,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-K",
-                    "baseLayerID": 24,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "f4e37a7552ba05e995613211a7146de5.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 38,
@@ -14736,7 +14490,6 @@
     },
     {
         "name": "Glow-L",
-        "baseLayerID": -1,
         "md5": "a75e45773ea6afaf8ae44f79f936fc82.svg",
         "type": "sprite",
         "tags": [
@@ -14763,7 +14516,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-L",
-                    "baseLayerID": 26,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "a75e45773ea6afaf8ae44f79f936fc82.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 33,
@@ -14783,7 +14536,6 @@
     },
     {
         "name": "Glow-M",
-        "baseLayerID": -1,
         "md5": "219b06faa5b816347165450d148213b4.svg",
         "type": "sprite",
         "tags": [
@@ -14810,7 +14562,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-M",
-                    "baseLayerID": 28,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "219b06faa5b816347165450d148213b4.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 42,
@@ -14830,7 +14582,6 @@
     },
     {
         "name": "Glow-N",
-        "baseLayerID": -1,
         "md5": "4b724479fb3b2184fd8be6f83fb20e54.svg",
         "type": "sprite",
         "tags": [
@@ -14857,7 +14608,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-N",
-                    "baseLayerID": 29,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "4b724479fb3b2184fd8be6f83fb20e54.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 37,
@@ -14877,7 +14628,6 @@
     },
     {
         "name": "Glow-O",
-        "baseLayerID": -1,
         "md5": "38b2b342659adc6fa289090975e0e71d.svg",
         "type": "sprite",
         "tags": [
@@ -14904,7 +14654,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-O",
-                    "baseLayerID": 31,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "38b2b342659adc6fa289090975e0e71d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 29,
@@ -14924,7 +14674,6 @@
     },
     {
         "name": "Glow-P",
-        "baseLayerID": -1,
         "md5": "1cfa849cc967069730b7e9d0809c9dc1.svg",
         "type": "sprite",
         "tags": [
@@ -14951,7 +14700,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-P",
-                    "baseLayerID": 33,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "1cfa849cc967069730b7e9d0809c9dc1.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 32,
@@ -14971,7 +14720,6 @@
     },
     {
         "name": "Glow-Q",
-        "baseLayerID": -1,
         "md5": "9d35979e9404ac234301269fcd7de288.svg",
         "type": "sprite",
         "tags": [
@@ -14998,7 +14746,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-Q",
-                    "baseLayerID": 34,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "9d35979e9404ac234301269fcd7de288.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 33,
@@ -15018,7 +14766,6 @@
     },
     {
         "name": "Glow-R",
-        "baseLayerID": -1,
         "md5": "fc067ee076ecaba8430ccd54d9414c1b.svg",
         "type": "sprite",
         "tags": [
@@ -15045,7 +14792,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-R",
-                    "baseLayerID": 36,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "fc067ee076ecaba8430ccd54d9414c1b.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 35,
@@ -15065,7 +14812,6 @@
     },
     {
         "name": "Glow-S",
-        "baseLayerID": -1,
         "md5": "19a93db8a294ccaec4d6eef4020a446f.svg",
         "type": "sprite",
         "tags": [
@@ -15092,7 +14838,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-S",
-                    "baseLayerID": 38,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "19a93db8a294ccaec4d6eef4020a446f.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 27,
@@ -15112,7 +14858,6 @@
     },
     {
         "name": "Glow-T",
-        "baseLayerID": -1,
         "md5": "d7bcda522a1e9504dafcf2fa0fcde39b.svg",
         "type": "sprite",
         "tags": [
@@ -15139,7 +14884,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-T",
-                    "baseLayerID": 40,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "d7bcda522a1e9504dafcf2fa0fcde39b.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 35,
@@ -15159,7 +14904,6 @@
     },
     {
         "name": "Glow-U",
-        "baseLayerID": -1,
         "md5": "790482a3c3691a1e96ef34eee7303872.svg",
         "type": "sprite",
         "tags": [
@@ -15186,7 +14930,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-U",
-                    "baseLayerID": 41,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "790482a3c3691a1e96ef34eee7303872.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 37,
@@ -15206,7 +14950,6 @@
     },
     {
         "name": "Glow-V",
-        "baseLayerID": -1,
         "md5": "6a00388d8dc6be645b843cef9c22681c.svg",
         "type": "sprite",
         "tags": [
@@ -15233,7 +14976,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-V",
-                    "baseLayerID": 43,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "6a00388d8dc6be645b843cef9c22681c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 35,
@@ -15253,7 +14996,6 @@
     },
     {
         "name": "Glow-W",
-        "baseLayerID": -1,
         "md5": "1a9ea7305a85b271c1de79beafe16cb4.svg",
         "type": "sprite",
         "tags": [
@@ -15280,7 +15022,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-W",
-                    "baseLayerID": 45,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "1a9ea7305a85b271c1de79beafe16cb4.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 45,
@@ -15300,7 +15042,6 @@
     },
     {
         "name": "Glow-X",
-        "baseLayerID": -1,
         "md5": "ec4e65b9ae475a676973128f4205df5f.svg",
         "type": "sprite",
         "tags": [
@@ -15327,7 +15068,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-X",
-                    "baseLayerID": 47,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "ec4e65b9ae475a676973128f4205df5f.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 40,
@@ -15347,7 +15088,6 @@
     },
     {
         "name": "Glow-Y",
-        "baseLayerID": -1,
         "md5": "683cd093bb3b254733a15df6f843464c.svg",
         "type": "sprite",
         "tags": [
@@ -15374,7 +15114,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-Y",
-                    "baseLayerID": 49,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "683cd093bb3b254733a15df6f843464c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 38,
@@ -15394,7 +15134,6 @@
     },
     {
         "name": "Glow-Z",
-        "baseLayerID": -1,
         "md5": "db89a4c9b123123542e0b7556ed3ff9f.svg",
         "type": "sprite",
         "tags": [
@@ -15421,7 +15160,7 @@
             "costumes": [
                 {
                     "costumeName": "Glow-Z",
-                    "baseLayerID": 51,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "db89a4c9b123123542e0b7556ed3ff9f.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 30,
@@ -15441,7 +15180,6 @@
     },
     {
         "name": "Story-A",
-        "baseLayerID": -1,
         "md5": "5406b37278d819d4787a588b9c91f68e.svg",
         "type": "sprite",
         "tags": [
@@ -15468,7 +15206,7 @@
             "costumes": [
                 {
                     "costumeName": "story-A-1",
-                    "baseLayerID": 61,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "5406b37278d819d4787a588b9c91f68e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 23,
@@ -15476,7 +15214,7 @@
                 },
                 {
                     "costumeName": "story-A-2",
-                    "baseLayerID": 62,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "f277943adf8d79b41b9b568321a786ee.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 23,
@@ -15484,7 +15222,7 @@
                 },
                 {
                     "costumeName": "story-A-3",
-                    "baseLayerID": 63,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "cc0cc7ae3240eab7d040e148cc663325.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -15504,7 +15242,6 @@
     },
     {
         "name": "Story-B",
-        "baseLayerID": -1,
         "md5": "2a8fac3c82d95f13203843a597b5757b.svg",
         "type": "sprite",
         "tags": [
@@ -15531,7 +15268,7 @@
             "costumes": [
                 {
                     "costumeName": "story-B-1",
-                    "baseLayerID": 64,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "2a8fac3c82d95f13203843a597b5757b.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 20,
@@ -15539,7 +15276,7 @@
                 },
                 {
                     "costumeName": "story-B-2",
-                    "baseLayerID": 65,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "07fa4ebc421d84743b6ced189dd2f9cf.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 19,
@@ -15547,7 +15284,7 @@
                 },
                 {
                     "costumeName": "story-B-3",
-                    "baseLayerID": 66,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "6c9a9203155f93f24f31b30e3bd76b6d.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 18,
@@ -15567,7 +15304,6 @@
     },
     {
         "name": "Story-C",
-        "baseLayerID": -1,
         "md5": "144845715016910e88e2a223ed4d3df1.svg",
         "type": "sprite",
         "tags": [
@@ -15594,7 +15330,7 @@
             "costumes": [
                 {
                     "costumeName": "story-C-1",
-                    "baseLayerID": 67,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "144845715016910e88e2a223ed4d3df1.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -15602,7 +15338,7 @@
                 },
                 {
                     "costumeName": "story-C-2",
-                    "baseLayerID": 68,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "1045c56c4be3d8d0650579864417fbc7.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -15610,7 +15346,7 @@
                 },
                 {
                     "costumeName": "story-C-3",
-                    "baseLayerID": 69,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "c8fd35294d17a369fecb6d6e4725d04a.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 20,
@@ -15630,7 +15366,6 @@
     },
     {
         "name": "Story-D",
-        "baseLayerID": -1,
         "md5": "dfd362f2da975c20aa7849a8fa2fb4df.svg",
         "type": "sprite",
         "tags": [
@@ -15657,7 +15392,7 @@
             "costumes": [
                 {
                     "costumeName": "story-D-1",
-                    "baseLayerID": 70,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "dfd362f2da975c20aa7849a8fa2fb4df.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 25,
@@ -15665,7 +15400,7 @@
                 },
                 {
                     "costumeName": "story-D-2",
-                    "baseLayerID": 71,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "3e4cc4cff08bb42bc690eff66dffbbe9.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 25,
@@ -15673,7 +15408,7 @@
                 },
                 {
                     "costumeName": "story-D-3",
-                    "baseLayerID": 72,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "bd7f984fe82d9d0fdcff0a87b3c0f9e0.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -15693,7 +15428,6 @@
     },
     {
         "name": "Story-E",
-        "baseLayerID": -1,
         "md5": "56473bacbdf6f0dbca1afb04e5aebaf7.svg",
         "type": "sprite",
         "tags": [
@@ -15720,7 +15454,7 @@
             "costumes": [
                 {
                     "costumeName": "story-E-1",
-                    "baseLayerID": 73,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "56473bacbdf6f0dbca1afb04e5aebaf7.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 20,
@@ -15728,7 +15462,7 @@
                 },
                 {
                     "costumeName": "story-E-2",
-                    "baseLayerID": 74,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "8bba14966fe35f0dccb66ef06a9843ca.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 20,
@@ -15736,7 +15470,7 @@
                 },
                 {
                     "costumeName": "story-E-3",
-                    "baseLayerID": 75,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "e8cfc63375f6d6c2a580823489427f38.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 18,
@@ -15756,7 +15490,6 @@
     },
     {
         "name": "Story-F",
-        "baseLayerID": -1,
         "md5": "5844ff29fc8663c8613f12169d2f07ef.svg",
         "type": "sprite",
         "tags": [
@@ -15783,7 +15516,7 @@
             "costumes": [
                 {
                     "costumeName": "story-F-1",
-                    "baseLayerID": 76,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "5844ff29fc8663c8613f12169d2f07ef.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 18,
@@ -15791,7 +15524,7 @@
                 },
                 {
                     "costumeName": "story-F-2",
-                    "baseLayerID": 77,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "0dbe4a064abea1a9a3bc0d2732643e6b.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 18,
@@ -15799,7 +15532,7 @@
                 },
                 {
                     "costumeName": "story-F-3",
-                    "baseLayerID": 78,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "3db373f4482e391e66d1b06335a96144.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 16,
@@ -15819,7 +15552,6 @@
     },
     {
         "name": "Story-G",
-        "baseLayerID": -1,
         "md5": "ee6454d15fbbe93e908a2ebbfad483a0.svg",
         "type": "sprite",
         "tags": [
@@ -15846,7 +15578,7 @@
             "costumes": [
                 {
                     "costumeName": "story-G-1",
-                    "baseLayerID": 79,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "ee6454d15fbbe93e908a2ebbfad483a0.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 23,
@@ -15854,7 +15586,7 @@
                 },
                 {
                     "costumeName": "story-G-2",
-                    "baseLayerID": 80,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "991023d303f79ce092f070392ffbd69f.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 23,
@@ -15862,7 +15594,7 @@
                 },
                 {
                     "costumeName": "story-G-3",
-                    "baseLayerID": 81,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "38f22c0d8dbe541bde409ba1f241d4c1.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 21,
@@ -15882,7 +15614,6 @@
     },
     {
         "name": "Story-H",
-        "baseLayerID": -1,
         "md5": "2a0e1308d6cb806818af696a89b21863.svg",
         "type": "sprite",
         "tags": [
@@ -15909,7 +15640,7 @@
             "costumes": [
                 {
                     "costumeName": "story-H-1",
-                    "baseLayerID": 82,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "2a0e1308d6cb806818af696a89b21863.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 24,
@@ -15917,7 +15648,7 @@
                 },
                 {
                     "costumeName": "story-H-2",
-                    "baseLayerID": 83,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "ca33be5270308a695c9b88af73f590dc.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 24,
@@ -15925,7 +15656,7 @@
                 },
                 {
                     "costumeName": "story-H-3",
-                    "baseLayerID": 84,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "668ba2b891f82ce78d8590f0287632b1.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -15945,7 +15676,6 @@
     },
     {
         "name": "Story-I",
-        "baseLayerID": -1,
         "md5": "705297637ea83af5b94b6fe2e34aeef4.svg",
         "type": "sprite",
         "tags": [
@@ -15972,7 +15702,7 @@
             "costumes": [
                 {
                     "costumeName": "story-I-1",
-                    "baseLayerID": 85,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "705297637ea83af5b94b6fe2e34aeef4.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 9,
@@ -15980,7 +15710,7 @@
                 },
                 {
                     "costumeName": "story-I-2",
-                    "baseLayerID": 86,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "7b3ae96764795727fa1cb0be68a9ca5e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 9,
@@ -15988,7 +15718,7 @@
                 },
                 {
                     "costumeName": "story-I-3",
-                    "baseLayerID": 87,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "3475aa570304accb7e6dbd2516234135.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 7,
@@ -16008,7 +15738,6 @@
     },
     {
         "name": "Story-J",
-        "baseLayerID": -1,
         "md5": "ac2e7eaecb80c5501e5e56802d03af00.svg",
         "type": "sprite",
         "tags": [
@@ -16035,7 +15764,7 @@
             "costumes": [
                 {
                     "costumeName": "story-J-1",
-                    "baseLayerID": 88,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "ac2e7eaecb80c5501e5e56802d03af00.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 14,
@@ -16043,7 +15772,7 @@
                 },
                 {
                     "costumeName": "story-J-2",
-                    "baseLayerID": 89,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "0ab9a94fc2e32160efc113a8e5ffb984.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 14,
@@ -16051,7 +15780,7 @@
                 },
                 {
                     "costumeName": "story-J-3",
-                    "baseLayerID": 90,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "c9356a022cfbc25be6c484e9781e4637.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 12,
@@ -16071,7 +15800,6 @@
     },
     {
         "name": "Story-K",
-        "baseLayerID": -1,
         "md5": "62dcc92dc3c6cb0271244190320c4f71.svg",
         "type": "sprite",
         "tags": [
@@ -16098,7 +15826,7 @@
             "costumes": [
                 {
                     "costumeName": "story-K-1",
-                    "baseLayerID": 91,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "62dcc92dc3c6cb0271244190320c4f71.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 24,
@@ -16106,7 +15834,7 @@
                 },
                 {
                     "costumeName": "story-K-2",
-                    "baseLayerID": 92,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "ef02339e8a0382367f0b5a414915b885.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 24,
@@ -16114,7 +15842,7 @@
                 },
                 {
                     "costumeName": "story-K-3",
-                    "baseLayerID": 93,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "07977708617d12381b22d1ee0f4926a3.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 21,
@@ -16134,7 +15862,6 @@
     },
     {
         "name": "Story-L",
-        "baseLayerID": -1,
         "md5": "7ce306e9c9c0dd0a24279606301f1d05.svg",
         "type": "sprite",
         "tags": [
@@ -16161,7 +15888,7 @@
             "costumes": [
                 {
                     "costumeName": "story-L-1",
-                    "baseLayerID": 94,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "7ce306e9c9c0dd0a24279606301f1d05.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 19,
@@ -16169,7 +15896,7 @@
                 },
                 {
                     "costumeName": "story-L-2",
-                    "baseLayerID": 95,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "067c21a9b2f91ed33e07131ce5a59210.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 19,
@@ -16177,7 +15904,7 @@
                 },
                 {
                     "costumeName": "story-L-3",
-                    "baseLayerID": 96,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "488d66f17c0089a7796d44cfc70792e8.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 17,
@@ -16197,7 +15924,6 @@
     },
     {
         "name": "Story-M",
-        "baseLayerID": -1,
         "md5": "b27f166f9ab4a3fb93a50a77c58c3df3.svg",
         "type": "sprite",
         "tags": [
@@ -16224,7 +15950,7 @@
             "costumes": [
                 {
                     "costumeName": "story-M-1",
-                    "baseLayerID": 97,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "b27f166f9ab4a3fb93a50a77c58c3df3.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 30,
@@ -16232,7 +15958,7 @@
                 },
                 {
                     "costumeName": "story-M-2",
-                    "baseLayerID": 98,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "55f00a23d0f5cc57be9533f126a7ac8c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 30,
@@ -16240,7 +15966,7 @@
                 },
                 {
                     "costumeName": "story-M-3",
-                    "baseLayerID": 99,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "613df2bd97784a239ab992f7a95458a0.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 27,
@@ -16260,7 +15986,6 @@
     },
     {
         "name": "Story-N",
-        "baseLayerID": -1,
         "md5": "293589fd5bbc358a20c165ab49c19833.svg",
         "type": "sprite",
         "tags": [
@@ -16287,7 +16012,7 @@
             "costumes": [
                 {
                     "costumeName": "story-N-1",
-                    "baseLayerID": 100,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "293589fd5bbc358a20c165ab49c19833.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 26,
@@ -16295,7 +16020,7 @@
                 },
                 {
                     "costumeName": "story-N-2",
-                    "baseLayerID": 101,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "5e07ee61cb20bc575720774584dfec53.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 26,
@@ -16303,7 +16028,7 @@
                 },
                 {
                     "costumeName": "story-N-3",
-                    "baseLayerID": 102,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "435697335345f946d943c1d89fdb459a.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 24,
@@ -16323,7 +16048,6 @@
     },
     {
         "name": "Story-O",
-        "baseLayerID": -1,
         "md5": "088beed7ce0dff554da06f54d0558bc0.svg",
         "type": "sprite",
         "tags": [
@@ -16350,7 +16074,7 @@
             "costumes": [
                 {
                     "costumeName": "story-O-1",
-                    "baseLayerID": 103,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "088beed7ce0dff554da06f54d0558bc0.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 25,
@@ -16358,7 +16082,7 @@
                 },
                 {
                     "costumeName": "story-O-2",
-                    "baseLayerID": 104,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "e8fa671bb1ca53c044bfb27225321c25.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 24,
@@ -16366,7 +16090,7 @@
                 },
                 {
                     "costumeName": "story-O-3",
-                    "baseLayerID": 105,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "a132bf3d4084ef8ca9e0797f64c0f082.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -16386,7 +16110,6 @@
     },
     {
         "name": "Story-P",
-        "baseLayerID": -1,
         "md5": "ad4a101b83f28ced16849be3e393caa9.svg",
         "type": "sprite",
         "tags": [
@@ -16413,7 +16136,7 @@
             "costumes": [
                 {
                     "costumeName": "story-P-1",
-                    "baseLayerID": 106,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "ad4a101b83f28ced16849be3e393caa9.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 20,
@@ -16421,7 +16144,7 @@
                 },
                 {
                     "costumeName": "story-P-2",
-                    "baseLayerID": 107,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "781c42f9da36bbc0ee3775f18ac98124.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 20,
@@ -16429,7 +16152,7 @@
                 },
                 {
                     "costumeName": "story-P-3",
-                    "baseLayerID": 108,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "bcaec7c778920d8d74c275c1aff634fe.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 17,
@@ -16449,7 +16172,6 @@
     },
     {
         "name": "Story-Q",
-        "baseLayerID": -1,
         "md5": "484e44f908e84d795c87cf994364e722.svg",
         "type": "sprite",
         "tags": [
@@ -16476,7 +16198,7 @@
             "costumes": [
                 {
                     "costumeName": "story-Q-1",
-                    "baseLayerID": 109,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "484e44f908e84d795c87cf994364e722.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 25,
@@ -16484,7 +16206,7 @@
                 },
                 {
                     "costumeName": "story-Q-2",
-                    "baseLayerID": 110,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "31f28be74dc7de42a5c4a38504d666ca.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 25,
@@ -16492,7 +16214,7 @@
                 },
                 {
                     "costumeName": "story-Q-3",
-                    "baseLayerID": 111,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "aef19097378515308e934a79f147032e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -16512,7 +16234,6 @@
     },
     {
         "name": "Story-R",
-        "baseLayerID": -1,
         "md5": "55999cb6783ef8351d841294d75af942.svg",
         "type": "sprite",
         "tags": [
@@ -16539,7 +16260,7 @@
             "costumes": [
                 {
                     "costumeName": "story-R-1",
-                    "baseLayerID": 112,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "55999cb6783ef8351d841294d75af942.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -16547,7 +16268,7 @@
                 },
                 {
                     "costumeName": "story-R-2",
-                    "baseLayerID": 113,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "926f8ff770cb15b42b12f209fd02d98c.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -16555,7 +16276,7 @@
                 },
                 {
                     "costumeName": "story-R-3",
-                    "baseLayerID": 114,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "a66d8f0ba6d40c624873edc8df58c014.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 20,
@@ -16575,7 +16296,6 @@
     },
     {
         "name": "Story-S",
-        "baseLayerID": -1,
         "md5": "fca1555f335392f1c4ef620bf098c0de.svg",
         "type": "sprite",
         "tags": [
@@ -16602,7 +16322,7 @@
             "costumes": [
                 {
                     "costumeName": "story-S-1",
-                    "baseLayerID": 115,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "fca1555f335392f1c4ef620bf098c0de.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 16,
@@ -16610,7 +16330,7 @@
                 },
                 {
                     "costumeName": "story-S-2",
-                    "baseLayerID": 116,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "c529ed7b40f4a949539f8f454e3fe475.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 16,
@@ -16618,7 +16338,7 @@
                 },
                 {
                     "costumeName": "story-S-3",
-                    "baseLayerID": 117,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "e96388c9197733bdadbad3ce014c0e59.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 14,
@@ -16638,7 +16358,6 @@
     },
     {
         "name": "Story-T",
-        "baseLayerID": -1,
         "md5": "d3b342c795a620b69639c02a419e8535.svg",
         "type": "sprite",
         "tags": [
@@ -16665,7 +16384,7 @@
             "costumes": [
                 {
                     "costumeName": "story-T-1",
-                    "baseLayerID": 118,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "d3b342c795a620b69639c02a419e8535.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -16673,7 +16392,7 @@
                 },
                 {
                     "costumeName": "story-T-2",
-                    "baseLayerID": 119,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "eeb0fd25c9273747ac38766d1959ba2b.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -16681,7 +16400,7 @@
                 },
                 {
                     "costumeName": "story-T-3",
-                    "baseLayerID": 120,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "a9683d4946b08a76864a51bd21d811cb.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 20,
@@ -16701,7 +16420,6 @@
     },
     {
         "name": "Story-U",
-        "baseLayerID": -1,
         "md5": "fcf99b6e8aeb2d504e1e9b2194640916.svg",
         "type": "sprite",
         "tags": [
@@ -16728,7 +16446,7 @@
             "costumes": [
                 {
                     "costumeName": "story-U-1",
-                    "baseLayerID": 121,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "fcf99b6e8aeb2d504e1e9b2194640916.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 24,
@@ -16736,7 +16454,7 @@
                 },
                 {
                     "costumeName": "story-U-2",
-                    "baseLayerID": 122,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "f442802f17225d6506ac9718810f179e.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 24,
@@ -16744,7 +16462,7 @@
                 },
                 {
                     "costumeName": "story-U-3",
-                    "baseLayerID": 123,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "0779f03a6589c60352b1d4806a4a61c0.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 21,
@@ -16764,7 +16482,6 @@
     },
     {
         "name": "Story-V",
-        "baseLayerID": -1,
         "md5": "750b47f1de2143f76354239b27e1e5f0.svg",
         "type": "sprite",
         "tags": [
@@ -16791,7 +16508,7 @@
             "costumes": [
                 {
                     "costumeName": "story-V-1",
-                    "baseLayerID": 124,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "750b47f1de2143f76354239b27e1e5f0.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 25,
@@ -16799,7 +16516,7 @@
                 },
                 {
                     "costumeName": "story-V-2",
-                    "baseLayerID": 125,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "03de7add77e31799ca568a9c671012b4.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 25,
@@ -16807,7 +16524,7 @@
                 },
                 {
                     "costumeName": "story-V-3",
-                    "baseLayerID": 126,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "29befe20b105b69471f5507d025ec3e0.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -16827,7 +16544,6 @@
     },
     {
         "name": "Story-W",
-        "baseLayerID": -1,
         "md5": "7d9d4c0da9bd1a3ddf253d1bea26f4e9.svg",
         "type": "sprite",
         "tags": [
@@ -16854,7 +16570,7 @@
             "costumes": [
                 {
                     "costumeName": "story-W-1",
-                    "baseLayerID": 127,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "7d9d4c0da9bd1a3ddf253d1bea26f4e9.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 37,
@@ -16862,7 +16578,7 @@
                 },
                 {
                     "costumeName": "story-W-2",
-                    "baseLayerID": 128,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "c0f48eb69cae4a611d3e7b7e06b0d1c1.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 37,
@@ -16870,7 +16586,7 @@
                 },
                 {
                     "costumeName": "story-W-3",
-                    "baseLayerID": 129,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "d1c922c9e9d53d2f6f36ca637e85de6b.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 34,
@@ -16890,7 +16606,6 @@
     },
     {
         "name": "Story-X",
-        "baseLayerID": -1,
         "md5": "92c452555b3d5a4993f107810043ea03.svg",
         "type": "sprite",
         "tags": [
@@ -16917,7 +16632,7 @@
             "costumes": [
                 {
                     "costumeName": "story-X-1",
-                    "baseLayerID": 130,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "92c452555b3d5a4993f107810043ea03.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -16925,7 +16640,7 @@
                 },
                 {
                     "costumeName": "story-X-2",
-                    "baseLayerID": 131,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "f688425da41c2b7f80d4b8752de69bc9.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -16933,7 +16648,7 @@
                 },
                 {
                     "costumeName": "story-X-3",
-                    "baseLayerID": 132,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "ec90479a0ce3c7706f1916daef0f3c67.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 20,
@@ -16953,7 +16668,6 @@
     },
     {
         "name": "Story-Y",
-        "baseLayerID": -1,
         "md5": "b3c252450d413fc75be0eafdbe4490dc.svg",
         "type": "sprite",
         "tags": [
@@ -16980,7 +16694,7 @@
             "costumes": [
                 {
                     "costumeName": "story-Y-1",
-                    "baseLayerID": 133,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "b3c252450d413fc75be0eafdbe4490dc.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -16988,7 +16702,7 @@
                 },
                 {
                     "costumeName": "story-Y-2",
-                    "baseLayerID": 134,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "1cfa161ae5d60ea163e4e0aa34d08f02.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 22,
@@ -16996,7 +16710,7 @@
                 },
                 {
                     "costumeName": "story-Y-3",
-                    "baseLayerID": 135,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "a1fc3c0fa304255364c0f98547e0e448.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 20,
@@ -17016,7 +16730,6 @@
     },
     {
         "name": "Story-Z",
-        "baseLayerID": -1,
         "md5": "86326c9180c485b557a075f4794939d7.svg",
         "type": "sprite",
         "tags": [
@@ -17043,7 +16756,7 @@
             "costumes": [
                 {
                     "costumeName": "story-Z-1",
-                    "baseLayerID": 136,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "86326c9180c485b557a075f4794939d7.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 19,
@@ -17051,7 +16764,7 @@
                 },
                 {
                     "costumeName": "story-Z-2",
-                    "baseLayerID": 137,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "e10b203e47bbb41edab78be59e628449.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 19,
@@ -17059,7 +16772,7 @@
                 },
                 {
                     "costumeName": "story-Z-3",
-                    "baseLayerID": 138,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "0788df7b1d9cf02dfdebc021d4f30ce4.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 17,


### PR DESCRIPTION
### Resolves
Resolves GH-2310
Resolves GH-2349
Resolves GH-2375

### Proposed Changes
- Changes name of the "theatre" backdrop to "theater"
- Resolves issue with "heart" backdrops
- Adds tags to ice skates (note: this will likely be removed / replaced soon
- Adds "baseball" theme
- Adds "spooky" theme (replaces old ghosts, bats, and woods backdrop)

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
