### PR TITLE
Made border color of stage selector be same as other border colors

### DIFF
--- a/src/components/stage-selector/stage-selector.css
+++ b/src/components/stage-selector/stage-selector.css
@@ -4,6 +4,7 @@
 $header-height: calc($stage-menu-height - 2px);
 
 .stage-selector {
+    background-clip: padding-box;
     display: flex;
     flex-direction: column;
     align-items: center;


### PR DESCRIPTION
### Resolves
#3009

### Proposed Changes
Just adds one line of code. Background color white will stop before border, so the border color is set correctly. 

### Test Coverage
Tested on MacOS Chrome
<img width="226" alt="screen shot 2018-08-31 at 4 15 49 pm" src="https://user-images.githubusercontent.com/5471273/44933967-2a58bd80-ad39-11e8-8744-cd2ce1121481.png">
