### PR TITLE
Translate monitor labels

### DIFF
--- a/src/lib/opcode-labels.js
+++ b/src/lib/opcode-labels.js
@@ -1,34 +1,62 @@
+import ScratchBlocks from 'scratch-blocks';
+
 const opcodeMap = {
     // Motion
     motion_direction: {
         category: 'motion',
-        label: 'direction'
+        labelFn: () => ScratchBlocks.ScratchMsgs.translate('MOTION_DIRECTION', 'direction')
     },
     motion_xposition: {
         category: 'motion',
-        label: 'x position'
+        labelFn: () => ScratchBlocks.ScratchMsgs.translate('MOTION_XPOSITION', 'x postion')
     },
     motion_yposition: {
         category: 'motion',
-        label: 'y position'
+        labelFn: () => ScratchBlocks.ScratchMsgs.translate('MOTION_YPOSITION', 'y postion')
     },
 
     // Looks
     looks_size: {
         category: 'looks',
-        label: 'size'
+        labelFn: () => ScratchBlocks.ScratchMsgs.translate('LOOKS_SIZE', 'size')
     },
     looks_costumenumbername: {
         category: 'looks',
-        labelFn: params => `costume ${params.NUMBER_NAME}`
+        labelFn: params => {
+            let label = ScratchBlocks.ScratchMsgs.translate(
+                'LOOKS_COSTUMENUMBERNAME',
+                'costume %1'
+            );
+            if (params.NUMBER_NAME === 'number') {
+                label = label.replace(/%1/, ScratchBlocks.ScratchMsgs.translate(
+                    'LOOKS_NUMBERNAME_NUMBER', 'number'));
+            } else {
+                label = label.replace(/%1/, ScratchBlocks.ScratchMsgs.translate(
+                    'LOOKS_NUMBERNAME_NAME', 'name'));
+            }
+            return label;
+        }
     },
     looks_backdropnumbername: {
         category: 'looks',
-        labelFn: params => `backdrop ${params.NUMBER_NAME}`
+        labelFn: params => {
+            let label = ScratchBlocks.ScratchMsgs.translate(
+                'LOOKS_BACKDROPNUMBERNAME',
+                'costume %1'
+            );
+            if (params.NUMBER_NAME === 'number') {
+                label = label.replace(/%1/, ScratchBlocks.ScratchMsgs.translate(
+                    'LOOKS_NUMBERNAME_NUMBER', 'number'));
+            } else {
+                label = label.replace(/%1/, ScratchBlocks.ScratchMsgs.translate(
+                    'LOOKS_NUMBERNAME_NAME', 'name'));
+            }
+            return label;
+        }
     },
     looks_backdropname: {
         category: 'looks',
-        label: 'backdrop name'
+        labelFn: () => ScratchBlocks.ScratchMsgs.translate('LOOKS_BACKDROPNAME', 'backdrop name')
     },
 
     // Data
@@ -44,30 +72,34 @@ const opcodeMap = {
     // Sound
     sound_volume: {
         category: 'sound',
-        label: 'volume'
+        labelFn: () => ScratchBlocks.ScratchMsgs.translate('SOUND_VOLUME', 'volume')
     },
     sound_tempo: {
         category: 'sound',
-        label: 'tempo'
+        labelFn: () => ScratchBlocks.ScratchMsgs.translate('SOUND_TEMPO', 'tempo')
     },
 
     // Sensing
     sensing_answer: {
         category: 'sensing',
-        label: 'answer'
+        labelFn: () => ScratchBlocks.ScratchMsgs.translate('SENSING_ANSWER', 'answer')
     },
     sensing_loudness: {
         category: 'sensing',
-        label: 'loudness'
+        labelFn: () => ScratchBlocks.ScratchMsgs.translate('SENSING_LOUDNESS', 'loudness')
     },
     sensing_username: {
         category: 'sensing',
-        label: 'username'
+        labelFn: () => ScratchBlocks.ScratchMsgs.translate('SENSING_USERNAME', 'username')
     },
     sensing_current: {
         category: 'sensing',
         labelFn: params => {
-            let currentMenu = params.CURRENTMENU.toLowerCase();
+            let currentMenu = params.CURRENTMENU.toUpperCase();
+            currentMenu = ScratchBlocks.ScratchMsgs.translate(
+                `SENSING_CURRENT_${currentMenu}`,
+                currentMenu.toLowerCase()
+            );
             if (currentMenu === 'dayofweek') {
                 currentMenu = 'day of week';
             }
@@ -76,7 +108,7 @@ const opcodeMap = {
     },
     sensing_timer: {
         category: 'sensing',
-        label: 'timer'
+        labelFn: () => ScratchBlocks.ScratchMsgs.translate('SENSING_TIMER', 'timer')
     }
 };
 


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves #

### Proposed Changes

_Describe what this Pull Request does_
Uses ScratchBlocks.ScratchMsgs to translate labels for monitors.

### Reason for Changes

_Explain why these changes should be made_
Allows translation of monitor labels for predefined monitors (e.g., volume, direction)

### Test Coverage

_Please show how you have added tests to cover your changes_
Current tests still pass.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
