### PR TITLE
Remove ‘he’ from the languages to ignore

### DIFF
--- a/src/components/language-selector/language-selector.jsx
+++ b/src/components/language-selector/language-selector.jsx
@@ -5,7 +5,7 @@ import locales from 'scratch-l10n';
 import styles from './language-selector.css';
 
 // supported languages to exclude from the menu, but allow as a URL option
-const ignore = ['he'];
+const ignore = [];
 
 const LanguageSelector = ({currentLocale, label, onChange}) => (
     <select


### PR DESCRIPTION
I left the ability to ignore languages in place so that we can continue to have languages that are available, but not in the menu for everyone.
