### PR TITLE
Create clickVisibleByXpath function in Selenium Helpers

### DIFF
--- a/test/helpers/selenium-helper.js
+++ b/test/helpers/selenium-helper.js
@@ -14,6 +14,7 @@ class SeleniumHelper {
             'clickText',
             'clickButton',
             'clickXpath',
+            'clickVisibleByXpath',
             'findByText',
             'findByXpath',
             'getDriver',
@@ -94,6 +95,10 @@ class SeleniumHelper {
 
     clickXpath (xpath) {
         return this.findByXpath(xpath).then(el => el.click());
+    }
+
+    clickVisibleByXpath (xpath) {
+        return this.driver.wait(until.elementIsVisible(this.findByXpath(xpath))).then(el => el.click());
     }
 
     clickText (text, scope) {

--- a/test/integration/project-loading.test.js
+++ b/test/integration/project-loading.test.js
@@ -4,6 +4,7 @@ import SeleniumHelper from '../helpers/selenium-helper';
 const {
     clickText,
     clickXpath,
+    clickVisibleByXpath,
     findByXpath,
     getDriver,
     getLogs,
@@ -73,7 +74,7 @@ describe('Loading scratch gui', () => {
             await loadUri(`${uri}#${projectId}`);
             await clickXpath('//button[@title="Try It"]');
             await new Promise(resolve => setTimeout(resolve, 3000));
-            await clickXpath('//img[@title="Go"]');
+            await clickVisibleByXpath('//img[@title="Go"]');
             await new Promise(resolve => setTimeout(resolve, 2000));
             await clickXpath('//img[@title="Stop"]');
             const logs = await getLogs();


### PR DESCRIPTION
### Proposed Changes

Creates and implements in one case the clickVisibleByXpath function in the SeleniumHelpers.  

### Reason for Changes

This should make sure that the element is visible on the screen before clicking it. This should remove some flakyness of tests, specifically the project-loading test: Load a project by ID directly through url.
