### PR TITLE
added build mode 'dist' to npm build options

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,21 @@ npm start
 ```
 Then go to [http://localhost:8601/](http://localhost:8601/) - the playground outputs the default GUI component
 
+## Developing alongside other Scratch repositories
+
+If you wish to develop scratch-gui alongside other scratch repositories that depend on it, you may wish
+to have the other repositories use your local scratch-gui build instead of fetching the current production
+version of the scratch-gui that is found by default using `npm install`.
+
+To do this:
+
+1. Make sure you have run `npm install` from this repository's top level
+2. Make sure you have run `npm install` from the top level of each repository (such as scratch-www) that depends on scratch-gui
+3. From this repository's top level, build the `dist` directory by running `BUILD_MODE=dist npm run build`
+4. From this repository's top level, establish a link to this repository by running `npm link`
+5. From the top level of each repository that depends on scratch-gui, run `npm link scratch-gui`
+6. Build or run the repositories that depend on scratch-gui
+
 ## Testing
 NOTE: If you're a windows user, please run these scripts in Windows `cmd.exe`  instead of Git Bash/MINGW64.
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -177,7 +177,7 @@ module.exports = [
         ])
     })
 ].concat(
-    process.env.NODE_ENV === 'production' ? (
+    process.env.NODE_ENV === 'production' || process.env.BUILD_MODE === 'dist' ? (
         // export as library
         defaultsDeep({}, base, {
             target: 'web',


### PR DESCRIPTION
added build mode 'dist' to npm build options, so you can build the dist directory in development by doing 
```
BUILD_MODE=dist npm run build
```

### Reason for Changes

When developing using scratch-www and scratch-gui together, there is currently no build option in scratch-gui that builds the dist directory without fully building all production assets. This option greatly speeds up the development build process in that case.

I don't think this is specifically testable using browsers or the testing suite.