### PR TITLE
Update 'mini cards' color UI

### DIFF
--- a/src/components/action-menu/action-menu.css
+++ b/src/components/action-menu/action-menu.css
@@ -28,7 +28,7 @@ button::-moz-focus-inner {
 }
 
 .button:hover {
-    background: $pen-primary;
+    background: $extensions-primary;
 }
 
 .button:active {
@@ -126,7 +126,7 @@ button::-moz-focus-inner {
     is not very easy to style.
 */
 .tooltip {
-    background-color: $pen-primary !important;
+    background-color: $extensions-primary !important;
     opacity: 1 !important;
     border: 1px solid hsla(0, 0%, 0%, .1) !important;
     box-shadow: 0 0 .5rem hsla(0, 0%, 0%, .25) !important;
@@ -134,7 +134,7 @@ button::-moz-focus-inner {
 }
 
 .tooltip:after {
-    background-color: $pen-primary;
+    background-color: $extensions-primary;
 }
 
 .coming-soon-tooltip {

--- a/src/components/camera-modal/camera-modal.css
+++ b/src/components/camera-modal/camera-modal.css
@@ -93,7 +93,7 @@ $main-button-size: 2.75rem;
 }
 
 .main-button:hover {
-    background: $pen-primary;
+    background: $extensions-primary;
     box-shadow: 0 0 0 6px $motion-transparent;
 }
 

--- a/src/components/cards/card.css
+++ b/src/components/cards/card.css
@@ -41,7 +41,7 @@
     left: 0;
     height: 1.8rem;
     width: 100%;
-    background: $motion-primary;
+    background: $extensions-primary;
 }
 
 .left-button, .right-button {
@@ -51,14 +51,15 @@
     z-index: 20;
     user-select: none;
     cursor: pointer;
-    background: $motion-primary;
-    box-shadow: 0 0 0 4px $motion-transparent;
     height: 40px;
     width: 40px;
+    background: $extensions-primary;
+    box-shadow: 0 0 0 4px $extensions-transparent;
     border-radius: 100%;
     display: flex;
     justify-content: center;
     align-items: center;
+    box-shadow: 0 0 0 6px $extensions-transparent;
 }
 
 .left-button {
@@ -88,9 +89,9 @@
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
-    background: $motion-primary;
-    border-bottom: 1px solid $motion-tertiary;
     padding: 0.5rem;
+    background: $extensions-primary;
+    border-bottom: 1px solid $extensions-tertiary;
     font-size: 0.625rem;
 }
 

--- a/src/components/cards/card.css
+++ b/src/components/cards/card.css
@@ -14,21 +14,21 @@
     top: 5%;
     background: $ui-white;
     border: 1px solid $ui-tertiary;
-    width: 10px;
+    width: .75rem;
     z-index: 10;
     opacity: 0.9;
     overflow: hidden;
 }
 
 .left-card {
-    left: -10px;
+    left: -.75rem;
     border-right: 0;
     border-top-left-radius: 0.75rem;
     border-bottom-left-radius: 0.75rem;
 }
 
 .right-card {
-    right: -10px;
+    right: -.75rem;
     border-left: 0;
     border-top-right-radius: 0.75rem;
     border-bottom-right-radius: 0.75rem;
@@ -39,7 +39,7 @@
     position: absolute;
     top: 0;
     left: 0;
-    height: 1.8rem;
+    height: 2.5rem;
     width: 100%;
     background: $extensions-primary;
 }
@@ -51,15 +51,24 @@
     z-index: 20;
     user-select: none;
     cursor: pointer;
-    height: 40px;
-    width: 40px;
     background: $extensions-primary;
     box-shadow: 0 0 0 4px $extensions-transparent;
+    height: 44px;
+    width: 44px;
     border-radius: 100%;
     display: flex;
     justify-content: center;
     align-items: center;
+    transition: all 0.25s ease;
+}
+
+.left-button:hover, .right-button:hover {
     box-shadow: 0 0 0 6px $extensions-transparent;
+    transform: scale(1.125);
+}
+
+.left-button img, .right-button img{
+    width: 1.75rem;
 }
 
 .left-button {
@@ -89,10 +98,10 @@
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
-    padding: 0.5rem;
     background: $extensions-primary;
     border-bottom: 1px solid $extensions-tertiary;
     font-size: 0.625rem;
+    font-weight: bold;
 }
 
 .remove-button, .all-button {
@@ -102,6 +111,11 @@
     flex-direction: row;
     justify-content: center;
     align-items: center;
+    padding: 0.75rem;
+}
+
+.remove-button:hover, .all-button:hover {
+    background-color: $ui-black-transparent;
 }
 
 .step-title {
@@ -162,14 +176,14 @@
     color: $motion-primary;
     font-weight: bold;
     font-size: 0.85rem;
-    margin: 14px 0px;
+    margin: .625rem 0px;
     text-align: center;
     font-weight: bold;
     text-align: center;
 }
 
 .help-icon, .close-icon {
-    height: 0.75rem;
+    height: 1rem;
 }
 
 .help-icon {
@@ -199,9 +213,9 @@
     display: flex;
     align-items: center;
     color: $ui-white;
-    font-size: 12px;
+    font-size: .75rem;
     font-weight: bold;
-    line-height: 15px;
+    line-height: 1rem;
     text-align: center;
 }
 
