### PR TITLE
Update paint to version that fixes crash when drawing transparent shapes in bitmap

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "scratch-audio": "0.1.0-prerelease.20180625202813",
     "scratch-blocks": "0.1.0-prerelease.1535662135",
     "scratch-l10n": "3.0.20180830210150",
-    "scratch-paint": "0.2.0-prerelease.20180912222409",
+    "scratch-paint": "0.2.0-prerelease.20180914201930",
     "scratch-render": "0.1.0-prerelease.20180907144714",
     "scratch-storage": "1.0.2",
     "scratch-svg-renderer": "0.2.0-prerelease.20180907141232",


### PR DESCRIPTION
Diff is https://github.com/LLK/scratch-paint/pull/682/files