### PR TITLE
Fix rename variable bug

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -366,9 +366,10 @@ class Blocks extends React.Component {
         this.ScratchBlocks.refreshStatusButtons(this.workspace);
     }
     handlePromptCallback (input, optionSelection) {
-        this.state.prompt.callback(input, optionSelection,
-            (optionSelection === 'local') ? [] :
-                this.props.vm.runtime.getAllVarNamesOfType(this.state.prompt.varType));
+        this.state.prompt.callback(
+            input,
+            this.props.vm.runtime.getAllVarNamesOfType(this.state.prompt.varType),
+            optionSelection);
         this.handlePromptClose();
     }
     handlePromptClose () {


### PR DESCRIPTION
### Resolves

Fixes issue introduced by variable scoping work where renaming variables no longer worked.

Now both creating a new global variable and renaming a global variable should check for name conflicts with any other sprite.

### Proposed Changes

Refactor variable prompt callback function to always pass the list of additional variable names. Scratch blocks will decide whether to use it or not based on whether the variable being created/renamed is global or not (respectively).

### Related PRs
This PR is related to the following: LLK/scratch-blocks#1644

### Test Branch
https://llk.github.io/scratch-gui/rename-var-bugfix-travis/