### PR TITLE
Add font-family for card css

### DIFF
--- a/src/components/cards/card.css
+++ b/src/components/cards/card.css
@@ -79,6 +79,7 @@
     overflow: hidden;
     box-shadow: 0px 5px 25px 5px $ui-black-transparent;
     align-items: center;
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
 .header-buttons {
@@ -162,7 +163,6 @@
     font-size: 0.85rem;
     margin: 14px 0px;
     text-align: center;
-    font-family: "Helvetica Neue";
     font-weight: bold;
     text-align: center;
 }
@@ -198,7 +198,6 @@
     display: flex;
     align-items: center;
     color: $ui-white;
-    font-family: "Helvetica Neue";
     font-size: 12px;
     font-weight: bold;
     line-height: 15px;


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/LLK/scratch-gui/issues/1961

### Proposed Changes

_Describe what this Pull Request does_

Uses the full font-family declaration for the card contents

### Reason for Changes

_Explain why these changes should be made_

Font was not being rendered correctly on the last card of how-tos, see https://github.com/LLK/scratch-gui/issues/1961

### Test Coverage

_Please show how you have added tests to cover your changes_


Tested on windows VM.

![image](https://user-images.githubusercontent.com/654102/41973792-0cbde0a8-79e4-11e8-9f98-aeb4080aee40.png)
![image](https://user-images.githubusercontent.com/654102/41973795-0dc4cb2e-79e4-11e8-9c82-4520d4aa5a87.png)

