### PR TITLE
Do not skip safari 9 browser test because it works now

### DIFF
--- a/test/smoke/browser.test.js
+++ b/test/smoke/browser.test.js
@@ -38,8 +38,7 @@ describe('Smoke tests on older browsers', () => {
         return expect(isDisplayed).toEqual(true);
     });
 
-    // Safari 9 has always been blank screened due to lack of Intl polyfill
-    test.skip('Safari 9 should not be unsupported', async () => {
+    test('Safari 9 should be supported', async () => {
         const driverConfig = {
             browserName: 'safari',
             platform: 'OS X 10.11',
@@ -55,7 +54,7 @@ describe('Smoke tests on older browsers', () => {
         return expect(isDisplayed).toEqual(true);
     });
 
-    test('Safari 10 should not be unsupported', async () => {
+    test('Safari 10 should be supported', async () => {
         const driverConfig = {
             browserName: 'safari',
             platform: 'OS X 10.11',


### PR DESCRIPTION
Safari 9 now loads, so we can remove the `.skip` in the browser integration test