### PR TITLE
Initial version of device connection modals

### DIFF
--- a/src/components/connection-modal/connected-step.jsx
+++ b/src/components/connection-modal/connected-step.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import Box from '../box/box.jsx';
+import Dots from './dots.jsx';
 
 import styles from './connection-modal.css';
 
@@ -21,6 +22,10 @@ const ConnectedStep = props => (
                     id="gui.connection.search"
                 />
             </Box>
+            <Dots
+                counter={3}
+                total={3}
+            />
         </Box>
     </Box>
 );

--- a/src/components/connection-modal/connected-step.jsx
+++ b/src/components/connection-modal/connected-step.jsx
@@ -11,17 +11,16 @@ import styles from './connection-modal.css';
 
 const ConnectedStep = props => (
     <Box className={styles.body}>
-        <Box className={styles.buttonRow}>
-            <button
-                className={styles.searchButton}
-                onClick={props.onSearch}
-            >
+        <Box className={styles.activityArea}>
+        </Box>
+        <Box className={styles.bottomArea}>
+            <Box className={styles.instructions}>
                 <FormattedMessage
                     defaultMessage="🔥connected🔥"
                     description="Button in prompt for starting a search"
                     id="gui.connection.search"
                 />
-            </button>
+            </Box>
         </Box>
     </Box>
 );

--- a/src/components/connection-modal/connected-step.jsx
+++ b/src/components/connection-modal/connected-step.jsx
@@ -1,0 +1,29 @@
+import {FormattedMessage} from 'react-intl';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import Box from '../box/box.jsx';
+
+import styles from './connection-modal.css';
+
+const ConnectedStep = props => (
+    <Box className={styles.body}>
+        <Box className={styles.buttonRow}>
+            <button
+                className={styles.searchButton}
+                onClick={props.onSearch}
+            >
+                <FormattedMessage
+                    defaultMessage="connected"
+                    description="Button in prompt for starting a search"
+                    id="gui.connection.search"
+                />
+            </button>
+        </Box>
+    </Box>
+);
+
+ConnectedStep.propTypes = {
+};
+
+export default ConnectedStep;

--- a/src/components/connection-modal/connected-step.jsx
+++ b/src/components/connection-modal/connected-step.jsx
@@ -6,6 +6,9 @@ import Box from '../box/box.jsx';
 
 import styles from './connection-modal.css';
 
