### PR TITLE
Pad bottom of costume/sound list to allow you to reach the bottom tile

### DIFF
--- a/src/components/asset-panel/selector.css
+++ b/src/components/asset-panel/selector.css
@@ -49,6 +49,8 @@ $fade-out-distance: 100px;
     overflow-y: scroll;
     display: flex;
     flex-direction: column;
+    /* Make sure there is room to scroll beyond the last tile */
+    padding-bottom: 70px;
 }
 
 .list-item {


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves issue where the bottom asset in the costume/sound list could not be reached because of the add button.
![image](https://user-images.githubusercontent.com/654102/43224006-e4b4fae2-9022-11e8-8516-124e7d4be296.png)

### Proposed Changes

_Describe what this Pull Request does_
![image](https://user-images.githubusercontent.com/654102/43224014-e8942e80-9022-11e8-8d77-fde3d75bfeb9.png)

Pad bottom of the list to allow it to scroll enough to reach
