### PR TITLE
Handle RTL for the Modal Component

### DIFF
--- a/src/components/button/button.css
+++ b/src/components/button/button.css
@@ -11,8 +11,15 @@
 }
 
 .icon {
-    margin-right: .5rem;
     height: 1.5rem;
+}
+
+[dir="ltr"] .icon {
+    margin-right: .5rem;
+}
+
+[dir="rtl"] .icon {
+    margin-left: .5rem;
 }
 
 .content {

--- a/src/components/camera-modal/camera-modal.css
+++ b/src/components/camera-modal/camera-modal.css
@@ -135,6 +135,10 @@ $main-button-size: 2.75rem;
     color: $ui-white;
 }
 
+[dir="rtl"] .retake-button img {
+    transform: scaleX(-1);
+}
+
 @keyframes flash {
     0% { opacity: 1; }
     100% { opacity: 0; }

--- a/src/components/camera-modal/camera-modal.jsx
+++ b/src/components/camera-modal/camera-modal.jsx
@@ -79,7 +79,7 @@ const CameraModal = ({intl, ...props}) => (
             {props.capture ?
                 <Box className={styles.buttonRow}>
                     <button
-                        className={styles.cancelButton}
+                        className={styles.retakeButton}
                         key="retake-button"
                         onClick={props.onBack}
                     >

--- a/src/components/camera-modal/camera-modal.jsx
+++ b/src/components/camera-modal/camera-modal.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {defineMessages, injectIntl, intlShape} from 'react-intl';
 import Box from '../box/box.jsx';
-import Modal from '../modal/modal.jsx';
+import Modal from '../../containers/modal.jsx';
 import styles from './camera-modal.css';
 import backIcon from './icon--back.svg';
 import cameraIcon from '../action-menu/icon--camera.svg';

--- a/src/components/connection-modal/connection-modal.css
+++ b/src/components/connection-modal/connection-modal.css
@@ -315,6 +315,10 @@
 
 [dir="rtl"] .button-icon-left {
     margin-left: 0.5rem;
+}
+
+/* reverse back arrow icon for RTL, don't reverse other connection icons */
+[dir="rtl"] .button-icon-back {
     transform: scaleX(-1);
 }
 

--- a/src/components/connection-modal/connection-modal.css
+++ b/src/components/connection-modal/connection-modal.css
@@ -51,8 +51,11 @@
     align-items: center;
 }
 
-.device-tile-image {
+[dir="ltr"].device-tile-image {
     margin-right: 0.5rem;
+}
+[dir="rtl"].device-tile-image {
+    margin-left: 0.5rem;
 }
 
 .device-tile-name-wrapper {
@@ -89,7 +92,14 @@
     align-items: flex-end;
     width: 22px;
     height: 16px;
+}
+
+[dir="ltr"] .signal-strength-meter {
     margin-right: 1rem;
+}
+
+[dir="rtl"] .signal-strength-meter {
+    margin-left: 1rem;
 }
 
 .signal-bar {
@@ -110,8 +120,15 @@
 .radar {
     width: 40px;
     height: 40px;
-    margin-right: 0.5rem;
     animation: spin 4s linear infinite;
+}
+
+[dir="ltr"] .radar {
+    margin-right: .5rem;
+}
+
+[dir="rtl"] .radar {
+    margin-left: .5rem;
 }
 
 @keyframes spin {
@@ -119,7 +136,6 @@
         transform: rotate(360deg);
     }
 }
-
 
 .device-activity {
     position: relative;
@@ -134,6 +150,7 @@
     position: absolute;
     top: -5px;
     right: -15px;
+    left: -15px;
     padding: 5px 5px;
     background-color: $motion-primary;
     border-radius: 100%;
@@ -199,12 +216,24 @@
     margin-left: 3rem;
 }
 
+[dir="ltr"] .scratch-link-help-step {
+    margin-left: 3rem;
+}
+
+[dir="rtl"] .scratch-link-help-step {
+    margin-right: 3rem;
+}
+
 .scratch-link-icon {
     max-width: 50px;
 }
 
-.help-step-image {
+[dir="ltr"] .help-step-image {
     margin-right: 0.5rem;
+}
+
+[dir="rtl"] .help-step-image {
+    margin-left: 0.5rem;
 }
 
 .help-step-number {
@@ -215,9 +244,16 @@
     align-items: center;
     color: $ui-white;
     font-weight: bold;
-    margin-right: 0.5rem;
     min-width: 2rem;
     height: 2rem;
+}
+
+[dir="ltr"] .help-step-number {
+    margin-right: 0.5rem;
+}
+
+[dir="rtl"] .help-step-number {
+    margin-left: 0.5rem;
 }
 
 .button-row {
@@ -265,12 +301,20 @@
     border-bottom-left-radius: 0;
 }
 
-.button-icon-right {
+[dir="ltr"] .button-icon-right {
     margin-left: 0.5rem;
 }
-
-.button-icon-left {
+[dir="rtl"] .button-icon-right {
     margin-right: 0.5rem;
+}
+
+[dir="ltr"] .button-icon-left {
+    margin-right: 0.5rem;
+}
+
+[dir="rtl"] .button-icon-left {
+    margin-left: 0.5rem;
+    transform: scaleX(-1);
 }
 
 .red-button {

--- a/src/components/connection-modal/connection-modal.css
+++ b/src/components/connection-modal/connection-modal.css
@@ -51,10 +51,11 @@
     align-items: center;
 }
 
-[dir="ltr"].device-tile-image {
+[dir="ltr"] .device-tile-image {
     margin-right: 0.5rem;
 }
-[dir="rtl"].device-tile-image {
+
+[dir="rtl"] .device-tile-image {
     margin-left: 0.5rem;
 }
 

--- a/src/components/connection-modal/connection-modal.jsx
+++ b/src/components/connection-modal/connection-modal.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import keyMirror from 'keymirror';
 
 import Box from '../box/box.jsx';
-import Modal from '../modal/modal.jsx';
+import Modal from '../../containers/modal.jsx';
 
 import ScanningStep from '../../containers/scanning-step.jsx';
 import ConnectingStep from './connecting-step.jsx';

--- a/src/components/connection-modal/error-step.jsx
+++ b/src/components/connection-modal/error-step.jsx
@@ -1,5 +1,6 @@
 import {FormattedMessage} from 'react-intl';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import React from 'react';
 
 import Box from '../box/box.jsx';
@@ -39,7 +40,7 @@ const ErrorStep = props => (
                     onClick={props.onScanning}
                 >
                     <img
-                        className={styles.buttonIconLeft}
+                        className={classNames(styles.buttonIconLeft, styles.buttonIconBack)}
                         src={backIcon}
                     />
                     <FormattedMessage

--- a/src/components/connection-modal/unavailable-step.jsx
+++ b/src/components/connection-modal/unavailable-step.jsx
@@ -1,5 +1,6 @@
 import {FormattedMessage} from 'react-intl';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import React from 'react';
 
 import Box from '../box/box.jsx';
@@ -64,7 +65,7 @@ const UnavailableStep = props => (
                     onClick={props.onScanning}
                 >
                     <img
-                        className={styles.buttonIconLeft}
+                        className={classNames(styles.buttonIconLeft, styles.buttonIconBack)}
                         src={backIcon}
                     />
                     <FormattedMessage

--- a/src/components/custom-procedures/custom-procedures.css
+++ b/src/components/custom-procedures/custom-procedures.css
@@ -91,6 +91,10 @@
     color: white;
 }
 
-.button-row button + button {
+[dir="ltr"] .button-row button + button {
     margin-left: 0.5rem;
+}
+
+[dir="rtl"] .button-row button + button {
+    margin-right: 0.5rem;
 }

--- a/src/components/custom-procedures/custom-procedures.jsx
+++ b/src/components/custom-procedures/custom-procedures.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import Modal from '../modal/modal.jsx';
+import Modal from '../../containers/modal.jsx';
 import Box from '../box/box.jsx';
 import {defineMessages, injectIntl, intlShape, FormattedMessage} from 'react-intl';
 

--- a/src/components/filter/filter.css
+++ b/src/components/filter/filter.css
@@ -18,11 +18,20 @@
 .filter-icon {
     position: absolute;
     top: 0;
-    left: 0;
 
     height: 1rem;
     width: 1rem;
+}
+
+[dir="ltr"] .filter-icon {
+    left: 0;
     margin: 0.75rem 0.75rem 0.75rem 1rem;
+}
+
+[dir="rtl"] .filter-icon {
+    right: 0;
+    margin: 0.75rem 1rem 0.75rem 0.75rem;
+    transform: scaleX(-1);
 }
 
 .filter:focus-within {
@@ -36,7 +45,6 @@
     opacity: 0;
     position: absolute;
     top: 0;
-    right: 0;
 
     display: flex;
     justify-content: center;
@@ -51,6 +59,14 @@
     pointer-events: none;
     cursor: default;
     transition: opacity 0.05s linear;
+}
+
+[dir="ltr"] .x-icon-wrapper {
+    right: 0;
+}
+
+[dir="rtl"] .x-icon-wrapper {
+    left: 0;
 }
 
 /*
@@ -96,13 +112,27 @@
     font-size: 0.75rem;
     letter-spacing: 0.15px;
     cursor: text;
+}
+
+[dir="ltr"] .filter-input {
     padding: .625rem 2rem .625rem 3rem;
+}
+
+[dir="rtl"] .filter-input {
+    padding: .625rem 3rem .625rem 2rem;
 }
 
 .filter-input::placeholder {
     opacity: .5;
-    padding: 0 0 0 0.25rem;
     color: $text-primary;
     font-size: 0.875rem;
     letter-spacing: 0.15px;
+}
+
+[dir="ltr"] .filter-input::placeholder {
+    padding: 0 0 0 0.25rem;
+}
+
+[dir="rtl"] .filter-input::placeholder {
+    padding: 0 0.25rem 0 0;
 }

--- a/src/components/modal/modal.css
+++ b/src/components/modal/modal.css
@@ -100,11 +100,22 @@ $sides: 20rem;
     user-select: none;
     letter-spacing: 0.4px;
     cursor: default;
+}
+
+[dir="ltr"] .header-item-title {
     margin: 0 -$sides 0 0;
 }
 
-.full-screen .header-item-title {
+[dir="rtl"] .header-item-title {
     margin: 0 0 0 -$sides;
+}
+
+[dir="ltr"] .full-screen .header-item-title {
+    margin: 0 0 0 -$sides;
+}
+
+[dir="rtl"] .full-screen .header-item-title {
+    margin: 0 -$sides 0 0;
 }
 
 .header-item-close {
@@ -120,13 +131,25 @@ $sides: 20rem;
 
 .back-button {
     font-weight: normal;
+    padding-right: 0;
     padding-left: 0;
+}
+
+[dir="rtl"] .back-button img {
+    transform: scaleX(-1);
 }
 
 .header-item-help {
     padding: 0;
-    margin-right: -4.75rem;
     z-index: 1;
+}
+
+[dir="ltr"] .header-item-help {
+    margin-right: -4.75rem;
+}
+
+[dir="rtl"] .header-item-help {
+    margin-left: -4.75rem;
 }
 
 .help-button {

--- a/src/components/modal/modal.css
+++ b/src/components/modal/modal.css
@@ -110,11 +110,11 @@ $sides: 20rem;
     margin: 0 0 0 -$sides;
 }
 
-[dir="ltr"] .full-screen .header-item-title {
+.full-screen [dir="ltr"] .header-item-title {
     margin: 0 0 0 -$sides;
 }
 
-[dir="rtl"] .full-screen .header-item-title {
+.full-screen [dir="rtl"] .header-item-title {
     margin: 0 -$sides 0 0;
 }
 

--- a/src/components/modal/modal.css
+++ b/src/components/modal/modal.css
@@ -154,6 +154,13 @@ $sides: 20rem;
 
 .help-button {
     font-weight: normal;
-    padding-right: 0;
     font-size: 0.75rem;
+}
+
+[dir="ltr"] .help-button {
+    padding-right: 0;
+}
+
+[dir="rtl"] .help-button {
+    padding-left: 0;
 }

--- a/src/components/modal/modal.jsx
+++ b/src/components/modal/modal.jsx
@@ -24,6 +24,7 @@ const ModalComponent = props => (
         onRequestClose={props.onRequestClose}
     >
         <Box
+            dir={props.isRtl ? 'rtl' : 'ltr'}
             direction="column"
             grow={1}
         >
@@ -103,6 +104,7 @@ ModalComponent.propTypes = {
     fullScreen: PropTypes.bool,
     headerClassName: PropTypes.string,
     headerImage: PropTypes.string,
+    isRtl: PropTypes.bool,
     onHelp: PropTypes.func,
     onRequestClose: PropTypes.func
 };

--- a/src/components/prompt/prompt.css
+++ b/src/components/prompt/prompt.css
@@ -60,8 +60,12 @@
     color: white;
 }
 
-.button-row button + button {
+[dir="ltr"] .button-row button + button {
     margin-left: 0.5rem;
+}
+
+[dir="rtl"] .button-row button + button {
+    margin-right: 0.5rem;
 }
 
 .more-options {

--- a/src/components/prompt/prompt.jsx
+++ b/src/components/prompt/prompt.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 
 import Box from '../box/box.jsx';
 import {ComingSoonTooltip} from '../coming-soon/coming-soon.jsx';
-import Modal from '../modal/modal.jsx';
+import Modal from '../../containers/modal.jsx';
 
 import styles from './prompt.css';
 

--- a/src/components/record-modal/playback-step.jsx
+++ b/src/components/record-modal/playback-step.jsx
@@ -87,7 +87,7 @@ const PlaybackStep = props => (
         </Box>
         <Box className={styles.buttonRow}>
             <button
-                className={styles.cancelButton}
+                className={styles.rerecordButton}
                 onClick={props.onBack}
             >
                 <img

--- a/src/components/record-modal/record-modal.css
+++ b/src/components/record-modal/record-modal.css
@@ -118,3 +118,7 @@
     opacity: 0.2;
     transition: 0.1s;
 }
+
+[dir="rtl"] .rerecord-button img {
+    transform: scaleX(-1);
+}

--- a/src/components/record-modal/record-modal.jsx
+++ b/src/components/record-modal/record-modal.jsx
@@ -4,7 +4,7 @@ import Box from '../box/box.jsx';
 import {defineMessages, injectIntl, intlShape} from 'react-intl';
 import RecordingStep from '../../containers/recording-step.jsx';
 import PlaybackStep from '../../containers/playback-step.jsx';
-import Modal from '../modal/modal.jsx';
+import Modal from '../../containers/modal.jsx';
 import styles from './record-modal.css';
 
 const messages = defineMessages({

--- a/src/containers/custom-procedures.jsx
+++ b/src/containers/custom-procedures.jsx
@@ -32,7 +32,8 @@ class CustomProcedures extends React.Component {
         this.blocks = blocksRef;
         const workspaceConfig = defaultsDeep({},
             CustomProcedures.defaultOptions,
-            this.props.options
+            this.props.options,
+            {rtl: this.props.isRtl}
         );
 
         // @todo This is a hack to make there be no toolbox.
@@ -117,6 +118,7 @@ class CustomProcedures extends React.Component {
 }
 
 CustomProcedures.propTypes = {
+    isRtl: PropTypes.bool,
     mutator: PropTypes.instanceOf(Element),
     onRequestClose: PropTypes.func.isRequired,
     options: PropTypes.shape({
@@ -147,6 +149,7 @@ CustomProcedures.defaultProps = {
 };
 
 const mapStateToProps = state => ({
+    isRtl: state.locales.isRtl,
     mutator: state.scratchGui.customProcedures.mutator
 });
 

--- a/src/containers/modal.jsx
+++ b/src/containers/modal.jsx
@@ -1,6 +1,7 @@
 import bindAll from 'lodash.bindall';
 import PropTypes from 'prop-types';
 import React from 'react';
+import {connect} from 'react-redux';
 
 import ModalComponent from '../components/modal/modal.jsx';
 
@@ -47,8 +48,15 @@ class Modal extends React.Component {
 
 Modal.propTypes = {
     id: PropTypes.string.isRequired,
+    isRtl: PropTypes.bool,
     onRequestClose: PropTypes.func,
     onRequestOpen: PropTypes.func
 };
 
-export default Modal;
+const mapStateToProps = state => ({
+    isRtl: state.locales.isRtl
+});
+
+export default connect(
+    mapStateToProps
+)(Modal);


### PR DESCRIPTION
### Resolves

Fixes #2756 

### Proposed Changes

Libraries and many other modals share the Modal Component.

Connected the Modal container to redux to make it aware of the RTL state, and then made sure that all places that use the modal component import the container, not the component directly.

### Test Coverage

* Current tests still run
Testing: [Add `/?locale=he` to the URL]
- [ ] All libraries open with the 'back' button on the right (sprites, costumes, backdrops, sounds, tutorials), and the list reversed
- [ ] new/edit variable modal should be RTL
- [ ] new/edit list modal should be RTL
- [ ] custom procedure modal should be RTL
- [ ] camera modal should be RTL
- [ ] hardware extension connection modals should be RTL and work
  - [ ] micro:bit
  - [ ] EV3

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
