### PR TITLE
Fix cursor in fullscreen

### DIFF
--- a/src/components/monitor/list-monitor.jsx
+++ b/src/components/monitor/list-monitor.jsx
@@ -26,7 +26,7 @@ const ListMonitor = ({draggable, label, width, height, value, onResizeMouseDown,
         </div>
         <div className={styles.listFooter}>
             <div
-                className={classNames(styles.addButton, 'no-drag')}
+                className={classNames(draggable ? styles.addButton : null, 'no-drag')}
                 onClick={draggable ? onAdd : null}
             >
                 {'+' /* TODO waiting on asset */}
@@ -35,7 +35,7 @@ const ListMonitor = ({draggable, label, width, height, value, onResizeMouseDown,
                 {`length ${value.length}`}
             </div>
             <div
-                className={classNames(styles.resizeHandle, 'no-drag')}
+                className={classNames(draggable ? styles.resizeHandle : null, 'no-drag')}
                 onMouseDown={draggable ? onResizeMouseDown : null}
             >
                 {'=' /* TODO waiting on asset */}


### PR DESCRIPTION
### Resolves

- Resolves #2473

### Proposed Changes

It makes button cursors change only when the monitor is draggable, which means it is in fullscreen.

### Reason for Changes

It could confuse some users if their cursor changed on a button that doesn't do anything.
