### PR TITLE
build dist, even when run without NODE_ENV=production

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -177,42 +177,41 @@ module.exports = [
         ])
     })
 ].concat(
-    process.env.NODE_ENV === 'production' ? (
-        // export as library
-        defaultsDeep({}, base, {
-            target: 'web',
-            entry: {
-                'scratch-gui': './src/index.js'
-            },
-            output: {
-                libraryTarget: 'umd',
-                path: path.resolve('dist')
-            },
-            externals: {
-                React: 'react',
-                ReactDOM: 'react-dom'
-            },
-            module: {
-                rules: base.module.rules.concat([
-                    {
-                        test: /\.(svg|png|wav|gif|jpg)$/,
-                        loader: 'file-loader',
-                        options: {
-                            outputPath: 'static/assets/',
-                            publicPath: '/static/assets/'
-                        }
+    // export as library
+    defaultsDeep({}, base, {
+        target: 'web',
+        entry: {
+            'scratch-gui': './src/index.js'
+        },
+        output: {
+            libraryTarget: 'umd',
+            path: path.resolve('dist')
+        },
+        externals: {
+            React: 'react',
+            ReactDOM: 'react-dom'
+        },
+        module: {
+            rules: base.module.rules.concat([
+                {
+                    test: /\.(svg|png|wav|gif|jpg)$/,
+                    loader: 'file-loader',
+                    options: {
+                        outputPath: 'static/assets/',
+                        publicPath: '/static/assets/'
                     }
-                ])
-            },
-            plugins: base.plugins.concat([
-                new CopyWebpackPlugin([{
-                    from: 'node_modules/scratch-blocks/media',
-                    to: 'static/blocks-media'
-                }]),
-                new CopyWebpackPlugin([{
-                    from: 'extension-worker.{js,js.map}',
-                    context: 'node_modules/scratch-vm/dist/web'
-                }])
+                }
             ])
-        })) : []
+        },
+        plugins: base.plugins.concat([
+            new CopyWebpackPlugin([{
+                from: 'node_modules/scratch-blocks/media',
+                to: 'static/blocks-media'
+            }]),
+            new CopyWebpackPlugin([{
+                from: 'extension-worker.{js,js.map}',
+                context: 'node_modules/scratch-vm/dist/web'
+            }])
+        ])
+    })
 );


### PR DESCRIPTION
make development faster by always building assets for dist directory, even when run without NODE_ENV=production .