### PR TITLE
Try to run in full screen on tablets

### DIFF
--- a/src/containers/preview-modal.jsx
+++ b/src/containers/preview-modal.jsx
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
 
+import tabletFullScreen from '../lib/tablet-full-screen';
+
 import PreviewModalComponent from '../components/preview-modal/preview-modal.jsx';
 import BrowserModalComponent from '../components/browser-modal/browser-modal.jsx';
 import supportedBrowser from '../lib/supported-browser';
@@ -27,6 +29,8 @@ class PreviewModal extends React.Component {
     }
     handleTryIt () {
         this.setState({previewing: true});
+        // try to run in fullscreen mode on tablets.
+        tabletFullScreen();
         this.props.onTryIt();
     }
     handleCancel () {

--- a/src/lib/tablet-full-screen.js
+++ b/src/lib/tablet-full-screen.js
@@ -5,10 +5,10 @@ import bowser from 'bowser';
  */
 export default function () {
     if (bowser.tablet) {
-        if (bowser.webkit || bowser.blink) {
+        if ((bowser.webkit || bowser.blink) && document.documentElement.webkitRequestFullScreen) {
             document.documentElement.webkitRequestFullScreen();
         }
-        if (bowser.gecko) {
+        if (bowser.gecko && document.documentElement.mozRequestFullScreen) {
             document.documentElement.mozRequestFullScreen();
         }
     }

--- a/src/lib/tablet-full-screen.js
+++ b/src/lib/tablet-full-screen.js
@@ -1,0 +1,15 @@
+import bowser from 'bowser';
+
+/**
+ * Helper method to request full screen in the browser when on a tablet.
+ */
+export default function () {
+    if (bowser.tablet) {
+        if (bowser.webkit || bowser.blink) {
+            document.documentElement.webkitRequestFullScreen();
+        }
+        if (bowser.gecko) {
+            document.documentElement.mozRequestFullScreen();
+        }
+    }
+}


### PR DESCRIPTION
Using `bowser` to detect tablets, and type of browser to call either `webkitRequestFullScreen()` or `mozRequestFullScreen()`

Full screen request must happen in reponse to a user-action, so it’s included in the ‘try-it’ handler for the preview modal.

We'll need to figure out where this goes when we no longer have the preview-modal.

### Resolves

Parts of the gui UI end up getting cut off on 7-inch tablets due to the amount of browser 'chrome'  (tabs, URL, menus etc). Detecting that it's a tablet and requesting full screen when the user decides to 'Try It' in the preview modal makes the UI much more usable.

### Proposed Changes

_Describe what this Pull Request does_
Requests that the browser run in full screen mode if it's a tablet

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [x] Chrome
