### PR TITLE
Fix micro:bit extension name and description

### DIFF
--- a/src/lib/libraries/extensions/index.jsx
+++ b/src/lib/libraries/extensions/index.jsx
@@ -115,13 +115,13 @@ export default [
         disabled: true
     },
     {
-        name: 'Micro:bit',
+        name: 'micro:bit',
         extensionId: 'microbit',
         iconURL: microbitImage,
         description: (
             <FormattedMessage
-                defaultMessage="Connect your projects with the physical world."
-                description="Description for the 'Micro:bit' extension"
+                defaultMessage="Connect your projects with the world."
+                description="Description for the 'micro:bit' extension"
                 id="gui.extension.microbit.description"
             />
         ),


### PR DESCRIPTION
Make the micro:bit extension name match the official branding, and shorten the description on the extension library tile so it fits on one line.