### PR TITLE
Handle RTL in modals

### DIFF
--- a/src/components/browser-modal/browser-modal.css
+++ b/src/components/browser-modal/browser-modal.css
@@ -34,6 +34,10 @@
     background-size: cover;
 }
 
+[dir="rtl"] .illustration {
+    transform: scaleX(-1);
+}
+
 .body {
     background: $ui-white;
     padding: 1.5rem 2.25rem;

--- a/src/components/browser-modal/browser-modal.jsx
+++ b/src/components/browser-modal/browser-modal.jsx
@@ -22,62 +22,65 @@ const BrowserModal = ({intl, ...props}) => (
         overlayClassName={styles.modalOverlay}
         onRequestClose={props.onBack}
     >
-        <Box className={styles.illustration} />
+        <div dir={props.isRtl ? 'rtl' : 'ltr'} >
+            <Box className={styles.illustration} />
 
-        <Box className={styles.body}>
-            <h2>
-                <FormattedMessage {...messages.label} />
-            </h2>
-            <p>
-                { /* eslint-disable max-len */ }
-                <FormattedMessage
-                    defaultMessage="We're very sorry, but Scratch 3.0 does not support Internet Explorer, Vivaldi, Opera or Silk. We recommend trying a newer browser such as Google Chrome, Mozilla Firefox, or Microsoft Edge."
-                    description="Unsupported browser description"
-                    id="gui.unsupportedBrowser.description"
-                />
-                { /* eslint-enable max-len */ }
-            </p>
-
-            <Box className={styles.buttonRow}>
-                <button
-                    className={styles.backButton}
-                    onClick={props.onBack}
-                >
+            <Box className={styles.body}>
+                <h2>
+                    <FormattedMessage {...messages.label} />
+                </h2>
+                <p>
+                    { /* eslint-disable max-len */ }
                     <FormattedMessage
-                        defaultMessage="Back"
-                        description="Button to go back in unsupported browser modal"
-                        id="gui.unsupportedBrowser.back"
+                        defaultMessage="We're very sorry, but Scratch 3.0 does not support Internet Explorer, Vivaldi, Opera or Silk. We recommend trying a newer browser such as Google Chrome, Mozilla Firefox, or Microsoft Edge."
+                        description="Unsupported browser description"
+                        id="gui.unsupportedBrowser.description"
                     />
-                </button>
+                    { /* eslint-enable max-len */ }
+                </p>
 
+                <Box className={styles.buttonRow}>
+                    <button
+                        className={styles.backButton}
+                        onClick={props.onBack}
+                    >
+                        <FormattedMessage
+                            defaultMessage="Back"
+                            description="Button to go back in unsupported browser modal"
+                            id="gui.unsupportedBrowser.back"
+                        />
+                    </button>
+
+                </Box>
+                <div className={styles.faqLinkText}>
+                    <FormattedMessage
+                        defaultMessage="To learn more, go to the {previewFaqLink}."
+                        description="Invitation to try 3.0 preview"
+                        id="gui.unsupportedBrowser.previewfaq"
+                        values={{
+                            previewFaqLink: (
+                                <a
+                                    className={styles.faqLink}
+                                    href="//scratch.mit.edu/3faq"
+                                >
+                                    <FormattedMessage
+                                        defaultMessage="FAQ"
+                                        description="link to Scratch 3.0 FAQ page"
+                                        id="gui.unsupportedBrowser.previewfaqlinktext"
+                                    />
+                                </a>
+                            )
+                        }}
+                    />
+                </div>
             </Box>
-            <div className={styles.faqLinkText}>
-                <FormattedMessage
-                    defaultMessage="To learn more, go to the {previewFaqLink}."
-                    description="Invitation to try 3.0 preview"
-                    id="gui.unsupportedBrowser.previewfaq"
-                    values={{
-                        previewFaqLink: (
-                            <a
-                                className={styles.faqLink}
-                                href="//scratch.mit.edu/3faq"
-                            >
-                                <FormattedMessage
-                                    defaultMessage="FAQ"
-                                    description="link to Scratch 3.0 FAQ page"
-                                    id="gui.unsupportedBrowser.previewfaqlinktext"
-                                />
-                            </a>
-                        )
-                    }}
-                />
-            </div>
-        </Box>
+        </div>
     </ReactModal>
 );
 
 BrowserModal.propTypes = {
     intl: intlShape.isRequired,
+    isRtl: PropTypes.bool,
     onBack: PropTypes.func.isRequired
 };
 

--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -125,7 +125,7 @@ const GUIComponent = props => {
                     <ImportModal />
                 ) : null}
                 {isRendererSupported ? null : (
-                    <WebGlModal />
+                    <WebGlModal isRtl={isRtl} />
                 )}
                 {tipsLibraryVisible ? (
                     <TipsLibrary />

--- a/src/components/import-modal/import-modal.css
+++ b/src/components/import-modal/import-modal.css
@@ -82,6 +82,10 @@ $sides: 20rem;
     justify-content: flex-start;
 }
 
+[dir="rtl"] .header-item-close img {
+    transform: scaleX(-1);
+}
+
 .body {
     background: $ui-white;
     padding: 1.5rem 2.25rem;

--- a/src/components/import-modal/import-modal.jsx
+++ b/src/components/import-modal/import-modal.jsx
@@ -42,110 +42,112 @@ const ImportModal = ({intl, ...props}) => (
         overlayClassName={styles.modalOverlay}
         onRequestClose={props.onCancel}
     >
-        <Box>
-            <div className={styles.header}>
-                <div
-                    className={classNames(
-                        styles.headerItem,
-                        styles.headerItemClose
-                    )}
-                >
-                    <CloseButton
-                        buttonType="back"
-                        size={CloseButton.SIZE_LARGE}
-                        onClick={props.onGoBack}
-                    />
-                </div>
-                <div
-                    className={classNames(
-                        styles.headerItem,
-                        styles.headerItemTitle
-                    )}
-                >
-                    <h2>
-                        {intl.formatMessage({...messages.title})}
-                    </h2>
-                </div>
-                <div className={classNames(styles.headerItem, styles.headerItemFilter)}>
-                    {null}
-                </div>
-            </div>
-        </Box>
-
-        <Box className={styles.body}>
-            <p>
-                {intl.formatMessage({...messages.formDescription})}
-            </p>
-            <Box
-                className={classNames(styles.inputRow,
-                    (props.hasValidationError ? styles.badInputContainer : styles.okInputContainer))
-                }
-            >
-                <input
-                    autoFocus
-                    placeholder={props.placeholder}
-                    value={props.inputValue}
-                    onChange={props.onChange}
-                    onKeyPress={props.onKeyPress}
-                />
-                <button
-                    className={styles.okButton}
-                    title={intl.formatMessage({
-                        defaultMessage: 'View Project',
-                        description: 'Tooltip for View button',
-                        id: 'gui.importModal.viewprojecttooltip'
-                    })}
-                    onClick={props.onViewProject}
-                >
-                    <FormattedMessage
-                        defaultMessage="View"
-                        description="Label for button to load a scratch 2.0 project"
-                        id="gui.importModal.viewproject"
-                    />
-                </button>
-            </Box>
-            {props.hasValidationError ?
-                <Box className={styles.errorRow}>
-                    <p>
-                        <FormattedMessage
-                            {...messages[`${props.errorMessage}`]}
+        <div dir={props.isRtl ? 'rtl' : 'ltr'} >
+            <Box>
+                <div className={styles.header}>
+                    <div
+                        className={classNames(
+                            styles.headerItem,
+                            styles.headerItemClose
+                        )}
+                    >
+                        <CloseButton
+                            buttonType="back"
+                            size={CloseButton.SIZE_LARGE}
+                            onClick={props.onGoBack}
                         />
-                    </p>
-                </Box> : null
-            }
-            <Box className={styles.buttonRow}>
-                <button
-                    onClick={props.onGoBack}
+                    </div>
+                    <div
+                        className={classNames(
+                            styles.headerItem,
+                            styles.headerItemTitle
+                        )}
+                    >
+                        <h2>
+                            {intl.formatMessage({...messages.title})}
+                        </h2>
+                    </div>
+                    <div className={classNames(styles.headerItem, styles.headerItemFilter)}>
+                        {null}
+                    </div>
+                </div>
+            </Box>
+
+            <Box className={styles.body}>
+                <p>
+                    {intl.formatMessage({...messages.formDescription})}
+                </p>
+                <Box
+                    className={classNames(styles.inputRow,
+                        (props.hasValidationError ? styles.badInputContainer : styles.okInputContainer))
+                    }
                 >
-                    <FormattedMessage
-                        defaultMessage="Go Back"
-                        description="Label for button to back out of importing a project"
-                        id="gui.importInfo.goback"
+                    <input
+                        autoFocus
+                        placeholder={props.placeholder}
+                        value={props.inputValue}
+                        onChange={props.onChange}
+                        onKeyPress={props.onKeyPress}
                     />
-                </button>
+                    <button
+                        className={styles.okButton}
+                        title={intl.formatMessage({
+                            defaultMessage: 'View Project',
+                            description: 'Tooltip for View button',
+                            id: 'gui.importModal.viewprojecttooltip'
+                        })}
+                        onClick={props.onViewProject}
+                    >
+                        <FormattedMessage
+                            defaultMessage="View"
+                            description="Label for button to load a scratch 2.0 project"
+                            id="gui.importModal.viewproject"
+                        />
+                    </button>
+                </Box>
+                {props.hasValidationError ?
+                    <Box className={styles.errorRow}>
+                        <p>
+                            <FormattedMessage
+                                {...messages[`${props.errorMessage}`]}
+                            />
+                        </p>
+                    </Box> : null
+                }
+                <Box className={styles.buttonRow}>
+                    <button
+                        onClick={props.onGoBack}
+                    >
+                        <FormattedMessage
+                            defaultMessage="Go Back"
+                            description="Label for button to back out of importing a project"
+                            id="gui.importInfo.goback"
+                        />
+                    </button>
+                </Box>
+                <Box className={styles.faqLinkText}>
+                    <FormattedMessage
+                        defaultMessage="To learn more, go to the {previewFaqLink}."
+                        description="Invitation to try 3.0 preview"
+                        id="gui.importInfo.previewfaq"
+                        values={{
+                            previewFaqLink: (
+                                <a
+                                    className={styles.faqLink}
+                                    href="//scratch.mit.edu/3faq"
+                                >
+                                    <FormattedMessage
+                                        defaultMessage="FAQ"
+                                        description="link to Scratch 3.0 FAQ page"
+                                        id="gui.importInfo.previewfaqlinktext"
+                                    />
+                                </a>
+                            )
+                        }}
+                    />
+                </Box>
             </Box>
-            <Box className={styles.faqLinkText}>
-                <FormattedMessage
-                    defaultMessage="To learn more, go to the {previewFaqLink}."
-                    description="Invitation to try 3.0 preview"
-                    id="gui.importInfo.previewfaq"
-                    values={{
-                        previewFaqLink: (
-                            <a
-                                className={styles.faqLink}
-                                href="//scratch.mit.edu/3faq"
-                            >
-                                <FormattedMessage
-                                    defaultMessage="FAQ"
-                                    description="link to Scratch 3.0 FAQ page"
-                                    id="gui.importInfo.previewfaqlinktext"
-                                />
-                            </a>
-                        )
-                    }}
-                />
-            </Box>
-        </Box>
+        </div>
     </ReactModal>
 );
 

--- a/src/components/preview-modal/preview-modal.css
+++ b/src/components/preview-modal/preview-modal.css
@@ -74,15 +74,26 @@
     color: white;
 }
 
-.button-row button + button {
+[dir="ltr"] .button-row button + button {
     margin-left: 0.5rem;
 }
 
+[dir="rtl"] .button-row button + button {
+    margin-right: 0.5rem;
+}
+
 .cat-icon {
-    margin-left: .125rem;
     width: 1.5rem;
     height: 1.5rem;
     vertical-align: middle;
+}
+
+[dir="ltr"] .cat-icon {
+    margin-left: .125rem;
+}
+
+[dir="rtl"] .cat-icon {
+    margin-right: .125rem;
 }
 
 .faq-link-text {

--- a/src/components/preview-modal/preview-modal.jsx
+++ b/src/components/preview-modal/preview-modal.jsx
@@ -28,106 +28,111 @@ const PreviewModal = ({intl, ...props}) => (
         overlayClassName={styles.modalOverlay}
         onRequestClose={props.onTryIt}
     >
-        <Box className={styles.illustration} />
+        <div dir={props.isRtl ? 'rtl' : 'ltr'} >
+            <Box className={styles.illustration} />
 
-        <Box className={styles.body}>
-            <h2>
-                <FormattedMessage
-                    defaultMessage="Welcome to the Scratch 3.0 Beta"
-                    description="Header for Beta Info Modal"
-                    id="gui.previewInfo.betawelcome"
-                />
-            </h2>
-            <p>
-                <FormattedMessage
-                    defaultMessage="We're working on the next generation of Scratch. We're excited for you to try it!"
-                    description="Invitation to try 3.0 Beta"
-                    id="gui.previewInfo.invitation"
-                />
-            </p>
-
-            <Box className={styles.buttonRow}>
-                <button
-                    className={styles.noButton}
-                    title={intl.formatMessage({
-                        defaultMessage: 'Not Now',
-                        description: 'Tooltip for Not Now button',
-                        id: 'gui.previewModal.notnowtooltip'
-                    })}
-                    onClick={props.onCancel}
-                >
+            <Box className={styles.body}>
+                <h2>
                     <FormattedMessage
-                        defaultMessage="Not Now"
-                        description="Label for button to back out of trying Scratch 3.0 Beta"
-                        id="gui.previewInfo.notnow"
+                        defaultMessage="Welcome to the Scratch 3.0 Beta"
+                        description="Header for Beta Info Modal"
+                        id="gui.previewInfo.betawelcome"
                     />
-                </button>
-                <button
-                    className={styles.okButton}
-                    title={intl.formatMessage({
-                        defaultMessage: 'Try It',
-                        description: 'Tooltip for Try It button',
-                        id: 'gui.previewModal.tryittooltip'
-                    })}
-                    onClick={props.onTryIt}
-                >
+                </h2>
+                <p>
+                    { /* eslint-disable max-len */ }
                     <FormattedMessage
-                        defaultMessage="Try It! {caticon}"
-                        description="Label for button to try Scratch 3.0 Beta"
-                        id="gui.previewModal.tryit"
+                        defaultMessage="We're working on the next generation of Scratch. We're excited for you to try it!"
+                        description="Invitation to try 3.0 Beta"
+                        id="gui.previewInfo.invitation"
+                    />
+                    { /* eslint-enable max-len */ }
+                </p>
+
+                <Box className={styles.buttonRow}>
+                    <button
+                        className={styles.noButton}
+                        title={intl.formatMessage({
+                            defaultMessage: 'Not Now',
+                            description: 'Tooltip for Not Now button',
+                            id: 'gui.previewModal.notnowtooltip'
+                        })}
+                        onClick={props.onCancel}
+                    >
+                        <FormattedMessage
+                            defaultMessage="Not Now"
+                            description="Label for button to back out of trying Scratch 3.0 Beta"
+                            id="gui.previewInfo.notnow"
+                        />
+                    </button>
+                    <button
+                        className={styles.okButton}
+                        title={intl.formatMessage({
+                            defaultMessage: 'Try It',
+                            description: 'Tooltip for Try It button',
+                            id: 'gui.previewModal.tryittooltip'
+                        })}
+                        onClick={props.onTryIt}
+                    >
+                        <FormattedMessage
+                            defaultMessage="Try It! {caticon}"
+                            description="Label for button to try Scratch 3.0 Beta"
+                            id="gui.previewModal.tryit"
+                            values={{
+                                caticon: (
+                                    <img
+                                        className={styles.catIcon}
+                                        src={catIcon}
+                                    />
+                                )
+                            }}
+                        />
+                    </button>
+                    <button
+                        className={styles.viewProjectButton}
+                        title={intl.formatMessage({
+                            defaultMessage: 'View 2.0 Project',
+                            description: 'Tooltip for View 2.0 Project button',
+                            id: 'gui.previewModal.viewprojecttooltip'
+                        })}
+                        onClick={props.onViewProject}
+                    >
+                        <FormattedMessage
+                            defaultMessage="View 2.0 Project"
+                            description="Label for button to import a 2.0 project"
+                            id="gui.previewModal.viewproject"
+                        />
+                    </button>
+                </Box>
+                <Box className={styles.faqLinkText}>
+                    <FormattedMessage
+                        defaultMessage="To learn more, go to the {previewFaqLink}."
+                        description="Invitation to try 3.0 Beta"
+                        id="gui.previewInfo.previewfaq"
                         values={{
-                            caticon: (
-                                <img
-                                    className={styles.catIcon}
-                                    src={catIcon}
-                                />
+                            previewFaqLink: (
+                                <a
+                                    className={styles.faqLink}
+                                    href="//scratch.mit.edu/3faq"
+                                >
+                                    <FormattedMessage
+                                        defaultMessage="FAQ"
+                                        description="link to Scratch 3.0 FAQ page"
+                                        id="gui.previewInfo.previewfaqlinktext"
+                                    />
+                                </a>
                             )
                         }}
                     />
-                </button>
-                <button
-                    className={styles.viewProjectButton}
-                    title={intl.formatMessage({
-                        defaultMessage: 'View 2.0 Project',
-                        description: 'Tooltip for View 2.0 Project button',
-                        id: 'gui.previewModal.viewprojecttooltip'
-                    })}
-                    onClick={props.onViewProject}
-                >
-                    <FormattedMessage
-                        defaultMessage="View 2.0 Project"
-                        description="Label for button to import a 2.0 project"
-                        id="gui.previewModal.viewproject"
-                    />
-                </button>
+                </Box>
             </Box>
-            <Box className={styles.faqLinkText}>
-                <FormattedMessage
-                    defaultMessage="To learn more, go to the {previewFaqLink}."
-                    description="Invitation to try 3.0 Beta"
-                    id="gui.previewInfo.previewfaq"
-                    values={{
-                        previewFaqLink: (
-                            <a
-                                className={styles.faqLink}
-                                href="//scratch.mit.edu/3faq"
-                            >
-                                <FormattedMessage
-                                    defaultMessage="FAQ"
-                                    description="link to Scratch 3.0 FAQ page"
-                                    id="gui.previewInfo.previewfaqlinktext"
-                                />
-                            </a>
-                        )
-                    }}
-                />
-            </Box>
-        </Box>
+        </div>
     </ReactModal>
 );
 
 PreviewModal.propTypes = {
     intl: intlShape.isRequired,
+    isRtl: PropTypes.bool,
     onCancel: PropTypes.func.isRequired,
     onTryIt: PropTypes.func.isRequired,
     onViewProject: PropTypes.func.isRequired

--- a/src/components/webgl-modal/webgl-modal.css
+++ b/src/components/webgl-modal/webgl-modal.css
@@ -34,6 +34,10 @@
     background-size: cover;
 }
 
+[dir="rtl"] .illustration {
+    transform: scaleX(-1);
+}
+
 .body {
     background: $ui-white;
     padding: 1.5rem 2.25rem;

--- a/src/components/webgl-modal/webgl-modal.jsx
+++ b/src/components/webgl-modal/webgl-modal.jsx
@@ -22,76 +22,79 @@ const WebGlModal = ({intl, ...props}) => (
         overlayClassName={styles.modalOverlay}
         onRequestClose={props.onBack}
     >
-        <Box className={styles.illustration} />
+        <div dir={props.isRtl ? 'rtl' : 'ltr'}>
+            <Box className={styles.illustration} />
 
-        <Box className={styles.body}>
-            <h2>
-                <FormattedMessage {...messages.label} />
-            </h2>
-            <p>
-                { /* eslint-disable max-len */ }
-                <FormattedMessage
-                    defaultMessage="Unfortunately it looks like your browser or computer {webGlLink}. This technology is needed for Scratch 3.0 to run."
-                    description="WebGL missing message"
-                    id="gui.webglModal.description"
-                    values={{
-                        webGlLink: (
-                            <a
-                                className={styles.faqLink}
-                                href="https://en.wikipedia.org/wiki/WebGL#Support"
-                            >
-                                <FormattedMessage
-                                    defaultMessage="does not support WebGL"
-                                    description="link part of your browser does not support WebGL message"
-                                    id="gui.webglModal.webgllink"
-                                />
-                            </a>
-                        )
-                    }}
-                />
-                { /* eslint-enable max-len */ }
-            </p>
-
-            <Box className={styles.buttonRow}>
-                <button
-                    className={styles.backButton}
-                    onClick={props.onBack}
-                >
+            <Box className={styles.body}>
+                <h2>
+                    <FormattedMessage {...messages.label} />
+                </h2>
+                <p>
+                    { /* eslint-disable max-len */ }
                     <FormattedMessage
-                        defaultMessage="Back"
-                        description="Label for button go back when browser is unsupported"
-                        id="gui.webglModal.back"
+                        defaultMessage="Unfortunately it looks like your browser or computer {webGlLink}. This technology is needed for Scratch 3.0 to run."
+                        description="WebGL missing message"
+                        id="gui.webglModal.description"
+                        values={{
+                            webGlLink: (
+                                <a
+                                    className={styles.faqLink}
+                                    href="https://en.wikipedia.org/wiki/WebGL#Support"
+                                >
+                                    <FormattedMessage
+                                        defaultMessage="does not support WebGL"
+                                        description="link part of your browser does not support WebGL message"
+                                        id="gui.webglModal.webgllink"
+                                    />
+                                </a>
+                            )
+                        }}
                     />
-                </button>
+                    { /* eslint-enable max-len */ }
+                </p>
 
+                <Box className={styles.buttonRow}>
+                    <button
+                        className={styles.backButton}
+                        onClick={props.onBack}
+                    >
+                        <FormattedMessage
+                            defaultMessage="Back"
+                            description="Label for button go back when browser is unsupported"
+                            id="gui.webglModal.back"
+                        />
+                    </button>
+
+                </Box>
+                <div className={styles.faqLinkText}>
+                    <FormattedMessage
+                        defaultMessage="To learn more, go to the {previewFaqLink}."
+                        description="Scratch 3.0 FAQ description"
+                        id="gui.webglModal.previewfaq"
+                        values={{
+                            previewFaqLink: (
+                                <a
+                                    className={styles.faqLink}
+                                    href="//scratch.mit.edu/3faq"
+                                >
+                                    <FormattedMessage
+                                        defaultMessage="FAQ"
+                                        description="link to Scratch 3.0 FAQ page"
+                                        id="gui.webglModal.previewfaqlinktext"
+                                    />
+                                </a>
+                            )
+                        }}
+                    />
+                </div>
             </Box>
-            <div className={styles.faqLinkText}>
-                <FormattedMessage
-                    defaultMessage="To learn more, go to the {previewFaqLink}."
-                    description="Scratch 3.0 FAQ description"
-                    id="gui.webglModal.previewfaq"
-                    values={{
-                        previewFaqLink: (
-                            <a
-                                className={styles.faqLink}
-                                href="//scratch.mit.edu/3faq"
-                            >
-                                <FormattedMessage
-                                    defaultMessage="FAQ"
-                                    description="link to Scratch 3.0 FAQ page"
-                                    id="gui.webglModal.previewfaqlinktext"
-                                />
-                            </a>
-                        )
-                    }}
-                />
-            </div>
-        </Box>
+        </div>
     </ReactModal>
 );
 
 WebGlModal.propTypes = {
     intl: intlShape.isRequired,
+    isRtl: PropTypes.bool,
     onBack: PropTypes.func.isRequired
 };
 

--- a/src/containers/error-boundary.jsx
+++ b/src/containers/error-boundary.jsx
@@ -77,4 +77,7 @@ const mapStateToProps = state => ({
     isRtl: state.locales.isRtl
 });
 
-export default connect(mapStateToProps)(ErrorBoundary);
+// no-op function to prevent dispatch prop being passed to component
+const mapDispatchToProps = () => {};
+
+export default connect(mapStateToProps, mapDispatchToProps)(ErrorBoundary);

--- a/src/containers/error-boundary.jsx
+++ b/src/containers/error-boundary.jsx
@@ -77,6 +77,4 @@ const mapStateToProps = state => ({
     isRtl: state.locales.isRtl
 });
 
-export default connect(
-    mapStateToProps
-)(ErrorBoundary);
+export default connect(mapStateToProps)(ErrorBoundary);

--- a/src/containers/error-boundary.jsx
+++ b/src/containers/error-boundary.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {connect} from 'react-redux';
 import bowser from 'bowser';
 import BrowserModalComponent from '../components/browser-modal/browser-modal.jsx';
 import CrashMessageComponent from '../components/crash-message/crash-message.jsx';
@@ -57,7 +58,10 @@ class ErrorBoundary extends React.Component {
             if (supportedBrowser()) {
                 return <CrashMessageComponent onReload={this.handleReload} />;
             }
-            return <BrowserModalComponent onBack={this.handleBack} />;
+            return (<BrowserModalComponent
+                isRtl={this.props.isRtl}
+                onBack={this.handleBack}
+            />);
         }
         return this.props.children;
     }
@@ -65,7 +69,14 @@ class ErrorBoundary extends React.Component {
 
 ErrorBoundary.propTypes = {
     action: PropTypes.string.isRequired, // Used for defining tracking action
-    children: PropTypes.node
+    children: PropTypes.node,
+    isRtl: PropTypes.bool
 };
 
-export default ErrorBoundary;
+const mapStateToProps = state => ({
+    isRtl: state.locales.isRtl
+});
+
+export default connect(
+    mapStateToProps
+)(ErrorBoundary);

--- a/src/containers/import-modal.jsx
+++ b/src/containers/import-modal.jsx
@@ -73,6 +73,7 @@ class ImportModal extends React.Component {
                 errorMessage={this.state.errorMessage}
                 hasValidationError={this.state.hasValidationError}
                 inputValue={this.state.inputValue}
+                isRtl={this.props.isRtl}
                 placeholder="scratch.mit.edu/projects/123456789"
                 onCancel={this.handleCancel}
                 onChange={this.handleChange}
@@ -85,12 +86,15 @@ class ImportModal extends React.Component {
 }
 
 ImportModal.propTypes = {
+    isRtl: PropTypes.bool,
     onBack: PropTypes.func.isRequired,
     onCancel: PropTypes.func.isRequired,
     onViewProject: PropTypes.func
 };
 
-const mapStateToProps = () => ({});
+const mapStateToProps = state => ({
+    isRtl: state.locales.isRtl
+});
 
 const mapDispatchToProps = dispatch => ({
     onBack: () => {

--- a/src/containers/preview-modal.jsx
+++ b/src/containers/preview-modal.jsx
@@ -39,12 +39,12 @@ class PreviewModal extends React.Component {
 
         // otherwise, show the intro modal
         return (<PreviewModalComponent
+            isRtl={this.props.isRtl}
             previewing={this.state.previewing}
             onCancel={this.handleCancel}
             onTryIt={this.handleTryIt}
             onViewProject={this.handleViewProject}
         />);
-        
     }
     handleTryIt () {
         this.setState({previewing: true});
@@ -62,6 +62,7 @@ class PreviewModal extends React.Component {
         return (supportedBrowser() ?
             this.introIfShown() :
             <BrowserModalComponent
+                isRtl={this.props.isRtl}
                 onBack={this.handleCancel}
             />
         );
@@ -70,11 +71,14 @@ class PreviewModal extends React.Component {
 
 PreviewModal.propTypes = {
     hideIntro: PropTypes.bool,
+    isRtl: PropTypes.bool,
     onTryIt: PropTypes.func,
     onViewProject: PropTypes.func
 };
 
-const mapStateToProps = () => ({});
+const mapStateToProps = state => ({
+    isRtl: state.locales.isRtl
+});
 
 const mapDispatchToProps = dispatch => ({
     onTryIt: () => {

--- a/src/containers/webgl-modal.jsx
+++ b/src/containers/webgl-modal.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import WebGlModalComponent from '../components/webgl-modal/webgl-modal.jsx';
 
@@ -9,10 +10,15 @@ class WebGlModal extends React.Component {
     render () {
         return (
             <WebGlModalComponent
+                isRtl={this.props.isRtl}
                 onBack={this.handleCancel}
             />
         );
     }
 }
+
+WebGlModal.propTypes = {
+    isRtl: PropTypes.bool
+};
 
 export default WebGlModal;


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves #2759 

### Proposed Changes

_Describe what this Pull Request does_
Wraps the modal content in a `<div dir=...` and sets the direction based on the `isRtl` state. Handles all the modals that use `ReactModal` directly not the `Modal` component.

### Test Coverage
Try it:
https://chrisgarrity.github.io/scratch-gui/feature/2759-modals/?locale=he

Manual Testing:
- [ ] Beta modal - button layout is rtl
- [ ] import project modal - back arrow is reversed and input field is reversed
- [ ] WebGL modal - text is RTL
- [ ] unsupported browser modal - text is RTL

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 * [x] Opera - gets unsupported browser modal
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
