### PR TITLE
Enable EV3 and micro:bit extensions

### DIFF
--- a/src/lib/libraries/extensions/index.jsx
+++ b/src/lib/libraries/extensions/index.jsx
@@ -103,7 +103,7 @@ export default [
             />
         ),
         featured: true,
-        disabled: true,
+        disabled: false,
         launchDeviceConnectionFlow: true,
         deviceImage: microbitDeviceImage,
         smallDeviceImage: microbitMenuImage,
@@ -128,7 +128,7 @@ export default [
             />
         ),
         featured: true,
-        disabled: true,
+        disabled: false,
         launchDeviceConnectionFlow: true,
         deviceImage: ev3DeviceImage,
         smallDeviceImage: ev3MenuImage,


### PR DESCRIPTION
This PR enables the EV3 and micro:bit extensions.

Waiting on final testing from @ericrosenbaum @BryceLTaylor.

/cc @thisandagain 