### PR TITLE
Instrument device connection events

### DIFF
--- a/src/containers/connection-modal.jsx
+++ b/src/containers/connection-modal.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import bindAll from 'lodash.bindall';
 import ConnectionModalComponent, {PHASES} from '../components/connection-modal/connection-modal.jsx';
 import VM from 'scratch-vm';
+import analytics from '../lib/analytics';
 
 class ConnectionModal extends React.Component {
     constructor (props) {
@@ -43,6 +44,11 @@ class ConnectionModal extends React.Component {
         this.setState({
             phase: PHASES.connecting
         });
+        analytics.event({
+            category: 'extensions',
+            action: 'connecting',
+            label: this.props.extensionId
+        });
     }
     handleDisconnect () {
         this.props.onStatusButtonUpdate(this.props.extensionId, 'not ready');
@@ -68,6 +74,11 @@ class ConnectionModal extends React.Component {
             this.setState({
                 phase: PHASES.error
             });
+            analytics.event({
+                category: 'extensions',
+                action: 'connecting error',
+                label: this.props.extensionId
+            });
         }
     }
     handleConnected () {
@@ -75,9 +86,19 @@ class ConnectionModal extends React.Component {
         this.setState({
             phase: PHASES.connected
         });
+        analytics.event({
+            category: 'extensions',
+            action: 'connected',
+            label: this.props.extensionId
+        });
     }
     handleHelp () {
         window.open(this.props.helpLink, '_blank');
+        analytics.event({
+            category: 'extensions',
+            action: 'help',
+            label: this.props.extensionId
+        });
     }
     render () {
         return (

--- a/src/containers/connection-modal.jsx
+++ b/src/containers/connection-modal.jsx
@@ -17,18 +17,13 @@ class ConnectionModal extends React.Component {
             'handleHelp'
         ]);
         this.state = {
-            phase: PHASES.scanning
+            phase: props.vm.getPeripheralIsConnected(props.extensionId) ?
+                PHASES.connected : PHASES.scanning
         };
     }
     componentDidMount () {
         this.props.vm.on('PERIPHERAL_CONNECTED', this.handleConnected);
         this.props.vm.on('PERIPHERAL_ERROR', this.handleError);
-
-        // Check if we're already connected
-        if (this.props.vm.getPeripheralIsConnected(this.props.extensionId)) {
-            this.handleConnected();
-        }
-
     }
     componentWillUnmount () {
         this.props.vm.removeListener('PERIPHERAL_CONNECTED', this.handleConnected);


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Resolves an issue that came up working with @ericrosenbaum about understanding device connection issues happening in the wild. 

### Proposed Changes

_Describe what this Pull Request does_

Add events for:
1. **Connecting** - after the device list has been discovered and the connect button has been clicked on one of them. Doesn't include any device identifiers, only the extension id (microbit, ev3, etc.)
2. **Connected** - when the device has been connected. 
3. **Connection Error** - when an error was encountered during the connection process. Does not get triggered when scratch-link is missing, since that would be basically the same as the number of people who add the extension, which comes from extension library instrumentation.
4. **Help** - when one of the help links has been opened from the connection modal. Figured we might want to know if this is getting people towards help effectively.

### Reason for Changes

_Explain why these changes should be made_

@ericrosenbaum and I talked about the concern that people may be having more trouble than expected connecting with devices, we just don't have any visibility into that.


### Test Coverage

_Please show how you have added tests to cover your changes_

Tested by checking the console logs after each event (in development, analytics are logged to the console). 

---

/cc @thisandagain this is an issue we haven't talked about specifically, did I cover the bases for things we want to get insight into?

/cc @ericrosenbaum I also moved the `handleConnected` check to the constructor, check the commit message on the second commit for slightly more detail. And this is all in the top-level connection-modal container, so for other devices that use a custom scanning step, this will still record the information mentioned above. 