### PR TITLE
Bring dragging sprites to front

### DIFF
--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -309,11 +309,13 @@ class Stage extends React.Component {
         const targetId = this.props.vm.getTargetIdForDrawableId(drawableId);
         if (targetId === null) return;
 
-        // Only start drags on non-draggable targets in editor drag mode
-        if (!this.props.useEditorDragStyle) {
-            const target = this.props.vm.runtime.getTargetById(targetId);
-            if (!target.draggable) return;
-        }
+        const target = this.props.vm.runtime.getTargetById(targetId);
+
+        // Do not start drag unless in editor drag mode or target is draggable
+        if (!(this.props.useEditorDragStyle || target.draggable)) return;
+
+        // Dragging always brings the target to the front
+        target.goToFront();
 
         this.props.vm.startDrag(targetId);
         this.setState({


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Resolves #1870 

Implements outstanding feature to pop dragging sprites to the front of the renderer draw list permanently, not just while it is being dragged. 

### Proposed Changes

_Describe what this Pull Request does_

Use the `target.goToFront` to bring the sprite forward at the start of the drag. This works for both editor and player drag modes.

![drag-mode](https://user-images.githubusercontent.com/654102/43148053-7f0e9c52-8f32-11e8-8a8c-36c6c3b4197e.gif)
