### PR TITLE
Fix file upload regression

### DIFF
--- a/src/components/action-menu/action-menu.jsx
+++ b/src/components/action-menu/action-menu.jsx
@@ -24,6 +24,7 @@ class ActionMenu extends React.Component {
             isOpen: false,
             forceHide: false
         };
+        this.mainTooltipId = `tooltip-${Math.random()}`;
     }
     componentDidMount () {
         // Touch start on the main button is caught to trigger open and not click
@@ -105,8 +106,6 @@ class ActionMenu extends React.Component {
             onClick
         } = this.props;
 
-        const mainTooltipId = `tooltip-${Math.random()}`;
-
         return (
             <div
                 className={classNames(styles.menuContainer, className, {
@@ -120,7 +119,7 @@ class ActionMenu extends React.Component {
                 <button
                     aria-label={mainTitle}
                     className={classNames(styles.button, styles.mainButton)}
-                    data-for={mainTooltipId}
+                    data-for={this.mainTooltipId}
                     data-tip={mainTitle}
                     ref={this.setButtonRef}
                     onClick={this.clickDelayer(onClick)}
@@ -134,7 +133,7 @@ class ActionMenu extends React.Component {
                 <ReactTooltip
                     className={styles.tooltip}
                     effect="solid"
-                    id={mainTooltipId}
+                    id={this.mainTooltipId}
                     place={tooltipPlace || 'left'}
                 />
                 <div className={styles.moreButtonsOuter}>
@@ -143,7 +142,7 @@ class ActionMenu extends React.Component {
                             fileAccept, fileChange, fileInput}, keyId) => {
                             const isComingSoon = !handleClick;
                             const hasFileInput = fileInput;
-                            const tooltipId = `${mainTooltipId}-${title}`;
+                            const tooltipId = `${this.mainTooltipId}-${title}`;
                             return (
                                 <div key={`${tooltipId}-${keyId}`}>
                                     <button


### PR DESCRIPTION
### Resolves

Resolves a recent (unfiled) regression where the file upload buttons in the action menus (e.g. for adding a new sprite/costume/sound/backdrop). The regression was introduced by [this change](https://github.com/LLK/scratch-gui/commit/67f4496947c143efa3e24f6214b36bfc651f25e3#diff-905aba88028780ed582fc4571ca6444fR145) which was fixing a different RTL bug.

### Proposed Changes

Since the `mainTooltpId` is now being used as part of the action menu items, make sure it is generated in the constructor of the action menu component instead of within the render method. This fixes a regression caused by a recent change where the file upload buttons in the action menu stopped working.

### Test Coverage

Manually tested the file upload buttons in the action menus to ensure they work again. Also tested RTL to ensure there wasn't a regression introduced there.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
