### PR TITLE
ignore paint editor messages in gui

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "clean": "rimraf ./build && mkdirp build && rimraf ./dist && mkdirp dist",
     "deploy": "touch build/.nojekyll && gh-pages -t -d build -m \"Build for $(git log --pretty=format:%H -n1)\"",
     "prune": "./prune-gh-pages.sh",
-    "i18n:src": "babel src > tmp.js && rimraf tmp.js && build-i18n-src ./translations/messages/ ./translations/",
+    "i18n:src": "babel src > tmp.js && rimraf tmp.js && build-i18n-src ./translations/messages/src ./translations/",
     "start": "webpack-dev-server",
     "test": "npm run test:lint && npm run test:unit && npm run build && npm run test:integration",
     "test:integration": "jest --runInBand test[\\\\/]integration",


### PR DESCRIPTION
The babel extraction process includes translations from node modules. The extraction process creates two directories: `translations/messages/src` and `translations/messages/node_modules`. When generating the file to sync with transifex we only want the messages in the `src` directory. The paint editor messages in transifex are synced from the paint editor repo.

If the node_modules directory isn't ignored we end up with duplicate keys, and building the file to sync with transifex fails.
