### PR TITLE
Increase timeout in integration test for loading project with url

### DIFF
--- a/test/integration/project-loading.test.js
+++ b/test/integration/project-loading.test.js
@@ -72,7 +72,7 @@ describe('Loading scratch gui', () => {
             const projectId = '96708228';
             await loadUri(`${uri}#${projectId}`);
             await clickXpath('//button[@title="Try It"]');
-            await new Promise(resolve => setTimeout(resolve, 2000));
+            await new Promise(resolve => setTimeout(resolve, 3000));
             await clickXpath('//img[@title="Go"]');
             await new Promise(resolve => setTimeout(resolve, 2000));
             await clickXpath('//img[@title="Stop"]');


### PR DESCRIPTION
### Resolves

Increases the timeout in a test  "Load a project by ID directly through url', which as been flaky

### Proposed Changes

Increases the timeout from 2 seconds to 3.5 seconds while the project loads.

### Reason for Changes

The test keeps failing by timing out, but the project loads, so it shouldn't.  It doesn't always fail, so I'm increasing the timeout.

