### PR TITLE
Expose AppStateHOC component

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import GUI from './containers/gui.jsx';
+import AppStateHOC from './lib/app-state-hoc.jsx';
 import GuiReducer, {guiInitialState, guiMiddleware, initFullScreen, initPlayer} from './reducers/gui';
 import LocalesReducer, {localesInitialState, initLocale} from './reducers/locales';
 import {ScratchPaintReducer} from 'scratch-paint';
@@ -13,6 +14,7 @@ const guiReducers = {
 
 export {
     GUI as default,
+    AppStateHOC,
     setAppElement,
     guiReducers,
     guiInitialState,


### PR DESCRIPTION
### Proposed Changes

For use from `scratch-desktop` and maybe other places.

### Reason for Changes

The `scratch-desktop` repository can use this component to more easily host the "whole" editor.

The main question I have is: is this the right component to use? If not, is there another that would make more sense or should we make a new editor-wrapper component?

### Test Coverage

Since this is just exposing existing code at the module boundary, there's no new code to test.
