### PR TITLE
Got rid of extra Edge x on monitor list

### DIFF
--- a/src/components/monitor-list/monitor-list.css
+++ b/src/components/monitor-list/monitor-list.css
@@ -8,3 +8,5 @@
     /* Scaling for monitors should happen from the top left */
     transform-origin: left top;
 }
+
+::-ms-clear { display: none; }


### PR DESCRIPTION
### Resolves

- Resolves #2106 

### Proposed Changes

Remove “clear field” X button on certain inputs for Edge?

### Reason for Changes

To remove the extra x.

### Test Coverage

Tested by inspection. Before:
![image](https://user-images.githubusercontent.com/6998018/41789822-882a5c48-7648-11e8-9477-a1ba735a05c8.png)

After:
![image](https://user-images.githubusercontent.com/6998018/41789843-92672678-7648-11e8-8e54-c896ff383c41.png)


### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [x] Firefox 
 * [ ] Safari

Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [x] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
