### PR TITLE
Update language selection menu

### DIFF
--- a/src/components/language-selector/language-selector.css
+++ b/src/components/language-selector/language-selector.css
@@ -8,8 +8,8 @@
 /* Position the language select over the language icon, and make it transparent */
 .language-select {
     position: absolute;
-    width: 3rem;
-    height: 3rem;
+    width: $language-selector-width;
+    height: $menu-bar-height;
     opacity: 0;
     user-select: none;
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;

--- a/src/components/language-selector/language-selector.css
+++ b/src/components/language-selector/language-selector.css
@@ -7,7 +7,7 @@
 
 /* Position the language select over the language icon, and make it transparent */
 .language-select {
-    position: relative;
+    position: absolute;
     width: 3rem;
     height: 3rem;
     opacity: 0;
@@ -17,11 +17,15 @@
 }
 
 [dir="ltr"] .language-select {
-    right: 40px;
+    right: 0;
 }
 
 [dir="rtl"] .language-select {
-    left: 40px;
+    left: 0;
+}
+
+.language-select option {
+    opacity: 1;
 }
 
 .language-select:focus {

--- a/src/components/language-selector/language-selector.css
+++ b/src/components/language-selector/language-selector.css
@@ -5,19 +5,23 @@
     height:  1.5rem;
 }
 
-.disabled {
-    opacity: .5;
+/* Position the language select over the language icon, and make it transparent */
+.language-select {
+    position: relative;
+    width: 3rem;
+    height: 3rem;
+    opacity: 0;
+    user-select: none;
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: .875rem;
 }
 
-.language-select {
-    margin: .5rem;
-    height: 1.85rem;
-    border: 1px solid $motion-primary;
-    user-select: none;
-    outline: none;
-    background: rgba(255, 255, 255, 0.5);
-    color: $motion-tertiary;
-    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+[dir="ltr"] .language-select {
+    right: 40px;
+}
+
+[dir="rtl"] .language-select {
+    left: 40px;
 }
 
 .language-select:focus {

--- a/src/components/language-selector/language-selector.jsx
+++ b/src/components/language-selector/language-selector.jsx
@@ -7,8 +7,9 @@ import styles from './language-selector.css';
 // supported languages to exclude from the menu, but allow as a URL option
 const ignore = ['he'];
 
-const LanguageSelector = ({currentLocale, onChange}) => (
+const LanguageSelector = ({currentLocale, label, onChange}) => (
     <select
+        aria-label={label}
         className={styles.languageSelect}
         value={currentLocale}
         onChange={onChange}
@@ -30,6 +31,7 @@ const LanguageSelector = ({currentLocale, onChange}) => (
 
 LanguageSelector.propTypes = {
     currentLocale: PropTypes.string,
+    label: PropTypes.string,
     onChange: PropTypes.func
 };
 

--- a/src/components/language-selector/language-selector.jsx
+++ b/src/components/language-selector/language-selector.jsx
@@ -1,58 +1,36 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import Box from '../box/box.jsx';
 import locales from 'scratch-l10n';
 import styles from './language-selector.css';
 
 // supported languages to exclude from the menu, but allow as a URL option
 const ignore = ['he'];
 
-class LanguageSelector extends React.Component {
-    render () {
-        const {
-            componentRef,
-            currentLocale,
-            onChange,
-            ...componentProps
-        } = this.props;
-        return (
-            <Box
-                {...componentProps}
-            >
-                <div
-                    className={styles.group}
-                    ref={componentRef}
-                >
-                    <select
-                        className={styles.languageSelect}
-                        value={currentLocale}
-                        onChange={onChange}
+const LanguageSelector = ({currentLocale, onChange}) => (
+    <select
+        className={styles.languageSelect}
+        value={currentLocale}
+        onChange={onChange}
+    >
+        {
+            Object.keys(locales)
+                .filter(l => !ignore.includes(l))
+                .map(locale => (
+                    <option
+                        key={locale}
+                        value={locale}
                     >
-                        {
-                            Object.keys(locales)
-                                .filter(l => !ignore.includes(l))
-                                .map(locale => (
-                                    <option
-                                        key={locale}
-                                        value={locale}
-                                    >
-                                        {locales[locale].name}
-                                    </option>
-                                ))
-                        }
-                    </select>
-                </div>
-            </Box>
-        );
-    }
-}
+                        {locales[locale].name}
+                    </option>
+                ))
+        }
+    </select>
+);
 
 LanguageSelector.propTypes = {
-    componentRef: PropTypes.func,
     currentLocale: PropTypes.string,
-    onChange: PropTypes.func,
-    open: PropTypes.bool
+    onChange: PropTypes.func
 };
 
 export default LanguageSelector;

--- a/src/components/menu-bar/menu-bar.css
+++ b/src/components/menu-bar/menu-bar.css
@@ -54,7 +54,7 @@
 
 .language-menu {
     display: inline-flex;
-    width: 3rem;
+    width: $language-selector-width;
 }
 
 .menu {

--- a/src/components/menu-bar/menu-bar.css
+++ b/src/components/menu-bar/menu-bar.css
@@ -48,8 +48,13 @@
     height:  1.5rem;
 }
 
+.language-caret {
+    vertical-align: text-top;
+}
+
 .language-menu {
     display: inline-flex;
+    width: 3rem;
 }
 
 .menu {

--- a/src/components/menu-bar/menu-bar.css
+++ b/src/components/menu-bar/menu-bar.css
@@ -49,7 +49,7 @@
 }
 
 .language-caret {
-    vertical-align: text-top;
+    margin-bottom: .625rem;
 }
 
 .language-menu {

--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -167,9 +167,7 @@ class MenuBar extends React.Component {
                         <div
                             className={classNames(styles.menuBarItem, styles.hoverable, styles.languageMenu)}
                         >
-                            <div
-                                aria-label={this.props.intl.formatMessage(ariaMessages.language)}
-                            >
+                            <div>
                                 <img
                                     className={styles.languageIcon}
                                     src={languageIcon}
@@ -179,7 +177,7 @@ class MenuBar extends React.Component {
                                     src={dropdownCaret}
                                 />
                             </div>
-                            <LanguageSelector />
+                            <LanguageSelector aria-label={this.props.intl.formatMessage(ariaMessages.language)} />
                         </div>
                         <div
                             className={classNames(styles.menuBarItem, styles.hoverable, {

--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -177,7 +177,7 @@ class MenuBar extends React.Component {
                                     src={dropdownCaret}
                                 />
                             </div>
-                            <LanguageSelector aria-label={this.props.intl.formatMessage(ariaMessages.language)} />
+                            <LanguageSelector label={this.props.intl.formatMessage(ariaMessages.language)} />
                         </div>
                         <div
                             className={classNames(styles.menuBarItem, styles.hoverable, {

--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -165,39 +165,21 @@ class MenuBar extends React.Component {
                             />
                         </div>
                         <div
-                            className={classNames(styles.menuBarItem, styles.hoverable, {
-                                [styles.active]: this.props.languageMenuOpen
-                            })}
-                            onMouseUp={this.handleLanguageMouseUp}
+                            className={classNames(styles.menuBarItem, styles.hoverable, styles.languageMenu)}
                         >
-                            {/* @TODO: remove coming soon tooltip wrapper  https://github.com/LLK/scratch-gui/issues/2664  */}
-                            <MenuBarItemTooltip
-                                enable
-                                id="menubar-selector"
-                                place="right"
+                            <div
+                                aria-label={this.props.intl.formatMessage(ariaMessages.language)}
                             >
-                                <div
-                                    aria-label={this.props.intl.formatMessage(ariaMessages.language)}
-                                    className={classNames(styles.languageMenu)}
-                                >
-                                    <img
-                                        className={styles.languageIcon}
-                                        src={languageIcon}
-                                    />
-                                    <img
-                                        className={styles.dropdownCaret}
-                                        src={dropdownCaret}
-                                    />
-                                </div>
-                                <MenuBarMenu
-                                    open={this.props.languageMenuOpen}
-                                    place={this.props.isRtl ? 'left' : 'right'}
-                                    onRequestClose={this.props.onRequestCloseLanguage}
-                                >
-                                    <LanguageSelector />
-                                </MenuBarMenu>
-
-                            </MenuBarItemTooltip>
+                                <img
+                                    className={styles.languageIcon}
+                                    src={languageIcon}
+                                />
+                                <img
+                                    className={styles.languageCaret}
+                                    src={dropdownCaret}
+                                />
+                            </div>
+                            <LanguageSelector />
                         </div>
                         <div
                             className={classNames(styles.menuBarItem, styles.hoverable, {

--- a/src/css/units.css
+++ b/src/css/units.css
@@ -6,6 +6,7 @@ $space: 0.5rem;
 $sprites-per-row: 5;
 
 $menu-bar-height: 3rem;
+$language-selector-width: 3rem;
 $sprite-info-height: 6rem;
 $stage-menu-height: 2.75rem;
 

--- a/test/integration/localization.test.js
+++ b/test/integration/localization.test.js
@@ -25,7 +25,7 @@ describe('Localization', () => {
     test('Localization', async () => {
         await loadUri(uri);
         await clickXpath('//button[@title="Try It"]');
-        await clickXpath('//*[@aria-label="language selector"]/following-sibling::select');
+        await clickXpath('//*[@aria-label="language selector"]');
         await clickText('Deutsch');
         await new Promise(resolve => setTimeout(resolve, 1000)); // wait for blocks refresh
 

--- a/test/integration/localization.test.js
+++ b/test/integration/localization.test.js
@@ -25,8 +25,7 @@ describe('Localization', () => {
     test('Localization', async () => {
         await loadUri(uri);
         await clickXpath('//button[@title="Try It"]');
-        await clickXpath('//*[@aria-label="language selector"]');
-        await clickText('English');
+        await clickXpath('//*[@aria-label="language selector"]/following-sibling::select');
         await clickText('Deutsch');
         await new Promise(resolve => setTimeout(resolve, 1000)); // wait for blocks refresh
 


### PR DESCRIPTION
### Resolves

- Resolves #2658 

### Proposed Changes

Initial update of language selection menu to avoid the menu within a menu. The language list is still a `select`, so the list of languages is styled by the browser being used. At some point we probably want to replace the `select` to have a consistent look for the languages across platforms. 
/cc @carljbowman 

Also removes the coming soon wrapper as it's no longer needed.

### Test Coverage
Try it:
https://chrisgarrity.github.io/scratch-gui/issue/2658-lang-select/

Updated language integration test to use the new menu.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
