### PR TITLE
Add ev3 connection message

### DIFF
--- a/src/components/connection-modal/connecting-step.jsx
+++ b/src/components/connection-modal/connecting-step.jsx
@@ -28,11 +28,7 @@ const ConnectingStep = props => (
         </Box>
         <Box className={styles.bottomArea}>
             <Box className={styles.instructions}>
-                <FormattedMessage
-                    defaultMessage="Connecting"
-                    description=""
-                    id="gui.connection.connecting"
-                />
+                {props.connectingMessage}
             </Box>
             <Dots
                 counter={1}
@@ -64,6 +60,7 @@ const ConnectingStep = props => (
 );
 
 ConnectingStep.propTypes = {
+    connectingMessage: PropTypes.node.isRequired,
     deviceImage: PropTypes.string.isRequired,
     onDisconnect: PropTypes.func
 };

--- a/src/components/connection-modal/connection-modal.jsx
+++ b/src/components/connection-modal/connection-modal.jsx
@@ -40,6 +40,7 @@ const ConnectionModalComponent = props => (
 );
 
 ConnectionModalComponent.propTypes = {
+    connectingMessage: PropTypes.node,
     name: PropTypes.node,
     onCancel: PropTypes.func.isRequired,
     phase: PropTypes.oneOf(Object.keys(PHASES)).isRequired,

--- a/src/components/connection-modal/error-step.jsx
+++ b/src/components/connection-modal/error-step.jsx
@@ -26,7 +26,7 @@ const ErrorStep = props => (
                 <FormattedMessage
                     defaultMessage="Oops, looks like something went wrong."
                     description="The device connection process has encountered an error."
-                    id="gui.connection.errorMessage"
+                    id="gui.connection.error.errorMessage"
                 />
             </div>
             <Dots
@@ -43,7 +43,9 @@ const ErrorStep = props => (
                         src={backIcon}
                     />
                     <FormattedMessage
-                        id="gui.connection.tryagainbutton"
+                        defaultMessage="Try again"
+                        description="Button to initiate trying the device connection again after an error"
+                        id="gui.connection.error.tryagainbutton"
                     />
                 </button>
                 <button
@@ -55,7 +57,9 @@ const ErrorStep = props => (
                         src={helpIcon}
                     />
                     <FormattedMessage
-                        id="gui.connection.helpbutton"
+                        defaultMessage="Help"
+                        description="Button to view help content"
+                        id="gui.connection.error.helpbutton"
                     />
                 </button>
             </Box>

--- a/src/components/connection-modal/unavailable-step.jsx
+++ b/src/components/connection-modal/unavailable-step.jsx
@@ -27,7 +27,7 @@ const UnavailableStep = props => (
                 <FormattedMessage
                     defaultMessage="Please start Scratch Link and turn on Bluetooth."
                     description="Scratch link is not installed message"
-                    id="gui.connection.unavailableMessage"
+                    id="gui.connection.unavailable.unavailableMessage"
                 />
             </div>
             <Dots
@@ -46,7 +46,7 @@ const UnavailableStep = props => (
                     <FormattedMessage
                         defaultMessage="Try again"
                         description="Button to initiate trying the device connection again after an error"
-                        id="gui.connection.tryagainbutton"
+                        id="gui.connection.unavailable.tryagainbutton"
                     />
                 </button>
                 <button
@@ -60,7 +60,7 @@ const UnavailableStep = props => (
                     <FormattedMessage
                         defaultMessage="Help"
                         description="Button to view help content"
-                        id="gui.connection.helpbutton"
+                        id="gui.connection.unavailable.helpbutton"
                     />
                 </button>
             </Box>

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -355,7 +355,8 @@ class Blocks extends React.Component {
                 extensionId: extensionId,
                 deviceImage: extension.deviceImage,
                 smallDeviceImage: extension.smallDeviceImage,
-                name: extension.name
+                name: extension.name,
+                connectingMessage: extension.connectingMessage
             }});
         }
     }
@@ -419,6 +420,7 @@ class Blocks extends React.Component {
                 ) : null}
                 {this.state.connectionModal ? (
                     <ConnectionModal
+                        connectingMessage={this.state.connectionModal.connectingMessage}
                         deviceImage={this.state.connectionModal.deviceImage}
                         extensionId={this.state.connectionModal.extensionId}
                         name={this.state.connectionModal.name}

--- a/src/containers/connection-modal.jsx
+++ b/src/containers/connection-modal.jsx
@@ -81,6 +81,7 @@ class ConnectionModal extends React.Component {
     render () {
         return (
             <ConnectionModalComponent
+                connectingMessage={this.props.connectingMessage}
                 deviceImage={this.props.deviceImage}
                 extensionId={this.props.extensionId}
                 name={this.props.name}
@@ -100,6 +101,7 @@ class ConnectionModal extends React.Component {
 }
 
 ConnectionModal.propTypes = {
+    connectingMessage: PropTypes.node.isRequired,
     deviceImage: PropTypes.string.isRequired,
     extensionId: PropTypes.string.isRequired,
     name: PropTypes.node.isRequired,

--- a/src/lib/libraries/extensions/index.jsx
+++ b/src/lib/libraries/extensions/index.jsx
@@ -129,7 +129,14 @@ export default [
         disabled: true,
         launchDeviceConnectionFlow: true,
         deviceImage: microbitDeviceImage,
-        smallDeviceImage: microbitMenuImage
+        smallDeviceImage: microbitMenuImage,
+        connectingMessage: (
+            <FormattedMessage
+                defaultMessage="Connecting"
+                description="Message to help people connect to their micro:bit."
+                id="gui.extension.microbit.connectingMessage"
+            />
+        )
     },
     {
         name: 'LEGO WeDo 2.0',
@@ -160,7 +167,14 @@ export default [
         disabled: true,
         launchDeviceConnectionFlow: true,
         deviceImage: ev3DeviceImage,
-        smallDeviceImage: ev3MenuImage
+        smallDeviceImage: ev3MenuImage,
+        connectingMessage: (
+            <FormattedMessage
+                defaultMessage="Connecting. Make sure the pin on your EV3 is set to 1234."
+                description="Message to help people connect to their EV3. Must note the PIN should be 1234."
+                id="gui.extension.ev3.connectingMessage"
+            />
+        )
     },
     {
         name: 'LEGO Boost',


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Closes https://github.com/LLK/scratch-gui/pull/2648 as a generic replacement, so device connecting extensions can show their own connecting instructions.

Closes https://github.com/LLK/scratch-gui/issues/2647

### Proposed Changes

_Describe what this Pull Request does_

Pass in device specific connection message. Leave the micro:bit one to the default "connecting"

### Reason for Changes

_Explain why these changes should be made_

### Test Coverage

_Please show how you have added tests to cover your changes_

Try connecting to a microbit and an ev3 and see that the connecting messages is different.



---

Note /cc @chrisgarrity I also fixed the issue with the messages not having default values by scoping them to different IDs