### PR TITLE
Handle RTL in menubar

### DIFF
--- a/src/components/coming-soon/coming-soon.css
+++ b/src/components/coming-soon/coming-soon.css
@@ -62,8 +62,15 @@
 }
 
 .coming-soon-image {
-    margin-left: .125rem;
     width: 1.25rem;
     height: 1.25rem;
     vertical-align: middle;
+}
+
+[dir="ltr"] .coming-soon-image {
+    margin-left: .125rem;
+}
+
+[dir="rtl"] .coming-soon-image {
+    margin-right: .125rem;
 }

--- a/src/components/menu-bar/menu-bar.css
+++ b/src/components/menu-bar/menu-bar.css
@@ -169,9 +169,16 @@
 }
 
 .dropdown-caret-icon {
-    margin-left: .5rem;
     width: 0.5rem;
     height: 0.5rem;
+}
+
+[dir="ltr"] .dropdown-caret-icon {
+    margin-left: .5rem;
+}
+
+[dir="rtl"] .dropdown-caret-icon {
+    margin-right: .5rem;
 }
 
 .disabled {

--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -91,10 +91,11 @@ MenuBarItemTooltip.propTypes = {
     place: PropTypes.oneOf(['top', 'bottom', 'left', 'right'])
 };
 
-const MenuItemTooltip = ({id, children, className}) => (
+const MenuItemTooltip = ({id, isRtl, children, className}) => (
     <ComingSoonTooltip
         className={classNames(styles.comingSoon, className)}
-        place="right"
+        isRtl={isRtl}
+        place={isRtl ? 'left' : 'right'}
         tooltipClassName={styles.comingSoonTooltip}
         tooltipId={id}
     >
@@ -105,7 +106,8 @@ const MenuItemTooltip = ({id, children, className}) => (
 MenuItemTooltip.propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
-    id: PropTypes.string
+    id: PropTypes.string,
+    isRtl: PropTypes.bool
 };
 
 const MenuBarMenu = ({
@@ -189,6 +191,7 @@ class MenuBar extends React.Component {
                                 </div>
                                 <MenuBarMenu
                                     open={this.props.languageMenuOpen}
+                                    place={this.props.isRtl ? 'left' : 'right'}
                                     onRequestClose={this.props.onRequestCloseLanguage}
                                 >
                                     <LanguageSelector />
@@ -211,9 +214,13 @@ class MenuBar extends React.Component {
                             </div>
                             <MenuBarMenu
                                 open={this.props.fileMenuOpen}
+                                place={this.props.isRtl ? 'left' : 'right'}
                                 onRequestClose={this.props.onRequestCloseFile}
                             >
-                                <MenuItemTooltip id="new">
+                                <MenuItemTooltip
+                                    id="new"
+                                    isRtl={this.props.isRtl}
+                                >
                                     <MenuItem>
                                         <FormattedMessage
                                             defaultMessage="New"
@@ -223,7 +230,10 @@ class MenuBar extends React.Component {
                                     </MenuItem>
                                 </MenuItemTooltip>
                                 <MenuSection>
-                                    <MenuItemTooltip id="save">
+                                    <MenuItemTooltip
+                                        id="save"
+                                        isRtl={this.props.isRtl}
+                                    >
                                         <MenuItem>
                                             <FormattedMessage
                                                 defaultMessage="Save now"
@@ -232,7 +242,10 @@ class MenuBar extends React.Component {
                                             />
                                         </MenuItem>
                                     </MenuItemTooltip>
-                                    <MenuItemTooltip id="copy">
+                                    <MenuItemTooltip
+                                        id="copy"
+                                        isRtl={this.props.isRtl}
+                                    >
                                         <MenuItem>
                                             <FormattedMessage
                                                 defaultMessage="Save as a copy"
@@ -285,9 +298,13 @@ class MenuBar extends React.Component {
                             </div>
                             <MenuBarMenu
                                 open={this.props.editMenuOpen}
+                                place={this.props.isRtl ? 'left' : 'right'}
                                 onRequestClose={this.props.onRequestCloseEdit}
                             >
-                                <MenuItemTooltip id="restore">
+                                <MenuItemTooltip
+                                    id="restore"
+                                    isRtl={this.props.isRtl}
+                                >
                                     <DeletionRestorer>{(handleRestore, {restorable /* eslint-disable-line no-unused-vars, max-len */, deletedItem}) => (
                                         <MenuItem
                                             className={classNames(styles.disabled)}
@@ -429,7 +446,7 @@ class MenuBar extends React.Component {
                     </MenuBarItemTooltip>
                     <MenuBarItemTooltip
                         id="account-nav"
-                        place="left"
+                        place={this.props.isRtl ? 'right' : 'left'}
                     >
                         <div
                             className={classNames(
@@ -462,6 +479,7 @@ MenuBar.propTypes = {
     enableCommunity: PropTypes.bool,
     fileMenuOpen: PropTypes.bool,
     intl: intlShape,
+    isRtl: PropTypes.bool,
     languageMenuOpen: PropTypes.bool,
     onClickEdit: PropTypes.func,
     onClickFile: PropTypes.func,
@@ -476,6 +494,7 @@ MenuBar.propTypes = {
 const mapStateToProps = state => ({
     fileMenuOpen: fileMenuOpen(state),
     editMenuOpen: editMenuOpen(state),
+    isRtl: state.locales.isRtl,
     languageMenuOpen: languageMenuOpen(state)
 });
 


### PR DESCRIPTION
Note: the coming soon tooltip positions are calculated by react-tooltip, and they do not handle RTL.

### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves #2757

### Proposed Changes

* The menus open to the left of the menubar item
* Tooltips open on the opposite side - however the tooltip offset is calculated by the react-tooltip library and it is not RTL aware.

### Testing
Try it: 
https://chrisgarrity.github.io/scratch-gui/feature/2757-menubar/?locale=he

- [ ] drop down menus align the right edge with the menubar item and open to the left.
- [ ] the user avatar coming soon tooltip opens on the right and points towards the user
- [ ] coming soon tooltips on menu items open to the left
