### PR TITLE
Fix project loader cleanup function. Safari does not support the use of .finally

### DIFF
--- a/src/containers/project-loader.jsx
+++ b/src/containers/project-loader.jsx
@@ -59,12 +59,14 @@ class ProjectLoader extends React.Component {
                     action: 'Import Project File',
                     nonInteraction: true
                 });
+                this.props.closeLoadingState();
+                // Reset the file input after project is loaded
+                // This is necessary in case the user wants to reload a project
+                thisFileInput.value = null;
             })
             .catch(error => {
                 log.warn(error);
                 alert(this.props.intl.formatMessage(messages.loadError)); // eslint-disable-line no-alert
-            })
-            .finally(() => {
                 this.props.closeLoadingState();
                 // Reset the file input after project is loaded
                 // This is necessary in case the user wants to reload a project


### PR DESCRIPTION
### Resolves

- Resolves an issue found during smoke testing where Safari 11.0 was not uploading projects.

### Proposed Changes

Remove the use of .finally which is not supported by Safari or Edge.
