### PR TITLE
fix for issue #2716 (brokenness in nav bar in にほんご language)

### DIFF
--- a/src/components/menu-bar/menu-bar.css
+++ b/src/components/menu-bar/menu-bar.css
@@ -66,6 +66,7 @@
     align-self: center;
     position: relative;
     align-items: center;
+    white-space: nowrap;
     height: $menu-bar-height;
 }
 


### PR DESCRIPTION
added a line to manu-bar css so as to prevent brokenness in nav bar in Japanese and Chinese languages.

### Resolves

issue #2716 

- Resolves #

### Proposed Changes

added a line `white-space: nowrap;` to menu-bar-item class in menu-bar.css.

### Reason for Changes

To prevent brokenness in nav bar in Japanese or Chinese language.

### Test Coverage

I did not add any automatic test case and only did visual check manually because I fixed only one style sheet file.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [x] Safari
 
Windows
 * [x] Chrome 
 * [x] Firefox 
 * [x] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
