### PR TITLE
Hack to make the renderer own the stage canvas

### DIFF
--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -72,6 +72,7 @@ const GUIComponent = props => {
         onActivateTab,
         onRequestCloseBackdropLibrary,
         onRequestCloseCostumeLibrary,
+        onSeeCommunity,
         previewInfoVisible,
         targetIsStage,
         soundsTabVisible,
@@ -141,7 +142,10 @@ const GUIComponent = props => {
                         onRequestClose={onRequestCloseBackdropLibrary}
                     />
                 ) : null}
-                <MenuBar enableCommunity={enableCommunity} />
+                <MenuBar
+                    enableCommunity={enableCommunity}
+                    onSeeCommunity={onSeeCommunity}
+                />
                 <Box className={styles.bodyWrapper}>
                     <Box className={styles.flexWrapper}>
                         <Box className={styles.editorWrapper}>
@@ -285,6 +289,7 @@ GUIComponent.propTypes = {
     onExtensionButtonClick: PropTypes.func,
     onRequestCloseBackdropLibrary: PropTypes.func,
     onRequestCloseCostumeLibrary: PropTypes.func,
+    onSeeCommunity: PropTypes.func,
     onTabSelect: PropTypes.func,
     previewInfoVisible: PropTypes.bool,
     soundsTabVisible: PropTypes.bool,

--- a/src/components/stage/stage.jsx
+++ b/src/components/stage/stage.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import classNames from 'classnames';
 
 import Box from '../box/box.jsx';
+import DOMElementRenderer from '../../containers/dom-element-renderer.jsx';
 import Loupe from '../loupe/loupe.jsx';
 import MonitorList from '../../containers/monitor-list.jsx';
 import Question from '../../containers/question.jsx';
@@ -12,7 +13,7 @@ import styles from './stage.css';
 
 const StageComponent = props => {
     const {
-        canvasRef,
+        canvas,
         dragRef,
         isColorPicking,
         isFullScreen,
@@ -21,6 +22,7 @@ const StageComponent = props => {
         stageSize,
         useEditorDragStyle,
         onDeactivateColorPicker,
+        onDoubleClick,
         onQuestionAnswered,
         ...boxProps
     } = props;
@@ -35,14 +37,14 @@ const StageComponent = props => {
                     [styles.stageWrapperOverlay]: isFullScreen,
                     [styles.withColorPicker]: !isFullScreen && isColorPicking
                 })}
+                onDoubleClick={onDoubleClick}
             >
-                <Box
+                <DOMElementRenderer
                     className={classNames(
                         styles.stage,
                         {[styles.stageOverlayContent]: isFullScreen}
                     )}
-                    componentRef={canvasRef}
-                    element="canvas"
+                    domElement={canvas}
                     height={stageDimensions.height}
                     width={stageDimensions.width}
                     {...boxProps}
@@ -93,7 +95,7 @@ const StageComponent = props => {
     );
 };
 StageComponent.propTypes = {
-    canvasRef: PropTypes.func,
+    canvas: PropTypes.instanceOf(Element).isRequired,
     colorInfo: Loupe.propTypes.colorInfo,
     dragRef: PropTypes.func,
     isColorPicking: PropTypes.bool,
@@ -105,7 +107,6 @@ StageComponent.propTypes = {
     useEditorDragStyle: PropTypes.bool
 };
 StageComponent.defaultProps = {
-    canvasRef: () => {},
     dragRef: () => {}
 };
 export default StageComponent;

--- a/src/components/stage/stage.jsx
+++ b/src/components/stage/stage.jsx
@@ -101,6 +101,7 @@ StageComponent.propTypes = {
     isColorPicking: PropTypes.bool,
     isFullScreen: PropTypes.bool.isRequired,
     onDeactivateColorPicker: PropTypes.func,
+    onDoubleClick: PropTypes.func,
     onQuestionAnswered: PropTypes.func,
     question: PropTypes.string,
     stageSize: PropTypes.oneOf(Object.keys(STAGE_DISPLAY_SIZES)).isRequired,

--- a/src/containers/dom-element-renderer.jsx
+++ b/src/containers/dom-element-renderer.jsx
@@ -1,0 +1,39 @@
+import omit from 'lodash.omit';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+/*
+ * DOMElementRenderer wraps a DOM element, allowing it to be
+ * rendered by React. It's up to the containing component
+ * to retain a reference to the element prop, or else it
+ * will be garbage collected after unmounting.
+ */
+class DOMElementRenderer extends React.Component {
+    constructor (props) {
+        super(props);
+        this.setContainer = this.setContainer.bind(this);
+    }
+    componentDidMount () {
+        this.container.appendChild(this.props.domElement);
+    }
+    componentWillUnmount () {
+        this.container.removeChild(this.props.domElement);
+    }
+    setContainer (c) {
+        this.container = c;
+    }
+    render () {
+        // Look at me, I'm the React now!
+        Object.assign(
+            this.props.domElement,
+            omit(this.props, ['domElement', 'children'])
+        )
+        return <div ref={this.setContainer} />;
+    }
+}
+
+DOMElementRenderer.propTypes = {
+    domElement: PropTypes.instanceOf(Element).isRequired
+}
+
+export default DOMElementRenderer;

--- a/src/containers/dom-element-renderer.jsx
+++ b/src/containers/dom-element-renderer.jsx
@@ -7,6 +7,9 @@ import React from 'react';
  * rendered by React. It's up to the containing component
  * to retain a reference to the element prop, or else it
  * will be garbage collected after unmounting.
+ *
+ * Props passed to the DOMElementRenderer will be set on the
+ * DOM element like it's a normal component.
  */
 class DOMElementRenderer extends React.Component {
     constructor (props) {
@@ -23,17 +26,19 @@ class DOMElementRenderer extends React.Component {
         this.container = c;
     }
     render () {
+        // Apply props to the DOM element, so its attributes
+        // are updated as if it were a normal component.
         // Look at me, I'm the React now!
         Object.assign(
             this.props.domElement,
             omit(this.props, ['domElement', 'children'])
-        )
+        );
         return <div ref={this.setContainer} />;
     }
 }
 
 DOMElementRenderer.propTypes = {
     domElement: PropTypes.instanceOf(Element).isRequired
-}
+};
 
 export default DOMElementRenderer;

--- a/src/containers/gui.jsx
+++ b/src/containers/gui.jsx
@@ -99,6 +99,7 @@ GUI.propTypes = {
     fetchingProject: PropTypes.bool,
     importInfoVisible: PropTypes.bool,
     loadingStateVisible: PropTypes.bool,
+    onSeeCommunity: PropTypes.func,
     previewInfoVisible: PropTypes.bool,
     projectData: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
     vm: PropTypes.instanceOf(VM)

--- a/src/containers/gui.jsx
+++ b/src/containers/gui.jsx
@@ -66,9 +66,6 @@ class GUI extends React.Component {
             });
         }
     }
