### PR TITLE
Shim array#includes and fix style assignment. Fixes IE11 and Safari10

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "chromedriver": "2.40.0",
     "classnames": "2.2.6",
     "copy-webpack-plugin": "^4.5.1",
+    "core-js": "2.5.7",
     "css-loader": "^0.28.11",
     "enzyme": "^3.1.0",
     "enzyme-adapter-react-16": "1.1.1",

--- a/src/containers/dom-element-renderer.jsx
+++ b/src/containers/dom-element-renderer.jsx
@@ -38,7 +38,7 @@ class DOMElementRenderer extends React.Component {
 
         // Convert react style prop to dom element styling.
         if (this.props.style) {
-            this.props.domElement.style = Style.string(this.props.style);
+            this.props.domElement.style.cssText = Style.string(this.props.style);
         }
 
         return <div ref={this.setContainer} />;

--- a/src/playground/index.jsx
+++ b/src/playground/index.jsx
@@ -1,4 +1,5 @@
 import 'es6-object-assign/auto';
+import 'core-js/fn/array/includes';
 import React from 'react';
 import ReactDOM from 'react-dom';
 


### PR DESCRIPTION
Bring this fix back from smoke to develop. These are the fixes for IE11 and Safari10. 

/cc @rschamp @chrisgarrity 