### PR TITLE
Use pageview with query param for tracking search usage

### DIFF
--- a/src/components/library/library.jsx
+++ b/src/components/library/library.jsx
@@ -62,12 +62,8 @@ class LibraryComponent extends React.Component {
         this.props.onItemSelected(this.getFilteredData()[id]);
     }
     handleClose () {
-        analytics.event({
-            category: 'library',
-            action: `${this.props.id}: close with search`,
-            label: this.state.filterQuery || '(empty)'
-        });
         this.props.onRequestClose();
+        analytics.pageview(`/${this.props.id}/search?q=${this.state.filterQuery}`);
     }
     handleTagClick (tag) {
         this.setState({


### PR DESCRIPTION
This replaces the event-based search analytics because that method does not allow us to get the advantages of more search-specific analytics.

/cc @thisandagain 