### PR TITLE
Don’t let Google try to auto translate the GUI

### DIFF
--- a/src/playground/index.ejs
+++ b/src/playground/index.ejs
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="google" value="notranslate">
     <link rel="shortcut icon" href="static/favicon.ico">
     <title><%= htmlWebpackPlugin.options.title %></title>
     <% if (htmlWebpackPlugin.options.sentryConfig) { %>


### PR DESCRIPTION
Add a meta tag to make sure google doesn’t try to autotranslate the editor:
https://support.google.com/webmasters/answer/79812?hl=en

This will also need to get added to the preview page (or anywhere we use gui), but we probably don't want to turn it off globally on www.