### PR TITLE
Add intl polyfill for Safari 9

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "gh-pages": "github:rschamp/gh-pages#publish-branch-to-subfolder",
     "html-webpack-plugin": "^3.2.0",
     "immutable": "3.8.2",
+    "intl": "1.2.5",
     "jest": "^21.0.0",
     "keymirror": "0.1.1",
     "lodash.bindall": "4.4.0",

--- a/src/playground/index.jsx
+++ b/src/playground/index.jsx
@@ -1,5 +1,8 @@
+// Polyfills
 import 'es6-object-assign/auto';
 import 'core-js/fn/array/includes';
+import 'intl'; // For Safari 9
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/LLK/scratch-gui/issues/2199

### Proposed Changes

_Describe what this Pull Request does_

Add the Intl polyfill, it is the same one used by scratch-www.

### Reason for Changes

_Explain why these changes should be made_

Safari 9 needs the polyfill.

Tested using Safari 9 iOS simulator