### PR TITLE
Set lang attribute for screen readers

### DIFF
--- a/src/containers/language-selector.jsx
+++ b/src/containers/language-selector.jsx
@@ -27,6 +27,7 @@ class LanguageSelector extends React.Component {
             children,
             ...props
         } = this.props;
+        document.documentElement.lang = this.props.currentLocale; //update the lang attribute of the html for screenreaders
         return (
             <LanguageSelectorComponent
                 onChange={this.handleChange}

--- a/src/containers/language-selector.jsx
+++ b/src/containers/language-selector.jsx
@@ -13,11 +13,13 @@ class LanguageSelector extends React.Component {
         bindAll(this, [
             'handleChange'
         ]);
+        document.documentElement.lang = this.props.currentLocale;
     }
     handleChange (e) {
         const newLocale = e.target.value;
         if (this.props.supportedLocales.includes(newLocale)) {
             this.props.onChangeLanguage(newLocale);
+            document.documentElement.lang = newLocale;
         }
     }
     render () {
@@ -27,7 +29,6 @@ class LanguageSelector extends React.Component {
             children,
             ...props
         } = this.props;
-        document.documentElement.lang = this.props.currentLocale; //update the lang attribute of the html for screenreaders
         return (
             <LanguageSelectorComponent
                 onChange={this.handleChange}

--- a/src/containers/language-selector.jsx
+++ b/src/containers/language-selector.jsx
@@ -13,7 +13,7 @@ class LanguageSelector extends React.Component {
         bindAll(this, [
             'handleChange'
         ]);
-        document.documentElement.lang = this.props.currentLocale;
+        document.documentElement.lang = props.currentLocale;
     }
     handleChange (e) {
         const newLocale = e.target.value;


### PR DESCRIPTION
### Resolves
#3049 

### Proposed Changes
Sets the lang attribute of the document in the GUI

### Reason for Changes
Setting the correct language is crucial for screen readers so they use the correct pronounciation

### Test Coverage
MacOS, Chrome, not tested with a screen reader