### PR TITLE
Add hideIntro prop to GUI component

### DIFF
--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -62,6 +62,7 @@ const GUIComponent = props => {
         costumeLibraryVisible,
         costumesTabVisible,
         enableCommunity,
+        hideIntro,
         importInfoVisible,
         intl,
         isPlayerOnly,
@@ -115,7 +116,7 @@ const GUIComponent = props => {
                 {...componentProps}
             >
                 {previewInfoVisible ? (
-                    <PreviewModal />
+                    <PreviewModal hideIntro={hideIntro} />
                 ) : null}
                 {loading ? (
                     <Loader />
@@ -281,6 +282,7 @@ GUIComponent.propTypes = {
     costumeLibraryVisible: PropTypes.bool,
     costumesTabVisible: PropTypes.bool,
     enableCommunity: PropTypes.bool,
+    hideIntro: PropTypes.bool,
     importInfoVisible: PropTypes.bool,
     intl: intlShape.isRequired,
     isPlayerOnly: PropTypes.bool,

--- a/src/containers/preview-modal.jsx
+++ b/src/containers/preview-modal.jsx
@@ -27,6 +27,25 @@ class PreviewModal extends React.Component {
             previewing: false
         };
     }
+
+    /**
+     * Conditionally returns an intro modal depending on the hideIntro prop
+     * @returns { React.Component | null } null if hideIntro is true, the intro modal component otherwise
+     */
+    introIfShown () {
+        if (this.props.hideIntro) {
+            return null; // If hideIntro is true, the intro modal should not appear
+        }
+
+        // otherwise, show the intro modal
+        return (<PreviewModalComponent
+            previewing={this.state.previewing}
+            onCancel={this.handleCancel}
+            onTryIt={this.handleTryIt}
+            onViewProject={this.handleViewProject}
+        />);
+        
+    }
     handleTryIt () {
         this.setState({previewing: true});
         // try to run in fullscreen mode on tablets.
@@ -41,12 +60,7 @@ class PreviewModal extends React.Component {
     }
     render () {
         return (supportedBrowser() ?
-            !this.props.hideIntro && <PreviewModalComponent
-                previewing={this.state.previewing}
-                onCancel={this.handleCancel}
-                onTryIt={this.handleTryIt}
-                onViewProject={this.handleViewProject}
-            /> :
+            this.introIfShown() :
             <BrowserModalComponent
                 onBack={this.handleCancel}
             />

--- a/src/containers/preview-modal.jsx
+++ b/src/containers/preview-modal.jsx
@@ -41,7 +41,7 @@ class PreviewModal extends React.Component {
     }
     render () {
         return (supportedBrowser() ?
-            <PreviewModalComponent
+            !this.props.hideIntro && <PreviewModalComponent
                 previewing={this.state.previewing}
                 onCancel={this.handleCancel}
                 onTryIt={this.handleTryIt}
@@ -55,6 +55,7 @@ class PreviewModal extends React.Component {
 }
 
 PreviewModal.propTypes = {
+    hideIntro: PropTypes.bool,
     onTryIt: PropTypes.func,
     onViewProject: PropTypes.func
 };


### PR DESCRIPTION
### Resolves
This PR resolves #2814.

### Proposed Changes
This PR adds a `hideIntro` prop that can be passed to the GUI element to hide the "Welcome to Scratch 3.0" modal. This does not hide the unsupported browser modal.

### Reason for Changes
As stated in #2814, this change is needed so that the scratch-www project page can opt to not show the intro modal when switching from community to project view.

### Test Coverage

Tested by making sure the intro modal still shows up when no `hideIntro` prop is passed to it.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [x] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
