### PR TITLE
Widen add-extension button to match category.

### DIFF
--- a/src/components/gui/gui.css
+++ b/src/components/gui/gui.css
@@ -201,7 +201,7 @@
 }
 
 .extension-button-container {
-    width: 3.25rem;
+    width: 3.75rem;
     height: 3.25rem;
     position: absolute;
     bottom: 0;


### PR DESCRIPTION
Goes along with https://github.com/LLK/scratch-blocks/pull/1646

### Resolves

_What Github issue does this resolve (please include link)?_

Matches the new width of the category menu that allows more of the translated category names to fit.

### Proposed Changes

_Describe what this Pull Request does_
Increase the width of the add-extension button by .5rem

### Reason for Changes

_Explain why these changes should be made_
localization

### Test Coverage

_Please show how you have added tests to cover your changes_


### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [x] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
