### PR TITLE
Fix booleans not showing up in monitors

### DIFF
--- a/src/containers/slider-monitor.jsx
+++ b/src/containers/slider-monitor.jsx
@@ -15,7 +15,7 @@ class SliderMonitor extends React.Component {
         ]);
 
         this.state = {
-            value: Number(props.value)
+            value: props.value
         };
     }
     componentWillReceiveProps (nextProps) {

--- a/src/lib/monitor-adapter.js
+++ b/src/lib/monitor-adapter.js
@@ -28,6 +28,16 @@ export default function ({id, spriteName, opcode, params, value}) {
     if (typeof value === 'number') {
         value = Number(value.toFixed(6));
     }
-    
+
+    // Turn the value to a string, for handle boolean values
+    if (typeof value === 'boolean') {
+        value = value.toString();
+    }
+
+    // Lists can contain booleans, which should also be turned to strings
+    if (Array.isArray(value)) {
+        value = value.map(item => item.toString());
+    }
+
     return {id, label, category, value};
 }


### PR DESCRIPTION
### Resolves

Fixes #2409.

### Proposed Changes

Makes boolean values (true, false) show up in (list and variable) monitors correctly. Before, they wouldn't show up at all.

### Reason for Changes

Compatibility with 2.0 and convenience.

### Test Coverage

Manually tested with [this project](https://scratch.mit.edu/projects/229992327/). Screenshots below. From left to right: 2.0, 3.0 before this PR, 3.0 with this PR.

!["true, true, true, false, false, false, apple"](https://user-images.githubusercontent.com/9948030/41682136-3ff8177c-74ad-11e8-8926-f18fe6d2c81d.png) !["(blank), (blank), 1, (blank), (blank), 0, NaN](https://user-images.githubusercontent.com/9948030/41682214-78ce6416-74ad-11e8-83be-6a1ececfd646.png) !["true, true, NaN, false, false, NaN, NaN"](https://user-images.githubusercontent.com/9948030/41682170-55313d94-74ad-11e8-93d4-5484900dea46.png)

Lists also tested (no screenshots here for brevity). They work right.

### Browser Coverage

N/A (tested on firefox/debian).