### PR TITLE
EV3/Microbit critical fixes for code freeze

### DIFF
--- a/src/containers/scanning-step.jsx
+++ b/src/containers/scanning-step.jsx
@@ -32,7 +32,10 @@ class ScanningStep extends React.Component {
             'PERIPHERAL_SCAN_TIMEOUT', this.handlePeripheralScanTimeout);
     }
     handlePeripheralScanTimeout () {
-        this.setState({scanning: false});
+        this.setState({
+            scanning: false,
+            deviceList: []
+        });
     }
     handlePeripheralListUpdate (newList) {
         // TODO: sort peripherals by signal strength? so they don't jump around
@@ -58,6 +61,7 @@ class ScanningStep extends React.Component {
                 onConnected={this.props.onConnected}
                 onConnecting={this.props.onConnecting}
                 onRefresh={this.handleRefresh}
+                scanning={this.state.scanning}
             />
         );
     }

--- a/src/containers/scanning-step.jsx
+++ b/src/containers/scanning-step.jsx
@@ -56,12 +56,12 @@ class ScanningStep extends React.Component {
             <ScanningStepComponent
                 deviceList={this.state.deviceList}
                 phase={this.state.phase}
+                scanning={this.state.scanning}
                 smallDeviceImage={this.props.smallDeviceImage}
                 title={this.props.extensionId}
                 onConnected={this.props.onConnected}
                 onConnecting={this.props.onConnecting}
                 onRefresh={this.handleRefresh}
-                scanning={this.state.scanning}
             />
         );
     }


### PR DESCRIPTION
### Resolves

[BLESession and BTSession should emit PERIPHERAL_SCAN_TIMEOUT #1348](https://github.com/LLK/scratch-vm/issues/1348)

- Matches this PR in `scratch-vm`: [https://github.com/LLK/scratch-vm/pull/1354](https://github.com/LLK/scratch-vm/pull/1354)