### PR TITLE
Localize custom procedure modal title

### DIFF
--- a/src/components/connection-modal/error-step.jsx
+++ b/src/components/connection-modal/error-step.jsx
@@ -43,8 +43,6 @@ const ErrorStep = props => (
                         src={backIcon}
                     />
                     <FormattedMessage
-                        defaultMessage="Try again"
-                        description="Button to initiate trying the device connection again after an error"
                         id="gui.connection.tryagainbutton"
                     />
                 </button>
@@ -57,8 +55,6 @@ const ErrorStep = props => (
                         src={helpIcon}
                     />
                     <FormattedMessage
-                        defaultMessage="Help"
-                        description="Button to view help content"
                         id="gui.connection.helpbutton"
                     />
                 </button>

--- a/src/components/custom-procedures/custom-procedures.jsx
+++ b/src/components/custom-procedures/custom-procedures.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Modal from '../modal/modal.jsx';
 import Box from '../box/box.jsx';
-import {FormattedMessage} from 'react-intl';
+import {defineMessages, injectIntl, intlShape, FormattedMessage} from 'react-intl';
 
 import booleanInputIcon from './icon--boolean-input.svg';
 import textInputIcon from './icon--text-input.svg';
@@ -10,10 +10,18 @@ import labelIcon from './icon--label.svg';
 
 import styles from './custom-procedures.css';
 
+const messages = defineMessages({
+    myblockModalTitle: {
+        defaultMessage: 'Make a Block',
+        description: 'Title for the modal where you create a custom block.',
+        id: 'gui.customProcedures.myblockModalTitle'
+    }
+});
+
 const CustomProcedures = props => (
     <Modal
         className={styles.modalContent}
-        contentLabel="Make a Block"
+        contentLabel={props.intl.formatMessage(messages.myblockModalTitle)}
         onRequestClose={props.onCancel}
     >
         <Box
@@ -133,6 +141,7 @@ const CustomProcedures = props => (
 
 CustomProcedures.propTypes = {
     componentRef: PropTypes.func.isRequired,
+    intl: intlShape,
     onAddBoolean: PropTypes.func.isRequired,
     onAddLabel: PropTypes.func.isRequired,
     onAddTextNumber: PropTypes.func.isRequired,
@@ -142,4 +151,4 @@ CustomProcedures.propTypes = {
     warp: PropTypes.bool.isRequired
 };
 
-export default CustomProcedures;
+export default injectIntl(CustomProcedures);


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- partially resolves #2535 
- _‘block name’ default text is in scratch-blocks_

### Proposed Changes

_Describe what this Pull Request does_

* Added localization for ‘Make a Block’

The changes in `error-step.jsx` were needed because the same id was defined in there and `unavailable_step.jsx`. The scripts to generate the json file for Transifex give an error if the same id is defined in two places. In error step it simply uses the id without redefining default value etc. The alternative would be to add a new messages.jsx file that has the definitions for shared text and include that in both places that use them.
### Reason for Changes

_Explain why these changes should be made_
localization

### Test Coverage

_Please show how you have added tests to cover your changes_
Current tests run, localization will have to be tested after translations are updated.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
