### PR TITLE
make project title editable, both in standalone and www modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,32 +47,69 @@ Instead of `BUILD_MODE=dist npm run build` you can also use `BUILD_MODE=dist npm
 * Follow the recipe above step by step and don't change the order. It is especially important to run npm first because installing after the linking will reset the linking.
 * Make sure the repositories are siblings on your machine's file tree.
 * If you have multiple Terminal tabs or windows open for the different Scratch repositories, make sure to use the same node version in all of them.
-* In the worst case unlink the repositories with `npm unlink` and start over.
+* In the worst case unlink the repositories by running `npm unlink` in both, and start over.
 
 ## Testing
-NOTE: If you're a windows user, please run these scripts in Windows `cmd.exe`  instead of Git Bash/MINGW64.
 
-Run linter, unit tests, build, and integration tests.
+### Documentation
+
+You may want to review the documentation for [Jest](https://facebook.github.io/jest/docs/en/api.html) and [Enzyme](http://airbnb.io/enzyme/docs/api/) as you write your tests.
+
+See [jest cli docs](https://facebook.github.io/jest/docs/en/cli.html#content) for more options.
+
+### Running tests
+
+*NOTE: If you're a windows user, please run these scripts in Windows `cmd.exe`  instead of Git Bash/MINGW64.*
+
+Before running any test, make sure you have run `npm install` from this (scratch-gui) repository's top level.
+
+#### Main testing command
+
+To run linter, unit tests, build, and integration tests, all at once:
 ```bash
 npm test
 ```
 
-Run unit tests in isolation.
+#### Running unit tests
+
+To run unit tests in isolation:
 ```bash
-npm run unit-test
+npm run test:unit
 ```
 
-Run unit tests in watch mode (watches for code changes and continuously runs tests). See [jest cli docs](https://facebook.github.io/jest/docs/en/cli.html#content) for more options.
+To run unit tests in watch mode (watches for code changes and continuously runs tests):
 ```bash
-npm run unit-test -- --watch
+npm run test:unit -- --watch
 ```
 
-Run integration tests in isolation.
+#### Running integration tests
+
+Integration tests use a headless browser to manipulate the actual html and javascript that the repo
+produces. You will not see this activity (though you can hear it when sounds are played!).
+
+Note that integration tests require you to first create a build that can be loaded in a browser:
+
 ```bash
