### PR TITLE
Fix warnings

### DIFF
--- a/src/containers/controls.jsx
+++ b/src/containers/controls.jsx
@@ -64,5 +64,7 @@ const mapStateToProps = state => ({
     projectRunning: state.scratchGui.vmStatus.running,
     turbo: state.scratchGui.vmStatus.turbo
 });
+// no-op function to prevent dispatch prop being passed to component
+const mapDispatchToProps = () => ({});
 
-export default connect(mapStateToProps)(Controls);
+export default connect(mapStateToProps, mapDispatchToProps)(Controls);

--- a/src/containers/error-boundary.jsx
+++ b/src/containers/error-boundary.jsx
@@ -78,6 +78,6 @@ const mapStateToProps = state => ({
 });
 
 // no-op function to prevent dispatch prop being passed to component
-const mapDispatchToProps = () => {};
+const mapDispatchToProps = () => ({});
 
 export default connect(mapStateToProps, mapDispatchToProps)(ErrorBoundary);

--- a/src/lib/vm-listener-hoc.jsx
+++ b/src/lib/vm-listener-hoc.jsx
@@ -89,6 +89,10 @@ const vmListenerHOC = function (WrappedComponent) {
                 onKeyUp,
                 onMonitorsUpdate,
                 onTargetsUpdate,
+                onProjectRunStart,
+                onProjectRunStop,
+                onTurboModeOff,
+                onTurboModeOn,
                 /* eslint-enable no-unused-vars */
                 ...props
             } = this.props;


### PR DESCRIPTION
### Proposed Changes

- Add correct empty MapDispatchToProps to components to prevent dispatch being passed as prop
- remove `on…` VM listeners from props passed to wrapped component.

### Reason for Changes

All the warnings in console had been bugging me so I fixed them

### Test Coverage

- Fewer warning show up in the console
- Normal tests run

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
