### PR TITLE
Add Intl to Crash Message Component.

### DIFF
--- a/src/components/crash-message/crash-message.jsx
+++ b/src/components/crash-message/crash-message.jsx
@@ -1,12 +1,7 @@
-/* eslint-disable react/jsx-no-literals */
-/*
-    @todo Rule is disabled because this component is rendered outside the
-    intl provider right now so cannot be translated.
-*/
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import Box from '../box/box.jsx';
+import {FormattedMessage} from 'react-intl';
 
 import styles from './crash-message.css';
 import reloadIcon from './reload.svg';
@@ -19,19 +14,30 @@ const CrashMessage = props => (
                 src={reloadIcon}
             />
             <h2>
-                Oops! Something went wrong.
+                <FormattedMessage
+                    defaultMessage="Oops! Something went wrong."
+                    description="Crash Message title"
+                    id="gui.crashMessage.label"
+                />
             </h2>
             <p>
-                We are so sorry, but it looks like Scratch has crashed. This bug has been
-                automatically reported to the Scratch Team. Please refresh your page to try
-                again.
-
+                <FormattedMessage
+                    defaultMessage="We are so sorry, but it looks like Scratch has crashed. This bug has been
+                        automatically reported to the Scratch Team. Please refresh your page to try
+                        again."
+                    description="Message to inform the user that page has crashed."
+                    id="gui.crashMessage.description"
+                />
             </p>
             <button
                 className={styles.reloadButton}
                 onClick={props.onReload}
             >
-                Reload
+                <FormattedMessage
+                    defaultMessage="Reload"
+                    description="Button to reload the page when page crashes"
+                    id="gui.crashMessage.reload"
+                />
             </button>
         </Box>
     </div>


### PR DESCRIPTION
### Resolves

- Resolve # [2984](https://github.com/LLK/scratch-gui/issues/2984)

### Proposed Changes

Allows Crash Message Component to be translated.

### Reason for Changes

The text in the component was a string literal.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
