### PR TITLE
[Master] Split BrowserModalComponent out of GUI

### DIFF
--- a/src/components/browser-modal/browser-modal.jsx
+++ b/src/components/browser-modal/browser-modal.jsx
@@ -84,4 +84,8 @@ BrowserModal.propTypes = {
     onBack: PropTypes.func.isRequired
 };
 
-export default injectIntl(BrowserModal);
+const WrappedBrowserModal = injectIntl(BrowserModal);
+
+WrappedBrowserModal.setAppElement = ReactModal.setAppElement;
+
+export default WrappedBrowserModal;

--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -115,8 +115,8 @@ const GUIComponent = props => {
                 dir={isRtl ? 'rtl' : 'ltr'}
                 {...componentProps}
             >
-                {previewInfoVisible ? (
-                    <PreviewModal hideIntro={hideIntro} />
+                {(previewInfoVisible && !hideIntro) ? (
+                    <PreviewModal />
                 ) : null}
                 {loading ? (
                     <Loader />
@@ -282,7 +282,6 @@ GUIComponent.propTypes = {
     costumeLibraryVisible: PropTypes.bool,
     costumesTabVisible: PropTypes.bool,
     enableCommunity: PropTypes.bool,
-    hideIntro: PropTypes.bool,
     importInfoVisible: PropTypes.bool,
     intl: intlShape.isRequired,
     isPlayerOnly: PropTypes.bool,

--- a/src/containers/gui.jsx
+++ b/src/containers/gui.jsx
@@ -72,12 +72,15 @@ class GUI extends React.Component {
                 `Failed to load project from server [id=${window.location.hash}]: ${this.state.errorMessage}`);
         }
         const {
-            assetHost, // eslint-disable-line no-unused-vars
+            /* eslint-disable no-unused-vars */
+            assetHost,
+            hideIntro,
+            projectData,
+            projectHost,
+            /* eslint-enable no-unused-vars */
             children,
             fetchingProject,
             loadingStateVisible,
-            projectData, // eslint-disable-line no-unused-vars
-            projectHost, // eslint-disable-line no-unused-vars
             vm,
             ...componentProps
         } = this.props;
@@ -97,6 +100,7 @@ GUI.propTypes = {
     assetHost: PropTypes.string,
     children: PropTypes.node,
     fetchingProject: PropTypes.bool,
+    hideIntro: PropTypes.bool,
     importInfoVisible: PropTypes.bool,
     loadingStateVisible: PropTypes.bool,
     onSeeCommunity: PropTypes.func,
@@ -106,7 +110,7 @@ GUI.propTypes = {
     vm: PropTypes.instanceOf(VM)
 };
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state, ownProps) => ({
     activeTabIndex: state.scratchGui.editorTab.activeTabIndex,
     backdropLibraryVisible: state.scratchGui.modals.backdropLibrary,
     blocksTabVisible: state.scratchGui.editorTab.activeTabIndex === BLOCKS_TAB_INDEX,
@@ -117,7 +121,7 @@ const mapStateToProps = state => ({
     isPlayerOnly: state.scratchGui.mode.isPlayerOnly,
     isRtl: state.locales.isRtl,
     loadingStateVisible: state.scratchGui.modals.loadingProject,
-    previewInfoVisible: state.scratchGui.modals.previewInfo,
+    previewInfoVisible: state.scratchGui.modals.previewInfo && !ownProps.hideIntro,
     targetIsStage: (
         state.scratchGui.targets.stage &&
         state.scratchGui.targets.stage.id === state.scratchGui.targets.editingTarget

--- a/src/containers/preview-modal.jsx
+++ b/src/containers/preview-modal.jsx
@@ -6,8 +6,6 @@ import {connect} from 'react-redux';
 import tabletFullScreen from '../lib/tablet-full-screen';
 
 import PreviewModalComponent from '../components/preview-modal/preview-modal.jsx';
-import BrowserModalComponent from '../components/browser-modal/browser-modal.jsx';
-import supportedBrowser from '../lib/supported-browser';
 
 import {
     closePreviewInfo,
@@ -27,25 +25,6 @@ class PreviewModal extends React.Component {
             previewing: false
         };
     }
-
-    /**
-     * Conditionally returns an intro modal depending on the hideIntro prop
-     * @returns { React.Component | null } null if hideIntro is true, the intro modal component otherwise
-     */
-    introIfShown () {
-        if (this.props.hideIntro) {
-            return null; // If hideIntro is true, the intro modal should not appear
-        }
-
-        // otherwise, show the intro modal
-        return (<PreviewModalComponent
-            isRtl={this.props.isRtl}
-            previewing={this.state.previewing}
-            onCancel={this.handleCancel}
-            onTryIt={this.handleTryIt}
-            onViewProject={this.handleViewProject}
-        />);
-    }
     handleTryIt () {
         this.setState({previewing: true});
         // try to run in fullscreen mode on tablets.
@@ -59,18 +38,19 @@ class PreviewModal extends React.Component {
         this.props.onViewProject();
     }
     render () {
-        return (supportedBrowser() ?
-            this.introIfShown() :
-            <BrowserModalComponent
+        return (
+            <PreviewModalComponent
                 isRtl={this.props.isRtl}
-                onBack={this.handleCancel}
+                previewing={this.state.previewing}
+                onCancel={this.handleCancel}
+                onTryIt={this.handleTryIt}
+                onViewProject={this.handleViewProject}
             />
         );
     }
 }
 
 PreviewModal.propTypes = {
-    hideIntro: PropTypes.bool,
     isRtl: PropTypes.bool,
     onTryIt: PropTypes.func,
     onViewProject: PropTypes.func

--- a/src/playground/index.jsx
+++ b/src/playground/index.jsx
@@ -7,16 +7,11 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 import analytics from '../lib/analytics';
-import GUI from '../containers/gui.jsx';
-import HashParserHOC from '../lib/hash-parser-hoc.jsx';
 import AppStateHOC from '../lib/app-state-hoc.jsx';
+import BrowserModalComponent from '../components/browser-modal/browser-modal.jsx';
+import supportedBrowser from '../lib/supported-browser';
 
 import styles from './index.css';
-
-if (process.env.NODE_ENV === 'production' && typeof window === 'object') {
-    // Warn before navigating away
-    window.onbeforeunload = () => true;
-}
 
 // Register "base" page view
 analytics.pageview('/');
@@ -25,16 +20,15 @@ const appTarget = document.createElement('div');
 appTarget.className = styles.app;
 document.body.appendChild(appTarget);
 
-GUI.setAppElement(appTarget);
-const WrappedGui = HashParserHOC(AppStateHOC(GUI));
+if (supportedBrowser()) {
+    // require needed here to avoid importing unsupported browser-crashing code
+    // at the top level
+    require('./render-gui.jsx').default(appTarget);
 
-// TODO a hack for testing the backpack, allow backpack host to be set by url param
-const backpackHostMatches = window.location.href.match(/[?&]backpack_host=([^&]*)&?/);
-const backpackHost = backpackHostMatches ? backpackHostMatches[1] : null;
-
-const backpackOptions = {
-    visible: true,
-    host: backpackHost
-};
-
-ReactDOM.render(<WrappedGui backpackOptions={backpackOptions} />, appTarget);
+} else {
+    BrowserModalComponent.setAppElement(appTarget);
+    const WrappedBrowserModalComponent = AppStateHOC(BrowserModalComponent, true /* localesOnly */);
+    const handleBack = () => {};
+    // eslint-disable-next-line react/jsx-no-bind
+    ReactDOM.render(<WrappedBrowserModalComponent onBack={handleBack} />, appTarget);
+}

--- a/src/playground/render-gui.jsx
+++ b/src/playground/render-gui.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import AppStateHOC from '../lib/app-state-hoc.jsx';
+import GUI from '../containers/gui.jsx';
+import HashParserHOC from '../lib/hash-parser-hoc.jsx';
+
+/*
+ * Render the GUI playground. This is a separate function because importing anything
+ * that instantiates the VM causes unsupported browsers to crash
+ * {object} appTarget - the DOM element to render to
+ */
+export default appTarget => {
+    GUI.setAppElement(appTarget);
+    const WrappedGui = HashParserHOC(AppStateHOC(GUI));
+
+    // TODO a hack for testing the backpack, allow backpack host to be set by url param
+    const backpackHostMatches = window.location.href.match(/[?&]backpack_host=([^&]*)&?/);
+    const backpackHost = backpackHostMatches ? backpackHostMatches[1] : null;
+
+    const backpackOptions = {
+        visible: true,
+        host: backpackHost
+    };
+    if (process.env.NODE_ENV === 'production' && typeof window === 'object') {
+        // Warn before navigating away
+        window.onbeforeunload = () => true;
+    }
+
+    ReactDOM.render(<WrappedGui backpackOptions={backpackOptions} />, appTarget);
+};


### PR DESCRIPTION
I know this is pretty ugly, but I think what we want to avoid crashing unsupported browsers

### Resolves

_What Github issue does this resolve (please include link)?_
Resolves failing smoke test in #2980 (already merged). _Should_ future-proof us from this type of regression in the future (Hello from the past future us! Sorry!)

### Proposed Changes

_Describe what this Pull Request does_
This splits the BrowserModalComponent out of the GUI, and protects all GUI-related modules from being imported unless the GUI is actually being mounted.  This protects unsupported browsers from running code that will crash them (like the VM).

### Reason for Changes

_Explain why these changes should be made_
If the VM is ever instantiated, which happens whenever GUI is instantiated due to default props, then IE11 will crash. So mount the BrowserModalComponent in a separate code path from the GUI, so that it can be displayed regardless of the code required by the GUI.

### Test Coverage

_Please show how you have added tests to cover your changes_
Failing smoke test now passes!

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [X] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [X] IE 11
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
