### PR TITLE
Correctly apply react style object to the dom element renderer

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "style-loader": "^0.21.0",
     "svg-to-image": "1.1.3",
     "text-encoding": "0.6.4",
+    "to-style": "1.3.3",
     "uglifyjs-webpack-plugin": "^1.2.5",
     "wav-encoder": "1.3.0",
     "web-audio-test-api": "^0.5.2",

--- a/src/components/stage-wrapper/stage-wrapper.jsx
+++ b/src/components/stage-wrapper/stage-wrapper.jsx
@@ -28,7 +28,6 @@ const StageWrapperComponent = function (props) {
                 {
                     isRendererSupported ?
                         <Stage
-                            shrink={0}
                             stageSize={stageSize}
                             vm={vm}
                         /> :

--- a/src/components/stage/stage.jsx
+++ b/src/components/stage/stage.jsx
@@ -37,6 +37,10 @@ const StageComponent = props => {
                     [styles.stageWrapperOverlay]: isFullScreen,
                     [styles.withColorPicker]: !isFullScreen && isColorPicking
                 })}
+                style={{
+                    minHeight: stageDimensions.height,
+                    minWidth: stageDimensions.width
+                }}
                 onDoubleClick={onDoubleClick}
             >
                 <DOMElementRenderer
@@ -45,8 +49,10 @@ const StageComponent = props => {
                         {[styles.stageOverlayContent]: isFullScreen}
                     )}
                     domElement={canvas}
-                    height={stageDimensions.height}
-                    width={stageDimensions.width}
+                    style={{
+                        height: stageDimensions.height,
+                        width: stageDimensions.width
+                    }}
                     {...boxProps}
                 />
                 <Box className={styles.monitorWrapper}>

--- a/src/containers/dom-element-renderer.jsx
+++ b/src/containers/dom-element-renderer.jsx
@@ -2,6 +2,7 @@ import omit from 'lodash.omit';
 import PropTypes from 'prop-types';
 import React from 'react';
 import Style from 'to-style';
+import stylePropType from 'react-style-proptype';
 
 /*
  * DOMElementRenderer wraps a DOM element, allowing it to be
@@ -46,7 +47,7 @@ class DOMElementRenderer extends React.Component {
 
 DOMElementRenderer.propTypes = {
     domElement: PropTypes.instanceOf(Element).isRequired,
-    style: PropTypes.object // eslint-disable-line react/forbid-prop-types
+    style: stylePropType
 };
 
 export default DOMElementRenderer;

--- a/src/containers/dom-element-renderer.jsx
+++ b/src/containers/dom-element-renderer.jsx
@@ -1,6 +1,7 @@
 import omit from 'lodash.omit';
 import PropTypes from 'prop-types';
 import React from 'react';
+import Style from 'to-style';
 
 /*
  * DOMElementRenderer wraps a DOM element, allowing it to be
@@ -31,14 +32,21 @@ class DOMElementRenderer extends React.Component {
         // Look at me, I'm the React now!
         Object.assign(
             this.props.domElement,
-            omit(this.props, ['domElement', 'children'])
+            omit(this.props, ['domElement', 'children', 'style'])
         );
+
+        // Convert react style prop to dom element styling.
+        if (this.props.style) {
+            this.props.domElement.style = Style.string(this.props.style);
+        }
+
         return <div ref={this.setContainer} />;
     }
 }
 
 DOMElementRenderer.propTypes = {
-    domElement: PropTypes.instanceOf(Element).isRequired
+    domElement: PropTypes.instanceOf(Element).isRequired,
+    style: PropTypes.object // eslint-disable-line react/forbid-prop-types
 };
 
 export default DOMElementRenderer;


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/LLK/scratch-gui/issues/2510
- Resolves https://github.com/LLK/scratch-gui/issues/2509

### Proposed Changes

_Describe what this Pull Request does_

Use the `to-style` module to correctly translate the style object to a style string in the DOMElementRenderer.

### Reason for Changes

_Explain why these changes should be made_

So that the width/height can be applied to the canvas as CSS, since the width/height attributes are managed by the renderer.

I also removed the `shrink={0}` property, since it isn't doing anything.

### Test Coverage

_Please show how you have added tests to cover your changes_

Manually tested the issues linked above

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [x] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [x] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
