### PR TITLE
fixRepeatDecode

### DIFF
--- a/src/containers/sprite-selector-item.jsx
+++ b/src/containers/sprite-selector-item.jsx
@@ -32,7 +32,17 @@ class SpriteSelectorItem extends React.Component {
         ]);
         this.svgRenderer = new SVGRenderer();
         // Asset ID of the SVG currently in SVGRenderer
-        this.svgRendererAssetId = null;
+        this.decodedAssetId = null;
+    }
+    shouldComponentUpdate (nextProps) {
+        // Ignore dragPayload due to https://github.com/LLK/scratch-gui/issues/3172.
+        // This function should be removed once the issue is fixed.
+        for (const property in nextProps) {
+            if (property !== 'dragPayload' && this.props[property] !== nextProps[property]) {
+                return true;
+            }
+        }
+        return false;
     }
     getCostumeUrl () {
         if (this.props.costumeURL) return this.props.costumeURL;
@@ -44,18 +54,20 @@ class SpriteSelectorItem extends React.Component {
         // Avoid parsing the SVG when possible, since it's expensive.
         if (asset.assetType === storage.AssetType.ImageVector) {
             // If the asset ID has not changed, no need to re-parse
-            if (this.svgRendererAssetId === this.props.assetId) {
+            if (this.decodedAssetId === this.props.assetId) {
+                // @todo consider caching more than one URL.
                 return this.cachedUrl;
             }
-
+            this.decodedAssetId = this.props.assetId;
             const svgString = this.props.vm.runtime.storage.get(this.props.assetId).decodeText();
             if (svgString.match(HAS_FONT_REGEXP)) {
-                this.svgRendererAssetId = this.props.assetId;
                 this.svgRenderer.loadString(svgString);
                 const svgText = this.svgRenderer.toString(true /* shouldInjectFonts */);
                 this.cachedUrl = `data:image/svg+xml;utf8,${encodeURIComponent(svgText)}`;
-                return this.cachedUrl;
+            } else {
+                this.cachedUrl = this.props.vm.runtime.storage.get(this.props.assetId).encodeDataURI();
             }
+            return this.cachedUrl;
         }
         return this.props.vm.runtime.storage.get(this.props.assetId).encodeDataURI();
     }


### PR DESCRIPTION
### Resolves
This (mostly) fixes https://github.com/LLK/scratch-gui/issues/3173 (https://llk.github.io/scratch-gui/develop/#105500895 runs super slow)

### Proposed Changes
decodeText takes a substantial amount of time (making each frame take ~200ms in the problem project). We were caching to prevent too many calls to svgRenderer.loadString. Now include decodeText in the caching too.

Additionally, sprite selector items don't need to rerender every frame. dragPayload is giving a different object every frame, even though every property of the objects match. For now, ignore dragPayload in shouldComponentUpdate. https://github.com/LLK/scratch-gui/issues/3172 is filed as a separate bug to clean this up later.

### Reason for Changes
Performance fix

### Test Coverage
Play geometry dash until you can finish all the levels. Perseverance is key.
Test that dragging still works as expected.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
