### PR TITLE
Fix the sprite layout by making the layout code apply to the wrapper

### DIFF
--- a/src/components/sprite-selector/sprite-list.jsx
+++ b/src/components/sprite-selector/sprite-list.jsx
@@ -57,7 +57,7 @@ const SpriteList = function (props) {
 
                 return (
                     <SortableAsset
-                        className={classNames(styles.itemWrapper, {
+                        className={classNames(styles.spriteWrapper, {
                             [styles.placeholder]: isSpriteDrag && index === draggingIndex})}
                         index={isSpriteDrag ? ordering.indexOf(index) : index}
                         key={sprite.name}

--- a/src/components/sprite-selector/sprite-selector.css
+++ b/src/components/sprite-selector/sprite-selector.css
@@ -16,8 +16,7 @@
     border-bottom: 0;
 }
 
-/* In prep for renaming sprite-selector-item to sprite */
-.sprite {
+.sprite-wrapper {
     /*
         Our goal is to fit sprites evenly in a row without leftover space.
         Flexbox's `space between` property gets us close, but doesn't flow
@@ -35,6 +34,10 @@
     min-width: 4rem;
     min-height: 4rem; /* @todo: calc height same as width */
     margin: calc($space / 2);
+}
+
+.sprite {
+    height: 100%;
 }
 
 


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/LLK/scratch-gui/issues/2430

### Proposed Changes

_Describe what this Pull Request does_

A wrapper element was added when doing sprite reordering, this brings the CSS that was within that wrapper out to the wrapper so that the flex layout works correctly

Broken (as discovered by @chrisgarrity)
![long-name-sprite--broken](https://user-images.githubusercontent.com/654102/41788747-b08598d4-761a-11e8-81ba-5190d2b4761b.gif)

Fixed
![long-name-sprite](https://user-images.githubusercontent.com/654102/41788758-b841432a-761a-11e8-9900-566b3064de23.gif)

