### PR TITLE
Clear the workspace undo when the workspace updates.

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -310,6 +310,11 @@ class Blocks extends React.Component {
             this.workspace.scale = scale;
             this.workspace.resize();
         }
+
+        // Clear the undo state of the workspace since this is a
+        // fresh workspace and we don't want any changes made to another sprites
+        // workspace to be 'undone' here.
+        this.workspace.clearUndo();
     }
     handleExtensionAdded (blocksInfo) {
         // select JSON from each block info object then reject the pseudo-blocks which don't have JSON, like separators


### PR DESCRIPTION
### Resolves

Resolves LLK/scratch-blocks#1447
Resolves LLK/scratch-blocks#1574

### Proposed Changes

Clear the workspace undo state when a workspace update has been emitted.

### Reason for Changes

Keeping the old workspace undo state around causes weird behavior like blocks from the previous another sprite or project's workspace showing up (see issues linked above).

### Test Coverage

Manual testing with:
- switching sprites
- switching between the code, costumes, and sounds tabs, and 
- loading new projects with a file or through project ID in the hash

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