-npm run integration-test
+npm run build
 ```
 
-You may want to review the documentation for [Jest](https://facebook.github.io/jest/docs/en/api.html) and [Enzyme](http://airbnb.io/enzyme/docs/api/) as you write your tests.
+Then, you can run all integration tests:
+
+```bash
+npm run test:integration
+```
+
+Or, you can run a single file of integration tests (in this example, the `backpack` tests):
+
+```bash
+$(npm bin)/jest --runInBand test/integration/backpack.test.js
+```
+
+If you want to watch the browser as it runs the test, rather than running headless, use:
+
+```bash
+USE_HEADLESS=no $(npm bin)/jest --runInBand test/integration/backpack.test.js
+```
 
 ## Publishing to GitHub Pages
 You can publish the GUI to github.io so that others on the Internet can view it.

--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -74,6 +74,7 @@ const GUIComponent = props => {
         onRequestCloseBackdropLibrary,
         onRequestCloseCostumeLibrary,
         onSeeCommunity,
+        onUpdateProjectTitle,
         previewInfoVisible,
         targetIsStage,
         soundsTabVisible,
@@ -147,6 +148,7 @@ const GUIComponent = props => {
                 <MenuBar
                     enableCommunity={enableCommunity}
                     onSeeCommunity={onSeeCommunity}
+                    onUpdateProjectTitle={onUpdateProjectTitle}
                 />
                 <Box className={styles.bodyWrapper}>
                     <Box className={styles.flexWrapper}>
@@ -294,6 +296,7 @@ GUIComponent.propTypes = {
     onRequestCloseCostumeLibrary: PropTypes.func,
     onSeeCommunity: PropTypes.func,
     onTabSelect: PropTypes.func,
+    onUpdateProjectTitle: PropTypes.func,
     previewInfoVisible: PropTypes.bool,
     soundsTabVisible: PropTypes.bool,
     stageSizeMode: PropTypes.oneOf(Object.keys(STAGE_SIZE_MODES)),

--- a/src/components/menu-bar/menu-bar.css
+++ b/src/components/menu-bar/menu-bar.css
@@ -109,22 +109,6 @@
     height: 34px;
 }
 
-.title-field {
-    border: 1px dashed $ui-black-transparent;
-    border-radius: .25rem;
-    width: 12rem;
-    height: 34px;
-    background-color: transparent;
-    padding: .5rem;
-}
-
-.title-field,
-.title-field::placeholder {
-    color: $ui-white;
-    font-weight: bold;
-    font-size: .8rem;
-}
-
 .share-button {
     background: $data-primary;
     height: 32px;

--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -13,6 +13,7 @@ import LanguageSelector from '../../containers/language-selector.jsx';
 import ProjectLoader from '../../containers/project-loader.jsx';
 import Menu from '../../containers/menu.jsx';
 import {MenuItem, MenuSection} from '../menu/menu.jsx';
+import ProjectTitleInput from './project-title-input.jsx';
 import ProjectSaver from '../../containers/project-saver.jsx';
 import DeletionRestorer from '../../containers/deletion-restorer.jsx';
 import TurboMode from '../../containers/turbo-mode.jsx';
@@ -393,11 +394,12 @@ class MenuBar extends React.Component {
                     </div>
                     <Divider className={classNames(styles.divider)} />
                     <div className={classNames(styles.menuBarItem)}>
-                        <MenuBarItemTooltip id="title-field">
-                            <input
-                                disabled
-                                className={classNames(styles.titleField)}
-                                placeholder="Untitled-1"
+                        <MenuBarItemTooltip
+                            enable
+                            id="title-field"
+                        >
+                            <ProjectTitleInput
+                                onUpdateProjectTitle={this.props.onUpdateProjectTitle}
                             />
                         </MenuBarItemTooltip>
                     </div>
@@ -521,7 +523,8 @@ MenuBar.propTypes = {
     onRequestCloseEdit: PropTypes.func,
     onRequestCloseFile: PropTypes.func,
     onRequestCloseLanguage: PropTypes.func,
-    onSeeCommunity: PropTypes.func
+    onSeeCommunity: PropTypes.func,
+    onUpdateProjectTitle: PropTypes.func
 };
 
 const mapStateToProps = state => ({

--- a/src/components/menu-bar/project-title-input.css
+++ b/src/components/menu-bar/project-title-input.css
@@ -17,11 +17,17 @@ $title-width: 12rem;
     padding: .5rem;
 }
 
-.title-field,
-.title-field::placeholder {
+.title-field {
     color: $ui-white;
     font-weight: bold;
     font-size: .8rem;
+}
+
+.title-field::placeholder {
+    color: $ui-white;
+    font-weight: normal;
+    font-size: .8rem;
+    font-style: italic;
 }
 
 .title-field:hover {
@@ -30,7 +36,7 @@ $title-width: 12rem;
 
 .title-field:focus {
     outline:none;
-    border: none;
+    border: 1px solid $ui-transparent;
     -webkit-box-shadow: 0 0 0 calc($space * .5) $ui-white-transparent;
     box-shadow: 0 0 0 calc($space * .5) $ui-white-transparent;
     background-color: $ui-white;

--- a/src/components/menu-bar/project-title-input.css
+++ b/src/components/menu-bar/project-title-input.css
@@ -1,0 +1,38 @@
+@import "../../css/colors.css";
+@import "../../css/units.css";
+@import "../../css/z-index.css";
+
+$title-width: 12rem;
+
+.title-field {
+    border: 1px dashed $ui-black-transparent;
+    border-radius: $form-radius;
+    -webkit-border-radius: $form-radius;
+    -moz-border-radius: $form-radius;
+    background-color: $ui-white-transparent;
+    background-clip: padding-box;
+    -webkit-background-clip: padding-box;
+    width: $title-width;
+    height: auto;
+    padding: .5rem;
+}
+
+.title-field,
+.title-field::placeholder {
+    color: $ui-white;
+    font-weight: bold;
+    font-size: .8rem;
+}
+
+.title-field:hover {
+    background-color: hsla(0, 100%, 100%, 0.5);
+}
+
+.title-field:focus {
+    outline:none;
+    border: none;
+    -webkit-box-shadow: 0 0 0 calc($space * .5) $ui-white-transparent;
+    box-shadow: 0 0 0 calc($space * .5) $ui-white-transparent;
+    background-color: $ui-white;
+    color: $text-primary;
+}

--- a/src/components/menu-bar/project-title-input.jsx
+++ b/src/components/menu-bar/project-title-input.jsx
@@ -3,12 +3,21 @@ import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
 import bindAll from 'lodash.bindall';
 import React from 'react';
+import {defineMessages, intlShape, injectIntl} from 'react-intl';
 
 import BufferedInputHOC from '../forms/buffered-input-hoc.jsx';
 import Input from '../forms/input.jsx';
 const BufferedInput = BufferedInputHOC(Input);
 
 import styles from './project-title-input.css';
+
+const messages = defineMessages({
+    projectTitlePlaceholder: {
+        id: 'gui.gui.projectTitlePlaceholder',
+        description: 'Placeholder for project title when blank',
+        defaultMessage: 'Project title here'
+    }
+});
 
 class ProjectTitleInput extends React.Component {
     constructor (props) {
@@ -28,8 +37,8 @@ class ProjectTitleInput extends React.Component {
         return (
             <BufferedInput
                 className={classNames(styles.titleField)}
-                maxlength="100"
-                placeholder=""
+                maxLength="100"
+                placeholder={this.props.intl.formatMessage(messages.projectTitlePlaceholder)}
                 tabIndex="0"
                 type="text"
                 value={this.props.projectTitle}
@@ -40,6 +49,7 @@ class ProjectTitleInput extends React.Component {
 }
 
 ProjectTitleInput.propTypes = {
+    intl: intlShape.isRequired,
     onUpdateProjectTitle: PropTypes.func,
     projectTitle: PropTypes.string
 };
@@ -50,7 +60,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = () => ({});
 
-export default connect(
+export default injectIntl(connect(
     mapStateToProps,
     mapDispatchToProps
-)(ProjectTitleInput);
+)(ProjectTitleInput));

--- a/src/components/menu-bar/project-title-input.jsx
+++ b/src/components/menu-bar/project-title-input.jsx
@@ -1,0 +1,56 @@
+import classNames from 'classnames';
+import {connect} from 'react-redux';
+import PropTypes from 'prop-types';
+import bindAll from 'lodash.bindall';
+import React from 'react';
+
+import BufferedInputHOC from '../forms/buffered-input-hoc.jsx';
+import Input from '../forms/input.jsx';
+const BufferedInput = BufferedInputHOC(Input);
+
+import styles from './project-title-input.css';
+
+class ProjectTitleInput extends React.Component {
+    constructor (props) {
+        super(props);
+        bindAll(this, [
+            'handleUpdateProjectTitle'
+        ]);
+    }
+    // call onUpdateProjectTitle if it is defined (only defined when gui
+    // is used within scratch-www)
+    handleUpdateProjectTitle (newTitle) {
+        if (this.props.onUpdateProjectTitle) {
+            this.props.onUpdateProjectTitle(newTitle);
+        }
+    }
+    render () {
+        return (
+            <BufferedInput
+                className={classNames(styles.titleField)}
+                maxlength="100"
+                placeholder=""
+                tabIndex="0"
+                type="text"
+                value={this.props.projectTitle}
+                onSubmit={this.handleUpdateProjectTitle}
+            />
+        );
+    }
+}
+
+ProjectTitleInput.propTypes = {
+    onUpdateProjectTitle: PropTypes.func,
+    projectTitle: PropTypes.string
+};
+
+const mapStateToProps = state => ({
+    projectTitle: state.scratchGui.projectTitle
+});
+
+const mapDispatchToProps = () => ({});
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(ProjectTitleInput);

--- a/src/components/prompt/prompt.jsx
+++ b/src/components/prompt/prompt.jsx
@@ -48,6 +48,7 @@ const PromptComponent = props => (
                 <input
                     autoFocus
                     className={styles.variableNameTextInput}
+                    name={props.label}
                     placeholder={props.placeholder}
                     onChange={props.onChange}
                     onKeyPress={props.onKeyPress}

--- a/src/containers/gui.jsx
+++ b/src/containers/gui.jsx
@@ -35,6 +35,10 @@ class GUI extends React.Component {
         };
     }
     componentDidMount () {
+        if (this.props.projectTitle) {
+            this.props.onUpdateReduxProjectTitle(this.props.projectTitle);
+        }
+
         if (this.props.vm.initialized) return;
         this.audioEngine = new AudioEngine();
         this.props.vm.attachAudioEngine(this.audioEngine);
@@ -51,9 +55,6 @@ class GUI extends React.Component {
                 this.setState({loadingError: true, errorMessage: e});
             });
         this.props.vm.initialized = true;
-        if (this.props.projectTitle) {
-            this.props.onUpdateReduxProjectTitle(this.props.projectTitle);
-        }
     }
     componentWillReceiveProps (nextProps) {
         if (this.props.projectData !== nextProps.projectData) {

--- a/src/containers/gui.jsx
+++ b/src/containers/gui.jsx
@@ -7,6 +7,7 @@ import ReactModal from 'react-modal';
 
 import ErrorBoundaryHOC from '../lib/error-boundary-hoc.jsx';
 import {openExtensionLibrary} from '../reducers/modals';
+import {setProjectTitle} from '../reducers/project-title';
 import {
     activateTab,
     BLOCKS_TAB_INDEX,
@@ -50,6 +51,9 @@ class GUI extends React.Component {
                 this.setState({loadingError: true, errorMessage: e});
             });
         this.props.vm.initialized = true;
+        if (this.props.projectTitle) {
+            this.props.onUpdateReduxProjectTitle(this.props.projectTitle);
+        }
     }
     componentWillReceiveProps (nextProps) {
         if (this.props.projectData !== nextProps.projectData) {
@@ -65,6 +69,9 @@ class GUI extends React.Component {
                     });
             });
         }
+        if (this.props.projectTitle !== nextProps.projectTitle) {
+            this.props.onUpdateReduxProjectTitle(nextProps.projectTitle);
+        }
     }
     render () {
         if (this.state.loadingError) {
@@ -75,8 +82,10 @@ class GUI extends React.Component {
             /* eslint-disable no-unused-vars */
             assetHost,
             hideIntro,
+            onUpdateReduxProjectTitle,
             projectData,
             projectHost,
+            projectTitle,
             /* eslint-enable no-unused-vars */
             children,
             fetchingProject,
@@ -97,14 +106,19 @@ class GUI extends React.Component {
 }
 
 GUI.propTypes = {
+    assetHost: PropTypes.string,
     children: PropTypes.node,
     fetchingProject: PropTypes.bool,
     hideIntro: PropTypes.bool,
     importInfoVisible: PropTypes.bool,
     loadingStateVisible: PropTypes.bool,
     onSeeCommunity: PropTypes.func,
+    onUpdateProjectTitle: PropTypes.func,
+    onUpdateReduxProjectTitle: PropTypes.func,
     previewInfoVisible: PropTypes.bool,
     projectData: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
+    projectHost: PropTypes.string,
+    projectTitle: PropTypes.string,
     vm: PropTypes.instanceOf(VM)
 };
 
@@ -134,7 +148,8 @@ const mapDispatchToProps = dispatch => ({
     onActivateCostumesTab: () => dispatch(activateTab(COSTUMES_TAB_INDEX)),
     onActivateSoundsTab: () => dispatch(activateTab(SOUNDS_TAB_INDEX)),
     onRequestCloseBackdropLibrary: () => dispatch(closeBackdropLibrary()),
-    onRequestCloseCostumeLibrary: () => dispatch(closeCostumeLibrary())
+    onRequestCloseCostumeLibrary: () => dispatch(closeCostumeLibrary()),
+    onUpdateReduxProjectTitle: title => dispatch(setProjectTitle(title))
 });
 
 const ConnectedGUI = connect(

--- a/src/containers/project-loader.jsx
+++ b/src/containers/project-loader.jsx
@@ -6,6 +6,7 @@ import {defineMessages, injectIntl, intlShape} from 'react-intl';
 
 import analytics from '../lib/analytics';
 import log from '../lib/log';
+import {setProjectTitle} from '../reducers/project-title';
 
 import {
     openLoadingProject,
@@ -75,6 +76,12 @@ class ProjectLoader extends React.Component {
         if (thisFileInput.files) { // Don't attempt to load if no file was selected
             this.props.openLoadingState();
             reader.readAsArrayBuffer(thisFileInput.files[0]);
+            if (thisFileInput.files[0].name) {
+                const matches = thisFileInput.files[0].name.match(/^(.*)\.sb3$/);
+                if (matches) {
+                    this.props.onSetProjectTitle(matches[1]);
+                }
+            }
         }
     }
     handleClick () {
@@ -112,6 +119,7 @@ ProjectLoader.propTypes = {
     children: PropTypes.func,
     closeLoadingState: PropTypes.func,
     intl: intlShape.isRequired,
+    onSetProjectTitle: PropTypes.func,
     openLoadingState: PropTypes.func,
     vm: PropTypes.shape({
         loadProject: PropTypes.func
@@ -124,6 +132,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
     closeLoadingState: () => dispatch(closeLoadingProject()),
+    onSetProjectTitle: title => dispatch(setProjectTitle(title)),
     openLoadingState: () => dispatch(openLoadingProject())
 });
 

--- a/src/containers/project-loader.jsx
+++ b/src/containers/project-loader.jsx
@@ -79,7 +79,7 @@ class ProjectLoader extends React.Component {
             if (thisFileInput.files[0].name) {
                 const matches = thisFileInput.files[0].name.match(/^(.*)\.sb3$/);
                 if (matches) {
-                    this.props.onSetProjectTitle(matches[1]);
+                    this.props.onSetProjectTitle(matches[1].substring(0, 100));
                 }
             }
         }

--- a/src/containers/project-saver.jsx
+++ b/src/containers/project-saver.jsx
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
 import storage from '../lib/storage';
+import {projectTitleInitialState} from '../reducers/project-title';
+
 
 /**
  * Project saver component passes a saveProject function to its child.
@@ -33,21 +35,15 @@ class ProjectSaver extends React.Component {
         document.body.appendChild(saveLink);
 
         this.props.saveProjectSb3().then(content => {
-            // TODO user-friendly project name
-            // File name: project-DATE-TIME
-            const date = new Date();
-            const timestamp = `${date.toLocaleDateString()}-${date.toLocaleTimeString()}`;
-            const filename = `untitled-project-${timestamp}.sb3`;
-
             // Use special ms version if available to get it working on Edge.
             if (navigator.msSaveOrOpenBlob) {
-                navigator.msSaveOrOpenBlob(content, filename);
+                navigator.msSaveOrOpenBlob(content, this.props.projectFilename);
                 return;
             }
 
             const url = window.URL.createObjectURL(content);
             saveLink.href = url;
-            saveLink.download = filename;
+            saveLink.download = this.props.projectFilename;
             saveLink.click();
             window.URL.revokeObjectURL(url);
             document.body.removeChild(saveLink);
@@ -86,14 +82,24 @@ class ProjectSaver extends React.Component {
     }
 }
 
+const getProjectFilename = (curTitle, defaultTitle) => {
+    let filenameTitle = curTitle;
+    if (!filenameTitle || filenameTitle.length === 0) {
+        filenameTitle = defaultTitle;
+    }
+    return `${filenameTitle.substring(0, 100)}.sb3`;
+};
+
 ProjectSaver.propTypes = {
     children: PropTypes.func,
+    projectFilename: PropTypes.string,
     projectId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     saveProjectSb3: PropTypes.func
 };
 
 const mapStateToProps = state => ({
     saveProjectSb3: state.scratchGui.vm.saveProjectSb3.bind(state.scratchGui.vm),
+    projectFilename: getProjectFilename(state.scratchGui.projectTitle, projectTitleInitialState),
     projectId: state.scratchGui.projectId
 });
 

--- a/src/css/colors.css
+++ b/src/css/colors.css
@@ -6,6 +6,7 @@ $ui-modal-overlay: hsla(215, 100%, 65%, 0.9); /* 90% transparent version of moti
 
 $ui-white: hsla(0, 100%, 100%, 1); /* #FFFFFF */
 $ui-white-transparent: hsla(0, 100%, 100%, 0.25); /* 25% transparent version of ui-white */
+$ui-transparent: hsla(0, 100%, 100%, 0); /* 25% transparent version of ui-white */
 
 $ui-black-transparent: hsla(0, 0%, 0%, 0.15); /* 15% transparent version of black */
 

--- a/src/lib/project-loader-hoc.jsx
+++ b/src/lib/project-loader-hoc.jsx
@@ -72,7 +72,6 @@ const ProjectLoaderHOC = function (WrappedComponent) {
                 assetHost,
                 projectHost,
                 projectId,
-                reduxProjectId,
                 setProjectId: setProjectIdProp,
                 /* eslint-enable no-unused-vars */
                 ...componentProps

--- a/src/lib/titled-hoc.jsx
+++ b/src/lib/titled-hoc.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import bindAll from 'lodash.bindall';
+import {defineMessages, intlShape, injectIntl} from 'react-intl';
+
+const messages = defineMessages({
+    defaultProjectTitle: {
+        id: 'gui.gui.defaultProjectTitle',
+        description: 'Default title for project',
+        defaultMessage: 'Scratch Project'
+    }
+});
+
+/* Higher Order Component to get and set the project title
+ * @param {React.Component} WrappedComponent component to receive project title related props
+ * @returns {React.Component} component with project loading behavior
+ */
+const TitledHOC = function (WrappedComponent) {
+    class TitledComponent extends React.Component {
+        constructor (props) {
+            super(props);
+            bindAll(this, [
+                'handleUpdateProjectTitle'
+            ]);
+            this.state = {
+                projectTitle: this.props.intl.formatMessage(messages.defaultProjectTitle)
+            };
+        }
+        handleUpdateProjectTitle (newTitle) {
+            this.setState({projectTitle: newTitle});
+        }
+        render () {
+            return (
+                <WrappedComponent
+                    projectTitle={this.state.projectTitle}
+                    onUpdateProjectTitle={this.handleUpdateProjectTitle}
+                    {...this.props}
+                />
+            );
+        }
+    }
+
+    TitledComponent.propTypes = {
+        intl: intlShape.isRequired
+    };
+
+    // return TitledComponent;
+    const IntlTitledComponent = injectIntl(TitledComponent);
+    return IntlTitledComponent;
+
+};
+
+export {
+    TitledHOC as default
+};

--- a/src/playground/index.jsx
+++ b/src/playground/index.jsx
@@ -5,6 +5,7 @@ import 'intl'; // For Safari 9
 
 import React from 'react';
 import ReactDOM from 'react-dom';
+import bindAll from 'lodash.bindall';
 
 import analytics from '../lib/analytics';
 import AppStateHOC from '../lib/app-state-hoc.jsx';
@@ -32,3 +33,54 @@ if (supportedBrowser()) {
     // eslint-disable-next-line react/jsx-no-bind
     ReactDOM.render(<WrappedBrowserModalComponent onBack={handleBack} />, appTarget);
 }
+
+// GUI.setAppElement(appTarget);
+//
+// // simple example of how you might manage project title externally.
+// // Changing project title within GUI interface will update it here.
+// class TitledGUI extends React.Component {
+//     constructor (props) {
+//         super(props);
+//         bindAll(this, [
+//             'handleUpdateProjectTitle'
+//         ]);
+//         this.state = {
+//             projectTitle: 'Untitled-1'
+//         };
+//     }
+//     handleUpdateProjectTitle (newTitle) {
+//         this.setState({projectTitle: newTitle});
+//     }
+//     render () {
+//         const {
+//             projectTitle, // eslint-disable-line no-unused-vars
+//             onUpdateProjectTitle, // eslint-disable-line no-unused-vars
+//             ...componentProps
+//         } = this.props;
+//         return (
+//             <GUI
+//                 {...componentProps}
+//                 projectTitle={this.state.projectTitle}
+//                 onUpdateProjectTitle={this.handleUpdateProjectTitle}
+//             />
+//         );
+//     }
+// }
+//
+// const WrappedGui = HashParserHOC(AppStateHOC(TitledGUI));
+//
+// // TODO a hack for testing the backpack, allow backpack host to be set by url param
+// const backpackHostMatches = window.location.href.match(/[?&]backpack_host=([^&]*)&?/);
+// const backpackHost = backpackHostMatches ? backpackHostMatches[1] : null;
+//
+// const backpackOptions = {
+//     visible: true,
+//     host: backpackHost
+// };
+//
+// ReactDOM.render(
+//     <WrappedGui
+//         backpackOptions={backpackOptions}
+//     />,
+//     appTarget
+// );

--- a/src/playground/index.jsx
+++ b/src/playground/index.jsx
@@ -5,7 +5,6 @@ import 'intl'; // For Safari 9
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import bindAll from 'lodash.bindall';
 
 import analytics from '../lib/analytics';
 import AppStateHOC from '../lib/app-state-hoc.jsx';
@@ -33,54 +32,3 @@ if (supportedBrowser()) {
     // eslint-disable-next-line react/jsx-no-bind
     ReactDOM.render(<WrappedBrowserModalComponent onBack={handleBack} />, appTarget);
 }
-
-// GUI.setAppElement(appTarget);
-//
-// // simple example of how you might manage project title externally.
-// // Changing project title within GUI interface will update it here.
-// class TitledGUI extends React.Component {
-//     constructor (props) {
-//         super(props);
-//         bindAll(this, [
-//             'handleUpdateProjectTitle'
-//         ]);
-//         this.state = {
-//             projectTitle: 'Untitled-1'
-//         };
-//     }
-//     handleUpdateProjectTitle (newTitle) {
-//         this.setState({projectTitle: newTitle});
-//     }
-//     render () {
-//         const {
-//             projectTitle, // eslint-disable-line no-unused-vars
-//             onUpdateProjectTitle, // eslint-disable-line no-unused-vars
-//             ...componentProps
-//         } = this.props;
-//         return (
-//             <GUI
-//                 {...componentProps}
-//                 projectTitle={this.state.projectTitle}
-//                 onUpdateProjectTitle={this.handleUpdateProjectTitle}
-//             />
-//         );
-//     }
-// }
-//
-// const WrappedGui = HashParserHOC(AppStateHOC(TitledGUI));
-//
-// // TODO a hack for testing the backpack, allow backpack host to be set by url param
-// const backpackHostMatches = window.location.href.match(/[?&]backpack_host=([^&]*)&?/);
-// const backpackHost = backpackHostMatches ? backpackHostMatches[1] : null;
-//
-// const backpackOptions = {
-//     visible: true,
-//     host: backpackHost
-// };
-//
-// ReactDOM.render(
-//     <WrappedGui
-//         backpackOptions={backpackOptions}
-//     />,
-//     appTarget
-// );

--- a/src/playground/player.jsx
+++ b/src/playground/player.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {connect} from 'react-redux';
+import bindAll from 'lodash.bindall';
 
 import Box from '../components/box/box.jsx';
 import GUI from '../containers/gui.jsx';
@@ -18,20 +19,43 @@ if (process.env.NODE_ENV === 'production' && typeof window === 'object') {
 
 import styles from './player.css';
 
-const Player = ({isPlayerOnly, onSeeInside, projectId}) => (
-    <Box
-        className={classNames({
-            [styles.stageOnly]: isPlayerOnly
-        })}
-    >
-        {isPlayerOnly && <button onClick={onSeeInside}>{'See inside'}</button>}
-        <GUI
-            enableCommunity
-            isPlayerOnly={isPlayerOnly}
-            projectId={projectId}
-        />
-    </Box>
-);
+class Player extends React.Component {
+    constructor (props) {
+        super(props);
+        bindAll(this, [
+            'handleUpdateProjectTitle'
+        ]);
+        this.state = {
+            projectTitle: 'Untitled-1'
+        };
+    }
+    handleUpdateProjectTitle (newTitle) {
+        this.setState({projectTitle: newTitle});
+    }
+    render () {
+        const {
+            isPlayerOnly,
+            onSeeInside,
+            projectId
+        } = this.props;
+        return (
+            <Box
+                className={classNames({
+                    [styles.stageOnly]: isPlayerOnly
+                })}
+            >
+                {isPlayerOnly && <button onClick={onSeeInside}>{'See inside'}</button>}
+                <GUI
+                    enableCommunity
+                    isPlayerOnly={isPlayerOnly}
+                    projectId={projectId}
+                    projectTitle={this.state.projectTitle}
+                    onUpdateProjectTitle={this.handleUpdateProjectTitle}
+                />
+            </Box>
+        );
+    }
+}
 
 Player.propTypes = {
     isPlayerOnly: PropTypes.bool,

--- a/src/playground/player.jsx
+++ b/src/playground/player.jsx
@@ -3,12 +3,12 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {connect} from 'react-redux';
-import bindAll from 'lodash.bindall';
 
 import Box from '../components/box/box.jsx';
 import GUI from '../containers/gui.jsx';
 import HashParserHOC from '../lib/hash-parser-hoc.jsx';
 import AppStateHOC from '../lib/app-state-hoc.jsx';
+import TitledHOC from '../lib/titled-hoc.jsx';
 
 import {setPlayer} from '../reducers/mode';
 
@@ -19,43 +19,20 @@ if (process.env.NODE_ENV === 'production' && typeof window === 'object') {
 
 import styles from './player.css';
 
-class Player extends React.Component {
-    constructor (props) {
-        super(props);
-        bindAll(this, [
-            'handleUpdateProjectTitle'
-        ]);
-        this.state = {
-            projectTitle: 'Untitled-1'
-        };
-    }
-    handleUpdateProjectTitle (newTitle) {
-        this.setState({projectTitle: newTitle});
-    }
-    render () {
-        const {
-            isPlayerOnly,
-            onSeeInside,
-            projectId
-        } = this.props;
-        return (
-            <Box
-                className={classNames({
-                    [styles.stageOnly]: isPlayerOnly
-                })}
-            >
-                {isPlayerOnly && <button onClick={onSeeInside}>{'See inside'}</button>}
-                <GUI
-                    enableCommunity
-                    isPlayerOnly={isPlayerOnly}
-                    projectId={projectId}
-                    projectTitle={this.state.projectTitle}
-                    onUpdateProjectTitle={this.handleUpdateProjectTitle}
-                />
-            </Box>
-        );
-    }
-}
+const Player = ({isPlayerOnly, onSeeInside, projectId}) => (
+    <Box
+        className={classNames({
+            [styles.stageOnly]: isPlayerOnly
+        })}
+    >
+        {isPlayerOnly && <button onClick={onSeeInside}>{'See inside'}</button>}
+        <GUI
+            enableCommunity
+            isPlayerOnly={isPlayerOnly}
+            projectId={projectId}
+        />
+    </Box>
+);
 
 Player.propTypes = {
     isPlayerOnly: PropTypes.bool,
@@ -72,7 +49,7 @@ const mapDispatchToProps = dispatch => ({
 });
 
 const ConnectedPlayer = connect(mapStateToProps, mapDispatchToProps)(Player);
-const WrappedPlayer = HashParserHOC(AppStateHOC(ConnectedPlayer));
+const WrappedPlayer = HashParserHOC(AppStateHOC(TitledHOC(ConnectedPlayer)));
 
 const appTarget = document.createElement('div');
 document.body.appendChild(appTarget);

--- a/src/playground/render-gui.jsx
+++ b/src/playground/render-gui.jsx
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom';
 import AppStateHOC from '../lib/app-state-hoc.jsx';
 import GUI from '../containers/gui.jsx';
 import HashParserHOC from '../lib/hash-parser-hoc.jsx';
+import TitledHOC from '../lib/titled-hoc.jsx';
 
 /*
  * Render the GUI playground. This is a separate function because importing anything
@@ -12,7 +13,7 @@ import HashParserHOC from '../lib/hash-parser-hoc.jsx';
  */
 export default appTarget => {
     GUI.setAppElement(appTarget);
-    const WrappedGui = HashParserHOC(AppStateHOC(GUI));
+    const WrappedGui = HashParserHOC(AppStateHOC(TitledHOC(GUI)));
 
     // TODO a hack for testing the backpack, allow backpack host to be set by url param
     const backpackHostMatches = window.location.href.match(/[?&]backpack_host=([^&]*)&?/);

--- a/src/reducers/gui.js
+++ b/src/reducers/gui.js
@@ -12,6 +12,7 @@ import modeReducer, {modeInitialState} from './mode';
 import monitorReducer, {monitorsInitialState} from './monitors';
 import monitorLayoutReducer, {monitorLayoutInitialState} from './monitor-layout';
 import projectIdReducer, {projectIdInitialState} from './project-id';
+import projectTitleReducer, {projectTitleInitialState} from './project-title';
 import restoreDeletionReducer, {restoreDeletionInitialState} from './restore-deletion';
 import stageSizeReducer, {stageSizeInitialState} from './stage-size';
 import targetReducer, {targetsInitialState} from './targets';
@@ -37,6 +38,7 @@ const guiInitialState = {
     monitors: monitorsInitialState,
     monitorLayout: monitorLayoutInitialState,
     projectId: projectIdInitialState,
+    projectTitle: projectTitleInitialState,
     restoreDeletion: restoreDeletionInitialState,
     targets: targetsInitialState,
     toolbox: toolboxInitialState,
@@ -80,6 +82,7 @@ const guiReducer = combineReducers({
     monitors: monitorReducer,
     monitorLayout: monitorLayoutReducer,
     projectId: projectIdReducer,
+    projectTitle: projectTitleReducer,
     restoreDeletion: restoreDeletionReducer,
     targets: targetReducer,
     toolbox: toolboxReducer,

--- a/src/reducers/project-title.js
+++ b/src/reducers/project-title.js
@@ -1,0 +1,23 @@
+const SET_PROJECT_TITLE = 'projectTitle/SET_PROJECT_TITLE';
+
+const initialState = 'Untitled-1';
+
+const reducer = function (state, action) {
+    if (typeof state === 'undefined') state = initialState;
+    switch (action.type) {
+    case SET_PROJECT_TITLE:
+        return action.title;
+    default:
+        return state;
+    }
+};
+const setProjectTitle = title => ({
+    type: SET_PROJECT_TITLE,
+    title: title
+});
+
+export {
+    reducer as default,
+    initialState as projectTitleInitialState,
+    setProjectTitle
+};

--- a/src/reducers/project-title.js
+++ b/src/reducers/project-title.js
@@ -1,6 +1,8 @@
 const SET_PROJECT_TITLE = 'projectTitle/SET_PROJECT_TITLE';
 
-const initialState = 'Untitled-1';
+// we are initializing to a blank string instead of an actual title,
+// because it would be hard to localize here
+const initialState = '';
 
 const reducer = function (state, action) {
     if (typeof state === 'undefined') state = initialState;

--- a/test/integration/blocks.test.js
+++ b/test/integration/blocks.test.js
@@ -68,11 +68,11 @@ describe('Working with the blocks', () => {
         await findByText('0', scope.reportedValue);
 
         await clickText('Make a Variable');
-        let el = await findByXpath("//input[@placeholder='']");
+        let el = await findByXpath("//input[@name='New variable name:']");
         await el.sendKeys('score');
         await clickButton('OK');
         await clickText('Make a Variable');
-        el = await findByXpath("//input[@placeholder='']");
+        el = await findByXpath("//input[@name='New variable name:']");
         await el.sendKeys('second variable');
         await clickButton('OK');
 
@@ -98,7 +98,7 @@ describe('Working with the blocks', () => {
         await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for scroll animation
 
         await clickText('Make a List');
-        let el = await findByXpath("//input[@placeholder='']");
+        let el = await findByXpath("//input[@name='New list name:']");
         await el.sendKeys('list1');
         await clickButton('OK');
 

--- a/test/integration/examples.test.js
+++ b/test/integration/examples.test.js
@@ -87,11 +87,11 @@ describe('blocks example', () => {
         await clickText('Variables');
         await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for scroll animation
         await clickText('Make a Variable');
-        let el = await findByXpath("//input[@placeholder='']");
+        let el = await findByXpath("//input[@name='New variable name:']");
         await el.sendKeys('score');
         await clickButton('OK');
         await clickText('Make a Variable');
-        el = await findByXpath("//input[@placeholder='']");
+        el = await findByXpath("//input[@name='New variable name:']");
         await el.sendKeys('second variable');
         await clickButton('OK');
         const logs = await getLogs();


### PR DESCRIPTION
Big help from pairing with @LiFaytheGoblin!!

relies on https://github.com/LLK/scratch-www/pull/2052 and should only be merged after it.

### Resolves

https://github.com/LLK/scratch-gui/issues/2815

Note: we haven't implemented the css changes per @carljbowman's comments on #2815.

### Proposed Changes

Makes project title editable in GUI editor. 

Uses new project title reducer to store and change project title. This is made available to the menu bar, where the project title input uses it to maintain state, and to project saver, which uses the title to determine the downloaded filename.

When run within www, title changes made in the GUI menu bar are updated in www and through it to the server.

Testing:

For testing, we should try unusual unicode characters.


### Related PR

https://github.com/LLK/scratch-www/pull/2052 in scratch-www should be used together with this.