### PR TITLE
Restore a deleted costume.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ cache:
 install:
 - npm --production=false install
 - npm --production=false update
+- cd node_modules/scratch-vm && npm --production=false install && npm run build && cd -
 script:
 - npm test
 - if [ "$TRAVIS_EVENT_TYPE" == "pull_request" ] && [ "$TRAVIS_BRANCH" == "master" ]; then  npm run test:smoke; fi

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
     "react": "^16.0.0",
     "react-dom": "^16.0.0"
   },
+  "dependencies": {
+    "scratch-vm": "github:kchadha/scratch-vm#restore-costume"
+  },
   "devDependencies": {
     "arraybuffer-loader": "^1.0.6",
     "autoprefixer": "^9.0.1",
@@ -102,7 +105,6 @@
     "scratch-render": "0.1.0-prerelease.20180811013828",
     "scratch-storage": "0.5.1",
     "scratch-svg-renderer": "0.2.0-prerelease.20180817005452",
-    "scratch-vm": "0.2.0-prerelease.20180820150913",
     "selenium-webdriver": "3.6.0",
     "startaudiocontext": "1.2.1",
     "style-loader": "^0.22.1",

--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -167,6 +167,11 @@ class MenuBar extends React.Component {
                 id="gui.menuBar.restoreSound"
             />);
         case 'Costume':
+            return (<FormattedMessage
+                defaultMessage="Restore Costume"
+                description="Menu bar item for restoring the last deleted costume."
+                id="gui.menuBar.restoreCostume"
+            />);
         default: {
             return (<FormattedMessage
                 defaultMessage="Restore"

--- a/src/containers/costume-tab.jsx
+++ b/src/containers/costume-tab.jsx
@@ -24,6 +24,8 @@ import {
     SOUNDS_TAB_INDEX
 } from '../reducers/editor-tab';
 
+import {setRestore} from '../reducers/restore-deletion';
+
 import addLibraryBackdropIcon from '../components/asset-panel/icon--add-backdrop-lib.svg';
 import addLibraryCostumeIcon from '../components/asset-panel/icon--add-costume-lib.svg';
 import fileUploadIcon from '../components/action-menu/icon--file-upload.svg';
@@ -135,7 +137,10 @@ class CostumeTab extends React.Component {
         this.setState({selectedCostumeIndex: costumeIndex});
     }
     handleDeleteCostume (costumeIndex) {
-        this.props.vm.deleteCostume(costumeIndex);
+        const restoreCostumeFun = this.props.vm.deleteCostume(costumeIndex);
+        this.props.dispatchUpdateRestore({
+            restoreFun: restoreCostumeFun,
+            deletedItem: 'Costume'});
     }
     handleDuplicateCostume (costumeIndex) {
         this.props.vm.duplicateCostume(costumeIndex);
@@ -232,6 +237,7 @@ class CostumeTab extends React.Component {
     }
     render () {
         const {
+            dispatchUpdateRestore, // eslint-disable-line no-unused-vars
             intl,
             onNewCostumeFromCameraClick,
             onNewLibraryBackdropClick,
@@ -325,6 +331,7 @@ class CostumeTab extends React.Component {
 
 CostumeTab.propTypes = {
     cameraModalVisible: PropTypes.bool,
+    dispatchUpdateRestore: PropTypes.func,
     editingTarget: PropTypes.string,
     intl: intlShape,
     onActivateSoundsTab: PropTypes.func.isRequired,
@@ -372,6 +379,9 @@ const mapDispatchToProps = dispatch => ({
     },
     onRequestCloseCameraModal: () => {
         dispatch(closeCameraCapture());
+    },
+    dispatchUpdateRestore: restoreState => {
+        dispatch(setRestore(restoreState));
     }
 });
 


### PR DESCRIPTION
### Resolves

Restoring the last deleted costume (no issue filed).

### Proposed Changes

Update the restore function state when deleting a costume. This should change the menu option in the Edit menu to read `Restore Costume`. Using the option should restore the costume that was last deleted.

#### Known Issues
- restoring a costume does not navigate back to the sound pane of the target whose sound was restored.
- restoring a costume adds it to the end of the sprite's sounds list (this is consistent with 2.0).

### Test Coverage

Manually tested. You can test here: https://llk.github.io/scratch-gui/restore-costume/

### Related PRs
LLK/scratch-vm#1511

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
