### PR TITLE
Fix device status indicator updating issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "redux-throttle": "0.1.1",
     "rimraf": "^2.6.1",
     "scratch-audio": "0.1.0-prerelease.20180625202813",
-    "scratch-blocks": "0.1.0-prerelease.1531144787",
+    "scratch-blocks": "0.1.0-prerelease.1531313153",
     "scratch-l10n": "3.0.20180703181510",
     "scratch-paint": "0.2.0-prerelease.20180709132225",
     "scratch-render": "0.1.0-prerelease.20180618173030",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "redux-throttle": "0.1.1",
     "rimraf": "^2.6.1",
     "scratch-audio": "0.1.0-prerelease.20180625202813",
-    "scratch-blocks": "0.1.0-prerelease.1531313153",
+    "scratch-blocks": "0.1.0-prerelease.1531338038",
     "scratch-l10n": "3.0.20180703181510",
     "scratch-paint": "0.2.0-prerelease.20180709132225",
     "scratch-render": "0.1.0-prerelease.20180618173030",

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -212,6 +212,8 @@ class Blocks extends React.Component {
         this.props.vm.addListener('targetsUpdate', this.onTargetsUpdate);
         this.props.vm.addListener('EXTENSION_ADDED', this.handleExtensionAdded);
         this.props.vm.addListener('BLOCKSINFO_UPDATE', this.handleBlocksInfoUpdate);
+        this.props.vm.addListener('PERIPHERAL_CONNECTED', this.handleStatusButtonUpdate);
+        this.props.vm.addListener('PERIPHERAL_ERROR', this.handleStatusButtonUpdate);
     }
     detachVM () {
         this.props.vm.removeListener('SCRIPT_GLOW_ON', this.onScriptGlowOn);
@@ -223,6 +225,8 @@ class Blocks extends React.Component {
         this.props.vm.removeListener('targetsUpdate', this.onTargetsUpdate);
         this.props.vm.removeListener('EXTENSION_ADDED', this.handleExtensionAdded);
         this.props.vm.removeListener('BLOCKSINFO_UPDATE', this.handleBlocksInfoUpdate);
+        this.props.vm.removeListener('PERIPHERAL_CONNECTED', this.handleStatusButtonUpdate);
+        this.props.vm.removeListener('PERIPHERAL_ERROR', this.handleStatusButtonUpdate);
     }
 
     updateToolboxBlockValue (id, value) {
@@ -357,8 +361,8 @@ class Blocks extends React.Component {
     handleConnectionModalClose () {
         this.setState({connectionModal: null});
     }
-    handleStatusButtonUpdate (extensionId, status) {
-        this.ScratchBlocks.updateStatusButton(this.workspace, extensionId, status);
+    handleStatusButtonUpdate () {
+        this.ScratchBlocks.refreshStatusButtons(this.workspace);
     }
     handlePromptCallback (input, optionSelection) {
         this.state.prompt.callback(input, optionSelection,

--- a/src/containers/connection-modal.jsx
+++ b/src/containers/connection-modal.jsx
@@ -56,13 +56,13 @@ class ConnectionModal extends React.Component {
         this.props.onCancel();
     }
     handleError () {
-        this.props.onStatusButtonUpdate(this.props.extensionId, 'not ready');
+        this.props.onStatusButtonUpdate();
         this.setState({
             phase: PHASES.error
         });
     }
     handleConnected () {
-        this.props.onStatusButtonUpdate(this.props.extensionId, 'ready');
+        this.props.onStatusButtonUpdate();
         this.setState({
             phase: PHASES.connected
         });

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -208,5 +208,12 @@ export default function (vm) {
         return monitoredBlock ? monitoredBlock.isMonitored : false;
     };
 
+    ScratchBlocks.FlyoutExtensionCategoryHeader.getExtensionState = function (extensionId) {
+        if (vm.getPeripheralIsConnected(extensionId)) {
+            return ScratchBlocks.StatusButtonState.READY;
+        }
+        return ScratchBlocks.StatusButtonState.NOT_READY;
+    };
+
     return ScratchBlocks;
 }


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/LLK/scratch-gui/issues/2542 and https://github.com/LLK/scratch-gui/issues/2541, together with https://github.com/LLK/scratch-blocks/pull/1637

Also closes https://github.com/LLK/scratch-gui/pull/2583

### Proposed Changes

_Describe what this Pull Request does_

Wires up the getExtensionStatus api from the blocks the same way the monitors are hooked up.