### PR TITLE
Remove confirmation dialog when deleting a sprite, costume, or sound.

### DIFF
--- a/src/containers/sprite-selector-item.jsx
+++ b/src/containers/sprite-selector-item.jsx
@@ -2,7 +2,6 @@ import bindAll from 'lodash.bindall';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
-import {defineMessages, injectIntl, intlShape} from 'react-intl';
 
 import {setHoveredSprite} from '../reducers/hovered-target';
 import {updateAssetDrag} from '../reducers/asset-drag';
@@ -11,14 +10,6 @@ import {getEventXY} from '../lib/touch-utils';
 import SpriteSelectorItemComponent from '../components/sprite-selector-item/sprite-selector-item.jsx';
 
 const dragThreshold = 3; // Same as the block drag threshold
-
-const messages = defineMessages({
-    deleteSpriteConfirmation: {
-        defaultMessage: 'Are you sure you want to delete this?',
-        description: 'Confirmation for deleting sprites',
-        id: 'gui.spriteSelectorItem.deleteSpriteConfirmation'
-    }
-});
 
 class SpriteSelectorItem extends React.Component {
     constructor (props) {
@@ -141,7 +132,6 @@ SpriteSelectorItem.propTypes = {
     dragType: PropTypes.string,
     id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     index: PropTypes.number,
-    intl: intlShape.isRequired,
     name: PropTypes.string,
     onClick: PropTypes.func,
     onDeleteButtonClick: PropTypes.func,
@@ -169,4 +159,4 @@ const mapDispatchToProps = dispatch => ({
 export default connect(
     mapStateToProps,
     mapDispatchToProps
-)(injectIntl(SpriteSelectorItem));
+)(SpriteSelectorItem);

--- a/src/containers/sprite-selector-item.jsx
+++ b/src/containers/sprite-selector-item.jsx
@@ -84,10 +84,7 @@ class SpriteSelectorItem extends React.Component {
     }
     handleDelete (e) {
         e.stopPropagation(); // To prevent from bubbling back to handleClick
-        // eslint-disable-next-line no-alert
-        if (window.confirm(this.props.intl.formatMessage(messages.deleteSpriteConfirmation))) {
-            this.props.onDeleteButtonClick(this.props.id);
-        }
+        this.props.onDeleteButtonClick(this.props.id);
     }
     handleDuplicate (e) {
         e.stopPropagation(); // To prevent from bubbling back to handleClick

--- a/test/integration/sounds.test.js
+++ b/test/integration/sounds.test.js
@@ -33,8 +33,6 @@ describe('Working with sounds', () => {
         // Delete the sound
         await rightClickText('Meow', scope.soundsTab);
         await clickText('delete', scope.soundsTab);
-        await driver.switchTo().alert()
-            .accept();
 
         // Add it back
         await clickXpath('//button[@aria-label="Choose a Sound"]');

--- a/test/integration/sprites.test.js
+++ b/test/integration/sprites.test.js
@@ -55,8 +55,6 @@ describe('Working with sprites', () => {
         await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for scroll animation
         await rightClickText('Sprite1', scope.spriteTile);
         await clickText('delete', scope.spriteTile);
-        await driver.switchTo().alert()
-            .accept();
         // Confirm that the stage has been switched to
         await findByText('Stage selected: no motion blocks');
         const logs = await getLogs();

--- a/test/unit/containers/sprite-selector-item.test.jsx
+++ b/test/unit/containers/sprite-selector-item.test.jsx
@@ -48,22 +48,11 @@ describe('SpriteSelectorItem Container', () => {
         onDeleteButtonClick = jest.fn();
         dispatchSetHoveredSprite = jest.fn();
         selected = true;
-        // Mock window.confirm() which is called when the close button is clicked.
-        global.confirm = jest.fn(() => true);
     });
 
-    test('should confirm if the user really wants to delete the sprite', () => {
+    test('should delete the sprite', () => {
         const wrapper = mountWithIntl(getContainer());
         wrapper.find(CloseButton).simulate('click');
-        expect(global.confirm).toHaveBeenCalled();
         expect(onDeleteButtonClick).toHaveBeenCalledWith(1337);
-    });
-
-    test('should not delete the sprite if the user cancels', () => {
-        global.confirm = jest.fn(() => false);
-        const wrapper = mountWithIntl(getContainer());
-        wrapper.find(CloseButton).simulate('click');
-        expect(global.confirm).toHaveBeenCalled();
-        expect(onDeleteButtonClick).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
### Proposed Changes

Remove the confirmation dialog that pops up when attempting to delete a sprite, costume, or sound.

### Reason for Changes

Now that the ability to restore the last deleted item has been added, this confirmation is no longer necessary.

### Test Coverage

Tested manually.
Updated existing tests to remove the confirmation dialog checks.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
