### PR TITLE
Restore deleted sprite.

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "scratch-render": "0.1.0-prerelease.20180808184135",
     "scratch-storage": "0.5.1",
     "scratch-svg-renderer": "0.2.0-prerelease.20180712223402",
-    "scratch-vm": "^0.2.0-prerelease.20180808205317",
+    "scratch-vm": "0.2.0-prerelease.20180809193416",
     "selenium-webdriver": "3.6.0",
     "startaudiocontext": "1.2.1",
     "style-loader": "^0.22.1",

--- a/src/components/menu-bar/menu-bar.css
+++ b/src/components/menu-bar/menu-bar.css
@@ -172,3 +172,7 @@
     width: 0.5rem;
     height: 0.5rem;
 }
+
+.disabled {
+    opacity: 0.5;
+}

--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -134,13 +134,20 @@ class MenuBar extends React.Component {
     constructor (props) {
         super(props);
         bindAll(this, [
-            'handleLanguageMouseUp'
+            'handleLanguageMouseUp',
+            'handleRestoreOption'
         ]);
     }
     handleLanguageMouseUp (e) {
         if (!this.props.languageMenuOpen) {
             this.props.onClickLanguage(e);
         }
+    }
+    handleRestoreOption (restoreFun) {
+        return () => {
+            restoreFun();
+            this.props.onRequestCloseEdit();
+        };
     }
     render () {
         return (
@@ -283,7 +290,7 @@ class MenuBar extends React.Component {
                                 <DeletionRestorer>{(handleRestore, {restorable, deletedItem}) => (
                                     <MenuItem
                                         className={classNames({[styles.disabled]: !restorable})}
-                                        onClick={handleRestore}
+                                        onClick={this.handleRestoreOption(handleRestore)}
                                     >
                                         {deletedItem === 'Sprite' ?
                                             <FormattedMessage

--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -14,6 +14,7 @@ import ProjectLoader from '../../containers/project-loader.jsx';
 import Menu from '../../containers/menu.jsx';
 import {MenuItem, MenuSection} from '../menu/menu.jsx';
 import ProjectSaver from '../../containers/project-saver.jsx';
+import DeletionRestorer from '../../containers/deletion-restorer.jsx';
 import TurboMode from '../../containers/turbo-mode.jsx';
 
 import {openTipsLibrary} from '../../reducers/modals';
@@ -279,15 +280,25 @@ class MenuBar extends React.Component {
                                 open={this.props.editMenuOpen}
                                 onRequestClose={this.props.onRequestCloseEdit}
                             >
-                                <MenuItemTooltip id="undo">
-                                    <MenuItem>
-                                        <FormattedMessage
-                                            defaultMessage="Undo"
-                                            description="Menu bar item for undoing"
-                                            id="gui.menuBar.undo"
-                                        />
+                                <DeletionRestorer>{(handleRestore, {restorable, deletedItem}) => (
+                                    <MenuItem
+                                        className={classNames({[styles.disabled]:!restorable})}
+                                        onClick={handleRestore}
+                                    >
+                                        {deletedItem === 'Sprite' ?
+                                            <FormattedMessage
+                                                defaultMessage="Restore Sprite"
+                                                description="Menu bar item for restoring the last deleted sprite."
+                                                id="gui.menuBar.restoreSprite"
+                                            /> :
+                                            <FormattedMessage
+                                                defaultMessage="Restore"
+                                                description="Menu bar item for restoring the last deleted item in its disabled state."
+                                                id="gui.menuBar.restore"
+                                            />
+                                        }
                                     </MenuItem>
-                                </MenuItemTooltip>
+                                )}</DeletionRestorer>
                                 <MenuItemTooltip id="redo">
                                     <MenuItem>
                                         <FormattedMessage

--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -282,7 +282,7 @@ class MenuBar extends React.Component {
                             >
                                 <DeletionRestorer>{(handleRestore, {restorable, deletedItem}) => (
                                     <MenuItem
-                                        className={classNames({[styles.disabled]:!restorable})}
+                                        className={classNames({[styles.disabled]: !restorable})}
                                         onClick={handleRestore}
                                     >
                                         {deletedItem === 'Sprite' ?
@@ -293,21 +293,12 @@ class MenuBar extends React.Component {
                                             /> :
                                             <FormattedMessage
                                                 defaultMessage="Restore"
-                                                description="Menu bar item for restoring the last deleted item in its disabled state."
+                                                description="Menu bar item for restoring the last deleted item in its disabled state." /* eslint-disable-line max-len */
                                                 id="gui.menuBar.restore"
                                             />
                                         }
                                     </MenuItem>
                                 )}</DeletionRestorer>
-                                <MenuItemTooltip id="redo">
-                                    <MenuItem>
-                                        <FormattedMessage
-                                            defaultMessage="Redo"
-                                            description="Menu bar item for redoing"
-                                            id="gui.menuBar.redo"
-                                        />
-                                    </MenuItem>
-                                </MenuItemTooltip>
                                 <MenuSection>
                                     <TurboMode>{(toggleTurboMode, {turboMode}) => (
                                         <MenuItem onClick={toggleTurboMode}>

--- a/src/containers/deletion-restorer.jsx
+++ b/src/containers/deletion-restorer.jsx
@@ -35,6 +35,7 @@ class DeletionRestorer extends React.Component {
         const {
             /* eslint-disable no-unused-vars */
             children,
+            dispatchUpdateRestore,
             /* eslint-enable no-unused-vars */
             ...props
         } = this.props;

--- a/src/containers/deletion-restorer.jsx
+++ b/src/containers/deletion-restorer.jsx
@@ -38,9 +38,11 @@ class DeletionRestorer extends React.Component {
             /* eslint-enable no-unused-vars */
             ...props
         } = this.props;
-        props.restorable = typeof this.props.restore === 'function';
-        props.deletedItem = this.props.deletedItem;
-        return this.props.children(this.restoreDeletion, props);
+        const restorable = typeof this.props.restore === 'function';
+        return this.props.children(this.restoreDeletion, {
+            ...props,
+            restorable
+        });
     }
 }
 

--- a/src/containers/deletion-restorer.jsx
+++ b/src/containers/deletion-restorer.jsx
@@ -1,0 +1,67 @@
+import bindAll from 'lodash.bindall';
+import PropTypes from 'prop-types';
+import React from 'react';
+import {connect} from 'react-redux';
+import {setRestore} from '../reducers/restore-deletion';
+
+/**
+ * DeletionRestorer component passes a restoreDeletion function to its child.
+ * It expects this child to be a function with the signature
+ *     function (restoreDeletion, props) {}
+ * The component can then be used to attach deletion restoring functionality
+ * to any other component:
+ *
+ * <DeletionRestorer>{(restoreDeletion, props) => (
+ *     <MyCoolComponent
+ *         onClick={restoreDeletion}
+ *         {...props}
+ *     />
+ * )}</DeletionRestorer>
+ */
+class DeletionRestorer extends React.Component {
+    constructor (props) {
+        super(props);
+        bindAll(this, [
+            'restoreDeletion'
+        ]);
+    }
+    restoreDeletion () {
+        if (typeof this.props.restore === 'function') {
+            this.props.restore();
+            this.props.dispatchUpdateRestore({restoreFun: null, deletedItem: ''});
+        }
+    }
+    render () {
+        const {
+            /* eslint-disable no-unused-vars */
+            children,
+            /* eslint-enable no-unused-vars */
+            ...props
+        } = this.props;
+        props.restorable = typeof this.props.restore === 'function';
+        props.deletedItem = this.props.deletedItem;
+        return this.props.children(this.restoreDeletion, props);
+    }
+}
+
+DeletionRestorer.propTypes = {
+    children: PropTypes.func,
+    deletedItem: PropTypes.string,
+    dispatchUpdateRestore: PropTypes.func,
+    restore: PropTypes.func
+};
+
+const mapStateToProps = state => ({
+    deletedItem: state.scratchGui.restoreDeletion.deletedItem,
+    restore: state.scratchGui.restoreDeletion.restoreFun
+});
+const mapDispatchToProps = dispatch => ({
+    dispatchUpdateRestore: updatedState => {
+        dispatch(setRestore(updatedState));
+    }
+});
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(DeletionRestorer);

--- a/src/containers/target-pane.jsx
+++ b/src/containers/target-pane.jsx
@@ -10,6 +10,7 @@ import {
 
 import {activateTab, COSTUMES_TAB_INDEX} from '../reducers/editor-tab';
 import {setReceivedBlocks} from '../reducers/hovered-target';
+import {setRestore} from '../reducers/restore-deletion';
 import DragConstants from '../lib/drag-constants';
 import TargetPaneComponent from '../components/target-pane/target-pane.jsx';
 import spriteLibraryContent from '../lib/libraries/sprites.json';
@@ -68,7 +69,12 @@ class TargetPane extends React.Component {
         this.props.vm.postSpriteInfo({y});
     }
     handleDeleteSprite (id) {
-        this.props.vm.deleteSprite(id);
+        const restoreFun = this.props.vm.deleteSprite(id);
+        this.props.dispatchUpdateRestore({
+            restoreFun: restoreFun,
+            deletedItem: 'Sprite'
+        });
+
     }
     handleDuplicateSprite (id) {
         this.props.vm.duplicateSprite(id);
@@ -240,6 +246,9 @@ const mapDispatchToProps = dispatch => ({
     },
     onReceivedBlocks: receivedBlocks => {
         dispatch(setReceivedBlocks(receivedBlocks));
+    },
+    dispatchUpdateRestore: restoreState => {
+        dispatch(setRestore(restoreState));
     }
 });
 

--- a/src/containers/target-pane.jsx
+++ b/src/containers/target-pane.jsx
@@ -181,6 +181,7 @@ class TargetPane extends React.Component {
         const {
             onActivateTab, // eslint-disable-line no-unused-vars
             onReceivedBlocks, // eslint-disable-line no-unused-vars
+            dispatchUpdateRestore, // eslint-disable-line no-unused-vars
             ...componentProps
         } = this.props;
         return (

--- a/src/reducers/gui.js
+++ b/src/reducers/gui.js
@@ -11,6 +11,7 @@ import modalReducer, {modalsInitialState} from './modals';
 import modeReducer, {modeInitialState} from './mode';
 import monitorReducer, {monitorsInitialState} from './monitors';
 import monitorLayoutReducer, {monitorLayoutInitialState} from './monitor-layout';
+import restoreDeletionReducer, {restoreDeletionInitialState} from './restore-deletion';
 import stageSizeReducer, {stageSizeInitialState} from './stage-size';
 import targetReducer, {targetsInitialState} from './targets';
 import toolboxReducer, {toolboxInitialState} from './toolbox';
@@ -34,6 +35,7 @@ const guiInitialState = {
     modals: modalsInitialState,
     monitors: monitorsInitialState,
     monitorLayout: monitorLayoutInitialState,
+    restoreDeletion: restoreDeletionInitialState,
     targets: targetsInitialState,
     toolbox: toolboxInitialState,
     vm: vmInitialState,
@@ -75,6 +77,7 @@ const guiReducer = combineReducers({
     modals: modalReducer,
     monitors: monitorReducer,
     monitorLayout: monitorLayoutReducer,
+    restoreDeletion: restoreDeletionReducer,
     targets: targetReducer,
     toolbox: toolboxReducer,
     vm: vmReducer,

--- a/src/reducers/restore-deletion.js
+++ b/src/reducers/restore-deletion.js
@@ -1,0 +1,33 @@
+const RESTORE_UPDATE = 'scratch-gui/restore-deletion/RESTORE_UPDATE';
+
+const initialState = {
+    restoreFun: null,
+    deletedItem: ''
+};
+
+const reducer = function (state, action) {
+    if (typeof state === 'undefined') state = initialState;
+
+    switch (action.type) {
+    case RESTORE_UPDATE:
+        return Object.assign({}, state, action.state);
+    default:
+        return state;
+    }
+};
+
+const setRestore = function (state) {
+    return {
+        type: RESTORE_UPDATE,
+        state: {
+            restoreFun: state.restoreFun,
+            deletedItem: state.deletedItem
+        }
+    };
+};
+
+export {
+    reducer as default,
+    initialState as restoreDeletionInitialState,
+    setRestore
+};


### PR DESCRIPTION
### Resolves

Towards implementing 'undelete' functionality from 2.0.

### Proposed Changes

- Remove 'Redo' item in the 'Edit' menu
- Replace 'Undo' item in the 'Edit' menu with 'Restore' which restores the last deleted sprite. Restore is disabled in the menu by default, and becomes enabled after a sprite gets deleted. When the option becomes enabled, it reads 'Restore sprite'. Clicking on the option should add the last deleted sprite to the project and then disable the 'Restore' option again, changing the text of the option back to 'Restore'

#### Not Addressed By This PR
- Restoring costumes, sounds, or blocks
- Removal of the confirmation dialog when deleting a sprite (this confirmation is linked to deleting all things: sprites, costumes, sounds, so it has not yet been removed)

### Related PRs
Depends on LLK/scratch-vm#1438, and tests will fail until that PR is merged in.

### Test Coverage

Manual testing. Changes can be tested at https://llk.github.io/scratch-gui/restore-sprite

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [x] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
