### PR TITLE
Add username setting to vm listener HOC

### DIFF
--- a/src/lib/vm-listener-hoc.jsx
+++ b/src/lib/vm-listener-hoc.jsx
@@ -37,6 +37,12 @@ const vmListenerHOC = function (WrappedComponent) {
                 document.addEventListener('keydown', this.handleKeyDown);
                 document.addEventListener('keyup', this.handleKeyUp);
             }
+            this.props.vm.postIOData('userData', {username: this.props.username});
+        }
+        componentWillReceiveProps (newProps) {
+            if (newProps.username !== this.props.username) {
+                this.props.vm.postIOData('userData', {username: newProps.username});
+            }
         }
         componentWillUnmount () {
             if (this.props.attachKeyboardEvents) {
@@ -72,6 +78,7 @@ const vmListenerHOC = function (WrappedComponent) {
             const {
                 /* eslint-disable no-unused-vars */
                 attachKeyboardEvents,
+                username,
                 onBlockDragUpdate,
                 onKeyDown,
                 onKeyUp,
@@ -90,13 +97,16 @@ const vmListenerHOC = function (WrappedComponent) {
         onKeyUp: PropTypes.func,
         onMonitorsUpdate: PropTypes.func.isRequired,
         onTargetsUpdate: PropTypes.func.isRequired,
+        username: PropTypes.string,
         vm: PropTypes.instanceOf(VM).isRequired
     };
     VMListener.defaultProps = {
         attachKeyboardEvents: true
     };
     const mapStateToProps = state => ({
-        vm: state.scratchGui.vm
+        vm: state.scratchGui.vm,
+        username: state.session && state.session.session ?
+            state.session.session.username : ''
     });
     const mapDispatchToProps = dispatch => ({
         onTargetsUpdate: data => {


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/LLK/scratch-vm/issues/306, depends on https://github.com/LLK/scratch-vm/pull/1387

### Proposed Changes

_Describe what this Pull Request does_

### Reason for Changes

_Explain why these changes should be made_

So that the username can be shown when it is set!

---

/cc @rschamp this uses the same way of getting the username from the session as the backpack code, so hopefully this is right. I also checked that this will be exported to the gui npm package used by www, and it _seems_ like the right place for it?