### PR TITLE
Issue/2530 block size locale

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "scratch-render": "0.1.0-prerelease.20180618173030",
     "scratch-storage": "0.5.1",
     "scratch-svg-renderer": "0.2.0-prerelease.20180712223402",
-    "scratch-vm": "0.1.0-prerelease.1531502959",
+    "scratch-vm": "0.1.0-prerelease.1531927323",
     "selenium-webdriver": "3.6.0",
     "startaudiocontext": "1.2.1",
     "style-loader": "^0.21.0",

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -94,7 +94,9 @@ class Blocks extends React.Component {
         addFunctionListener(this.workspace, 'zoom', this.onWorkspaceMetricsChange);
 
         this.attachVM();
-        this.setLocale();
+        if (this.props.isVisible) {
+            this.setLocale();
+        }
 
         analytics.pageview('/editors/blocks');
     }
@@ -117,9 +119,9 @@ class Blocks extends React.Component {
             this.ScratchBlocks.hideChaff();
         }
 
-        if (prevProps.locale !== this.props.locale) {
-            this.setLocale();
-        }
+        // if (prevProps.locale !== this.props.locale) {
+        //     this.setLocale();
+        // }
 
         if (prevProps.toolboxXML !== this.props.toolboxXML) {
             // rather than update the toolbox "sync" -- update it in the next frame
@@ -138,10 +140,17 @@ class Blocks extends React.Component {
         // @todo hack to resize blockly manually in case resize happened while hidden
         // @todo hack to reload the workspace due to gui bug #413
         if (this.props.isVisible) { // Scripts tab
+
             this.workspace.setVisible(true);
-            this.props.vm.refreshWorkspace();
+            if (prevProps.locale !== this.props.locale || this.props.locale !== this.props.vm.getLocale()) {
+                this.setLocale();
+            } else {
+                this.props.vm.refreshWorkspace();
+            }
+
             // Re-enable toolbox refreshes without causing one. See #updateToolbox for more info.
             this.workspace.toolboxRefreshEnabled_ = true;
+            // this.workspace.setToolboxRefreshEnabled(true);
             window.dispatchEvent(new Event('resize'));
         } else {
             this.workspace.setVisible(false);


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves #2530 

### Proposed Changes

_Describe what this Pull Request does_
Updates `blocks.jsx` so that the blocks and VM locales are only changed when the blocks are visible to prevent sizing issues. Depends on a new VM that includes `getLocale()`

### Reason for Changes

_Explain why these changes should be made_
Localization

### Test Coverage

_Please show how you have added tests to cover your changes_
Load http://localhost:8601/?enable=language#222183421
-[ ] change the language while in the paint or sound editors. Switch back to the Code tab, switch tabs several times
- [ ] make sure code doesn't change position
- [ ] switch between sprites 

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
