### PR TITLE
Fix 2px error in stage sizing

### DIFF
--- a/src/components/stage/stage.css
+++ b/src/components/stage/stage.css
@@ -18,6 +18,9 @@
 
     /* Allow custom touch handling to prevent scrolling on Edge */
     touch-action: none;
+
+    /* Make sure border is not included in size calculation */
+    box-sizing: content-box !important;
 }
 
 .with-color-picker {


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves #2413 

### Proposed Changes

_Describe what this Pull Request does_

Forces the stage canvas element to use `box-sizing: content-box;` so that the border is not included in the sizing. 

### Reason for Changes

_Explain why these changes should be made_

See bottom of https://github.com/LLK/scratch-gui/issues/2413 for explanation

It is not clear to me that this fixes any kind of blurriness, though. The original issue does not cite a specific project or give any specifics, so it is tough for me to tell if this helped. 

@cwillisf if you can repro the original blurriness, could you check if this fixes it?
### Test Coverage

_Please show how you have added tests to cover your changes_

![image](https://user-images.githubusercontent.com/654102/41774284-02c2f304-75ed-11e8-991f-9fbb49ef5cff.png)
