### PR TITLE
Fix shadow placeholder color

### DIFF
--- a/src/components/asset-panel/selector.css
+++ b/src/components/asset-panel/selector.css
@@ -70,5 +70,5 @@ $fade-out-distance: 100px;
 
 .list-item.placeholder {
     background: black;
-    filter: opacity(15%) brightness(20%);
+    filter: opacity(15%) brightness(0%);
 }

--- a/src/components/sprite-selector/sprite-selector.css
+++ b/src/components/sprite-selector/sprite-selector.css
@@ -110,5 +110,5 @@
 
 .placeholder > .sprite {
     background: black;
-    filter: opacity(15%) brightness(20%);
+    filter: opacity(15%) brightness(0%);
 }


### PR DESCRIPTION
### Resolves

- Resolves #2491

### Proposed Changes

Changes brightness from 20% to 0% to make it dark enough to not see the text.

### Reason for Changes

It could confuse users if the sprite is still faintly visible.