### PR TITLE
Add project and asset host props

### DIFF
--- a/src/containers/backpack.jsx
+++ b/src/containers/backpack.jsx
@@ -136,8 +136,8 @@ const getTokenAndUsername = state => {
     // Look for the session state provided by scratch-www
     if (state.session && state.session.session) {
         return {
-            token: state.session.session.token,
-            username: state.session.session.username
+            token: state.session.session.user.token,
+            username: state.session.session.user.username
         };
     }
     // Otherwise try to pull testing params out of the URL, or return nulls

--- a/src/containers/backpack.jsx
+++ b/src/containers/backpack.jsx
@@ -27,6 +27,7 @@ class Backpack extends React.Component {
             'handleDrop',
             'handleToggle',
             'handleDelete',
+            'getBackpackAssetURL',
             'refreshContents'
         ]);
         this.state = {
@@ -44,10 +45,13 @@ class Backpack extends React.Component {
         if (props.host && !storage._hasAddedBackpackSource) {
             storage.addWebSource(
                 [storage.AssetType.ImageVector, storage.AssetType.ImageBitmap, storage.AssetType.Sound],
-                asset => `${props.host}/${asset.assetId}.${asset.dataFormat}`
+                this.getBackpackAssetURL
             );
             storage._hasAddedBackpackSource = true;
         }
+    }
+    getBackpackAssetURL (asset) {
+        return `${this.props.host}/${asset.assetId}.${asset.dataFormat}`;
     }
     handleToggle () {
         const newState = !this.state.expanded;

--- a/src/containers/gui.jsx
+++ b/src/containers/gui.jsx
@@ -72,10 +72,12 @@ class GUI extends React.Component {
                 `Failed to load project from server [id=${window.location.hash}]: ${this.state.errorMessage}`);
         }
         const {
+            assetHost, // eslint-disable-line no-unused-vars
             children,
             fetchingProject,
             loadingStateVisible,
             projectData, // eslint-disable-line no-unused-vars
+            projectHost, // eslint-disable-line no-unused-vars
             vm,
             ...componentProps
         } = this.props;
@@ -92,17 +94,22 @@ class GUI extends React.Component {
 }
 
 GUI.propTypes = {
-    ...GUIComponent.propTypes,
+    assetHost: PropTypes.string,
+    children: PropTypes.node,
     fetchingProject: PropTypes.bool,
     importInfoVisible: PropTypes.bool,
     loadingStateVisible: PropTypes.bool,
     onSeeCommunity: PropTypes.func,
     previewInfoVisible: PropTypes.bool,
     projectData: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
+    projectHost: PropTypes.string,
     vm: PropTypes.instanceOf(VM)
 };
 
-GUI.defaultProps = GUIComponent.defaultProps;
+GUI.defaultProps = {
+    assetHost: 'https://assets.scratch.mit.edu',
+    projectHost: 'https://projects.scratch.mit.edu'
+};
 
 const mapStateToProps = state => ({
     activeTabIndex: state.scratchGui.editorTab.activeTabIndex,

--- a/src/containers/gui.jsx
+++ b/src/containers/gui.jsx
@@ -94,7 +94,6 @@ class GUI extends React.Component {
 }
 
 GUI.propTypes = {
-    assetHost: PropTypes.string,
     children: PropTypes.node,
     fetchingProject: PropTypes.bool,
     importInfoVisible: PropTypes.bool,
@@ -102,13 +101,7 @@ GUI.propTypes = {
     onSeeCommunity: PropTypes.func,
     previewInfoVisible: PropTypes.bool,
     projectData: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
-    projectHost: PropTypes.string,
     vm: PropTypes.instanceOf(VM)
-};
-
-GUI.defaultProps = {
-    assetHost: 'https://assets.scratch.mit.edu',
-    projectHost: 'https://projects.scratch.mit.edu'
 };
 
 const mapStateToProps = state => ({

--- a/src/lib/backpack-api.js
+++ b/src/lib/backpack-api.js
@@ -12,7 +12,7 @@ const getBackpackContents = ({
 }) => new Promise((resolve, reject) => {
     xhr({
         method: 'GET',
-        uri: `${host}${username}?limit=${limit}&offset=${offset}`,
+        uri: `${host}/${username}?limit=${limit}&offset=${offset}`,
         headers: {'x-token': token},
         json: true
     }, (error, response) => {
@@ -43,7 +43,7 @@ const saveBackpackObject = ({
 }) => new Promise((resolve, reject) => {
     xhr({
         method: 'POST',
-        uri: `${host}${username}`,
+        uri: `${host}/${username}`,
         headers: {'x-token': token},
         json: {type, mime, name, body, thumbnail}
     }, (error, response) => {
@@ -62,7 +62,7 @@ const deleteBackpackObject = ({
 }) => new Promise((resolve, reject) => {
     xhr({
         method: 'DELETE',
-        uri: `${host}${username}/${id}`,
+        uri: `${host}/${username}/${id}`,
         headers: {'x-token': token}
     }, (error, response) => {
         if (error || response.statusCode !== 200) {

--- a/src/lib/project-loader-hoc.jsx
+++ b/src/lib/project-loader-hoc.jsx
@@ -19,6 +19,9 @@ const ProjectLoaderHOC = function (WrappedComponent) {
                 projectData: null,
                 fetchingProject: false
             };
+            storage.setProjectHost(props.projectHost);
+            storage.setAssetHost(props.assetHost);
+
         }
         componentDidMount () {
             if (this.props.projectId || this.props.projectId === 0) {
@@ -26,6 +29,12 @@ const ProjectLoaderHOC = function (WrappedComponent) {
             }
         }
         componentWillUpdate (nextProps) {
+            if (this.props.projectHost !== nextProps.projectHost) {
+                storage.setProjectHost(nextProps.projectHost);
+            }
+            if (this.props.assetHost !== nextProps.assetHost) {
+                storage.setAssetHost(nextProps.assetHost);
+            }
             if (this.props.projectId !== nextProps.projectId) {
                 this.setState({fetchingProject: true}, () => {
                     this.updateProject(nextProps.projectId);
@@ -67,9 +76,13 @@ const ProjectLoaderHOC = function (WrappedComponent) {
         }
     }
     ProjectLoaderComponent.propTypes = {
+        assetHost: PropTypes.string,
+        projectHost: PropTypes.string,
         projectId: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
     };
     ProjectLoaderComponent.defaultProps = {
+        assetHost: 'https://assets.scratch.mit.edu',
+        projectHost: 'https://projects.scratch.mit.edu',
         projectId: 0
     };
 

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -32,10 +32,7 @@ class Storage extends ScratchStorage {
         this.projectHost = projectHost;
     }
     getProjectURL (projectAsset) {
-        const [projectId, revision] = projectAsset.assetId.split('.');
-        return revision ?
-            `${this.projectHost}/internalapi/project/${projectId}/get/${revision}` :
-            `${this.projectHost}/internalapi/project/${projectId}/get/`;
+        return `${this.projectHost}/internalapi/project/${projectAsset.assetId}/get/`;
     }
     setAssetHost (assetHost) {
         this.assetHost = assetHost;

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -2,9 +2,6 @@ import ScratchStorage from 'scratch-storage';
 
 import defaultProjectAssets from './default-project';
 
-const PROJECT_SERVER = 'https://projects.scratch.mit.edu';
-const ASSET_SERVER = 'https://cdn.assets.scratch.mit.edu';
-
 /**
  * Wrapper for ScratchStorage which adds default web sources.
  * @todo make this more configurable
@@ -12,29 +9,37 @@ const ASSET_SERVER = 'https://cdn.assets.scratch.mit.edu';
 class Storage extends ScratchStorage {
     constructor () {
         super();
-        this.addWebSource(
-            [this.AssetType.Project],
-            projectAsset => {
-                const [projectId, revision] = projectAsset.assetId.split('.');
-                return revision ?
-                    `${PROJECT_SERVER}/internalapi/project/${projectId}/get/${revision}` :
-                    `${PROJECT_SERVER}/internalapi/project/${projectId}/get/`;
-            }
-        );
-        this.addWebSource(
-            [this.AssetType.ImageVector, this.AssetType.ImageBitmap, this.AssetType.Sound],
-            asset => `${ASSET_SERVER}/internalapi/asset/${asset.assetId}.${asset.dataFormat}/get/`
-        );
-        this.addWebSource(
-            [this.AssetType.Sound],
-            asset => `static/extension-assets/scratch3_music/${asset.assetId}.${asset.dataFormat}`
-        );
         defaultProjectAssets.forEach(asset => this.cache(
             this.AssetType[asset.assetType],
             this.DataFormat[asset.dataFormat],
             asset.data,
             asset.id
         ));
+    }
+    setProjectHost (projectHost) {
+        if (this.projectHost) return;
+        this.addWebSource(
+            [this.AssetType.Project],
+            projectAsset => {
+                const [projectId, revision] = projectAsset.assetId.split('.');
+                return revision ?
+                    `${projectHost}/internalapi/project/${projectId}/get/${revision}` :
+                    `${projectHost}/internalapi/project/${projectId}/get/`;
+            }
+        );
+        this.projectHost = projectHost;
+    }
+    setAssetHost (assetHost) {
+        if (this.assetHost) return;
+        this.addWebSource(
+            [this.AssetType.ImageVector, this.AssetType.ImageBitmap, this.AssetType.Sound],
+            asset => `${assetHost}/internalapi/asset/${asset.assetId}.${asset.dataFormat}/get/`
+        );
+        this.addWebSource(
+            [this.AssetType.Sound],
+            asset => `static/extension-assets/scratch3_music/${asset.assetId}.${asset.dataFormat}`
+        );
+        this.assetHost = assetHost;
     }
 }
 

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -15,31 +15,33 @@ class Storage extends ScratchStorage {
             asset.data,
             asset.id
         ));
-    }
-    setProjectHost (projectHost) {
-        if (this.projectHost) return;
         this.addWebSource(
             [this.AssetType.Project],
-            projectAsset => {
-                const [projectId, revision] = projectAsset.assetId.split('.');
-                return revision ?
-                    `${projectHost}/internalapi/project/${projectId}/get/${revision}` :
-                    `${projectHost}/internalapi/project/${projectId}/get/`;
-            }
+            this.getProjectURL.bind(this)
         );
-        this.projectHost = projectHost;
-    }
-    setAssetHost (assetHost) {
-        if (this.assetHost) return;
         this.addWebSource(
             [this.AssetType.ImageVector, this.AssetType.ImageBitmap, this.AssetType.Sound],
-            asset => `${assetHost}/internalapi/asset/${asset.assetId}.${asset.dataFormat}/get/`
+            this.getAssetURL.bind(this)
         );
         this.addWebSource(
             [this.AssetType.Sound],
             asset => `static/extension-assets/scratch3_music/${asset.assetId}.${asset.dataFormat}`
         );
+    }
+    setProjectHost (projectHost) {
+        this.projectHost = projectHost;
+    }
+    getProjectURL (projectAsset) {
+        const [projectId, revision] = projectAsset.assetId.split('.');
+        return revision ?
+            `${this.projectHost}/internalapi/project/${projectId}/get/${revision}` :
+            `${this.projectHost}/internalapi/project/${projectId}/get/`;
+    }
+    setAssetHost (assetHost) {
         this.assetHost = assetHost;
+    }
+    getAssetURL (asset) {
+        return `${this.assetHost}/internalapi/asset/${asset.assetId}.${asset.dataFormat}/get/`;
     }
 }
 


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves #2197 

### Proposed Changes

_Describe what this Pull Request does_
Adds props for project and asset hosts. Also, fix path and redux store references for the backpack (found while testing configuration of project, asset and backpack hosts).


### Reason for Changes

_Explain why these changes should be made_
This allows end-to-end local development and staging of the GUI embedded into scratch-www, since we need to be able to configure the project and asset storage to point at the local or staging project and asset servers.

### Test Coverage

_Please show how you have added tests to cover your changes_
We don't have the infrastructure in this repo to test this yet.

### Browser Coverage
N/A
