### PR TITLE
Swap order of “start sound” and “play sound until done”

### DIFF
--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -270,12 +270,12 @@ const looks = function (isStage, targetId) {
 const sound = function (isStage, targetId) {
     return `
     <category name="%{BKY_CATEGORY_SOUND}" id="sound" colour="#D65CD6" secondaryColour="#BD42BD">
-        <block id="${targetId}_sound_play" type="sound_play">
+        <block id="${targetId}_sound_playuntildone" type="sound_playuntildone">
             <value name="SOUND_MENU">
                 <shadow type="sound_sounds_menu"/>
             </value>
         </block>
-        <block id="${targetId}_sound_playuntildone" type="sound_playuntildone">
+        <block id="${targetId}_sound_play" type="sound_play">
             <value name="SOUND_MENU">
                 <shadow type="sound_sounds_menu"/>
             </value>


### PR DESCRIPTION
Change the order of the blocks in the menu, so that "play sound until done" appears first, followed by "start sound". 

We made this change to make it more likely that people will try out the "play sound until done" block first, before the "start sound" block. We want them to use the "until done" block first because it seems easier to understand its behavior when it is used in a stack of other command blocks, or in a loop. 