### PR TITLE
Show only 2 other tutorials in last step of each tutorial.

### DIFF
--- a/src/components/cards/card.css
+++ b/src/components/cards/card.css
@@ -153,7 +153,7 @@
     display: flex;
     flex-direction: row;
     justify-content: space-around;
-    padding: 0 0.5rem 0.5rem;
+    padding: 0 1rem 0.5rem;
 }
 
 .deck {
@@ -167,7 +167,7 @@
 }
 
 .deck-image {
-    width: 130px;
+    width: 200px;
     height: 100px;
     object-fit: cover;
 }
@@ -180,6 +180,7 @@
     text-align: center;
     font-weight: bold;
     text-align: center;
+    max-width: 200px;
 }
 
 .help-icon, .close-icon {

--- a/src/components/cards/cards.jsx
+++ b/src/components/cards/cards.jsx
@@ -152,7 +152,7 @@ const PreviewsStep = ({deckIds, content, onActivateDeckFactory, onShowAll}) => (
             />
         </div>
         <div className={styles.decks}>
-            {deckIds.map(id => (
+            {deckIds.slice(0, 2).map(id => (
                 <div
                     className={styles.deck}
                     key={`deck-preview-${id}`}

--- a/src/lib/libraries/decks/index.jsx
+++ b/src/lib/libraries/decks/index.jsx
@@ -96,8 +96,7 @@ export default {
         }, {
             deckIds: [
                 'add-a-backdrop',
-                'add-sprite',
-                'glide-around'
+                'add-sprite'
             ]
         }
         ]
@@ -170,8 +169,7 @@ export default {
         }, {
             deckIds: [
                 'add-a-backdrop',
-                'glide-around',
-                'hide-and-show'
+                'glide-around'
             ]
         }
         ]
@@ -238,8 +236,7 @@ export default {
         }, {
             deckIds: [
                 'add-a-backdrop',
-                'add-sprite',
-                'switch-costume'
+                'add-sprite'
             ]
         }
         ]
@@ -323,8 +320,7 @@ export default {
         }, {
             deckIds: [
                 'add-a-backdrop',
-                'move-around-with-arrow-keys',
-                'add-effects'
+                'move-around-with-arrow-keys'
             ]
         }
         ]
@@ -425,7 +421,6 @@ export default {
             image: stepScoreWhenTouch
         }, {
             deckIds: [
-                'add-a-backdrop',
                 'add-effects',
                 'move-around-with-arrow-keys'
             ]
@@ -455,8 +450,7 @@ export default {
             {
                 deckIds: [
                     'add-a-backdrop',
-                    'switch-costume',
-                    'change-size'
+                    'switch-costume'
                 ]
             }
         ]
@@ -475,8 +469,7 @@ export default {
         }, {
             deckIds: [
                 'change-size',
-                'switch-costume',
-                'spin-video'
+                'switch-costume'
             ]
         }]
     },
@@ -494,8 +487,7 @@ export default {
         }, {
             deckIds: [
                 'glide-around',
-                'spin-video',
-                'switch-costume'
+                'spin-video'
             ]
         }]
     },
@@ -513,8 +505,7 @@ export default {
         }, {
             deckIds: [
                 'add-a-backdrop',
-                'switch-costume',
-                'change-size'
+                'switch-costume'
             ]
         }]
     },
@@ -533,8 +524,7 @@ export default {
         }, {
             deckIds: [
                 'Make-Music',
-                'switch-costume',
-                'change-size'
+                'switch-costume'
             ]
         }]
 
@@ -547,8 +537,7 @@ export default {
         }, {
             deckIds: [
                 'add-a-backdrop',
-                'switch-costume',
-                'change-size'
+                'switch-costume'
             ]
         }]
     },
@@ -566,8 +555,7 @@ export default {
         }, {
             deckIds: [
                 'add-a-backdrop',
-                'switch-costume',
-                'change-size'
+                'switch-costume'
             ]
         }]
     },
@@ -586,8 +574,7 @@ export default {
         }, {
             deckIds: [
                 'add-a-backdrop',
-                'add-effects',
-                'change-size'
+                'add-effects'
             ]
         }]
     },
@@ -600,8 +587,7 @@ export default {
         }, {
             deckIds: [
                 'add-a-backdrop',
-                'switch-costume',
-                'change-size'
+                'switch-costume'
             ]
         }]
     },
@@ -619,8 +605,7 @@ export default {
         }, {
             deckIds: [
                 'add-a-backdrop',
-                'switch-costume',
-                'change-size'
+                'switch-costume'
             ]
         }]
     }


### PR DESCRIPTION
Enforce this by using `slice` so that no more are ever shown, which would mess up the layout.

Also fixes the issue where the card text could push out when translated into other languages

### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/LLK/scratch-gui/issues/2526
- Resolves https://github.com/LLK/scratch-gui/issues/2719

### Proposed Changes

_Describe what this Pull Request does_

Make the deck preview wider and more padded out from the edges. Also enforce a max width to force titles to wrap.

![image](https://user-images.githubusercontent.com/654102/43216913-2fd32482-900e-11e8-903c-13e8c390d604.png)
