### PR TITLE
Add variables to dropdown menu, and more goodies

### DIFF
--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -145,38 +145,41 @@ export default function (vm) {
                 block = blocks.getBlock(ofBlock.id);
             }
             if (block) {
-                // Get the name of the sprite which is selected. This is based on the OBJECT dropdown's selected value,
-                // which may be different from the value returned by a block placed within that input, if present.
-                // TODO: Variables should probably not be fetched at all if the OBJECT dropdown contains a block.
+                // Get the shadow block of the OBJECT dropdown. If the block in the OBJECT slot is not a shadow block,
+                // the slot must be occupied by an actual block; in this case, do nothing, and leave the default list
+                // of sprite properties remaining.
                 const objectInput = blocks.getInputs(block).OBJECT;
                 const objectInputBlock = blocks.getBlock(objectInput.block);
-                const valueField = blocks.getFields(objectInputBlock).OBJECT;
-                const objectName = valueField.value;
+                if (objectInputBlock.shadow) {
+                    // Get the name of the object from the dropdown shadow block.
+                    const valueField = blocks.getFields(objectInputBlock).OBJECT;
+                    const objectName = valueField.value;
 
-                let target;
+                    let target;
 
-                // If the stage is the selected object (of the dropdown), return properties relevant to it.
-                if (objectName === '_stage_') {
-                    const backdropNumber = ScratchBlocks.ScratchMsgs.translate(
-                        'SENSING_OF_BACKDROPNUMBER', 'backdrop #');
-                    const backdropName = ScratchBlocks.ScratchMsgs.translate(
-                        'SENSING_OF_BACKDROPNAME', 'backdrop name');
-                    output = [
-                        [backdropNumber, 'backdrop #'],
-                        [backdropName, 'backdrop name'],
-                        [volume, 'volume']
-                    ];
-                    target = vm.runtime.getTargetForStage();
-                } else {
-                    target = vm.runtime.getSpriteTargetByName(objectName);
-                }
+                    // If the stage is the selected object (of the dropdown), return properties relevant to it.
+                    if (objectName === '_stage_') {
+                        const backdropNumber = ScratchBlocks.ScratchMsgs.translate(
+                            'SENSING_OF_BACKDROPNUMBER', 'backdrop #');
+                        const backdropName = ScratchBlocks.ScratchMsgs.translate(
+                            'SENSING_OF_BACKDROPNAME', 'backdrop name');
+                        output = [
+                            [backdropNumber, 'backdrop #'],
+                            [backdropName, 'backdrop name'],
+                            [volume, 'volume']
+                        ];
+                        target = vm.runtime.getTargetForStage();
+                    } else {
+                        target = vm.runtime.getSpriteTargetByName(objectName);
+                    }
 
-                // Also return the object's local variables. In the case of the stage, these are the project's global
-                // variables.
-                if (target) {
-                    // Pass true to skip the stage: we only want the sprite's own local variables.
-                    const variableNames = target.getAllVariableNamesInScopeByType('', true);
-                    output = output.concat(variableNames.map(name => [name, name]));
+                    // Also return the object's local variables. In the case of the stage, these are the project's global
+                    // variables.
+                    if (target) {
+                        // Pass true to skip the stage: we only want the sprite's own local variables.
+                        const variableNames = target.getAllVariableNamesInScopeByType('', true);
+                        output = output.concat(variableNames.map(name => [name, name]));
+                    }
                 }
             }
         }

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -178,6 +178,7 @@ export default function (vm) {
                     if (target) {
                         // Pass true to skip the stage: we only want the sprite's own local variables.
                         const variableNames = target.getAllVariableNamesInScopeByType('', true);
+                        variableNames.sort(ScratchBlocks.scratchBlocksUtils.compareStrings);
                         output = output.concat(variableNames.map(name => [name, name]));
                     }
                 }

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -247,9 +247,7 @@ export default function (vm) {
     };
 
     ScratchBlocks.Blocks.sensing_of_property_menu.init = function () {
-        const json = jsonForMenuBlock('PROPERTY', variablePropertyMenu, sensingColors, [
-            ['Top value, hard-coded', 'TODO...']
-        ]);
+        const json = jsonForMenuBlock('PROPERTY', variablePropertyMenu, sensingColors, []);
         this.jsonInit(json);
     };
 

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -131,8 +131,8 @@ export default function (vm) {
         ];
 
         const sourceBlock = thisValue.sourceBlock_; // This is the <shadow>.
