### PR TITLE
Prevent tab and label wrapping

### DIFF
--- a/src/components/forms/label.css
+++ b/src/components/forms/label.css
@@ -12,6 +12,8 @@
     margin-right: .5rem;
     user-select: none;
     cursor: default;
+
+    white-space: nowrap;
 }
 
 .input-label {

--- a/src/components/gui/gui.css
+++ b/src/components/gui/gui.css
@@ -79,6 +79,7 @@
     align-items: center;
 
     user-select: none;
+    white-space: nowrap;
 }
 
 /* Use z-indices to force left-on-top for tabs */

--- a/src/components/sprite-info/sprite-info.css
+++ b/src/components/sprite-info/sprite-info.css
@@ -44,6 +44,10 @@
 }
 
 /* @todo: refactor radio divs to input */
+.radio-wrapper {
+    white-space: nowrap; /* make sure visibilty buttons don't wrap */
+}
+
 .radio {
     filter: saturate(0);
     cursor: pointer;

--- a/src/components/sprite-info/sprite-info.jsx
+++ b/src/components/sprite-info/sprite-info.jsx
@@ -176,7 +176,7 @@ class SpriteInfo extends React.Component {
                                 /> :
                                 null
                         }
-                        <div>
+                        <div className={styles.radioWrapper}>
                             <div
                                 className={classNames(
                                     styles.radio,


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves #2448  (tab wrapping in Japanese). Also ensures that none of the Sprite info area wraps. Does not address the issue where the sprite info area is too big and pushes the stage info off the screen.

### Proposed Changes

_Describe what this Pull Request does_
Adds `white-space: nowrap` to the tab labels and labels in the sprite info area.

### Reason for Changes

_Explain why these changes should be made_
These areas are not designed for text wrapping and the results are unpredictable.

### Test Coverage

Usual tests run.

Try is out: https://chrisgarrity.github.io/scratch-gui/issue/2448-ja-overflow/?locale=ja

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
