### PR TITLE
Prevent react recycling components causing safari render bug

### DIFF
--- a/src/components/connection-modal/scanning-step.jsx
+++ b/src/components/connection-modal/scanning-step.jsx
@@ -30,7 +30,7 @@ const ScanningStep = props => (
                         </div>
                     </div>
                 ) : (
-                    <Box className={styles.deviceTilePane}>
+                    <div className={styles.deviceTilePane}>
                         {props.deviceList.map(device =>
                             (<DeviceTile
                                 key={device.peripheralId}
@@ -41,7 +41,7 @@ const ScanningStep = props => (
                                 onConnecting={props.onConnecting}
                             />)
                         )}
-                    </Box>
+                    </div>
                 )
             ) : (
                 <Box className={styles.instructions}>


### PR DESCRIPTION
Resolves https://github.com/LLK/scratch-gui/issues/2652

It seems that the way react was recycling components was causing the render bug from #2652. I'm not 100% sure why, but just using a plain div fixed the issue...