-        if (sourceBlock) {
-            const ofBlock = sourceBlock.parentBlock_; // This is the "of" block.
+        const ofBlock = sourceBlock && sourceBlock.parentBlock_; // This is the "of" block.
+        if (ofBlock) {
             let block, blocks;
             if (vm.editingTarget) {
                 blocks = vm.editingTarget.blocks;

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -153,10 +153,10 @@ export default function (vm) {
                 const valueField = blocks.getFields(objectInputBlock).OBJECT;
                 const objectName = valueField.value;
 
-                // Only return options for local variables of sprites, since the stage's local variables are really
-                // the project's global variables.
+                let target;
+
+                // If the stage is the selected object (of the dropdown), return properties relevant to it.
                 if (objectName === '_stage_') {
-                    // If the stage is the selected object (of the dropdown), only return properties relevant to it.
                     const backdropNumber = ScratchBlocks.ScratchMsgs.translate(
                         'SENSING_OF_BACKDROPNUMBER', 'backdrop #');
                     const backdropName = ScratchBlocks.ScratchMsgs.translate(
@@ -166,13 +166,17 @@ export default function (vm) {
                         [backdropName, 'backdrop name'],
                         [volume, 'volume']
                     ];
+                    target = vm.runtime.getTargetForStage();
                 } else {
-                    const target = vm.runtime.getSpriteTargetByName(objectName);
-                    if (target) {
-                        // Pass true to skip the stage: we only want the sprite's own local variables.
-                        const variableNames = target.getAllVariableNamesInScopeByType('', true);
-                        output = output.concat(variableNames.map(name => [name, name]));
-                    }
+                    target = vm.runtime.getSpriteTargetByName(objectName);
+                }
+
+                // Also return the object's local variables. In the case of the stage, these are the project's global
+                // variables.
+                if (target) {
+                    // Pass true to skip the stage: we only want the sprite's own local variables.
+                    const variableNames = target.getAllVariableNamesInScopeByType('', true);
+                    output = output.concat(variableNames.map(name => [name, name]));
                 }
             }
         }

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -133,7 +133,8 @@ export default function (vm) {
         const sourceBlock = thisValue.sourceBlock_; // This is the <shadow>.
         const ofBlock = sourceBlock && sourceBlock.parentBlock_; // This is the "of" block.
         if (ofBlock) {
-            let block, blocks;
+            let block;
+            let blocks;
             if (vm.editingTarget) {
                 blocks = vm.editingTarget.blocks;
                 block = blocks.getBlock(ofBlock.id);
@@ -152,24 +153,26 @@ export default function (vm) {
                 const valueField = blocks.getFields(objectInputBlock).OBJECT;
                 const objectName = valueField.value;
 
-                // Don't return options for local variables of the stage, since the stage's local variables are really
+                // Only return options for local variables of sprites, since the stage's local variables are really
                 // the project's global variables.
-                if (objectName !== '_stage_') {
+                if (objectName === '_stage_') {
+                    // If the stage is the selected object (of the dropdown), only return properties relevant to it.
+                    const backdropNumber = ScratchBlocks.ScratchMsgs.translate(
+                        'SENSING_OF_BACKDROPNUMBER', 'backdrop #');
+                    const backdropName = ScratchBlocks.ScratchMsgs.translate(
+                        'SENSING_OF_BACKDROPNAME', 'backdrop name');
+                    output = [
+                        [backdropNumber, 'backdrop #'],
+                        [backdropName, 'backdrop name'],
+                        [volume, 'volume']
+                    ];
+                } else {
                     const target = vm.runtime.getSpriteTargetByName(objectName);
                     if (target) {
                         // Pass true to skip the stage: we only want the sprite's own local variables.
                         const variableNames = target.getAllVariableNamesInScopeByType('', true);
                         output = output.concat(variableNames.map(name => [name, name]));
                     }
-                } else {
-                    // If the stage is the selected object (of the dropdown), only return properties relevant to it.
-                    const backdropNumber = ScratchBlocks.ScratchMsgs.translate('SENSING_OF_BACKDROPNUMBER', 'backdrop #');
-                    const backdropName = ScratchBlocks.ScratchMsgs.translate('SENSING_OF_BACKDROPNAME', 'backdrop name');
-                    output = [
-                        [backdropNumber, 'backdrop #'],
-                        [backdropName, 'backdrop name'],
-                        [volume, 'volume']
-                    ];
                 }
             }
         }

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -111,6 +111,25 @@ export default function (vm) {
     };
 
     const variablePropertyMenu = function (thisValue) {
+        // Fill the output array with sprite properties by default. This will be changed to stage properties if the
+        // stage is selected.
+        const xPosition = ScratchBlocks.ScratchMsgs.translate('SENSING_OF_XPOSITION', 'x position');
+        const yPosition = ScratchBlocks.ScratchMsgs.translate('SENSING_OF_YPOSITION', 'y position');
+        const direction = ScratchBlocks.ScratchMsgs.translate('SENSING_OF_DIRECTION', 'direction');
+        const costumeNumber = ScratchBlocks.ScratchMsgs.translate('SENSING_OF_COSTUMENUMBER', 'costume #');
+        const costumeName = ScratchBlocks.ScratchMsgs.translate('SENSING_OF_COSTUMENAME', 'costume name');
+        const size = ScratchBlocks.ScratchMsgs.translate('SENSING_OF_SIZE', 'size');
+        const volume = ScratchBlocks.ScratchMsgs.translate('SENSING_OF_VOLUME', 'volume');
+        let output = [
+            [xPosition, 'x position'],
+            [yPosition, 'y position'],
+            [direction, 'direction'],
+            [costumeNumber, 'costume #'],
+            [costumeName, 'costume name'],
+            [size, 'size'],
+            [volume, 'volume']
+        ];
+
         const sourceBlock = thisValue.sourceBlock_; // This is the <shadow>.
         if (sourceBlock) {
             const ofBlock = sourceBlock.parentBlock_; // This is the "of" block.
@@ -140,13 +159,21 @@ export default function (vm) {
                     if (target) {
                         // Pass true to skip the stage: we only want the sprite's own local variables.
                         const variableNames = target.getAllVariableNamesInScopeByType('', true);
-                        return variableNames.map(name => [name, name]);
+                        output = output.concat(variableNames.map(name => [name, name]));
                     }
+                } else {
+                    // If the stage is the selected object (of the dropdown), only return properties relevant to it.
+                    const backdropNumber = ScratchBlocks.ScratchMsgs.translate('SENSING_OF_BACKDROPNUMBER', 'backdrop #');
+                    const backdropName = ScratchBlocks.ScratchMsgs.translate('SENSING_OF_BACKDROPNAME', 'backdrop name');
+                    output = [
+                        [backdropNumber, 'backdrop #'],
+                        [backdropName, 'backdrop name'],
+                        [volume, 'volume']
+                    ];
                 }
-                return [];
             }
         }
-        return [];
+        return output;
     };
 
     const soundColors = ScratchBlocks.Colours.sounds;

--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -463,6 +463,9 @@ const sensing = function (isStage) {
         <block type="sensing_resettimer"/>
         ${blockSeparator}
         <block id="of" type="sensing_of">
+            <value name="PROPERTY">
+                <shadow id="sensing_of_property_menu" type="sensing_of_property_menu"/>
+            </value>
             <value name="OBJECT">
                 <shadow id="sensing_of_object_menu" type="sensing_of_object_menu"/>
             </value>


### PR DESCRIPTION
### Resolves

Resolves LLK/scratch-vm#1425: "For this sprite only" (local) variables are now shown in the dropdown.

Resolves LLK/scratch-blocks#1418: This is unintentional (a side-effect of reusing the basic code for the object dropdown), but the property dropdown now accepts blocks.

Fixes backdrop options (backdrop name, backdrop #) from being shown in sprite dropdowns, and vice versa (x position, etc, in stage dropdown). I couldn't spot an issue for this one.

**Depends on LLK/scratch-blocks#1712.** Merge this one after that one!

### Proposed Changes

This PR reworks how the `PROPERTY` dropdown of the "(property) of (object)" sensing reporter block works internally, allowing for the changes listed above.

Note that the property dropdown now accepts blocks. That's not intentional - it's just that I reused most of the code for the object dropdown. I'm not sure how to make it a "square" dropdown (i.e. one which does not accept blocks). In my opinion, letting it accept blocks is a good thing anyways, since it allows and encourages dynamically accessing variables (or even ordinary attributes, like "x position" and "direction"). The argument against it is that an unfamiliar user might try placing a block such as "volume" into that dropdown, and then be confused as to why it always returns 0. But I think that any such user would quickly figure out the error they made; I think the functional benefit greatly outweighs the minor potential difficulty.

That said, I'm okay with making the input not accept blocks, if it'd be preferred to merge this sooner and keep discussion about that topic in its particular issue.

There are some comments I have on specific parts of the code. I'll leave those in a review of the PR.

### Reason for Changes

These are nearly all bug-fixes / enhancements which make the Scratch 3.0 editor match 2.0.

### Test Coverage

I haven't added any new unit tests, but this has been tested manually:

* The "of" block can be dragged out of the flyout with default or changed dropdowns without any errors.
* With the stage selected, the dropdown includes (translated) options for properties relevant to the stage, and the project's global variables.
* With a sprite selected, the dropdown includes (translated) options for properties relevant to sprites, and all variables which are local to that sprite, and no global variables.
* With a block placed inside the object dropdown, the property dropdown includes generic properties applicable to sprites (x position, volume, etc), and no variables.
* Variables are sorted the same way other variable menus are sorted.