-    componentWillUnmount () {
-        this.props.vm.stopAll();
-    }
     render () {
         if (this.state.loadingError) {
             throw new Error(

--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -367,7 +367,6 @@ class Stage extends React.Component {
             onActivateColorPicker, // eslint-disable-line no-unused-vars
             ...props
         } = this.props;
-        if (!this.canvas) this.canvas = this.setCanvas();
         return (
             <StageComponent
                 canvas={this.canvas}

--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -37,7 +37,6 @@ class Stage extends React.Component {
             'onWheel',
             'updateRect',
             'questionListener',
-            'setCanvas',
             'setDragCanvas',
             'clearDragCanvas',
             'drawDragCanvas',
@@ -52,16 +51,22 @@ class Stage extends React.Component {
             colorInfo: null,
             question: null
         };
+        if (this.props.vm.runtime.renderer) {
+            this.renderer = this.props.vm.runtime.renderer;
+            this.canvas = this.props.vm.runtime.renderer._gl.canvas;
+        } else {
+            this.canvas = document.createElement('canvas');
+            this.renderer = new Renderer(this.canvas);
+            this.props.vm.attachRenderer(this.renderer);
+        }
+        this.props.vm.attachV2SVGAdapter(new V2SVGAdapter());
+        this.props.vm.setVideoProvider(new VideoProvider());
     }
     componentDidMount () {
         this.attachRectEvents();
         this.attachMouseEvents(this.canvas);
         this.updateRect();
-        this.renderer = new Renderer(this.canvas);
-        this.props.vm.attachRenderer(this.renderer);
-        this.props.vm.attachV2SVGAdapter(new V2SVGAdapter());
         this.props.vm.runtime.addListener('QUESTION', this.questionListener);
-        this.props.vm.setVideoProvider(new VideoProvider());
     }
     shouldComponentUpdate (nextProps, nextState) {
         return this.props.stageSize !== nextProps.stageSize ||
@@ -353,9 +358,6 @@ class Stage extends React.Component {
             commonStopDragActions();
         }
     }
-    setCanvas (canvas) {
-        this.canvas = canvas;
-    }
     setDragCanvas (canvas) {
         this.dragCanvas = canvas;
     }
@@ -365,9 +367,10 @@ class Stage extends React.Component {
             onActivateColorPicker, // eslint-disable-line no-unused-vars
             ...props
         } = this.props;
+        if (!this.canvas) this.canvas = this.setCanvas();
         return (
             <StageComponent
-                canvasRef={this.setCanvas}
+                canvas={this.canvas}
                 colorInfo={this.state.colorInfo}
                 dragRef={this.setDragCanvas}
                 question={this.state.question}

--- a/src/playground/player.jsx
+++ b/src/playground/player.jsx
@@ -1,12 +1,15 @@
 import classNames from 'classnames';
+import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
+import {connect} from 'react-redux';
 
 import Box from '../components/box/box.jsx';
 import GUI from '../containers/gui.jsx';
 import HashParserHOC from '../lib/hash-parser-hoc.jsx';
 import AppStateHOC from '../lib/app-state-hoc.jsx';
-const WrappedGui = HashParserHOC(AppStateHOC(GUI));
+
+import {setPlayer} from '../reducers/mode';
 
 if (process.env.NODE_ENV === 'production' && typeof window === 'object') {
     // Warn before navigating away
@@ -15,42 +18,37 @@ if (process.env.NODE_ENV === 'production' && typeof window === 'object') {
 
 import styles from './player.css';
 
-class Player extends React.Component {
-    constructor (props) {
-        super(props);
-        this.handleSeeInside = this.handleSeeInside.bind(this);
-        this.handleSeeCommunity = this.handleSeeCommunity.bind(this);
-        this.state = {
-            isPlayerOnly: true
-        };
-    }
-    handleSeeInside () {
-        this.setState({isPlayerOnly: false});
-    }
-    handleSeeCommunity () {
-        this.setState({isPlayerOnly: true});
-    }
-    render () {
-        return (
-            <Box
-                className={classNames({
-                    [styles.stageOnly]: this.state.isPlayerOnly
-                })}
-            >
-                {this.state.isPlayerOnly && (
-                    <button onClick={this.handleSeeInside}>{'See inside'}</button>
-                )}
-                <WrappedGui
-                    enableCommunity
-                    isPlayerOnly={this.state.isPlayerOnly}
-                    onSeeCommunity={this.handleSeeCommunity}
-                />
-            </Box>
-        );
-    }
-}
+const Player = ({isPlayerOnly, onSeeInside}) => (
+    <Box
+        className={classNames({
+            [styles.stageOnly]: isPlayerOnly
+        })}
+    >
+        {isPlayerOnly && <button onClick={onSeeInside}>{'See inside'}</button>}
+        <GUI
+            enableCommunity
+            isPlayerOnly={isPlayerOnly}
+        />
+    </Box>
+);
+
+Player.propTypes = {
+    isPlayerOnly: PropTypes.bool,
+    onSeeInside: PropTypes.func
+};
+
+const mapStateToProps = state => ({
+    isPlayerOnly: state.scratchGui.mode.isPlayerOnly
+});
+
+const mapDispatchToProps = dispatch => ({
+    onSeeInside: () => dispatch(setPlayer(false))
+});
+
+const ConnectedPlayer = connect(mapStateToProps, mapDispatchToProps)(Player);
+const WrappedPlayer = HashParserHOC(AppStateHOC(ConnectedPlayer));
 
 const appTarget = document.createElement('div');
 document.body.appendChild(appTarget);
 
-ReactDOM.render(<Player />, appTarget);
+ReactDOM.render(<WrappedPlayer isPlayerOnly />, appTarget);

--- a/src/playground/player.jsx
+++ b/src/playground/player.jsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
@@ -13,14 +14,41 @@ if (process.env.NODE_ENV === 'production' && typeof window === 'object') {
 }
 
 import styles from './player.css';
-const Player = () => (
-    <Box className={styles.stageOnly}>
-        <WrappedGui
-            isPlayerOnly
-            isFullScreen={false}
-        />
-    </Box>
-);
+
+class Player extends React.Component {
+    constructor (props) {
+        super(props);
+        this.handleSeeInside = this.handleSeeInside.bind(this);
+        this.handleSeeCommunity = this.handleSeeCommunity.bind(this);
+        this.state = {
+            isPlayerOnly: true
+        };
+    }
+    handleSeeInside () {
+        this.setState({isPlayerOnly: false});
+    }
+    handleSeeCommunity () {
+        this.setState({isPlayerOnly: true});
+    }
+    render () {
+        return (
+            <Box
+                className={classNames({
+                    [styles.stageOnly]: this.state.isPlayerOnly
+                })}
+            >
+                {this.state.isPlayerOnly && (
+                    <button onClick={this.handleSeeInside}>{'See inside'}</button>
+                )}
+                <WrappedGui
+                    enableCommunity
+                    isPlayerOnly={this.state.isPlayerOnly}
+                    onSeeCommunity={this.handleSeeCommunity}
+                />
+            </Box>
+        );
+    }
+}
 
 const appTarget = document.createElement('div');
 document.body.appendChild(appTarget);


### PR DESCRIPTION
This is for demonstration purposes, if this is the way we decide, I will make official APIs on the VM and the renderer for checking for a renderer or canvas respectively.  I'm not 100% on adding another wrapper around the canvas, but this seemed like the easiest to read way to do it, and doesn't break any CSS.

@paulkaplan When @cwillisf and I spoke yesterday about the possibility of attaching a new canvas to the renderer, we decided it wouldn't be as clean as keeping the canvas around. The WebGL context stores a lot of state that would need to be maintained, and we would invariably miss something, or it could break down the line as we changed things.

/cc @chrisgarrity 

### Resolves

_What Github issue does this resolve (please include link)?_

Fixes the issue where the stage becomes blank after changing language or switching between player/editor mode.  This was due to the GUI and/or Stage components unmounting and remounting the Renderer's `canvas` element.

### Proposed Changes

_Describe what this Pull Request does_
This moves the Stage's `canvas` ownership from the Stage React component to the Renderer.  Then instead of creating/destroying `canvas` elements in React, append/remove the element from a wrapper component.

### Reason for Changes

_Explain why these changes should be made_
Doing this maintains the state of the `canvas`, and the Renderer's WebGL context.  Therefore we can very quickly remount the canvas, and don't have to recreate the renderer, or the textures stored in the WebGL context.

### Test Coverage

_Please show how you have added tests to cover your changes_
I don't think there's a super great way to test this with an automated test yet. But I improved the "player" playground (player.html), so that you can swap between player and editor mode and see that the state isn't lost.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [X] Chrome 
 * [ ] Firefox 
 * [X] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
