### PR TITLE
Inject fonts thumbnails

### DIFF
--- a/src/containers/sprite-selector-item.jsx
+++ b/src/containers/sprite-selector-item.jsx
@@ -12,6 +12,8 @@ import {SVGRenderer} from 'scratch-svg-renderer';
 import SpriteSelectorItemComponent from '../components/sprite-selector-item/sprite-selector-item.jsx';
 
 const dragThreshold = 3; // Same as the block drag threshold
+// Contains 'font-family', but doesn't only contain 'font-family="none"'
+const HAS_FONT_REGEXP = new RegExp('font-family(?!="none")', 'g');
 
 class SpriteSelectorItem extends React.Component {
     constructor (props) {
@@ -42,9 +44,11 @@ class SpriteSelectorItem extends React.Component {
         // Avoid parsing the SVG when possible, since it's expensive.
         if (asset.assetType === storage.AssetType.ImageVector) {
             const svgString = this.props.vm.runtime.storage.get(this.props.assetId).decodeText();
-            if (svgString.indexOf('font-family') !== -1) {
+            if (svgString.match(HAS_FONT_REGEXP)) {
                 // If the asset ID has not changed, no need to re-parse
-                if (this.svgRendererAssetId === this.props.assetId) return this.cachedUrl;
+                if (this.svgRendererAssetId === this.props.assetId) {
+                    return this.cachedUrl;
+                }
 
                 this.svgRendererAssetId = this.props.assetId;
                 this.svgRenderer.loadString(svgString);

--- a/src/containers/sprite-selector-item.jsx
+++ b/src/containers/sprite-selector-item.jsx
@@ -43,13 +43,13 @@ class SpriteSelectorItem extends React.Component {
         // If the SVG refers to fonts, they must be inlined in order to display correctly in the img tag.
         // Avoid parsing the SVG when possible, since it's expensive.
         if (asset.assetType === storage.AssetType.ImageVector) {
+            // If the asset ID has not changed, no need to re-parse
+            if (this.svgRendererAssetId === this.props.assetId) {
+                return this.cachedUrl;
+            }
+
             const svgString = this.props.vm.runtime.storage.get(this.props.assetId).decodeText();
             if (svgString.match(HAS_FONT_REGEXP)) {
-                // If the asset ID has not changed, no need to re-parse
-                if (this.svgRendererAssetId === this.props.assetId) {
-                    return this.cachedUrl;
-                }
-
                 this.svgRendererAssetId = this.props.assetId;
                 this.svgRenderer.loadString(svgString);
                 const svgText = this.svgRenderer.toString(true /* shouldInjectFonts */);

--- a/src/containers/sprite-selector-item.jsx
+++ b/src/containers/sprite-selector-item.jsx
@@ -13,7 +13,7 @@ import SpriteSelectorItemComponent from '../components/sprite-selector-item/spri
 
 const dragThreshold = 3; // Same as the block drag threshold
 // Contains 'font-family', but doesn't only contain 'font-family="none"'
-const HAS_FONT_REGEXP = new RegExp('font-family(?!="none")', 'g');
+const HAS_FONT_REGEXP = 'font-family(?!="none")';
 
 class SpriteSelectorItem extends React.Component {
     constructor (props) {
@@ -137,6 +137,7 @@ class SpriteSelectorItem extends React.Component {
             dragPayload,
             receivedBlocks,
             costumeURL,
+            vm,
             /* eslint-enable no-unused-vars */
             ...props
         } = this.props;
@@ -191,8 +192,12 @@ const mapDispatchToProps = dispatch => ({
     onDrag: data => dispatch(updateAssetDrag(data))
 });
 
-
-export default connect(
+const ConnectedComponent = connect(
     mapStateToProps,
     mapDispatchToProps
 )(SpriteSelectorItem);
+
+export {
+    ConnectedComponent as default,
+    HAS_FONT_REGEXP // Exposed for testing
+};

--- a/test/unit/containers/sprite-selector-item.test.jsx
+++ b/test/unit/containers/sprite-selector-item.test.jsx
@@ -57,14 +57,6 @@ describe('SpriteSelectorItem Container', () => {
         expect(onDeleteButtonClick).toHaveBeenCalledWith(1337);
     });
 
-    test('should not delete the sprite if the user cancels', () => {
-        global.confirm = jest.fn(() => false);
-        const wrapper = mountWithIntl(getContainer());
-        wrapper.find(CloseButton).simulate('click');
-        expect(global.confirm).toHaveBeenCalled();
-        expect(onDeleteButtonClick).not.toHaveBeenCalled();
-    });
-
     test('Has font regexp works', () => {
         expect('font-family="Sans Serif"'.match(HAS_FONT_REGEXP)).toBeTruthy();
         expect('font-family="none" font-family="Sans Serif"'.match(HAS_FONT_REGEXP)).toBeTruthy();

--- a/test/unit/containers/sprite-selector-item.test.jsx
+++ b/test/unit/containers/sprite-selector-item.test.jsx
@@ -4,6 +4,7 @@ import configureStore from 'redux-mock-store';
 import {Provider} from 'react-redux';
 
 import SpriteSelectorItem from '../../../src/containers/sprite-selector-item';
+import {HAS_FONT_REGEXP} from '../../../src/containers/sprite-selector-item';
 import CloseButton from '../../../src/components/close-button/close-button';
 
 describe('SpriteSelectorItem Container', () => {
@@ -54,5 +55,19 @@ describe('SpriteSelectorItem Container', () => {
         const wrapper = mountWithIntl(getContainer());
         wrapper.find(CloseButton).simulate('click');
         expect(onDeleteButtonClick).toHaveBeenCalledWith(1337);
+    });
+
+    test('should not delete the sprite if the user cancels', () => {
+        global.confirm = jest.fn(() => false);
+        const wrapper = mountWithIntl(getContainer());
+        wrapper.find(CloseButton).simulate('click');
+        expect(global.confirm).toHaveBeenCalled();
+        expect(onDeleteButtonClick).not.toHaveBeenCalled();
+    });
+
+    test('Has font regexp works', () => {
+        expect('font-family="Sans Serif"'.match(HAS_FONT_REGEXP)).toBeTruthy();
+        expect('font-family="none"'.match(HAS_FONT_REGEXP)).toBeFalsy();
+        expect('font-family="none" font-family="Sans Serif"'.match(HAS_FONT_REGEXP)).toBeTruthy();
     });
 });

--- a/test/unit/containers/sprite-selector-item.test.jsx
+++ b/test/unit/containers/sprite-selector-item.test.jsx
@@ -67,7 +67,9 @@ describe('SpriteSelectorItem Container', () => {
 
     test('Has font regexp works', () => {
         expect('font-family="Sans Serif"'.match(HAS_FONT_REGEXP)).toBeTruthy();
-        expect('font-family="none"'.match(HAS_FONT_REGEXP)).toBeFalsy();
         expect('font-family="none" font-family="Sans Serif"'.match(HAS_FONT_REGEXP)).toBeTruthy();
+        expect('font-family = "Sans Serif"'.match(HAS_FONT_REGEXP)).toBeTruthy();
+
+        expect('font-family="none"'.match(HAS_FONT_REGEXP)).toBeFalsy();
     });
 });


### PR DESCRIPTION
### Resolves
Fixes https://github.com/LLK/scratch-gui/issues/2762

### Proposed Changes
Inject fonts before setting SVG as image source on thumbnails

### Reason for Changes
This allows thumbnails to render Scratch's fonts correctly

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
