### PR TITLE
chore(package): update scratch-blocks to version 0.1.0-prerelease.153…

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "redux-throttle": "0.1.1",
     "rimraf": "^2.6.1",
     "scratch-audio": "0.1.0-prerelease.20180625202813",
-    "scratch-blocks": "0.1.0-prerelease.1530135682",
+    "scratch-blocks": "0.1.0-prerelease.1531144787",
     "scratch-l10n": "3.0.20180703181510",
     "scratch-paint": "0.2.0-prerelease.20180709132225",
     "scratch-render": "0.1.0-prerelease.20180618173030",


### PR DESCRIPTION
@kchadha this includes the fix for https://github.com/LLK/scratch-blocks/pull/1634