### PR TITLE
Make delete message translateable

### DIFF
--- a/src/containers/sprite-selector-item.jsx
+++ b/src/containers/sprite-selector-item.jsx
@@ -2,6 +2,7 @@ import bindAll from 'lodash.bindall';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
+import {defineMessages, injectIntl, intlShape} from 'react-intl';
 
 import {setHoveredSprite} from '../reducers/hovered-target';
 import {updateAssetDrag} from '../reducers/asset-drag';
@@ -10,6 +11,14 @@ import {getEventXY} from '../lib/touch-utils';
 import SpriteSelectorItemComponent from '../components/sprite-selector-item/sprite-selector-item.jsx';
 
 const dragThreshold = 3; // Same as the block drag threshold
+
+const messages = defineMessages({
+    deleteSpriteConfirmation: {
+        defaultMessage: 'Are you sure you want to delete this?',
+        description: 'Confirmation for deleting sprites',
+        id: 'gui.spriteSelectorItem.deleteSpriteConfirmation'
+    }
+});
 
 class SpriteSelectorItem extends React.Component {
     constructor (props) {
@@ -75,9 +84,8 @@ class SpriteSelectorItem extends React.Component {
     }
     handleDelete (e) {
         e.stopPropagation(); // To prevent from bubbling back to handleClick
-        // @todo add i18n here
         // eslint-disable-next-line no-alert
-        if (window.confirm('Are you sure you want to delete this?')) {
+        if (window.confirm(props.intl.formatMessage(messages.deleteSpriteConfirmation))) {
             this.props.onDeleteButtonClick(this.props.id);
         }
     }
@@ -136,6 +144,7 @@ SpriteSelectorItem.propTypes = {
     dragType: PropTypes.string,
     id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     index: PropTypes.number,
+    intl: intlShape.isRequired,
     name: PropTypes.string,
     onClick: PropTypes.func,
     onDeleteButtonClick: PropTypes.func,
@@ -163,3 +172,4 @@ export default connect(
     mapStateToProps,
     mapDispatchToProps
 )(SpriteSelectorItem);
+export default injectIntl(SpriteSelectorItem);

--- a/src/containers/sprite-selector-item.jsx
+++ b/src/containers/sprite-selector-item.jsx
@@ -85,7 +85,7 @@ class SpriteSelectorItem extends React.Component {
     handleDelete (e) {
         e.stopPropagation(); // To prevent from bubbling back to handleClick
         // eslint-disable-next-line no-alert
-        if (window.confirm(props.intl.formatMessage(messages.deleteSpriteConfirmation))) {
+        if (window.confirm(this.props.intl.formatMessage(messages.deleteSpriteConfirmation))) {
             this.props.onDeleteButtonClick(this.props.id);
         }
     }
@@ -168,8 +168,8 @@ const mapDispatchToProps = dispatch => ({
     onDrag: data => dispatch(updateAssetDrag(data))
 });
 
+
 export default connect(
     mapStateToProps,
     mapDispatchToProps
-)(SpriteSelectorItem);
-export default injectIntl(SpriteSelectorItem);
+)(injectIntl(SpriteSelectorItem));


### PR DESCRIPTION
### Resolves
Fixes #2697

### Proposed Changes
Make the `Are you sure you want to delete this?` message translateable

### Reason for Changes
It was always in English.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
