### PR TITLE
[MASTER] Temporarily exclude RTL languages from the menu

### DIFF
--- a/src/components/language-selector/language-selector.jsx
+++ b/src/components/language-selector/language-selector.jsx
@@ -5,6 +5,9 @@ import Box from '../box/box.jsx';
 import locales from 'scratch-l10n';
 import styles from './language-selector.css';
 
+// supported languages to exclude from the menu, but allow as a URL option
+const ignore = ['he'];
+
 class LanguageSelector extends React.Component {
     render () {
         const {
@@ -26,14 +29,18 @@ class LanguageSelector extends React.Component {
                         value={currentLocale}
                         onChange={onChange}
                     >
-                        {Object.keys(locales).map(locale => (
-                            <option
-                                key={locale}
-                                value={locale}
-                            >
-                                {locales[locale].name}
-                            </option>
-                        ))}
+                        {
+                            Object.keys(locales)
+                                .filter(l => !ignore.includes(l))
+                                .map(locale => (
+                                    <option
+                                        key={locale}
+                                        value={locale}
+                                    >
+                                        {locales[locale].name}
+                                    </option>
+                                ))
+                        }
                     </select>
                 </div>
             </Box>


### PR DESCRIPTION
Right to left (RTL) languages are not yet fully supported in the editor, so we don't want to give the impression they are by including them in the menu.

Translators can still load the language with the `?locale=he` URL argument.

Currently the excluded languages is just 'he', but I wanted to write it in such a way that it can be used for multiple languages later if we need it.