### PR TITLE
Make extension help links clickable in modal

### DIFF
--- a/src/components/modal/modal.css
+++ b/src/components/modal/modal.css
@@ -126,6 +126,7 @@ $sides: 20rem;
 .header-item-help {
     padding: 0;
     margin-right: -4.75rem;
+    z-index: 1;
 }
 
 .help-button {


### PR DESCRIPTION
### Resolves
- Resolves #2700 

### Proposed Changes
This PR adds `z-index: 1` to the `.header-item-help` class in modal.css

### Reason for Changes
Without setting a z-index on the help item in the extension connection modal, Firefox does not allow users to click on the "help" link. Adding a z-index to match the working close button in the header fixes this issue, and does not break other browsers.

### Browser Coverage

Mac
 * [x] Chrome (67)
 * [x] Firefox (60 and 63)
 * [x] Safari (11.1.1)
