### PR TITLE
Update Stage Select UI

### DIFF
--- a/src/components/stage-selector/stage-selector.css
+++ b/src/components/stage-selector/stage-selector.css
@@ -20,10 +20,12 @@ $header-height: calc($stage-menu-height - 2px);
     border-style: solid;
     border-bottom: 0;
     cursor: pointer;
-    transition: border-color 0.25s ease-out, box-shadow 0.25s ease-out;
+    transition: all 0.25s ease;
 }
 
 .stage-selector.is-selected {
+    border-top-left-radius: .625rem;
+    border-top-right-radius: .625rem;
     border-color: $motion-primary;
     box-shadow: 0px 0px 0px 4px $motion-transparent;
 }
@@ -44,6 +46,7 @@ $header-height: calc($stage-menu-height - 2px);
     border-top-right-radius: $space;
     border-bottom: 1px solid $ui-black-transparent;
     width: 100%;
+    transition: background-color 0.25s ease;
 }
 
 .header-title {
@@ -53,6 +56,15 @@ $header-height: calc($stage-menu-height - 2px);
 
     /* @todo: make this a mixin for all UI text labels */
     user-select: none;
+    transition: color 0.25s ease;
+}
+
+.stage-selector.is-selected .header {
+    background-color: $motion-primary;
+}
+
+.stage-selector.is-selected .header-title {
+    color: $ui-white;
 }
 
 .count {
@@ -71,9 +83,11 @@ $header-height: calc($stage-menu-height - 2px);
 
 .costume-canvas {
     display: block;
+    margin-top: .25rem;
     width: 100%;
     user-select: none;
-    border-bottom: 1px solid $ui-black-transparent;
+    border: 1px solid $ui-black-transparent;
+    border-radius: .25rem;
     box-shadow: inset 0 0 4px $ui-black-transparent;
 }
 

--- a/src/components/stage-selector/stage-selector.jsx
+++ b/src/components/stage-selector/stage-selector.jsx
@@ -80,9 +80,9 @@ const StageSelector = props => {
             {url ? (
                 <CostumeCanvas
                     className={styles.costumeCanvas}
-                    height={54}
+                    height={48}
                     url={url}
-                    width={72}
+                    width={64}
                 />
             ) : null}
             <div className={styles.label}>


### PR DESCRIPTION
## Proposed Changes
- Make stage look more distinguished: add some space around the preview such that it is not flush with the stage area width, add a border all the way around, and round the corners to match the actual stage.
- Make the stage select state more apparent and consistent with the Sprite selected state

### Stage Not Selected
<img width="493" alt="screen shot 2018-07-12 at 1 57 08 pm" src="https://user-images.githubusercontent.com/3409578/42650842-88e1075c-85db-11e8-94e9-ae6f6ce43a5a.png">

### Stage Selected
<img width="491" alt="screen shot 2018-07-12 at 1 57 16 pm" src="https://user-images.githubusercontent.com/3409578/42650852-8f1e5fd4-85db-11e8-95b5-1e8268a30f19.png">


## Reason for Changes
Currently, the stage preview within the Stage Info Area was not very noticeable, especially when no stage has been added and it appears white.  

In addition to the stage preview not standing out, there was some concern that the Stage's selected state was not very noticeable. We should continue to monitor this issue with these changes.