@@ -229,10 +243,10 @@
     height: 0.5rem;
     margin: 0 0.25rem;
     border-radius: 100%;
-    background: transparent;
-    border: 2px solid $ui-white-transparent;
+    background: $ui-white-transparent;
 }
 
 .active-step-pip {
-    background: white;
+    background: $ui-white;
+    box-shadow: 0px 0px 0px 2px $ui-black-transparent;
 }

--- a/src/components/import-modal/import-modal.css
+++ b/src/components/import-modal/import-modal.css
@@ -45,7 +45,7 @@ $sides: 20rem;
 
     box-sizing: border-box;
     width: 100%;
-    background-color: $pen-primary;
+    background-color: $extensions-primary;
 }
 
 .header-item {
@@ -129,12 +129,12 @@ $sides: 20rem;
     font-weight: bold;
     font-size: .875rem;
     cursor: pointer;
-    border: 0px solid $pen-primary;
+    border: 0px solid $extensions-primary;
     outline: none;
 }
 
 .input-row button.ok-button {
-    background: $pen-primary;
+    background: $extensions-primary;
     color: white;
 }
 

--- a/src/components/preview-modal/preview-modal.css
+++ b/src/components/preview-modal/preview-modal.css
@@ -69,8 +69,8 @@
 }
 
 .button-row button.view-project-button {
-    background: $pen-primary;
-    border-color: $pen-primary;
+    background: $extensions-primary;
+    border-color: $extensions-primary;
     color: white;
 }
 

--- a/src/css/colors.css
+++ b/src/css/colors.css
@@ -26,4 +26,6 @@ $control-primary: hsla(38, 100%, 55%, 1); /* #FFAB19 */
 
 $data-primary: hsla(30, 100%, 55%, 1); /* #FF8C1A */
 
-$pen-primary: hsla(163, 85%, 40%, 1); /* #0FBD8C */
+$extensions-primary: hsla(163, 85%, 40%, 1); /* #0FBD8C */
+$extensions-tertiary: hsla(163, 85%, 30%, 1); /* #0B8E69 */
+$extensions-transparent: hsla(163, 85%, 40%, 0.35); /* 35% transparent version of extensions-primary */


### PR DESCRIPTION
### Resolves

- Resolves https://github.com/LLK/scratch-gui/issues/2571

### Proposed Changes

- Updates color variable `$pen-primary` to `$extensions-primary`
- Changes overall UI color from blue to aqua using the new color variables
- Resizes "mini card" navigation bar and next/prev elements for touch
- Add hover feedback to elements

### Reason for Changes

The blue elements in the current UI blend in too much with the rest of the UI. We would like to have the tips content to "pop" more.

/cc @ntlrsk @kosiecki17 @SpeakkVisually 