### PR TITLE
Update Toolbox when blocks container updates and is visible.

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -145,10 +145,9 @@ class Blocks extends React.Component {
                 this.setLocale();
             } else {
                 this.props.vm.refreshWorkspace();
+                this.updateToolbox();
             }
 
-            // Re-enable toolbox refreshes without causing one. See #updateToolbox for more info.
-            this.workspace.toolboxRefreshEnabled_ = true;
             window.dispatchEvent(new Event('resize'));
         } else {
             this.workspace.setVisible(false);
@@ -165,8 +164,8 @@ class Blocks extends React.Component {
         this.ScratchBlocks.ScratchMsgs.setLocale(this.props.locale);
         this.props.vm.setLocale(this.props.locale, this.props.messages)
             .then(() => {
-                this.workspace.updateToolbox(this.props.toolboxXML);
                 this.props.vm.refreshWorkspace();
+                this.updateToolbox();
                 this.workspace.getFlyout().setRecyclingEnabled(true);
             });
     }


### PR DESCRIPTION
### Resolves

- Resolves #2515

### Proposed Changes

Call `updateToolbox` whenever the blocks container updates and is visible so that changes to dynamic menus (e.g. when a costume is renamed) are picked up. 

Update `setLocale` to call `updateToolbox` so that the toolbox refresh gets re-enabled in this updated workflow. This is needed for getting translated toolbox strings like 'Hello' and 'Hmmm...' to stay in sync with language changes.

/cc @gnarf 

### Test Coverage

Manual testing of different changes to dynamic menus, switching sprites, switching tabs, changing languages, etc.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
