### PR TITLE
Make title field shrink for smaller screens

### DIFF
--- a/src/components/menu-bar/menu-bar.css
+++ b/src/components/menu-bar/menu-bar.css
@@ -85,7 +85,7 @@
     background-color: $ui-black-transparent;
 }
 
-.growableMenuBarItem {
+.menu-bar-itam.growable {
     max-width: 12rem;
     flex: 1;
 }

--- a/src/components/menu-bar/menu-bar.css
+++ b/src/components/menu-bar/menu-bar.css
@@ -37,6 +37,7 @@
     justify-content: flex-start;
     flex-wrap: nowrap;
     align-items: center;
+    flex-grow: 1;
 }
 
 .scratch-logo {
@@ -82,6 +83,11 @@
 .menu-bar-item.active,
 .menu-bar-item.hoverable:hover {
     background-color: $ui-black-transparent;
+}
+
+.growableMenuBarItem {
+    max-width: 12rem;
+    flex: 1;
 }
 
 .file-group {

--- a/src/components/menu-bar/menu-bar.css
+++ b/src/components/menu-bar/menu-bar.css
@@ -90,6 +90,11 @@
     flex: 1;
 }
 
+.title-field-growable {
+    flex-grow: 1;
+    width: 2rem;
+}
+
 .file-group {
     display: flex;
     flex-direction: row;

--- a/src/components/menu-bar/menu-bar.css
+++ b/src/components/menu-bar/menu-bar.css
@@ -85,7 +85,7 @@
     background-color: $ui-black-transparent;
 }
 
-.menu-bar-itam.growable {
+.menu-bar-item.growable {
     max-width: 12rem;
     flex: 1;
 }

--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -393,7 +393,7 @@ class MenuBar extends React.Component {
                         <FormattedMessage {...ariaMessages.tutorials} />
                     </div>
                     <Divider className={classNames(styles.divider)} />
-                    <div className={classNames(styles.menuBarItem, styles.growableMenuBarItem)}>
+                    <div className={classNames(styles.menuBarItem, styles.growable)}>
                         <MenuBarItemTooltip
                             enable
                             id="title-field"

--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -399,6 +399,7 @@ class MenuBar extends React.Component {
                             id="title-field"
                         >
                             <ProjectTitleInput
+                                className={classNames(styles.titleFieldGrowable)}
                                 onUpdateProjectTitle={this.props.onUpdateProjectTitle}
                             />
                         </MenuBarItemTooltip>

--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -393,7 +393,7 @@ class MenuBar extends React.Component {
                         <FormattedMessage {...ariaMessages.tutorials} />
                     </div>
                     <Divider className={classNames(styles.divider)} />
-                    <div className={classNames(styles.menuBarItem)}>
+                    <div className={classNames(styles.menuBarItem, styles.growableMenuBarItem)}>
                         <MenuBarItemTooltip
                             enable
                             id="title-field"

--- a/src/components/menu-bar/project-title-input.css
+++ b/src/components/menu-bar/project-title-input.css
@@ -2,6 +2,11 @@
 @import "../../css/units.css";
 @import "../../css/z-index.css";
 
+/*
+If project-title-input.jsx is part of a menu bar say menu-bar.jsx, it can have additional css classes that
+can set a width for example or what it should do in a flex box (eg. grow).
+*/
+
 .title-field {
     border: 1px dashed $ui-black-transparent;
     border-radius: $form-radius;

--- a/src/components/menu-bar/project-title-input.css
+++ b/src/components/menu-bar/project-title-input.css
@@ -2,8 +2,6 @@
 @import "../../css/units.css";
 @import "../../css/z-index.css";
 
-$title-width: 12rem;
-
 .title-field {
     border: 1px dashed $ui-black-transparent;
     border-radius: $form-radius;
@@ -12,11 +10,8 @@ $title-width: 12rem;
     background-color: $ui-white-transparent;
     background-clip: padding-box;
     -webkit-background-clip: padding-box;
-    width: $title-width;
     height: auto;
     padding: .5rem;
-    flex-grow: 1;
-    width: 2rem;
 }
 
 .title-field {

--- a/src/components/menu-bar/project-title-input.css
+++ b/src/components/menu-bar/project-title-input.css
@@ -15,6 +15,8 @@ $title-width: 12rem;
     width: $title-width;
     height: auto;
     padding: .5rem;
+    flex-grow: 1;
+    width: 2rem;
 }
 
 .title-field {

--- a/src/components/menu-bar/project-title-input.jsx
+++ b/src/components/menu-bar/project-title-input.jsx
@@ -36,7 +36,7 @@ class ProjectTitleInput extends React.Component {
     render () {
         return (
             <BufferedInput
-                className={classNames(styles.titleField)}
+                className={classNames(styles.titleField, this.props.className)}
                 maxLength="100"
                 placeholder={this.props.intl.formatMessage(messages.projectTitlePlaceholder)}
                 tabIndex="0"
@@ -49,6 +49,7 @@ class ProjectTitleInput extends React.Component {
 }
 
 ProjectTitleInput.propTypes = {
+    className: PropTypes.string,
     intl: intlShape.isRequired,
     onUpdateProjectTitle: PropTypes.func,
     projectTitle: PropTypes.string


### PR DESCRIPTION
### Resolves
#2641 

### Proposed Changes
I did some changes to flex box and items to make the title field shrink

### Reason for Changes
If the title field doesn't shrink the login box will lead to a scrolling condition on smaller screens. Very ugly.

### Test Coverage
MacOS Chrome + Safari, resized screens. Works down to 980px. Npm test passes.