### PR TITLE
Robust URL handling for tutorial and locale

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "postcss-loader": "^3.0.0",
     "postcss-simple-vars": "^5.0.1",
     "prop-types": "^15.5.10",
+    "query-string": "^5.1.1",
     "raf": "^3.4.0",
     "raw-loader": "^0.5.1",
     "react": "16.2.0",

--- a/src/lib/detect-locale.js
+++ b/src/lib/detect-locale.js
@@ -3,6 +3,8 @@
  * Utility function to detect locale from the browser setting or paramenter on the URL.
  */
 
+import queryString from 'query-string';
+
 /**
  * look for language setting in the browser. Check against supported locales.
  * If there's a parameter in the URL, override the browser setting
@@ -23,13 +25,18 @@ const detectLocale = supportedLocales => {
         }
     }
 
-    if (window.location.search.indexOf('locale=') !== -1 ||
-        window.location.search.indexOf('lang=') !== -1) {
-        const urlLocale = window.location.search.match(/(?:locale|lang)=([\w-]+)/)[1].toLowerCase();
-        if (supportedLocales.includes(urlLocale)) {
-            locale = urlLocale;
-        }
+    const queryParams = queryString.parse(location.search);
+    // Flatten potential arrays and remove falsy values
+    const potentialLocales = [].concat(queryParams.locale, queryParams.lang).filter(l => l);
+    if (!potentialLocales.length) {
+        return locale;
     }
+
+    const urlLocale = potentialLocales[0].toLowerCase();
+    if (supportedLocales.includes(urlLocale)) {
+        return urlLocale;
+    }
+
     return locale;
 };
 

--- a/src/lib/tutorial-from-url.js
+++ b/src/lib/tutorial-from-url.js
@@ -5,6 +5,7 @@
 
 import tutorials from './libraries/decks/index.jsx';
 import analytics from './analytics';
+import queryString from 'query-string';
 
 /**
  * Get the tutorial id from the given numerical id (representing the
@@ -34,11 +35,14 @@ const getDeckIdFromUrlId = urlId => {
  * requested or found.
  */
 const detectTutorialId = () => {
-    if (window.location.search.indexOf('tutorial=') !== -1) {
-        const urlTutorialId = window.location.search.match(/(?:tutorial)=(\d+)/)[1];
-        if (urlTutorialId) {
-            return getDeckIdFromUrlId(Number(urlTutorialId));
-        }
+    const queryParams = queryString.parse(location.search);
+    const tutorialID = Number(
+        Array.isArray(queryParams.tutorial) ?
+            queryParams.tutorial[0] :
+            queryParams.tutorial
+    );
+    if (!isNaN(tutorialID)) {
+        return getDeckIdFromUrlId(tutorialID);
     }
     return null;
 };

--- a/test/unit/util/detect-locale.test.js
+++ b/test/unit/util/detect-locale.test.js
@@ -67,4 +67,20 @@ describe('detectLocale', () => {
         );
         expect(detectLocale(supportedLocales)).toEqual('en');
     });
+
+    test('works with an empty locale', () => {
+        Object.defineProperty(window.location,
+            'search',
+            {value: '?locale='}
+        );
+        expect(detectLocale(supportedLocales)).toEqual('en');
+    });
+
+    test('if multiple, uses the first locale', () => {
+        Object.defineProperty(window.location,
+            'search',
+            {value: '?locale=de&locale=en'}
+        );
+        expect(detectLocale(supportedLocales)).toEqual('de');
+    });
 });

--- a/test/unit/util/tutorial-from-url.test.js
+++ b/test/unit/util/tutorial-from-url.test.js
@@ -1,0 +1,40 @@
+jest.mock('../../../src/lib/analytics.js', () => ({
+    event: () => {}
+}));
+
+jest.mock('../../../src/lib/libraries/decks/index.jsx', () => ({
+    foo: {urlId: 1}
+}));
+
+import {detectTutorialId} from '../../../src/lib/tutorial-from-url.js';
+
+Object.defineProperty(
+    window.location,
+    'search',
+    {value: '', writable: true}
+);
+
+test('returns the tutorial ID if the urlId matches', () => {
+    window.location.search = '?tutorial=1';
+    expect(detectTutorialId()).toBe('foo');
+});
+
+test('returns null if no matching urlId', () => {
+    window.location.search = '?tutorial=10';
+    expect(detectTutorialId()).toBe(null);
+});
+
+test('returns null if empty template', () => {
+    window.location.search = '?tutorial=';
+    expect(detectTutorialId()).toBe(null);
+});
+
+test('returns null if non-numeric template', () => {
+    window.location.search = '?tutorial=asdf';
+    expect(detectTutorialId()).toBe(null);
+});
+
+test('takes the first of multiple', () => {
+    window.location.search = '?tutorial=1&tutorial=2';
+    expect(detectTutorialId()).toBe('foo');
+});


### PR DESCRIPTION
### Resolves

- Resolves #3167

### Proposed Changes

Import the `query-string` package (a popular and battle-tested option) to safely parse query strings.

### Reason for Changes

The code relying on regexes and direct string manipulation of the query string is brittle and has bugs.

### Test Coverage

Added new unit tests.

Manual test plan:

- Tutorial:
  - http://localhost:8601/?tutorial=sdf
  - doesn't crash anymore
  - http://localhost:8601/?tutorial=1
  - opens the first tutorial
- Locale:
  - http://localhost:8601/?locale=fr
  - loads the french version
  - http://localhost:8601/?locale=
  - doesn't crash

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
