### PR TITLE
Stop block drag surface from stopping mouse enter events

### DIFF
--- a/src/components/blocks/blocks.css
+++ b/src/components/blocks/blocks.css
@@ -40,6 +40,14 @@
     box-sizing: content-box;
 }
 
+.blocks :global(.blocklyBlockDragSurface) {
+    /*
+        Fix an issue where the drag surface was preventing hover events for sharing blocks.
+        This does not prevent user interaction on the blocks themselves.
+    */
+    pointer-events: none;
+}
+
 /*
     Shrink category font to fit "My Blocks" for now.
     Probably will need different solutions for language support later, so


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves the issue @kchadha mentioned where after doing certain things, you could not share the blocks anymore. 

### Proposed Changes

_Describe what this Pull Request does_

Set `pointer-events: none` on the drag surface SVG, so that it does not prevent mouse-enter events.

### Reason for Changes

_Explain why these changes should be made_

The drag surface was sometimes preventing the mouseenter events from happening.
