### PR TITLE
Fix connection modal padding for RTL

### DIFF
--- a/src/components/connection-modal/connection-modal.css
+++ b/src/components/connection-modal/connection-modal.css
@@ -121,7 +121,14 @@
 .radar-small {
     width: 40px;
     height: 40px;
+}
+
+[dir="ltr"] .radar-small {
     margin-right: 0.5rem;
+}
+
+[dir="rtl"] .radar-small {
+    margin-left: 0.5rem;
 }
 
 .radar-big {
@@ -184,6 +191,7 @@
     position: absolute;
     top: -5px;
     right: -15px;
+    left: -15px;
     padding: 5px 5px;
     background-color: $pen-primary;
     border-radius: 100%;
@@ -232,7 +240,6 @@
     flex-direction: row;
     justify-content: flex-start;
     align-items: center;
-    margin-left: 3rem;
 }
 
 [dir="ltr"] .scratch-link-help-step {

--- a/src/components/modal/modal.css
+++ b/src/components/modal/modal.css
@@ -83,8 +83,12 @@ $sides: 20rem;
     user-select: none;
 }
 
-.header-image {
+[dir="ltr"] .header-image {
     margin-right: 0.5rem;
+}
+
+[dir="rtl"] .header-image {
+    margin-left: 0.5rem;
 }
 
 .header-item-filter {


### PR DESCRIPTION
### Resolves
- Resolves #2982


### Proposed Changes

Adds direction dependent margins to the connection modal. There should be padding between the microbit icon and the title in the titlebar, and there should be padding between the searching for signal spinner and the text.

### Test Coverage
Current tests run.

#### Manual testing:
https://chrisgarrity.github.io/scratch-gui/issue/2982-extension-padding/?locale=he
- [ ] try adding the microbit (or any hardware extension) - there should be space between the icon and title in the titlebar.
- [ ] Any other icons (e.g. connecting spinner), should also have appropriate space between them and text when in Hebrew.
- [ ] Check that English (and other LTR) still looks ok.


### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Safari
 
Windows
 * [x] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
