### PR TITLE
Handle mouseUp on language select for firefox

### DIFF
--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -2,6 +2,7 @@ import classNames from 'classnames';
 import {connect} from 'react-redux';
 import {defineMessages, FormattedMessage, injectIntl, intlShape} from 'react-intl';
 import PropTypes from 'prop-types';
+import bindAll from 'lodash.bindall';
 import React from 'react';
 
 import Box from '../box/box.jsx';
@@ -128,297 +129,311 @@ MenuBarMenu.propTypes = {
     open: PropTypes.bool,
     place: PropTypes.oneOf(['left', 'right'])
 };
-
-const MenuBar = props => (
-    <Box className={styles.menuBar}>
-        <div className={styles.mainMenu}>
-            <div className={styles.fileGroup}>
-                <div className={classNames(styles.menuBarItem)}>
-                    <img
-                        alt="Scratch"
-                        className={styles.scratchLogo}
-                        draggable={false}
-                        src={scratchLogo}
-                    />
-                </div>
-                <div
-                    className={classNames(styles.menuBarItem, styles.hoverable, {
-                        [styles.active]: props.languageMenuOpen
-                    })}
-                    onMouseUp={props.onClickLanguage}
-                >
-                    <MenuBarItemTooltip
-                        enable={window.location.search.indexOf('enable=language') !== -1}
-                        id="menubar-selector"
-                        place="right"
-                    >
+class MenuBar extends React.Component {
+    constructor (props) {
+        super(props);
+        bindAll(this, [
+            'handleLanguageMouseUp'
+        ]);
+    }
+    handleLanguageMouseUp (e) {
+        if (!this.props.languageMenuOpen) {
+            this.props.onClickLanguage(e);
+        }
+    }
+    render () {
+        return (
+            <Box className={styles.menuBar}>
+                <div className={styles.mainMenu}>
+                    <div className={styles.fileGroup}>
+                        <div className={classNames(styles.menuBarItem)}>
+                            <img
+                                alt="Scratch"
+                                className={styles.scratchLogo}
+                                draggable={false}
+                                src={scratchLogo}
+                            />
+                        </div>
                         <div
-                            aria-label={props.intl.formatMessage(ariaMessages.language)}
-                            className={classNames(styles.languageMenu)}
+                            className={classNames(styles.menuBarItem, styles.hoverable, {
+                                [styles.active]: this.props.languageMenuOpen
+                            })}
+                            onMouseUp={this.handleLanguageMouseUp}
+                        >
+                            <MenuBarItemTooltip
+                                enable={window.location.search.indexOf('enable=language') !== -1}
+                                id="menubar-selector"
+                                place="right"
+                            >
+                                <div
+                                    aria-label={this.props.intl.formatMessage(ariaMessages.language)}
+                                    className={classNames(styles.languageMenu)}
+                                >
+                                    <img
+                                        className={styles.languageIcon}
+                                        src={languageIcon}
+                                    />
+                                    <img
+                                        className={styles.dropdownCaret}
+                                        src={dropdownCaret}
+                                    />
+                                </div>
+                                <MenuBarMenu
+                                    open={this.props.languageMenuOpen}
+                                    onRequestClose={this.props.onRequestCloseLanguage}
+                                >
+                                    <LanguageSelector />
+                                </MenuBarMenu>
+
+                            </MenuBarItemTooltip>
+                        </div>
+                        <div
+                            className={classNames(styles.menuBarItem, styles.hoverable, {
+                                [styles.active]: this.props.fileMenuOpen
+                            })}
+                            onMouseUp={this.props.onClickFile}
+                        >
+                            <div className={classNames(styles.fileMenu)}>
+                                <FormattedMessage
+                                    defaultMessage="File"
+                                    description="Text for file dropdown menu"
+                                    id="gui.menuBar.file"
+                                />
+                            </div>
+                            <MenuBarMenu
+                                open={this.props.fileMenuOpen}
+                                onRequestClose={this.props.onRequestCloseFile}
+                            >
+                                <MenuItemTooltip id="new">
+                                    <MenuItem>
+                                        <FormattedMessage
+                                            defaultMessage="New"
+                                            description="Menu bar item for creating a new project"
+                                            id="gui.menuBar.new"
+                                        />
+                                    </MenuItem>
+                                </MenuItemTooltip>
+                                <MenuSection>
+                                    <MenuItemTooltip id="save">
+                                        <MenuItem>
+                                            <FormattedMessage
+                                                defaultMessage="Save now"
+                                                description="Menu bar item for saving now"
+                                                id="gui.menuBar.saveNow"
+                                            />
+                                        </MenuItem>
+                                    </MenuItemTooltip>
+                                    <MenuItemTooltip id="copy">
+                                        <MenuItem>
+                                            <FormattedMessage
+                                                defaultMessage="Save as a copy"
+                                                description="Menu bar item for saving as a copy"
+                                                id="gui.menuBar.saveAsCopy"
+                                            /></MenuItem>
+                                    </MenuItemTooltip>
+                                </MenuSection>
+                                <MenuSection>
+                                    <ProjectLoader>{(renderFileInput, loadProject, loadProps) => (
+                                        <MenuItem
+                                            onClick={loadProject}
+                                            {...loadProps}
+                                        >
+                                            <FormattedMessage
+                                                defaultMessage="Load from your computer"
+                                                description="Menu bar item for uploading a project from your computer"
+                                                id="gui.menuBar.uploadFromComputer"
+                                            />
+                                            {renderFileInput()}
+                                        </MenuItem>
+                                    )}</ProjectLoader>
+                                    <ProjectSaver>{(saveProject, saveProps) => (
+                                        <MenuItem
+                                            onClick={saveProject}
+                                            {...saveProps}
+                                        >
+                                            <FormattedMessage
+                                                defaultMessage="Save to your computer"
+                                                description="Menu bar item for downloading a project to your computer"
+                                                id="gui.menuBar.downloadToComputer"
+                                            />
+                                        </MenuItem>
+                                    )}</ProjectSaver>
+                                </MenuSection>
+                            </MenuBarMenu>
+                        </div>
+                        <div
+                            className={classNames(styles.menuBarItem, styles.hoverable, {
+                                [styles.active]: this.props.editMenuOpen
+                            })}
+                            onMouseUp={this.props.onClickEdit}
+                        >
+                            <div className={classNames(styles.editMenu)}>
+                                <FormattedMessage
+                                    defaultMessage="Edit"
+                                    description="Text for edit dropdown menu"
+                                    id="gui.menuBar.edit"
+                                />
+                            </div>
+                            <MenuBarMenu
+                                open={this.props.editMenuOpen}
+                                onRequestClose={this.props.onRequestCloseEdit}
+                            >
+                                <MenuItemTooltip id="undo">
+                                    <MenuItem>
+                                        <FormattedMessage
+                                            defaultMessage="Undo"
+                                            description="Menu bar item for undoing"
+                                            id="gui.menuBar.undo"
+                                        />
+                                    </MenuItem>
+                                </MenuItemTooltip>
+                                <MenuItemTooltip id="redo">
+                                    <MenuItem>
+                                        <FormattedMessage
+                                            defaultMessage="Redo"
+                                            description="Menu bar item for redoing"
+                                            id="gui.menuBar.redo"
+                                        />
+                                    </MenuItem>
+                                </MenuItemTooltip>
+                                <MenuSection>
+                                    <MenuItemTooltip id="turbo">
+                                        <MenuItem>
+                                            <FormattedMessage
+                                                defaultMessage="Turbo mode"
+                                                description="Menu bar item for toggling turbo mode"
+                                                id="gui.menuBar.turboMode"
+                                            />
+                                        </MenuItem>
+                                    </MenuItemTooltip>
+                                </MenuSection>
+                            </MenuBarMenu>
+                        </div>
+                    </div>
+                    <Divider className={classNames(styles.divider)} />
+                    <div className={classNames(styles.menuBarItem)}>
+                        <MenuBarItemTooltip id="title-field">
+                            <input
+                                disabled
+                                className={classNames(styles.titleField)}
+                                placeholder="Untitled-1"
+                            />
+                        </MenuBarItemTooltip>
+                    </div>
+                    <div className={classNames(styles.menuBarItem)}>
+                        <MenuBarItemTooltip id="share-button">
+                            <Button className={classNames(styles.shareButton)}>
+                                <FormattedMessage
+                                    defaultMessage="Share"
+                                    description="Label for project share button"
+                                    id="gui.menuBar.share"
+                                />
+                            </Button>
+                        </MenuBarItemTooltip>
+                    </div>
+                    <div className={classNames(styles.menuBarItem, styles.communityButtonWrapper)}>
+                        {this.props.enableCommunity ?
+                            <Button
+                                className={classNames(styles.communityButton)}
+                                iconClassName={styles.communityButtonIcon}
+                                iconSrc={communityIcon}
+                                onClick={this.props.onSeeCommunity}
+                            >
+                                <FormattedMessage
+                                    defaultMessage="See Community"
+                                    description="Label for see community button"
+                                    id="gui.menuBar.seeCommunity"
+                                />
+                            </Button> :
+                            <MenuBarItemTooltip id="community-button">
+                                <Button
+                                    className={classNames(styles.communityButton)}
+                                    iconClassName={styles.communityButtonIcon}
+                                    iconSrc={communityIcon}
+                                >
+                                    <FormattedMessage
+                                        defaultMessage="See Community"
+                                        description="Label for see community button"
+                                        id="gui.menuBar.seeCommunity"
+                                    />
+                                </Button>
+                            </MenuBarItemTooltip>
+                        }
+                    </div>
+                </div>
+                <div className={classNames(styles.menuBarItem, styles.feedbackButtonWrapper)}>
+                    <a
+                        className={styles.feedbackLink}
+                        href="https://scratch.mit.edu/discuss/topic/299791/"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                    >
+                        <Button
+                            className={styles.feedbackButton}
+                            iconSrc={feedbackIcon}
+                        >
+                            <FormattedMessage
+                                defaultMessage="Give Feedback"
+                                description="Label for feedback form modal button"
+                                id="gui.menuBar.giveFeedback"
+                            />
+                        </Button>
+                    </a>
+                </div>
+                <div className={styles.accountInfoWrapper}>
+                    <div
+                        aria-label={this.props.intl.formatMessage(ariaMessages.howTo)}
+                        className={classNames(styles.menuBarItem, styles.hoverable)}
+                        onClick={this.props.onOpenTipLibrary}
+                    >
+                        <img
+                            className={styles.helpIcon}
+                            src={helpIcon}
+                        />
+                    </div>
+                    <MenuBarItemTooltip id="mystuff">
+                        <div
+                            className={classNames(
+                                styles.menuBarItem,
+                                styles.hoverable,
+                                styles.mystuffButton
+                            )}
                         >
                             <img
-                                className={styles.languageIcon}
-                                src={languageIcon}
+                                className={styles.mystuffIcon}
+                                src={mystuffIcon}
                             />
+                        </div>
+                    </MenuBarItemTooltip>
+                    <MenuBarItemTooltip
+                        id="account-nav"
+                        place="left"
+                    >
+                        <div
+                            className={classNames(
+                                styles.menuBarItem,
+                                styles.hoverable,
+                                styles.accountNavMenu
+                            )}
+                        >
                             <img
-                                className={styles.dropdownCaret}
+                                className={styles.profileIcon}
+                                src={profileIcon}
+                            />
+                            <span>
+                                {'scratch-cat' /* @todo username */}
+                            </span>
+                            <img
+                                className={styles.dropdownCaretIcon}
                                 src={dropdownCaret}
                             />
                         </div>
-                        <MenuBarMenu
-                            open={props.languageMenuOpen}
-                            onRequestClose={props.onRequestCloseLanguage}
-                        >
-                            <LanguageSelector />
-                        </MenuBarMenu>
-
                     </MenuBarItemTooltip>
                 </div>
-                <div
-                    className={classNames(styles.menuBarItem, styles.hoverable, {
-                        [styles.active]: props.fileMenuOpen
-                    })}
-                    onMouseUp={props.onClickFile}
-                >
-                    <div className={classNames(styles.fileMenu)}>
-                        <FormattedMessage
-                            defaultMessage="File"
-                            description="Text for file dropdown menu"
-                            id="gui.menuBar.file"
-                        />
-                    </div>
-                    <MenuBarMenu
-                        open={props.fileMenuOpen}
-                        onRequestClose={props.onRequestCloseFile}
-                    >
-                        <MenuItemTooltip id="new">
-                            <MenuItem>
-                                <FormattedMessage
-                                    defaultMessage="New"
-                                    description="Menu bar item for creating a new project"
-                                    id="gui.menuBar.new"
-                                />
-                            </MenuItem>
-                        </MenuItemTooltip>
-                        <MenuSection>
-                            <MenuItemTooltip id="save">
-                                <MenuItem>
-                                    <FormattedMessage
-                                        defaultMessage="Save now"
-                                        description="Menu bar item for saving now"
-                                        id="gui.menuBar.saveNow"
-                                    />
-                                </MenuItem>
-                            </MenuItemTooltip>
-                            <MenuItemTooltip id="copy">
-                                <MenuItem>
-                                    <FormattedMessage
-                                        defaultMessage="Save as a copy"
-                                        description="Menu bar item for saving as a copy"
-                                        id="gui.menuBar.saveAsCopy"
-                                    /></MenuItem>
-                            </MenuItemTooltip>
-                        </MenuSection>
-                        <MenuSection>
-                            <ProjectLoader>{(renderFileInput, loadProject, loadProps) => (
-                                <MenuItem
-                                    onClick={loadProject}
-                                    {...loadProps}
-                                >
-                                    <FormattedMessage
-                                        defaultMessage="Load from your computer"
-                                        description="Menu bar item for uploading a project from your computer"
-                                        id="gui.menuBar.uploadFromComputer"
-                                    />
-                                    {renderFileInput()}
-                                </MenuItem>
-                            )}</ProjectLoader>
-                            <ProjectSaver>{(saveProject, saveProps) => (
-                                <MenuItem
-                                    onClick={saveProject}
-                                    {...saveProps}
-                                >
-                                    <FormattedMessage
-                                        defaultMessage="Save to your computer"
-                                        description="Menu bar item for downloading a project to your computer"
-                                        id="gui.menuBar.downloadToComputer"
-                                    />
-                                </MenuItem>
-                            )}</ProjectSaver>
-                        </MenuSection>
-                    </MenuBarMenu>
-                </div>
-                <div
-                    className={classNames(styles.menuBarItem, styles.hoverable, {
-                        [styles.active]: props.editMenuOpen
-                    })}
-                    onMouseUp={props.onClickEdit}
-                >
-                    <div className={classNames(styles.editMenu)}>
-                        <FormattedMessage
-                            defaultMessage="Edit"
-                            description="Text for edit dropdown menu"
-                            id="gui.menuBar.edit"
-                        />
-                    </div>
-                    <MenuBarMenu
-                        open={props.editMenuOpen}
-                        onRequestClose={props.onRequestCloseEdit}
-                    >
-                        <MenuItemTooltip id="undo">
-                            <MenuItem>
-                                <FormattedMessage
-                                    defaultMessage="Undo"
-                                    description="Menu bar item for undoing"
-                                    id="gui.menuBar.undo"
-                                />
-                            </MenuItem>
-                        </MenuItemTooltip>
-                        <MenuItemTooltip id="redo">
-                            <MenuItem>
-                                <FormattedMessage
-                                    defaultMessage="Redo"
-                                    description="Menu bar item for redoing"
-                                    id="gui.menuBar.redo"
-                                />
-                            </MenuItem>
-                        </MenuItemTooltip>
-                        <MenuSection>
-                            <MenuItemTooltip id="turbo">
-                                <MenuItem>
-                                    <FormattedMessage
-                                        defaultMessage="Turbo mode"
-                                        description="Menu bar item for toggling turbo mode"
-                                        id="gui.menuBar.turboMode"
-                                    />
-                                </MenuItem>
-                            </MenuItemTooltip>
-                        </MenuSection>
-                    </MenuBarMenu>
-                </div>
-            </div>
-            <Divider className={classNames(styles.divider)} />
-            <div className={classNames(styles.menuBarItem)}>
-                <MenuBarItemTooltip id="title-field">
-                    <input
-                        disabled
-                        className={classNames(styles.titleField)}
-                        placeholder="Untitled-1"
-                    />
-                </MenuBarItemTooltip>
-            </div>
-            <div className={classNames(styles.menuBarItem)}>
-                <MenuBarItemTooltip id="share-button">
-                    <Button className={classNames(styles.shareButton)}>
-                        <FormattedMessage
-                            defaultMessage="Share"
-                            description="Label for project share button"
-                            id="gui.menuBar.share"
-                        />
-                    </Button>
-                </MenuBarItemTooltip>
-            </div>
-            <div className={classNames(styles.menuBarItem, styles.communityButtonWrapper)}>
-                {props.enableCommunity ?
-                    <Button
-                        className={classNames(styles.communityButton)}
-                        iconClassName={styles.communityButtonIcon}
-                        iconSrc={communityIcon}
-                        onClick={props.onSeeCommunity}
-                    >
-                        <FormattedMessage
-                            defaultMessage="See Community"
-                            description="Label for see community button"
-                            id="gui.menuBar.seeCommunity"
-                        />
-                    </Button> :
-                    <MenuBarItemTooltip id="community-button">
-                        <Button
-                            className={classNames(styles.communityButton)}
-                            iconClassName={styles.communityButtonIcon}
-                            iconSrc={communityIcon}
-                        >
-                            <FormattedMessage
-                                defaultMessage="See Community"
-                                description="Label for see community button"
-                                id="gui.menuBar.seeCommunity"
-                            />
-                        </Button>
-                    </MenuBarItemTooltip>
-                }
-            </div>
-        </div>
-        <div className={classNames(styles.menuBarItem, styles.feedbackButtonWrapper)}>
-            <a
-                className={styles.feedbackLink}
-                href="https://scratch.mit.edu/discuss/topic/299791/"
-                rel="noopener noreferrer"
-                target="_blank"
-            >
-                <Button
-                    className={styles.feedbackButton}
-                    iconSrc={feedbackIcon}
-                >
-                    <FormattedMessage
-                        defaultMessage="Give Feedback"
-                        description="Label for feedback form modal button"
-                        id="gui.menuBar.giveFeedback"
-                    />
-                </Button>
-            </a>
-        </div>
-        <div className={styles.accountInfoWrapper}>
-            <div
-                aria-label={props.intl.formatMessage(ariaMessages.howTo)}
-                className={classNames(styles.menuBarItem, styles.hoverable)}
-                onClick={props.onOpenTipLibrary}
-            >
-                <img
-                    className={styles.helpIcon}
-                    src={helpIcon}
-                />
-            </div>
-            <MenuBarItemTooltip id="mystuff">
-                <div
-                    className={classNames(
-                        styles.menuBarItem,
-                        styles.hoverable,
-                        styles.mystuffButton
-                    )}
-                >
-                    <img
-                        className={styles.mystuffIcon}
-                        src={mystuffIcon}
-                    />
-                </div>
-            </MenuBarItemTooltip>
-            <MenuBarItemTooltip
-                id="account-nav"
-                place="left"
-            >
-                <div
-                    className={classNames(
-                        styles.menuBarItem,
-                        styles.hoverable,
-                        styles.accountNavMenu
-                    )}
-                >
-                    <img
-                        className={styles.profileIcon}
-                        src={profileIcon}
-                    />
-                    <span>
-                        {'scratch-cat' /* @todo username */}
-                    </span>
-                    <img
-                        className={styles.dropdownCaretIcon}
-                        src={dropdownCaret}
-                    />
-                </div>
-            </MenuBarItemTooltip>
-        </div>
-    </Box>
-);
+            </Box>
+        );
+    }
+}
 
 MenuBar.propTypes = {
     editMenuOpen: PropTypes.bool,


### PR DESCRIPTION
The onMouseUp handler for the menu rerenders the language menu before the select onChange function runs on Firefox. So it resets the language value back to the previous value and the locale doesn’t update.  With this change it doesn’t fire the openlanguageMenu action if the menu is open.

### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves #2538 

### Proposed Changes

_Describe what this Pull Request does_
Add new handler for onLanguageMouseup that checks for whether the menu is already open.

(Note: the `mapDispatchToProps (dispatch, props)...` wasn't working. The props are just the ones passed in, not anything mapped to state. It appeared to work, but it turned out I still had the onMouseup handler checking for the menu being open.)

### Reason for Changes

_Explain why these changes should be made_
https://github.com/facebook/react/issues/12584
On firefox the React `select` doesn't update if there's another event handler on the same element.

### Test Coverage

_Please show how you have added tests to cover your changes_

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
