### PR TITLE
Restyle the question answer box for RTL

### DIFF
--- a/src/components/question/question.css
+++ b/src/components/question/question.css
@@ -33,7 +33,6 @@
 .question-submit-button {
     position: absolute;
     top: calc($space / 2);
-    right: calc($space / 2);
 
     width: calc(2rem - $space);
     height: calc(2rem - $space);
@@ -45,11 +44,26 @@
     background: $motion-primary;
 }
 
+[dir="ltr"] .question-submit-button {
+    right: calc($space / 2);
+}
+
+[dir="rtl"] .question-submit-button {
+    left: calc($space / 2);
+}
+
 /* Input overrides: width, font-weight, focus outline and padding */
 .question-input > input {
     width: 100%;
-    padding: 0 2rem 0 0.75rem; /* To make room for the submit button */
     font-weight: normal;
+}
+
+[dir="ltr"] .question-input > input {
+    padding: 0 2rem 0 .75rem; /* To make room for the submit button */
+}
+
+[dir="rtl"] .question-input > input {
+    padding: 0 .75rem 0 2rem; /* To make room for the submit button */
 }
 
 .question-input > input:focus {
@@ -60,5 +74,6 @@
     width: calc(2rem - $space);
     height: calc(2rem - $space);
     position: relative;
+    right: -7px;
     left: -7px;
 }


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves #2817 

### Proposed Changes

Adds styles for RTL to put the submit button on the left and set the padding, margins and positions correctly.

### Testing

- [ ] In Hebrew, the answer input for the `ask and wait` block should have the cursor on the right and the submit button on the left.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Safari
 
Windows
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
