### PR TITLE
Pass RTL state to paint editor

### DIFF
--- a/src/containers/paint-editor-wrapper.jsx
+++ b/src/containers/paint-editor-wrapper.jsx
@@ -56,6 +56,7 @@ PaintEditorWrapper.propTypes = {
     name: PropTypes.string,
     rotationCenterX: PropTypes.number,
     rotationCenterY: PropTypes.number,
+    rtl: PropTypes.bool,
     selectedCostumeIndex: PropTypes.number.isRequired,
     vm: PropTypes.instanceOf(VM)
 };
@@ -74,6 +75,7 @@ const mapStateToProps = (state, {selectedCostumeIndex}) => {
         imageFormat: costume && costume.dataFormat,
         imageId: targetId && `${targetId}${costume.skinId}`,
         image: state.scratchGui.vm.getCostume(index),
+        rtl: state.locales.isRtl,
         vm: state.scratchGui.vm
     };
 };


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/LLK/scratch-paint/issues/614

### Proposed Changes

Pass rtl prop to paint so it can handle RTL layout

### Testing
- color picker should have text to the right