### PR TITLE
Don't load the default project on top of everything

### DIFF
--- a/src/lib/project-loader-hoc.jsx
+++ b/src/lib/project-loader-hoc.jsx
@@ -24,19 +24,14 @@ const ProjectLoaderHOC = function (WrappedComponent) {
             };
             storage.setProjectHost(props.projectHost);
             storage.setAssetHost(props.assetHost);
-            if (props.projectId !== props.reduxProjectId) {
-                props.setProjectId(props.projectId);
-            }
+            props.setProjectId(props.projectId);
             if (
                 props.projectId !== '' &&
                 props.projectId !== null &&
                 typeof props.projectId !== 'undefined'
             ) {
                 this.updateProject(props.projectId);
-            } else {
-                this.updateProject(props.reduxProjectId);
             }
-
         }
         componentWillUpdate (nextProps) {
             if (this.props.projectHost !== nextProps.projectHost) {
@@ -100,12 +95,11 @@ const ProjectLoaderHOC = function (WrappedComponent) {
     };
     ProjectLoaderComponent.defaultProps = {
         assetHost: 'https://assets.scratch.mit.edu',
-        projectHost: 'https://projects.scratch.mit.edu'
+        projectHost: 'https://projects.scratch.mit.edu',
+        projectId: 0
     };
 
-    const mapStateToProps = state => ({
-        reduxProjectId: state.scratchGui.projectId
-    });
+    const mapStateToProps = () => ({});
 
     const mapDispatchToProps = dispatch => ({
         setProjectId: id => dispatch(setProjectId(id))

--- a/src/reducers/project-id.js
+++ b/src/reducers/project-id.js
@@ -1,6 +1,6 @@
 const SET_PROJECT_ID = 'scratch-gui/project-id/SET_PROJECT_ID';
 
-const initialState = 0;
+const initialState = null;
 
 const reducer = function (state, action) {
     if (typeof state === 'undefined') state = initialState;


### PR DESCRIPTION
Just use `ProjectLoaderHOC` to translate props to redux. Trying to be clever about using both props and redux state together was... not clever.

Resolves #3040