+// todo: update the flyout status button here?
+// this.ScratchBlocks.updateStatusButton('microbit', this.ScratchBlocks.StatusButtonState.READY);
+
 const ConnectedStep = props => (
     <Box className={styles.body}>
         <Box className={styles.buttonRow}>

--- a/src/components/connection-modal/connected-step.jsx
+++ b/src/components/connection-modal/connected-step.jsx
@@ -14,7 +14,7 @@ const ConnectedStep = props => (
                 onClick={props.onSearch}
             >
                 <FormattedMessage
-                    defaultMessage="connected"
+                    defaultMessage="🔥connected🔥"
                     description="Button in prompt for starting a search"
                     id="gui.connection.search"
                 />

--- a/src/components/connection-modal/connected-step.jsx
+++ b/src/components/connection-modal/connected-step.jsx
@@ -8,9 +8,6 @@ import Dots from './dots.jsx';
 import styles from './connection-modal.css';
 import classNames from 'classnames';
 
-// todo: update the flyout status button here?
-// this.ScratchBlocks.updateStatusButton('microbit', this.ScratchBlocks.StatusButtonState.READY);
-
 const ConnectedStep = props => (
     <Box className={styles.body}>
         <Box className={styles.activityArea} />

--- a/src/components/connection-modal/connected-step.jsx
+++ b/src/components/connection-modal/connected-step.jsx
@@ -33,7 +33,7 @@ const ConnectedStep = props => (
                 >
                     <FormattedMessage
                         defaultMessage="disconnect"
-                        description="Disconnect the "
+                        description="Disconnect the device"
                         id="gui.connection.disconnect"
                     />
                 </button>
@@ -53,6 +53,8 @@ const ConnectedStep = props => (
 );
 
 ConnectedStep.propTypes = {
+    onCancel: PropTypes.func,
+    onDisconnect: PropTypes.func
 };
 
 export default ConnectedStep;

--- a/src/components/connection-modal/connected-step.jsx
+++ b/src/components/connection-modal/connected-step.jsx
@@ -6,26 +6,48 @@ import Box from '../box/box.jsx';
 import Dots from './dots.jsx';
 
 import styles from './connection-modal.css';
+import classNames from 'classnames';
 
 // todo: update the flyout status button here?
 // this.ScratchBlocks.updateStatusButton('microbit', this.ScratchBlocks.StatusButtonState.READY);
 
 const ConnectedStep = props => (
     <Box className={styles.body}>
-        <Box className={styles.activityArea}>
-        </Box>
+        <Box className={styles.activityArea} />
         <Box className={styles.bottomArea}>
             <Box className={styles.instructions}>
                 <FormattedMessage
-                    defaultMessage="🔥connected🔥"
-                    description="Button in prompt for starting a search"
-                    id="gui.connection.search"
+                    defaultMessage="Connected"
+                    description=""
+                    id="gui.connection.connected"
                 />
             </Box>
             <Dots
                 counter={3}
                 total={3}
             />
+            <div className={styles.cornerButtons}>
+                <button
+                    className={classNames(styles.redButton, styles.connectionButton)}
+                    onClick={props.onDisconnect}
+                >
+                    <FormattedMessage
+                        defaultMessage="disconnect"
+                        description="Disconnect the "
+                        id="gui.connection.disconnect"
+                    />
+                </button>
+                <button
+                    className={styles.connectionButton}
+                    onClick={props.onCancel}
+                >
+                    <FormattedMessage
+                        defaultMessage="go to editor"
+                        description=""
+                        id="gui.connection.go to editor"
+                    />
+                </button>
+            </div>
         </Box>
     </Box>
 );

--- a/src/components/connection-modal/connected-step.jsx
+++ b/src/components/connection-modal/connected-step.jsx
@@ -20,7 +20,7 @@ const ConnectedStep = props => (
                 />
             </Box>
             <Dots
-                counter={3}
+                success
                 total={3}
             />
             <div className={styles.cornerButtons}>

--- a/src/components/connection-modal/connecting-step.jsx
+++ b/src/components/connection-modal/connecting-step.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import Box from '../box/box.jsx';
+import Dots from './dots.jsx';
 
 import styles from './connection-modal.css';
 
@@ -18,6 +19,10 @@ const ConnectingStep = props => (
                     id="gui.connection.search"
                 />
             </Box>
+            <Dots
+                counter={2}
+                total={3}
+            />
         </Box>
     </Box>
 );

--- a/src/components/connection-modal/connecting-step.jsx
+++ b/src/components/connection-modal/connecting-step.jsx
@@ -8,17 +8,16 @@ import styles from './connection-modal.css';
 
 const ConnectingStep = props => (
     <Box className={styles.body}>
-        <Box className={styles.buttonRow}>
-            <button
-                className={styles.searchButton}
-                onClick={props.onSearch}
-            >
+        <Box className={styles.activityArea}>
+        </Box>
+        <Box className={styles.bottomArea}>
+            <Box className={styles.instructions}>
                 <FormattedMessage
                     defaultMessage="🔌connecting🔌"
                     description="Button in prompt for starting a search"
                     id="gui.connection.search"
                 />
-            </button>
+            </Box>
         </Box>
     </Box>
 );

--- a/src/components/connection-modal/connecting-step.jsx
+++ b/src/components/connection-modal/connecting-step.jsx
@@ -1,0 +1,29 @@
+import {FormattedMessage} from 'react-intl';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import Box from '../box/box.jsx';
+
+import styles from './connection-modal.css';
+
+const ConnectingStep = props => (
+    <Box className={styles.body}>
+        <Box className={styles.buttonRow}>
+            <button
+                className={styles.searchButton}
+                onClick={props.onSearch}
+            >
+                <FormattedMessage
+                    defaultMessage="connecting"
+                    description="Button in prompt for starting a search"
+                    id="gui.connection.search"
+                />
+            </button>
+        </Box>
+    </Box>
+);
+
+ConnectingStep.propTypes = {
+};
+
+export default ConnectingStep;

--- a/src/components/connection-modal/connecting-step.jsx
+++ b/src/components/connection-modal/connecting-step.jsx
@@ -14,7 +14,7 @@ const ConnectingStep = props => (
                 onClick={props.onSearch}
             >
                 <FormattedMessage
-                    defaultMessage="connecting"
+                    defaultMessage="🔌connecting🔌"
                     description="Button in prompt for starting a search"
                     id="gui.connection.search"
                 />

--- a/src/components/connection-modal/connecting-step.jsx
+++ b/src/components/connection-modal/connecting-step.jsx
@@ -19,7 +19,7 @@ const ConnectingStep = props => (
                 />
             </Box>
             <Dots
-                counter={2}
+                counter={1}
                 total={3}
             />
             <button

--- a/src/components/connection-modal/connecting-step.jsx
+++ b/src/components/connection-modal/connecting-step.jsx
@@ -9,8 +9,7 @@ import styles from './connection-modal.css';
 
 const ConnectingStep = props => (
     <Box className={styles.body}>
-        <Box className={styles.activityArea}>
-        </Box>
+        <Box className={styles.activityArea} />
         <Box className={styles.bottomArea}>
             <Box className={styles.instructions}>
                 <FormattedMessage

--- a/src/components/connection-modal/connecting-step.jsx
+++ b/src/components/connection-modal/connecting-step.jsx
@@ -14,7 +14,7 @@ const ConnectingStep = props => (
         <Box className={styles.bottomArea}>
             <Box className={styles.instructions}>
                 <FormattedMessage
-                    defaultMessage="🔌connecting🔌"
+                    defaultMessage="Connecting"
                     description=""
                     id="gui.connection.connecting"
                 />
@@ -24,7 +24,7 @@ const ConnectingStep = props => (
                 total={3}
             />
             <button
-                className={styles.blueButton}
+                className={styles.connectionButton}
                 onClick={props.onAbortConnecting}
             >
                 <FormattedMessage

--- a/src/components/connection-modal/connecting-step.jsx
+++ b/src/components/connection-modal/connecting-step.jsx
@@ -15,19 +15,30 @@ const ConnectingStep = props => (
             <Box className={styles.instructions}>
                 <FormattedMessage
                     defaultMessage="🔌connecting🔌"
-                    description="Button in prompt for starting a search"
-                    id="gui.connection.search"
+                    description=""
+                    id="gui.connection.connecting"
                 />
             </Box>
             <Dots
                 counter={2}
                 total={3}
             />
+            <button
+                className={styles.blueButton}
+                onClick={props.onAbortConnecting}
+            >
+                <FormattedMessage
+                    defaultMessage="X"
+                    description="Button to cancel connecting"
+                    id="gui.connection.cancelbutton"
+                />
+            </button>
         </Box>
     </Box>
 );
 
 ConnectingStep.propTypes = {
+    onAbortConnecting: PropTypes.func
 };
 
 export default ConnectingStep;

--- a/src/components/connection-modal/connecting-step.jsx
+++ b/src/components/connection-modal/connecting-step.jsx
@@ -25,7 +25,7 @@ const ConnectingStep = props => (
             />
             <button
                 className={styles.connectionButton}
-                onClick={props.onAbortConnecting}
+                onClick={props.onDisconnect}
             >
                 <FormattedMessage
                     defaultMessage="X"
@@ -38,7 +38,7 @@ const ConnectingStep = props => (
 );
 
 ConnectingStep.propTypes = {
-    onAbortConnecting: PropTypes.func
+    onDisconnect: PropTypes.func
 };
 
 export default ConnectingStep;

--- a/src/components/connection-modal/connection-modal.css
+++ b/src/components/connection-modal/connection-modal.css
@@ -1,0 +1,81 @@
+@import "../../css/colors.css";
+@import "../../css/units.css";
+
+.modal-content {
+    width: 360px;
+}
+
+.body {
+    background: $ui-white;
+    padding: 1.5rem 2.25rem;
+}
+
+.label {
+    font-weight: 500;
+    margin: 0 0 0.75rem;
+}
+
+.input {
+    margin-bottom: 1.5rem;
+    width: 100%;
+    border: 1px solid $ui-black-transparent;
+    border-radius: 5px;
+    padding: 0 1rem;
+    height: 3rem;
+    color: $text-primary-transparent;
+    font-size: .875rem;
+}
+
+.button-row {
+    font-weight: bolder;
+    text-align: right;
+}
+
+.button-row button {
+    padding: 0.75rem 1rem;
+    border-radius: 0.25rem;
+    background: white;
+    border: 1px solid $ui-black-transparent;
+    font-weight: 600;
+    font-size: 0.85rem;
+}
+
+.button-row button.ok-button {
+    background: $motion-primary;
+    border: $motion-primary;
+    color: white;
+}
+
+.button-row button + button {
+    margin-left: 0.5rem;
+}
+
+.more-options {
+    border-top: 1px dashed hsla(0, 0%, 0%, .25);
+    overflow: visible;
+    padding: 1rem;
+    text-align: center;
+    margin: 0 0 1rem;
+}
+
+.hide-more-options {
+    display: none;
+}
+
+.more-options-accordion {
+    width: 60%;
+    margin: 0 auto;
+}
+
+.more-options-text {
+    opacity: .5;
+}
+
+.more-options-icon {
+    width: .75rem;
+    height: .75rem;
+    margin-left: .5rem;
+    vertical-align: middle;
+    padding-bottom: .2rem;
+    opacity: .5;
+}

--- a/src/components/connection-modal/connection-modal.css
+++ b/src/components/connection-modal/connection-modal.css
@@ -84,6 +84,7 @@
 .bottomArea {
     height: 150px;
     background-color: $ui-white;
+    text-align: center;
 }
 
 .instructions {

--- a/src/components/connection-modal/connection-modal.css
+++ b/src/components/connection-modal/connection-modal.css
@@ -11,7 +11,6 @@
 
 .body {
     background: $ui-white;
-    padding: 1.5rem 2.25rem;
 }
 
 .label {
@@ -21,32 +20,36 @@
 
 .button-row {
     font-weight: bolder;
-    text-align: right;
+    text-align: center;
 }
 
-.button-row button {
+.blue-button {
     padding: 0.75rem 1rem;
     border-radius: 0.25rem;
-    background: white;
-    border: 1px solid $ui-black-transparent;
+    background: $motion-primary;
+    color: white;
     font-weight: 600;
     font-size: 0.85rem;
+    margin: 0.25rem;
 }
 
-.button-row button.ok-button {
-    background: $motion-primary;
-    border: $motion-primary;
-    color: white;
+.refresh-button {
 }
 
-.button-row button + button {
-    margin-left: 0.5rem;
+.device-tile-pane {
+    overflow-y: scroll;
+    width: 100%;
+    height: 100%;
+    padding: 0.5rem;
 }
 
 .device-tile {
+    background-color: $ui-white;
+    border-radius: 0.25rem;
+    padding: 10px;
     width: 100%;
     height: 55px;
-    margin: 10px;
+    margin-bottom: 0.5rem;
 }
 
 .device-tile button {
@@ -59,6 +62,31 @@
     color: white;
 }
 
+.signal-strength-text {
+    margin: 5px;
+}
+
 .device-tile-widgets {
     float: right;
+}
+
+.activityArea {
+    height: 165px;
+    background-color: $motion-light-transparent;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.activityAreaInfo {
+}
+
+.bottomArea {
+    height: 150px;
+    background-color: $ui-white;
+}
+
+.instructions {
+    text-align: center;
+    padding: 1rem;
 }

--- a/src/components/connection-modal/connection-modal.css
+++ b/src/components/connection-modal/connection-modal.css
@@ -2,7 +2,7 @@
 @import "../../css/units.css";
 
 .modal-content {
-    width: 360px;
+    width: 480px;
 }
 
 .header {
@@ -41,4 +41,24 @@
 
 .button-row button + button {
     margin-left: 0.5rem;
+}
+
+.device-tile {
+    width: 100%;
+    height: 55px;
+    margin: 10px;
+}
+
+.device-tile button {
+    padding: 0.75rem 1rem;
+    border-radius: 0.25rem;
+    font-weight: 600;
+    font-size: 0.85rem;
+    background: $motion-primary;
+    border: $motion-primary;
+    color: white;
+}
+
+.device-tile-widgets {
+    float: right;
 }

--- a/src/components/connection-modal/connection-modal.css
+++ b/src/components/connection-modal/connection-modal.css
@@ -5,6 +5,10 @@
     width: 360px;
 }
 
+.header {
+    background-color: $pen-primary;
+}
+
 .body {
     background: $ui-white;
     padding: 1.5rem 2.25rem;
@@ -13,17 +17,6 @@
 .label {
     font-weight: 500;
     margin: 0 0 0.75rem;
-}
-
-.input {
-    margin-bottom: 1.5rem;
-    width: 100%;
-    border: 1px solid $ui-black-transparent;
-    border-radius: 5px;
-    padding: 0 1rem;
-    height: 3rem;
-    color: $text-primary-transparent;
-    font-size: .875rem;
 }
 
 .button-row {
@@ -48,34 +41,4 @@
 
 .button-row button + button {
     margin-left: 0.5rem;
-}
-
-.more-options {
-    border-top: 1px dashed hsla(0, 0%, 0%, .25);
-    overflow: visible;
-    padding: 1rem;
-    text-align: center;
-    margin: 0 0 1rem;
-}
-
-.hide-more-options {
-    display: none;
-}
-
-.more-options-accordion {
-    width: 60%;
-    margin: 0 auto;
-}
-
-.more-options-text {
-    opacity: .5;
-}
-
-.more-options-icon {
-    width: .75rem;
-    height: .75rem;
-    margin-left: .5rem;
-    vertical-align: middle;
-    padding-bottom: .2rem;
-    opacity: .5;
 }

--- a/src/components/connection-modal/connection-modal.css
+++ b/src/components/connection-modal/connection-modal.css
@@ -18,24 +18,6 @@
     margin: 0 0 0.75rem;
 }
 
-.button-row {
-    font-weight: bolder;
-    text-align: center;
-}
-
-.blue-button {
-    padding: 0.75rem 1rem;
-    border-radius: 0.25rem;
-    background: $motion-primary;
-    color: white;
-    font-weight: 600;
-    font-size: 0.85rem;
-    margin: 0.25rem;
-}
-
-.refresh-button {
-}
-
 .device-tile-pane {
     overflow-y: scroll;
     width: 100%;
@@ -78,10 +60,32 @@
     align-items: center;
 }
 
-.activityAreaInfo {
+.button-row {
+    font-weight: bolder;
+    text-align: center;
 }
 
-.bottomArea {
+.connection-button {
+    padding: 0.75rem 1rem;
+    border-radius: 0.5rem;
+    background: $motion-primary;
+    color: white;
+    font-weight: 600;
+    font-size: 0.85rem;
+    margin: 0.25rem;
+}
+
+.red-button {
+    background: $red-primary;
+}
+
+.corner-buttons {
+    display: flex;
+    justify-content: space-between;
+    padding: 1rem;
+}
+
+.bottom-area {
     height: 150px;
     background-color: $ui-white;
     text-align: center;

--- a/src/components/connection-modal/connection-modal.css
+++ b/src/components/connection-modal/connection-modal.css
@@ -95,3 +95,49 @@
     text-align: center;
     padding: 1rem;
 }
+
+.dots-row {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    padding-bottom: 1rem;
+}
+
+.dots-holder {
+    display: flex;
+    padding: 0.2rem;
+    border-radius: 1rem;
+    background: $motion-light-transparent;
+}
+
+.dots-holder-success {
+    background: $pen-transparent;
+}
+
+.dots-holder-error {
+    background: $error-transparent;
+}
+
+.dot {
+    width: 0.5rem;
+    height: 0.5rem;
+    margin: 0 0.3rem;
+    border-radius: 100%;
+}
+
+.inactive-step-dot {
+    background: $motion-transparent;
+}
+
+.active-step-dot {
+    background: $motion-primary;
+}
+
+.success-dot {
+    background: $pen-primary;
+}
+
+.error-dot {
+    background: $error-primary;
+}

--- a/src/components/connection-modal/connection-modal.jsx
+++ b/src/components/connection-modal/connection-modal.jsx
@@ -14,7 +14,7 @@ import styles from './connection-modal.css';
 const ConnectionModalComponent = props => (
     <Modal
         className={styles.modalContent}
-        contentLabel={props.title}
+        contentLabel={''}
         headerClassName={styles.header}
         onRequestClose={props.onCancel}
     >

--- a/src/components/connection-modal/connection-modal.jsx
+++ b/src/components/connection-modal/connection-modal.jsx
@@ -20,7 +20,7 @@ const ConnectionModalComponent = props => (
                     onClick={props.onCancel}
                 >
                     <FormattedMessage
-                        defaultMessage="💩"
+                        defaultMessage="cancel"
                         description="Button in prompt for cancelling the dialog"
                         id="gui.prompt.cancel"
                     />

--- a/src/components/connection-modal/connection-modal.jsx
+++ b/src/components/connection-modal/connection-modal.jsx
@@ -28,7 +28,10 @@ const ConnectionModalComponent = props => (
 );
 
 ConnectionModalComponent.propTypes = {
+    extensionId: PropTypes.string.isRequired,
     onCancel: PropTypes.func.isRequired,
+    onConnected: PropTypes.func.isRequired,
+    onConnecting: PropTypes.func.isRequired,
     phase: PropTypes.string.isRequired,
     title: PropTypes.string.isRequired
 };

--- a/src/components/connection-modal/connection-modal.jsx
+++ b/src/components/connection-modal/connection-modal.jsx
@@ -1,0 +1,38 @@
+import {FormattedMessage} from 'react-intl';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import Box from '../box/box.jsx';
+import Modal from '../modal/modal.jsx';
+
+import styles from './connection-modal.css';
+
+const ConnectionModalComponent = props => (
+    <Modal
+        className={styles.modalContent}
+        contentLabel={props.title}
+        onRequestClose={props.onCancel}
+    >
+        <Box className={styles.body}>
+            <Box className={styles.buttonRow}>
+                <button
+                    className={styles.cancelButton}
+                    onClick={props.onCancel}
+                >
+                    <FormattedMessage
+                        defaultMessage="💩"
+                        description="Button in prompt for cancelling the dialog"
+                        id="gui.prompt.cancel"
+                    />
+                </button>
+            </Box>
+        </Box>
+    </Modal>
+);
+
+ConnectionModalComponent.propTypes = {
+    onCancel: PropTypes.func.isRequired,
+    title: PropTypes.string.isRequired
+};
+
+export default ConnectionModalComponent;

--- a/src/components/connection-modal/connection-modal.jsx
+++ b/src/components/connection-modal/connection-modal.jsx
@@ -1,37 +1,40 @@
-import {FormattedMessage} from 'react-intl';
 import PropTypes from 'prop-types';
 import React from 'react';
 
 import Box from '../box/box.jsx';
 import Modal from '../modal/modal.jsx';
 
+import ScanningStep from '../../containers/scanning-step.jsx';
+import ConnectingStep from './connecting-step.jsx';
+import ConnectedStep from './connected-step.jsx';
+import ErrorStep from './error-step.jsx';
+
 import styles from './connection-modal.css';
+
+const phases = {
+    scanning: ScanningStep,
+    connecting: ConnectingStep,
+    connected: ConnectedStep,
+    error: ErrorStep
+};
 
 const ConnectionModalComponent = props => (
     <Modal
         className={styles.modalContent}
         contentLabel={props.title}
+        headerClassName={styles.header}
         onRequestClose={props.onCancel}
     >
         <Box className={styles.body}>
-            <Box className={styles.buttonRow}>
-                <button
-                    className={styles.cancelButton}
-                    onClick={props.onCancel}
-                >
-                    <FormattedMessage
-                        defaultMessage="cancel"
-                        description="Button in prompt for cancelling the dialog"
-                        id="gui.prompt.cancel"
-                    />
-                </button>
-            </Box>
+            {React.createElement(phases[props.phase], props)}
         </Box>
     </Modal>
 );
 
 ConnectionModalComponent.propTypes = {
     onCancel: PropTypes.func.isRequired,
+    onSearch: PropTypes.func.isRequired,
+    phase: PropTypes.string.isRequired,
     title: PropTypes.string.isRequired
 };
 

--- a/src/components/connection-modal/connection-modal.jsx
+++ b/src/components/connection-modal/connection-modal.jsx
@@ -11,13 +11,6 @@ import ErrorStep from './error-step.jsx';
 
 import styles from './connection-modal.css';
 
-const phases = {
-    scanning: ScanningStep,
-    connecting: ConnectingStep,
-    connected: ConnectedStep,
-    error: ErrorStep
-};
-
 const ConnectionModalComponent = props => (
     <Modal
         className={styles.modalContent}
@@ -26,14 +19,16 @@ const ConnectionModalComponent = props => (
         onRequestClose={props.onCancel}
     >
         <Box className={styles.body}>
-            {React.createElement(phases[props.phase], props)}
+            {props.phase === 'scanning' && <ScanningStep {...props} />}
+            {props.phase === 'connecting' && <ConnectingStep {...props} />}
+            {props.phase === 'connected' && <ConnectedStep {...props} />}
+            {props.phase === 'error' && <ErrorStep {...props} />}
         </Box>
     </Modal>
 );
 
 ConnectionModalComponent.propTypes = {
     onCancel: PropTypes.func.isRequired,
-    onSearch: PropTypes.func.isRequired,
     phase: PropTypes.string.isRequired,
     title: PropTypes.string.isRequired
 };

--- a/src/components/connection-modal/connection-modal.jsx
+++ b/src/components/connection-modal/connection-modal.jsx
@@ -28,10 +28,7 @@ const ConnectionModalComponent = props => (
 );
 
 ConnectionModalComponent.propTypes = {
-    extensionId: PropTypes.string.isRequired,
     onCancel: PropTypes.func.isRequired,
-    onConnected: PropTypes.func.isRequired,
-    onConnecting: PropTypes.func.isRequired,
     phase: PropTypes.string.isRequired,
     title: PropTypes.string.isRequired
 };

--- a/src/components/connection-modal/device-tile.jsx
+++ b/src/components/connection-modal/device-tile.jsx
@@ -6,12 +6,13 @@ import Box from '../box/box.jsx';
 
 import styles from './connection-modal.css';
 
+//@todo make this into a 'class component'
 const DeviceTile = props => (
     <Box className={styles.deviceTile}>
         <Box>
             <span>{props.name}</span>
             <Box className={styles.deviceTileWidgets}>
-                <span>{props.RSSI}</span>
+                <span className={styles.signalStrengthText}>{props.RSSI}</span>
                 <button
                     onClick={()=>props.onConnecting(props.peripheralId)}
                 >

--- a/src/components/connection-modal/device-tile.jsx
+++ b/src/components/connection-modal/device-tile.jsx
@@ -1,0 +1,36 @@
+import {FormattedMessage} from 'react-intl';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import Box from '../box/box.jsx';
+
+import styles from './connection-modal.css';
+
+const DeviceTile = props => (
+    <Box className={styles.deviceTile}>
+        <Box>
+            <span>{props.name}</span>
+            <Box className={styles.deviceTileWidgets}>
+                <span>{props.RSSI}</span>
+                <button
+                    onClick={()=>props.onConnecting(props.peripheralId)}
+                >
+                    <FormattedMessage
+                        defaultMessage="connect"
+                        description=""
+                        id="gui.connection.connect"
+                    />
+                </button>
+            </Box>
+        </Box>
+    </Box>
+);
+
+DeviceTile.propTypes = {
+    RSSI: PropTypes.number,
+    name: PropTypes.string,
+    onConnecting: PropTypes.function,
+    peripheralId: PropTypes.string
+};
+
+export default DeviceTile;

--- a/src/components/connection-modal/device-tile.jsx
+++ b/src/components/connection-modal/device-tile.jsx
@@ -1,36 +1,48 @@
 import {FormattedMessage} from 'react-intl';
 import PropTypes from 'prop-types';
 import React from 'react';
-
+import bindAll from 'lodash.bindall';
 import Box from '../box/box.jsx';
 
 import styles from './connection-modal.css';
 
-//@todo make this into a 'class component'
-const DeviceTile = props => (
-    <Box className={styles.deviceTile}>
-        <Box>
-            <span>{props.name}</span>
-            <Box className={styles.deviceTileWidgets}>
-                <span className={styles.signalStrengthText}>{props.RSSI}</span>
-                <button
-                    onClick={()=>props.onConnecting(props.peripheralId)}
-                >
-                    <FormattedMessage
-                        defaultMessage="connect"
-                        description=""
-                        id="gui.connection.connect"
-                    />
-                </button>
+class DeviceTile extends React.Component {
+    constructor (props) {
+        super(props);
+        bindAll(this, [
+            'handleConnecting'
+        ]);
+    }
+    handleConnecting () {
+        this.props.onConnecting(this.props.peripheralId);
+    }
+    render () {
+        return (
+            <Box className={styles.deviceTile}>
+                <Box>
+                    <span>{this.props.name}</span>
+                    <Box className={styles.deviceTileWidgets}>
+                        <span className={styles.signalStrengthText}>{this.props.RSSI}</span>
+                        <button
+                            onClick={this.handleConnecting}
+                        >
+                            <FormattedMessage
+                                defaultMessage="connect"
+                                description=""
+                                id="gui.connection.connect"
+                            />
+                        </button>
+                    </Box>
+                </Box>
             </Box>
-        </Box>
-    </Box>
-);
+        );
+    }
+}
 
 DeviceTile.propTypes = {
     RSSI: PropTypes.number,
     name: PropTypes.string,
-    onConnecting: PropTypes.function,
+    onConnecting: PropTypes.func,
     peripheralId: PropTypes.string
 };
 

--- a/src/components/connection-modal/device-tile.jsx
+++ b/src/components/connection-modal/device-tile.jsx
@@ -22,7 +22,7 @@ class DeviceTile extends React.Component {
                 <Box>
                     <span>{this.props.name}</span>
                     <Box className={styles.deviceTileWidgets}>
-                        <span className={styles.signalStrengthText}>{this.props.RSSI}</span>
+                        <span className={styles.signalStrengthText}>{this.props.rssi}</span>
                         <button
                             onClick={this.handleConnecting}
                         >
@@ -40,10 +40,10 @@ class DeviceTile extends React.Component {
 }
 
 DeviceTile.propTypes = {
-    RSSI: PropTypes.number,
     name: PropTypes.string,
     onConnecting: PropTypes.func,
-    peripheralId: PropTypes.string
+    peripheralId: PropTypes.string,
+    rssi: PropTypes.number
 };
 
 export default DeviceTile;

--- a/src/components/connection-modal/dots.jsx
+++ b/src/components/connection-modal/dots.jsx
@@ -1,0 +1,18 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import Box from '../box/box.jsx';
+import styles from './connection-modal.css';
+
+const Dots = props => (
+    <Box className={styles.dots}>
+        <div>{'step: '}{props.counter}{' / '}{props.total}</div>
+    </Box>
+);
+
+Dots.propTypes = {
+    counter: PropTypes.number,
+    total: PropTypes.number
+};
+
+export default Dots;

--- a/src/components/connection-modal/dots.jsx
+++ b/src/components/connection-modal/dots.jsx
@@ -1,18 +1,59 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import classNames from 'classnames';
 
 import Box from '../box/box.jsx';
 import styles from './connection-modal.css';
 
 const Dots = props => (
-    <Box className={styles.dots}>
-        <div>{'step: '}{props.counter}{' / '}{props.total}</div>
+    <Box className={styles.dotsRow}>
+        <div
+            className={classNames(
+                styles.dotsHolder,
+                {
+                    [styles.dotsHolderError]: props.error,
+                    [styles.dotsHolderSuccess]: props.success
+                }
+            )}
+        >
+            {Array(props.total).fill(0)
+                .map((_, i) => {
+                    let type = 'inactive';
+                    if (props.counter === i) type = 'active';
+                    if (props.success) type = 'success';
+                    if (props.error) type = 'error';
+                    return (<Dot
+                        key={`dot-${i}`}
+                        type={type}
+                    />);
+                })}
+        </div>
     </Box>
 );
 
 Dots.propTypes = {
     counter: PropTypes.number,
+    error: PropTypes.bool,
+    success: PropTypes.bool,
     total: PropTypes.number
+};
+
+const Dot = props => (
+    <div
+        className={classNames(
+            styles.dot,
+            {
+                [styles.inactiveStepDot]: props.type === 'inactive',
+                [styles.activeStepDot]: props.type === 'active',
+                [styles.successDot]: props.type === 'success',
+                [styles.errorDot]: props.type === 'error'
+            }
+        )}
+    />
+);
+
+Dot.propTypes = {
+    type: PropTypes.string
 };
 
 export default Dots;

--- a/src/components/connection-modal/error-step.jsx
+++ b/src/components/connection-modal/error-step.jsx
@@ -8,17 +8,38 @@ import styles from './connection-modal.css';
 
 const ErrorStep = props => (
     <Box className={styles.body}>
-        <Box className={styles.buttonRow}>
-            <button
-                className={styles.searchButton}
-                onClick={props.onSearch}
-            >
+        <Box className={styles.activityArea}>
+        </Box>
+        <Box className={styles.bottomArea}>
+            <div className={styles.instructions}>
                 <FormattedMessage
-                    defaultMessage="🤕error🤕"
-                    description="Button in prompt for starting a search"
-                    id="gui.connection.search"
+                    defaultMessage="Oops, looks like something went wrong."
+                    description="The device connection process has encountered an error."
+                    id="gui.connection.errorMessage"
                 />
-            </button>
+            </div>
+            <Box className={styles.buttonRow}>
+                <button
+                    className={styles.blueButton}
+                    onClick={props.onSearch}
+                >
+                    <FormattedMessage
+                        defaultMessage="Try again"
+                        description="Button to initiate trying the device connection again after an error"
+                        id="gui.connection.tryagainbutton"
+                    />
+                </button>
+                <button
+                    className={styles.blueButton}
+                    onClick={props.onSearch}
+                >
+                    <FormattedMessage
+                        defaultMessage="Help"
+                        description="Button to go to help content"
+                        id="gui.connection.helpbutton"
+                    />
+                </button>
+            </Box>
         </Box>
     </Box>
 );

--- a/src/components/connection-modal/error-step.jsx
+++ b/src/components/connection-modal/error-step.jsx
@@ -1,0 +1,29 @@
+import {FormattedMessage} from 'react-intl';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import Box from '../box/box.jsx';
+
+import styles from './connection-modal.css';
+
+const ErrorStep = props => (
+    <Box className={styles.body}>
+        <Box className={styles.buttonRow}>
+            <button
+                className={styles.searchButton}
+                onClick={props.onSearch}
+            >
+                <FormattedMessage
+                    defaultMessage="error"
+                    description="Button in prompt for starting a search"
+                    id="gui.connection.search"
+                />
+            </button>
+        </Box>
+    </Box>
+);
+
+ErrorStep.propTypes = {
+};
+
+export default ErrorStep;

--- a/src/components/connection-modal/error-step.jsx
+++ b/src/components/connection-modal/error-step.jsx
@@ -14,7 +14,7 @@ const ErrorStep = props => (
                 onClick={props.onSearch}
             >
                 <FormattedMessage
-                    defaultMessage="error"
+                    defaultMessage="🤕error🤕"
                     description="Button in prompt for starting a search"
                     id="gui.connection.search"
                 />

--- a/src/components/connection-modal/error-step.jsx
+++ b/src/components/connection-modal/error-step.jsx
@@ -8,8 +8,7 @@ import styles from './connection-modal.css';
 
 const ErrorStep = props => (
     <Box className={styles.body}>
-        <Box className={styles.activityArea}>
-        </Box>
+        <Box className={styles.activityArea} />
         <Box className={styles.bottomArea}>
             <div className={styles.instructions}>
                 <FormattedMessage
@@ -20,7 +19,6 @@ const ErrorStep = props => (
             </div>
             <Box className={styles.buttonRow}>
                 <button
-                    className={styles.blueButton}
                     onClick={props.onSearch}
                 >
                     <FormattedMessage
@@ -30,7 +28,7 @@ const ErrorStep = props => (
                     />
                 </button>
                 <button
-                    className={styles.blueButton}
+                    className={styles.connectionButton}
                     onClick={props.onSearch}
                 >
                     <FormattedMessage

--- a/src/components/connection-modal/error-step.jsx
+++ b/src/components/connection-modal/error-step.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import Box from '../box/box.jsx';
+import Dots from './dots.jsx';
 
 import styles from './connection-modal.css';
 
@@ -17,6 +18,10 @@ const ErrorStep = props => (
                     id="gui.connection.errorMessage"
                 />
             </div>
+            <Dots
+                error
+                total={3}
+            />
             <Box className={styles.buttonRow}>
                 <button
                     className={styles.connectionButton}

--- a/src/components/connection-modal/error-step.jsx
+++ b/src/components/connection-modal/error-step.jsx
@@ -20,7 +20,7 @@ const ErrorStep = props => (
             <Box className={styles.buttonRow}>
                 <button
                     className={styles.connectionButton}
-                    onClick={props.onSearch}
+                    onClick={props.onScanning}
                 >
                     <FormattedMessage
                         defaultMessage="Try again"
@@ -30,11 +30,11 @@ const ErrorStep = props => (
                 </button>
                 <button
                     className={styles.connectionButton}
-                    onClick={props.onSearch}
+                    onClick={props.onHelp}
                 >
                     <FormattedMessage
                         defaultMessage="Help"
-                        description="Button to go to help content"
+                        description="Button to view help content"
                         id="gui.connection.helpbutton"
                     />
                 </button>
@@ -44,6 +44,8 @@ const ErrorStep = props => (
 );
 
 ErrorStep.propTypes = {
+    onHelp: PropTypes.func,
+    onScanning: PropTypes.func
 };
 
 export default ErrorStep;

--- a/src/components/connection-modal/error-step.jsx
+++ b/src/components/connection-modal/error-step.jsx
@@ -19,6 +19,7 @@ const ErrorStep = props => (
             </div>
             <Box className={styles.buttonRow}>
                 <button
+                    className={styles.connectionButton}
                     onClick={props.onSearch}
                 >
                     <FormattedMessage

--- a/src/components/connection-modal/scanning-step.jsx
+++ b/src/components/connection-modal/scanning-step.jsx
@@ -12,17 +12,25 @@ const ScanningStep = props => (
         <Box className={styles.activityArea}>
             {props.scanning ? (
                 props.deviceList.length === 0 ? (
-                    <div>{'👀Scanning👀'}</div>
+                    <div className={styles.activityAreaInfo}>
+                        <FormattedMessage
+                            defaultMessage="Looking for devices"
+                            description=""
+                            id="gui.connection.scanning.lookingfordevices"
+                        />
+                    </div>
                 ) : (
-                    props.deviceList.map(device =>
-                        (<DeviceTile
-                            RSSI={device.RSSI}
-                            key={device.peripheralId}
-                            name={device.name}
-                            peripheralId={device.peripheralId}
-                            onConnecting={props.onConnecting}
-                        />)
-                    )
+                    <Box className={styles.deviceTilePane}>
+                        {props.deviceList.map(device =>
+                            (<DeviceTile
+                                RSSI={device.RSSI}
+                                key={device.peripheralId}
+                                name={device.name}
+                                peripheralId={device.peripheralId}
+                                onConnecting={props.onConnecting}
+                            />)
+                        )}
+                    </Box>
                 )
             ) : (
                 <Box className={styles.instructions}>
@@ -34,24 +42,26 @@ const ScanningStep = props => (
                 </Box>
             )}
         </Box>
-        <Box className={styles.instructions}>
-            <FormattedMessage
-                defaultMessage="Select your device in the list above."
-                description=""
-                id="gui.connection.scanning.instructions"
-            />
-        </Box>
-        <Box className={styles.buttonRow}>
-            <button
-                className={styles.searchButton}
-                onClick={props.onScan}
-            >
+        <Box className={styles.bottomArea}>
+            <Box className={styles.instructions}>
                 <FormattedMessage
-                    defaultMessage="refresh"
-                    description="Button in prompt for starting a search"
-                    id="gui.connection.search"
+                    defaultMessage="Select your device in the list above."
+                    description=""
+                    id="gui.connection.scanning.instructions"
                 />
-            </button>
+            </Box>
+            <Box className={styles.buttonRow}>
+                <button
+                    className={styles.blueButton}
+                    onClick={props.onConnecting}
+                >
+                    <FormattedMessage
+                        defaultMessage="refresh"
+                        description="Button in prompt for starting a search"
+                        id="gui.connection.search"
+                    />
+                </button>
+            </Box>
         </Box>
     </Box>
 );
@@ -63,7 +73,6 @@ ScanningStep.propTypes = {
         peripheralId: PropTypes.string
     })),
     onConnecting: PropTypes.function,
-    onScan: PropTypes.function,
     scanning: PropTypes.bool.isRequired
 };
 

--- a/src/components/connection-modal/scanning-step.jsx
+++ b/src/components/connection-modal/scanning-step.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 
 import Box from '../box/box.jsx';
 import DeviceTile from './device-tile.jsx';
+import Dots from './dots.jsx';
 
 import styles from './connection-modal.css';
 
@@ -50,6 +51,10 @@ const ScanningStep = props => (
                     id="gui.connection.scanning.instructions"
                 />
             </Box>
+            <Dots
+                counter={1}
+                total={3}
+            />
             <Box className={styles.buttonRow}>
                 <button
                     className={styles.blueButton}

--- a/src/components/connection-modal/scanning-step.jsx
+++ b/src/components/connection-modal/scanning-step.jsx
@@ -3,26 +3,33 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import Box from '../box/box.jsx';
+import DeviceTile from './device-tile.jsx';
 
 import styles from './connection-modal.css';
 
 const ScanningStep = props => (
     <Box className={styles.body}>
         <Box className={styles.activityArea}>
-            {props.searching ? (
-                props.devices.length === 0 ? (
+            {props.scanning ? (
+                props.deviceList.length === 0 ? (
                     <div>{'👀Scanning👀'}</div>
                 ) : (
-                    props.devices.map(device => (
-                        <div>{device.name}</div>
-                    ))
+                    props.deviceList.map(device =>
+                        (<DeviceTile
+                            RSSI={device.RSSI}
+                            key={device.peripheralId}
+                            name={device.name}
+                            peripheralId={device.peripheralId}
+                            onConnecting={props.onConnecting}
+                        />)
+                    )
                 )
             ) : (
                 <Box className={styles.instructions}>
                     <FormattedMessage
-                        defaultMessage="Select your device in the list above."
+                        defaultMessage="No devices found"
                         description=""
-                        id="gui.connection.scanning.instructions"
+                        id="gui.connection.scanning.noDevicesFound"
                     />
                 </Box>
             )}
@@ -37,7 +44,7 @@ const ScanningStep = props => (
         <Box className={styles.buttonRow}>
             <button
                 className={styles.searchButton}
-                onClick={props.onSearch}
+                onClick={props.onScan}
             >
                 <FormattedMessage
                     defaultMessage="refresh"
@@ -50,15 +57,19 @@ const ScanningStep = props => (
 );
 
 ScanningStep.propTypes = {
-    devices: PropTypes.arrayOf(PropTypes.shape({
-        name: PropTypes.string
+    deviceList: PropTypes.arrayOf(PropTypes.shape({
+        name: PropTypes.string,
+        RSSI: PropTypes.number,
+        peripheralId: PropTypes.string
     })),
-    searching: PropTypes.bool.isRequired
+    onConnecting: PropTypes.function,
+    onScan: PropTypes.function,
+    scanning: PropTypes.bool.isRequired
 };
 
 ScanningStep.defaultProps = {
-    devices: [],
-    searching: true
+    deviceList: [],
+    scanning: true
 };
 
 export default ScanningStep;

--- a/src/components/connection-modal/scanning-step.jsx
+++ b/src/components/connection-modal/scanning-step.jsx
@@ -1,0 +1,58 @@
+import {FormattedMessage} from 'react-intl';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import Box from '../box/box.jsx';
+
+import styles from './connection-modal.css';
+
+const ScanningStep = props => (
+    <Box className={styles.body}>
+        <Box className={styles.activityArea}>
+            {props.searching ? (
+                props.devices.length === 0 ? (
+                    <div>search icon here</div>
+                ) : (
+                    props.devices.map(device => (
+                        <div>{device.name}</div>
+                    ))
+                )
+            ) : (
+                <div>No devices found, click on this hyperlink right now</div>
+            )}
+        </Box>
+        <Box className={styles.instructions}>
+            <FormattedMessage
+                defaultMessage="Select your device in the list above."
+                description=""
+                id="gui.connection.scanning.instructions"
+            />
+        </Box>
+        <Box className={styles.buttonRow}>
+            <button
+                className={styles.searchButton}
+                onClick={props.onSearch}
+            >
+                <FormattedMessage
+                    defaultMessage="scanning"
+                    description="Button in prompt for starting a search"
+                    id="gui.connection.search"
+                />
+            </button>
+        </Box>
+    </Box>
+);
+
+ScanningStep.propTypes = {
+    devices: PropTypes.arrayOf(PropTypes.shape({
+        name: PropTypes.string
+    })),
+    searching: PropTypes.bool.isRequired
+};
+
+ScanningStep.defaultProps = {
+    devices: [],
+    searching: true
+};
+
+export default ScanningStep;

--- a/src/components/connection-modal/scanning-step.jsx
+++ b/src/components/connection-modal/scanning-step.jsx
@@ -11,14 +11,20 @@ const ScanningStep = props => (
         <Box className={styles.activityArea}>
             {props.searching ? (
                 props.devices.length === 0 ? (
-                    <div>search icon here</div>
+                    <div>{'👀Scanning👀'}</div>
                 ) : (
                     props.devices.map(device => (
                         <div>{device.name}</div>
                     ))
                 )
             ) : (
-                <div>No devices found, click on this hyperlink right now</div>
+                <Box className={styles.instructions}>
+                    <FormattedMessage
+                        defaultMessage="Select your device in the list above."
+                        description=""
+                        id="gui.connection.scanning.instructions"
+                    />
+                </Box>
             )}
         </Box>
         <Box className={styles.instructions}>
@@ -34,7 +40,7 @@ const ScanningStep = props => (
                 onClick={props.onSearch}
             >
                 <FormattedMessage
-                    defaultMessage="scanning"
+                    defaultMessage="refresh"
                     description="Button in prompt for starting a search"
                     id="gui.connection.search"
                 />

--- a/src/components/connection-modal/scanning-step.jsx
+++ b/src/components/connection-modal/scanning-step.jsx
@@ -58,7 +58,7 @@ const ScanningStep = props => (
             <Box className={styles.buttonRow}>
                 <button
                     className={styles.blueButton}
-                    onClick={props.onConnecting}
+                    onClick={props.onRefresh}
                 >
                     <FormattedMessage
                         defaultMessage="refresh"
@@ -77,7 +77,8 @@ ScanningStep.propTypes = {
         RSSI: PropTypes.number,
         peripheralId: PropTypes.string
     })),
-    onConnecting: PropTypes.function,
+    onConnecting: PropTypes.func,
+    onRefresh: PropTypes.func,
     scanning: PropTypes.bool.isRequired
 };
 

--- a/src/components/connection-modal/scanning-step.jsx
+++ b/src/components/connection-modal/scanning-step.jsx
@@ -52,7 +52,7 @@ const ScanningStep = props => (
                 />
             </Box>
             <Dots
-                counter={1}
+                counter={0}
                 total={3}
             />
             <button

--- a/src/components/connection-modal/scanning-step.jsx
+++ b/src/components/connection-modal/scanning-step.jsx
@@ -24,10 +24,10 @@ const ScanningStep = props => (
                     <Box className={styles.deviceTilePane}>
                         {props.deviceList.map(device =>
                             (<DeviceTile
-                                RSSI={device.RSSI}
                                 key={device.peripheralId}
                                 name={device.name}
                                 peripheralId={device.peripheralId}
+                                rssi={device.rssi}
                                 onConnecting={props.onConnecting}
                             />)
                         )}
@@ -72,7 +72,7 @@ const ScanningStep = props => (
 ScanningStep.propTypes = {
     deviceList: PropTypes.arrayOf(PropTypes.shape({
         name: PropTypes.string,
-        RSSI: PropTypes.number,
+        rssi: PropTypes.number,
         peripheralId: PropTypes.string
     })),
     onConnecting: PropTypes.func,

--- a/src/components/connection-modal/scanning-step.jsx
+++ b/src/components/connection-modal/scanning-step.jsx
@@ -55,18 +55,16 @@ const ScanningStep = props => (
                 counter={1}
                 total={3}
             />
-            <Box className={styles.buttonRow}>
-                <button
-                    className={styles.blueButton}
-                    onClick={props.onRefresh}
-                >
-                    <FormattedMessage
-                        defaultMessage="refresh"
-                        description="Button in prompt for starting a search"
-                        id="gui.connection.search"
-                    />
-                </button>
-            </Box>
+            <button
+                className={styles.connectionButton}
+                onClick={props.onRefresh}
+            >
+                <FormattedMessage
+                    defaultMessage="refresh"
+                    description="Button in prompt for starting a search"
+                    id="gui.connection.search"
+                />
+            </button>
         </Box>
     </Box>
 );

--- a/src/components/modal/modal.jsx
+++ b/src/components/modal/modal.jsx
@@ -26,7 +26,7 @@ const ModalComponent = props => (
             direction="column"
             grow={1}
         >
-            <div className={styles.header}>
+            <div className={classNames(styles.header, props.headerClassName)}>
                 <div
                     className={classNames(
                         styles.headerItem,
@@ -74,6 +74,7 @@ ModalComponent.propTypes = {
         PropTypes.object
     ]).isRequired,
     fullScreen: PropTypes.bool,
+    headerClassName: PropTypes.string,
     onRequestClose: PropTypes.func
 };
 

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -39,6 +39,8 @@ class Blocks extends React.Component {
             'attachVM',
             'detachVM',
             'handleCategorySelected',
+            'handleConnectionModalStart',
+            'handleConnectionModalClose',
             'handlePromptStart',
             'handlePromptCallback',
             'handlePromptClose',
@@ -57,12 +59,16 @@ class Blocks extends React.Component {
             'setLocale'
         ]);
         this.ScratchBlocks.prompt = this.handlePromptStart;
+        this.ScratchBlocks.statusButtonCallback = this.handleConnectionModalStart;
         this.state = {
             workspaceMetrics: {},
-            prompt: null
+            prompt: null,
+            connectionModal: null
         };
         this.onTargetsUpdate = debounce(this.onTargetsUpdate, 100);
         this.toolboxUpdateQueue = [];
+
+        this.state.connectionModal = true;
     }
     componentDidMount () {
         this.ScratchBlocks.FieldColourSlider.activateEyedropper_ = this.props.onActivateColorPicker;
@@ -95,6 +101,7 @@ class Blocks extends React.Component {
     shouldComponentUpdate (nextProps, nextState) {
         return (
             this.state.prompt !== nextState.prompt ||
+            this.state.connectionModal !== nextState.connectionModal ||
             this.props.isVisible !== nextProps.isVisible ||
             this.props.toolboxXML !== nextProps.toolboxXML ||
             this.props.extensionLibraryVisible !== nextProps.extensionLibraryVisible ||
@@ -327,6 +334,15 @@ class Blocks extends React.Component {
             optVarType !== this.ScratchBlocks.BROADCAST_MESSAGE_VARIABLE_TYPE;
         this.setState(p);
     }
+    handleConnectionModalStart (extensionId) {
+        const c = {connectionModal: {
+            id: extensionId
+        }};
+        this.setState(c);
+    }
+    handleConnectionModalClose () {
+        this.setState({connectionModal: null});
+    }
     handlePromptCallback (data) {
         this.state.prompt.callback(data);
         this.handlePromptClose();
@@ -366,17 +382,20 @@ class Blocks extends React.Component {
                     {...props}
                 />
                 {this.state.prompt ? (
-                    // <Prompt
-                    //     label={this.state.prompt.message}
-                    //     placeholder={this.state.prompt.defaultValue}
-                    //     showMoreOptions={this.state.prompt.showMoreOptions}
-                    //     title={this.state.prompt.title}
-                    //     onCancel={this.handlePromptClose}
-                    //     onOk={this.handlePromptCallback}
-                    // />
-                    <ConnectionModal
-                        title={'OMG a modal 😲 🔥 💯'}
+                    <Prompt
+                        label={this.state.prompt.message}
+                        placeholder={this.state.prompt.defaultValue}
+                        showMoreOptions={this.state.prompt.showMoreOptions}
+                        title={this.state.prompt.title}
                         onCancel={this.handlePromptClose}
+                        onOk={this.handlePromptCallback}
+                    />
+                ) : null}
+                {this.state.connectionModal ? (
+                    <ConnectionModal
+                        id={this.state.connectionModal.id}
+                        vm={vm}
+                        onCancel={this.handleConnectionModalClose}
                     />
                 ) : null}
                 {extensionLibraryVisible ? (

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -9,6 +9,7 @@ import VM from 'scratch-vm';
 
 import analytics from '../lib/analytics';
 import Prompt from './prompt.jsx';
+import ConnectionModal from './connection-modal.jsx';
 import BlocksComponent from '../components/blocks/blocks.jsx';
 import ExtensionLibrary from './extension-library.jsx';
 import CustomProcedures from './custom-procedures.jsx';
@@ -365,13 +366,17 @@ class Blocks extends React.Component {
                     {...props}
                 />
                 {this.state.prompt ? (
-                    <Prompt
-                        label={this.state.prompt.message}
-                        placeholder={this.state.prompt.defaultValue}
-                        showMoreOptions={this.state.prompt.showMoreOptions}
-                        title={this.state.prompt.title}
+                    // <Prompt
+                    //     label={this.state.prompt.message}
+                    //     placeholder={this.state.prompt.defaultValue}
+                    //     showMoreOptions={this.state.prompt.showMoreOptions}
+                    //     title={this.state.prompt.title}
+                    //     onCancel={this.handlePromptClose}
+                    //     onOk={this.handlePromptCallback}
+                    // />
+                    <ConnectionModal
+                        title={'OMG a modal 😲 🔥 💯'}
                         onCancel={this.handlePromptClose}
-                        onOk={this.handlePromptCallback}
                     />
                 ) : null}
                 {extensionLibraryVisible ? (

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -67,8 +67,6 @@ class Blocks extends React.Component {
         };
         this.onTargetsUpdate = debounce(this.onTargetsUpdate, 100);
         this.toolboxUpdateQueue = [];
-
-        this.state.connectionModal = true;
     }
     componentDidMount () {
         this.ScratchBlocks.FieldColourSlider.activateEyedropper_ = this.props.onActivateColorPicker;
@@ -336,7 +334,7 @@ class Blocks extends React.Component {
     }
     handleConnectionModalStart (extensionId) {
         const c = {connectionModal: {
-            id: extensionId
+            extensionId: extensionId
         }};
         this.setState(c);
     }
@@ -393,7 +391,7 @@ class Blocks extends React.Component {
                 ) : null}
                 {this.state.connectionModal ? (
                     <ConnectionModal
-                        id={this.state.connectionModal.id}
+                        extensionId={this.state.connectionModal.extensionId}
                         vm={vm}
                         onCancel={this.handleConnectionModalClose}
                     />

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -41,6 +41,7 @@ class Blocks extends React.Component {
             'handleCategorySelected',
             'handleConnectionModalStart',
             'handleConnectionModalClose',
+            'handleStatusButtonUpdate',
             'handlePromptStart',
             'handlePromptCallback',
             'handlePromptClose',
@@ -341,6 +342,9 @@ class Blocks extends React.Component {
     handleConnectionModalClose () {
         this.setState({connectionModal: null});
     }
+    handleStatusButtonUpdate (extensionId, status) {
+        this.ScratchBlocks.updateStatusButton(this.workspace, extensionId, status);
+    }
     handlePromptCallback (data) {
         this.state.prompt.callback(data);
         this.handlePromptClose();
@@ -394,6 +398,7 @@ class Blocks extends React.Component {
                         extensionId={this.state.connectionModal.extensionId}
                         vm={vm}
                         onCancel={this.handleConnectionModalClose}
+                        onStatusButtonUpdate={this.handleStatusButtonUpdate}
                     />
                 ) : null}
                 {extensionLibraryVisible ? (

--- a/src/containers/connection-modal.jsx
+++ b/src/containers/connection-modal.jsx
@@ -20,6 +20,11 @@ class ConnectionModal extends React.Component {
                 phase: 'connected'
             });
         });
+        this.props.vm.on('PERIPHERAL_ERROR', () => {
+            this.setState({
+                phase: 'error'
+            });
+        });
     }
     handleConnecting (peripheralId) {
         this.props.vm.connectToPeripheral(this.props.extensionId, peripheralId);

--- a/src/containers/connection-modal.jsx
+++ b/src/containers/connection-modal.jsx
@@ -2,13 +2,13 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import bindAll from 'lodash.bindall';
 import ConnectionModalComponent from '../components/connection-modal/connection-modal.jsx';
+import VM from 'scratch-vm';
 
 class ConnectionModal extends React.Component {
     constructor (props) {
         super(props);
         bindAll(this, [
-            'handleCancel',
-            'handleSearch'
+            'handleCancel'
         ]);
         this.state = {
             phase: 'scanning'
@@ -17,16 +17,13 @@ class ConnectionModal extends React.Component {
     handleCancel () {
         this.props.onCancel();
     }
-    handleSearch () {
-        this.props.onSearch();
-    }
     render () {
         return (
             <ConnectionModalComponent
-                title={this.props.id}
-                onCancel={this.handleCancel}
-                onSearch={this.handleSearch}
                 phase={this.state.phase}
+                title={this.props.id}
+                vm={this.props.vm}
+                onCancel={this.handleCancel}
             />
         );
     }
@@ -35,7 +32,7 @@ class ConnectionModal extends React.Component {
 ConnectionModal.propTypes = {
     id: PropTypes.string.isRequired,
     onCancel: PropTypes.func.isRequired,
-    onSearch: PropTypes.func.isRequired
+    vm: PropTypes.instanceOf(VM).isRequired
 };
 
 export default ConnectionModal;

--- a/src/containers/connection-modal.jsx
+++ b/src/containers/connection-modal.jsx
@@ -14,23 +14,44 @@ class ConnectionModal extends React.Component {
             phase: 'scanning'
         };
     }
+    componentDidMount () {
+        this.props.vm.on('PERIPHERAL_CONNECTED', () => {
+            this.setState({
+                phase: 'connected'
+            });
+        });
+    }
+    handleConnecting (peripheralId) {
+        this.props.vm.connectToPeripheral(this.props.extensionId, peripheralId);
+        this.setState({
+            phase: 'connecting'
+        });
+    }
+    handleConnected () {
+        this.setState({
+            phase: 'connected'
+        });
+    }
     handleCancel () {
         this.props.onCancel();
     }
     render () {
         return (
             <ConnectionModalComponent
+                extensionId={this.props.extensionId}
                 phase={this.state.phase}
-                title={this.props.id}
+                title={this.props.extensionId}
                 vm={this.props.vm}
                 onCancel={this.handleCancel}
+                onConnected={this.handleConnected}
+                onConnecting={this.handleConnecting.bind(this)}
             />
         );
     }
 }
 
 ConnectionModal.propTypes = {
-    id: PropTypes.string.isRequired,
+    extensionId: PropTypes.string.isRequired,
     onCancel: PropTypes.func.isRequired,
     vm: PropTypes.instanceOf(VM).isRequired
 };

--- a/src/containers/connection-modal.jsx
+++ b/src/containers/connection-modal.jsx
@@ -1,0 +1,31 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import bindAll from 'lodash.bindall';
+import ConnectionModalComponent from '../components/connection-modal/connection-modal.jsx';
+
+class ConnectionModal extends React.Component {
+    constructor (props) {
+        super(props);
+        bindAll(this, [
+            'handleCancel'
+        ]);
+    }
+    handleCancel () {
+        this.props.onCancel();
+    }
+    render () {
+        return (
+            <ConnectionModalComponent
+                title={this.props.title}
+                onCancel={this.handleCancel}
+            />
+        );
+    }
+}
+
+ConnectionModal.propTypes = {
+    onCancel: PropTypes.func.isRequired,
+    title: PropTypes.string.isRequired
+};
+
+export default ConnectionModal;

--- a/src/containers/connection-modal.jsx
+++ b/src/containers/connection-modal.jsx
@@ -8,6 +8,7 @@ class ConnectionModal extends React.Component {
     constructor (props) {
         super(props);
         bindAll(this, [
+            'handleScanning',
             'handleConnected',
             'handleConnecting',
             'handleDisconnect',
@@ -30,6 +31,11 @@ class ConnectionModal extends React.Component {
     componentWillUnmount () {
         this.props.vm.removeListener('PERIPHERAL_CONNECTED', this.handleConnected);
         this.props.vm.removeListener('PERIPHERAL_ERROR', this.handleError);
+    }
+    handleScanning () {
+        this.setState({
+            phase: 'scanning'
+        });
     }
     handleConnecting (peripheralId) {
         this.props.vm.connectToPeripheral(this.props.extensionId, peripheralId);
@@ -58,6 +64,9 @@ class ConnectionModal extends React.Component {
             phase: 'connected'
         });
     }
+    handleHelp () {
+        // @todo: implement the help button
+    }
     render () {
         return (
             <ConnectionModalComponent
@@ -69,6 +78,8 @@ class ConnectionModal extends React.Component {
                 onConnected={this.handleConnected}
                 onConnecting={this.handleConnecting}
                 onDisconnect={this.handleDisconnect}
+                onHelp={this.handleHelp}
+                onScanning={this.handleScanning}
             />
         );
     }

--- a/src/containers/connection-modal.jsx
+++ b/src/containers/connection-modal.jsx
@@ -44,6 +44,7 @@ class ConnectionModal extends React.Component {
         });
     }
     handleDisconnect () {
+        this.props.onStatusButtonUpdate(this.props.extensionId, 'not ready');
         this.props.vm.disconnectExtensionSession(this.props.extensionId);
         this.props.onCancel();
     }
@@ -55,11 +56,13 @@ class ConnectionModal extends React.Component {
         this.props.onCancel();
     }
     handleError () {
+        this.props.onStatusButtonUpdate(this.props.extensionId, 'not ready');
         this.setState({
             phase: 'error'
         });
     }
     handleConnected () {
+        this.props.onStatusButtonUpdate(this.props.extensionId, 'ready');
         this.setState({
             phase: 'connected'
         });
@@ -88,6 +91,7 @@ class ConnectionModal extends React.Component {
 ConnectionModal.propTypes = {
     extensionId: PropTypes.string.isRequired,
     onCancel: PropTypes.func.isRequired,
+    onStatusButtonUpdate: PropTypes.func.isRequired,
     vm: PropTypes.instanceOf(VM).isRequired
 };
 

--- a/src/containers/connection-modal.jsx
+++ b/src/containers/connection-modal.jsx
@@ -8,23 +8,19 @@ class ConnectionModal extends React.Component {
     constructor (props) {
         super(props);
         bindAll(this, [
-            'handleCancel'
+            'handleAbortConnecting',
+            'handleConnected',
+            'handleConnecting'
         ]);
         this.state = {
             phase: 'scanning'
         };
     }
     componentDidMount () {
-        this.props.vm.on('PERIPHERAL_CONNECTED', () => {
-            this.setState({
-                phase: 'connected'
-            });
-        });
-        this.props.vm.on('PERIPHERAL_ERROR', () => {
-            this.setState({
-                phase: 'error'
-            });
-        });
+        this.props.vm.on('PERIPHERAL_CONNECTED', this.handleConnected);
+    }
+    componentWillUnmount () {
+        this.props.vm.removeListener('PERIPHERAL_CONNECTED', this.handleConnected);
     }
     handleConnecting (peripheralId) {
         this.props.vm.connectToPeripheral(this.props.extensionId, peripheralId);
@@ -32,13 +28,16 @@ class ConnectionModal extends React.Component {
             phase: 'connecting'
         });
     }
+    handleAbortConnecting () {
+        // @todo: abort the current device connection process in the VM
+        this.setState({
+            phase: 'scanning'
+        });
+    }
     handleConnected () {
         this.setState({
             phase: 'connected'
         });
-    }
-    handleCancel () {
-        this.props.onCancel();
     }
     render () {
         return (
@@ -47,9 +46,10 @@ class ConnectionModal extends React.Component {
                 phase={this.state.phase}
                 title={this.props.extensionId}
                 vm={this.props.vm}
-                onCancel={this.handleCancel}
+                onAbortConnecting={this.handleAbortConnecting}
+                onCancel={this.props.onCancel}
                 onConnected={this.handleConnected}
-                onConnecting={this.handleConnecting.bind(this)}
+                onConnecting={this.handleConnecting}
             />
         );
     }

--- a/src/containers/connection-modal.jsx
+++ b/src/containers/connection-modal.jsx
@@ -10,7 +10,8 @@ class ConnectionModal extends React.Component {
         bindAll(this, [
             'handleAbortConnecting',
             'handleConnected',
-            'handleConnecting'
+            'handleConnecting',
+            'handleError'
         ]);
         this.state = {
             phase: 'scanning'
@@ -18,14 +19,21 @@ class ConnectionModal extends React.Component {
     }
     componentDidMount () {
         this.props.vm.on('PERIPHERAL_CONNECTED', this.handleConnected);
+        this.props.vm.on('PERIPHERAL_ERROR', this.handleError);
     }
     componentWillUnmount () {
         this.props.vm.removeListener('PERIPHERAL_CONNECTED', this.handleConnected);
+        this.props.vm.removeListener('PERIPHERAL_ERROR', this.handleError);
     }
     handleConnecting (peripheralId) {
         this.props.vm.connectToPeripheral(this.props.extensionId, peripheralId);
         this.setState({
             phase: 'connecting'
+        });
+    }
+    handleError () {
+        this.setState({
+            phase: 'error'
         });
     }
     handleAbortConnecting () {

--- a/src/containers/scanning-step.jsx
+++ b/src/containers/scanning-step.jsx
@@ -11,14 +11,14 @@ class ScanningStep extends React.Component {
             'handleCancel'
         ]);
         this.state = {
-            searching: true,
-            devices: []
+            scanning: true,
+            deviceList: []
         };
     }
     componentDidMount () {
-        this.props.vm.on('peripheral_added', id => {
-            // console.log('gui says peripheral added', id);
-            this.setState({devices:this.state.devices.concat(id)})
+        this.props.vm.startDeviceScan(this.props.extensionId);
+        this.props.vm.on('PERIPHERAL_LIST_UPDATE', newList => {
+            this.setState({deviceList: newList});
         });
     }
     componentWillUnmount () {
@@ -27,24 +27,29 @@ class ScanningStep extends React.Component {
     handleCancel () {
         this.props.onCancel();
     }
-    handleSearch () {
-        this.props.onSearch();
+    handleScan () {
+        this.props.onScan();
     }
     render () {
         return (
             <ScanningStepComponent
+                deviceList={this.state.deviceList}
                 phase={this.state.phase}
-                title={this.props.id}
+                title={this.props.extensionId}
                 onCancel={this.handleCancel}
+                onConnected={this.props.onConnected}
+                onConnecting={this.props.onConnecting}
             />
         );
     }
 }
 
 ScanningStep.propTypes = {
-    id: PropTypes.string.isRequired,
+    extensionId: PropTypes.string.isRequired,
     onCancel: PropTypes.func.isRequired,
-    onSearch: PropTypes.func.isRequired,
+    onConnected: PropTypes.func.isRequired,
+    onConnecting: PropTypes.func.isRequired,
+    onScan: PropTypes.func.isRequired,
     vm: PropTypes.instanceOf(VM).isRequired
 };
 

--- a/src/containers/scanning-step.jsx
+++ b/src/containers/scanning-step.jsx
@@ -18,7 +18,11 @@ class ScanningStep extends React.Component {
     componentDidMount () {
         this.props.vm.startDeviceScan(this.props.extensionId);
         this.props.vm.on('PERIPHERAL_LIST_UPDATE', newList => {
-            this.setState({deviceList: newList});
+            // TODO: sort peripherals by signal strength? so they don't jump around
+            const peripheralArray = Object.keys(newList).map(id =>
+                newList[id]
+            );
+            this.setState({deviceList: peripheralArray});
         });
     }
     componentWillUnmount () {

--- a/src/containers/scanning-step.jsx
+++ b/src/containers/scanning-step.jsx
@@ -1,9 +1,9 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import bindAll from 'lodash.bindall';
-import ConnectionModalComponent from '../components/connection-modal/connection-modal.jsx';
+import ScanningStepComponent from '../components/connection-modal/scanning-step.jsx';
 
-class ConnectionModal extends React.Component {
+class ScanningStep extends React.Component {
     constructor (props) {
         super(props);
         bindAll(this, [
@@ -11,7 +11,8 @@ class ConnectionModal extends React.Component {
             'handleSearch'
         ]);
         this.state = {
-            phase: 'scanning'
+            searching: true,
+            devices: []
         };
     }
     handleCancel () {
@@ -22,7 +23,7 @@ class ConnectionModal extends React.Component {
     }
     render () {
         return (
-            <ConnectionModalComponent
+            <ScanningStepComponent
                 title={this.props.id}
                 onCancel={this.handleCancel}
                 onSearch={this.handleSearch}
@@ -32,10 +33,10 @@ class ConnectionModal extends React.Component {
     }
 }
 
-ConnectionModal.propTypes = {
+ScanningStep.propTypes = {
     id: PropTypes.string.isRequired,
     onCancel: PropTypes.func.isRequired,
     onSearch: PropTypes.func.isRequired
 };
 
-export default ConnectionModal;
+export default ScanningStep;

--- a/src/containers/scanning-step.jsx
+++ b/src/containers/scanning-step.jsx
@@ -2,18 +2,27 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import bindAll from 'lodash.bindall';
 import ScanningStepComponent from '../components/connection-modal/scanning-step.jsx';
+import VM from 'scratch-vm';
 
 class ScanningStep extends React.Component {
     constructor (props) {
         super(props);
         bindAll(this, [
-            'handleCancel',
-            'handleSearch'
+            'handleCancel'
         ]);
         this.state = {
             searching: true,
             devices: []
         };
+    }
+    componentDidMount () {
+        this.props.vm.on('peripheral_added', id => {
+            // console.log('gui says peripheral added', id);
+            this.setState({devices:this.state.devices.concat(id)})
+        });
+    }
+    componentWillUnmount () {
+        // remove the listener
     }
     handleCancel () {
         this.props.onCancel();
@@ -24,10 +33,9 @@ class ScanningStep extends React.Component {
     render () {
         return (
             <ScanningStepComponent
+                phase={this.state.phase}
                 title={this.props.id}
                 onCancel={this.handleCancel}
-                onSearch={this.handleSearch}
-                phase={this.state.phase}
             />
         );
     }
@@ -36,7 +44,8 @@ class ScanningStep extends React.Component {
 ScanningStep.propTypes = {
     id: PropTypes.string.isRequired,
     onCancel: PropTypes.func.isRequired,
-    onSearch: PropTypes.func.isRequired
+    onSearch: PropTypes.func.isRequired,
+    vm: PropTypes.instanceOf(VM).isRequired
 };
 
 export default ScanningStep;

--- a/src/containers/scanning-step.jsx
+++ b/src/containers/scanning-step.jsx
@@ -34,6 +34,7 @@ class ScanningStep extends React.Component {
         this.setState({deviceList: peripheralArray});
     }
     handleRefresh () {
+        this.props.vm.startDeviceScan(this.props.extensionId);
         this.setState({
             scanning: true,
             deviceList: []

--- a/src/containers/scanning-step.jsx
+++ b/src/containers/scanning-step.jsx
@@ -8,7 +8,8 @@ class ScanningStep extends React.Component {
     constructor (props) {
         super(props);
         bindAll(this, [
-            'handleCancel'
+            'handlePeripheralListUpdate',
+            'handleRefresh'
         ]);
         this.state = {
             scanning: true,
@@ -17,22 +18,26 @@ class ScanningStep extends React.Component {
     }
     componentDidMount () {
         this.props.vm.startDeviceScan(this.props.extensionId);
-        this.props.vm.on('PERIPHERAL_LIST_UPDATE', newList => {
-            // TODO: sort peripherals by signal strength? so they don't jump around
-            const peripheralArray = Object.keys(newList).map(id =>
-                newList[id]
-            );
-            this.setState({deviceList: peripheralArray});
-        });
+        this.props.vm.on(
+            'PERIPHERAL_LIST_UPDATE', this.handlePeripheralListUpdate);
     }
     componentWillUnmount () {
-        // remove the listener
+        // @todo: stop the device scan here
+        this.props.vm.removeListener(
+            'PERIPHERAL_LIST_UPDATE', this.handlePeripheralListUpdate);
     }
-    handleCancel () {
-        this.props.onCancel();
+    handlePeripheralListUpdate (newList) {
+        // TODO: sort peripherals by signal strength? so they don't jump around
+        const peripheralArray = Object.keys(newList).map(id =>
+            newList[id]
+        );
+        this.setState({deviceList: peripheralArray});
     }
-    handleScan () {
-        this.props.onScan();
+    handleRefresh () {
+        this.setState({
+            scanning: true,
+            deviceList: []
+        });
     }
     render () {
         return (
@@ -40,9 +45,9 @@ class ScanningStep extends React.Component {
                 deviceList={this.state.deviceList}
                 phase={this.state.phase}
                 title={this.props.extensionId}
-                onCancel={this.handleCancel}
                 onConnected={this.props.onConnected}
                 onConnecting={this.props.onConnecting}
+                onRefresh={this.handleRefresh}
             />
         );
     }
@@ -50,10 +55,8 @@ class ScanningStep extends React.Component {
 
 ScanningStep.propTypes = {
     extensionId: PropTypes.string.isRequired,
-    onCancel: PropTypes.func.isRequired,
     onConnected: PropTypes.func.isRequired,
     onConnecting: PropTypes.func.isRequired,
-    onScan: PropTypes.func.isRequired,
     vm: PropTypes.instanceOf(VM).isRequired
 };
 

--- a/src/css/colors.css
+++ b/src/css/colors.css
@@ -15,6 +15,7 @@ $text-primary-transparent: hsla(225, 15%, 40%, 0.75);
 $motion-primary: hsla(215, 100%, 65%, 1); /* #4C97FF */
 $motion-tertiary: hsla(215, 60%, 50%, 1); /* #3373CC */
 $motion-transparent: hsla(215, 100%, 65%, 0.35); /* 35% transparent version of motion-primary */
+$motion-light-transparent: hsla(215, 100%, 65%, 0.1); /* 10% transparent version of motion-primary */
 
 $red-primary: hsla(20, 100%, 55%, 1); /* #FF661A */
 $red-tertiary: hsla(20, 100%, 45%, 1); /* #E64D00 */

--- a/src/css/colors.css
+++ b/src/css/colors.css
@@ -28,3 +28,7 @@ $control-primary: hsla(38, 100%, 55%, 1); /* #FFAB19 */
 $data-primary: hsla(30, 100%, 55%, 1); /* #FF8C1A */
 
 $pen-primary: hsla(163, 85%, 40%, 1); /* #0FBD8C */
+$pen-transparent: hsla(163, 85%, 40%, 0.25); /* #0FBD8C */
+
+$error-primary: hsla(30, 100%, 55%, 1); /* #FF8C1A */
+$error-transparent: hsla(30, 100%, 55%, 0.25); /* #FF8C1A */

--- a/src/lib/libraries/extensions/index.jsx
+++ b/src/lib/libraries/extensions/index.jsx
@@ -120,7 +120,7 @@ export default [
             />
         ),
         featured: true,
-        disabled: true
+        disabled: false
     },
     {
         name: 'LEGO WeDo 2.0',
@@ -134,7 +134,7 @@ export default [
             />
         ),
         featured: true,
-        disabled: true
+        disabled: false
     },
     {
         name: 'LEGO MINDSTORMS EV3',
@@ -148,7 +148,7 @@ export default [
             />
         ),
         featured: true,
-        disabled: true
+        disabled: false
     },
     {
         name: 'LEGO Boost',

--- a/src/lib/libraries/extensions/index.jsx
+++ b/src/lib/libraries/extensions/index.jsx
@@ -120,7 +120,7 @@ export default [
             />
         ),
         featured: true,
-        disabled: false
+        disabled: true
     },
     {
         name: 'LEGO WeDo 2.0',
@@ -134,7 +134,7 @@ export default [
             />
         ),
         featured: true,
-        disabled: false
+        disabled: true
     },
     {
         name: 'LEGO MINDSTORMS EV3',
@@ -148,7 +148,7 @@ export default [
             />
         ),
         featured: true,
-        disabled: false
+        disabled: true
     },
     {
         name: 'LEGO Boost',


### PR DESCRIPTION
This adds a set of modal dialogs to walk the user through connecting to a hardware device via an extension. Eventually these dialogs will contain images and other information specific to individual hardware devices, but for now they are generic. There are many cosmetic details remaining to bring these dialogs to spec.

Other miscellaneous changes include a small change to the base modal component to support more flexible styling, and adding some new colors. 

The connection status indicator button at the top of the blocks category launches the connection modal and also updates to when the device has connected, but there are some known issues with it (the indicator gets out of sync in connection succeeds after closing the modal, and when switching sprites). 
 