### PR TITLE
Fix loading projects by hash on player example

### DIFF
--- a/src/playground/player.jsx
+++ b/src/playground/player.jsx
@@ -18,7 +18,7 @@ if (process.env.NODE_ENV === 'production' && typeof window === 'object') {
 
 import styles from './player.css';
 
-const Player = ({isPlayerOnly, onSeeInside, ...props}) => (
+const Player = ({isPlayerOnly, onSeeInside, projectId}) => (
     <Box
         className={classNames({
             [styles.stageOnly]: isPlayerOnly
@@ -28,14 +28,15 @@ const Player = ({isPlayerOnly, onSeeInside, ...props}) => (
         <GUI
             enableCommunity
             isPlayerOnly={isPlayerOnly}
-            {...props}
+            projectId={projectId}
         />
     </Box>
 );
 
 Player.propTypes = {
     isPlayerOnly: PropTypes.bool,
-    onSeeInside: PropTypes.func
+    onSeeInside: PropTypes.func,
+    projectId: PropTypes.number
 };
 
 const mapStateToProps = state => ({

--- a/src/playground/player.jsx
+++ b/src/playground/player.jsx
@@ -36,7 +36,7 @@ const Player = ({isPlayerOnly, onSeeInside, projectId}) => (
 Player.propTypes = {
     isPlayerOnly: PropTypes.bool,
     onSeeInside: PropTypes.func,
-    projectId: PropTypes.number
+    projectId: PropTypes.string
 };
 
 const mapStateToProps = state => ({

--- a/src/playground/player.jsx
+++ b/src/playground/player.jsx
@@ -18,7 +18,7 @@ if (process.env.NODE_ENV === 'production' && typeof window === 'object') {
 
 import styles from './player.css';
 
-const Player = ({isPlayerOnly, onSeeInside}) => (
+const Player = ({isPlayerOnly, onSeeInside, ...props}) => (
     <Box
         className={classNames({
             [styles.stageOnly]: isPlayerOnly
@@ -28,6 +28,7 @@ const Player = ({isPlayerOnly, onSeeInside}) => (
         <GUI
             enableCommunity
             isPlayerOnly={isPlayerOnly}
+            {...props}
         />
     </Box>
 );

--- a/test/helpers/selenium-helper.js
+++ b/test/helpers/selenium-helper.js
@@ -44,6 +44,9 @@ class SeleniumHelper {
             args.push('--headless');
         }
         chromeCapabilities.set('chromeOptions', {args});
+        chromeCapabilities.setLoggingPrefs({
+            performance: 'ALL'
+        });
         this.driver = new webdriver.Builder()
             .forBrowser('chrome')
             .withCapabilities(chromeCapabilities)

--- a/test/integration/examples.test.js
+++ b/test/integration/examples.test.js
@@ -35,6 +35,14 @@ describe('player example', () => {
         await clickXpath('//img[@title="Stop"]');
         const logs = await getLogs();
         await expect(logs).toEqual([]);
+        const projectRequests = await driver.manage().logs()
+            .get('performance')
+            .then(pLogs => pLogs.map(log => JSON.parse(log.message).message)
+                .filter(m => m.method === 'Network.requestWillBeSent')
+                .map(m => m.params.request.url)
+                .filter(url => url === 'https://projects.scratch.mit.edu/internalapi/project/96708228/get/')
+            );
+        await expect(projectRequests).toEqual(['https://projects.scratch.mit.edu/internalapi/project/96708228/get/']);
     });
 });
 
@@ -58,6 +66,14 @@ describe('blocks example', () => {
         await clickXpath('//img[@title="Stop"]');
         const logs = await getLogs();
         await expect(logs).toEqual([]);
+        const projectRequests = await driver.manage().logs()
+            .get('performance')
+            .then(pLogs => pLogs.map(log => JSON.parse(log.message).message)
+                .filter(m => m.method === 'Network.requestWillBeSent')
+                .map(m => m.params.request.url)
+                .filter(url => url === 'https://projects.scratch.mit.edu/internalapi/project/96708228/get/')
+            );
+        await expect(projectRequests).toEqual(['https://projects.scratch.mit.edu/internalapi/project/96708228/get/']);
     });
 
     test('Change categories', async () => {


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Resolves `/player.html#<project id>` not loading the project with id `<project id>`

### Proposed Changes

_Describe what this Pull Request does_
Pass on uncaptured props from Player component to GUI

### Reason for Changes

_Explain why these changes should be made_
Passing on the props down from the HashParserHOC allows the HOC to load the project specified by the hash and give this information to the GUI.

### Test Coverage

_Please show how you have added tests to cover your changes_
I modified the integration tests to gather "performance" logs, which include which requests are made by the browser. This allows us to make sure that the project is actually being requested in the examples.

### Browser Coverage
N/A