### PR TITLE
Handle localized library strings for Analytics

### DIFF
--- a/src/components/library-item/library-item.jsx
+++ b/src/components/library-item/library-item.jsx
@@ -106,7 +106,10 @@ class LibraryItem extends React.PureComponent {
 }
 
 LibraryItem.propTypes = {
-    description: PropTypes.string,
+    description: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.node
+    ]),
     disabled: PropTypes.bool,
     featured: PropTypes.bool,
     iconURL: PropTypes.string.isRequired,

--- a/src/containers/extension-library.jsx
+++ b/src/containers/extension-library.jsx
@@ -46,10 +46,17 @@ class ExtensionLibrary extends React.PureComponent {
                 });
             }
         }
+        let gaLabel = '';
+        if (typeof (item.name) === 'string') {
+            gaLabel = item.name;
+        } else {
+            // Name is localized, get the default message for the gaLabel
+            gaLabel = item.name.props.defaultMessage;
+        }
         analytics.event({
             category: 'library',
             action: 'Select Extension',
-            label: item.name
+            label: gaLabel
         });
     }
     render () {


### PR DESCRIPTION
### Resolves

Eliminate warnings and errors due to library item text (name and desctiption) being localized components instead of simply a string. Some are not localized (e.g. LEGO EV3), so either string or component is still possible.

### Proposed Changes

_Describe what this Pull Request does_
Check whether `item.name` is a string or an object. If it's an object grab the `defaultMessage` prop for reactGA. Also change LibraryItem.propTypes to allow description to be a string or node.

### Reason for Changes

_Explain why these changes should be made_
Eliminates errors and warnings in the console when clicking on library items.

### Test Coverage

Current tests pass.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
