### PR TITLE
Show multiple alerts in a stack and allow for custom alert icons.

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "scratch-render": "0.1.0-prerelease.20180918201144",
     "scratch-storage": "1.0.2",
     "scratch-svg-renderer": "0.2.0-prerelease.20180907141232",
-    "scratch-vm": "0.2.0-prerelease.20180918201814",
+    "scratch-vm": "0.2.0-prerelease.20180925190229",
     "selenium-webdriver": "3.6.0",
     "startaudiocontext": "1.2.1",
     "style-loader": "^0.23.0",

--- a/src/components/alerts/alert.css
+++ b/src/components/alerts/alert.css
@@ -18,6 +18,7 @@
 
 .alert-icon {
     vertical-align: middle;
+    margin-right: 5px;
 }
 
 .alert-message {

--- a/src/components/alerts/alert.css
+++ b/src/components/alerts/alert.css
@@ -13,7 +13,11 @@
     border-radius: 8px;
     padding: 12px;
     box-shadow: 2px 2px 2px 2px rgba(255, 140, 26, 0.25);
-    margin-bottom: 4px;
+    margin-bottom: 7px;
+}
+
+.alert-icon {
+    vertical-align: middle;
 }
 
 .alert-message {

--- a/src/components/alerts/alert.css
+++ b/src/components/alerts/alert.css
@@ -13,6 +13,7 @@
     border-radius: 8px;
     padding: 12px;
     box-shadow: 2px 2px 2px 2px rgba(255, 140, 26, 0.25);
+    margin-bottom: 4px;
 }
 
 .alert-message {

--- a/src/components/alerts/alert.jsx
+++ b/src/components/alerts/alert.jsx
@@ -1,50 +1,39 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import bindAll from 'lodash.bindall';
 
 import Box from '../box/box.jsx';
 import Button from '../button/button.jsx';
 
 import styles from './alert.css';
 
-class AlertComponent extends React.Component {
-    constructor (props) {
-        super(props);
-        bindAll(this, [
-            'handleOnCloseAlert'
-        ]);
-    }
-    handleOnCloseAlert () {
-        this.props.onCloseAlert(this.props.index);
-    }
-    render () {
-        return (
-            <Box
-                className={styles.alert}
-            >
-                <div className={styles.alertMessage}>
-                    {this.props.iconURL ? (
-                        <img
-                            className={styles.alertIcon}
-                            src={this.props.iconURL}
-                        />
-                    ) : null}
-                    {this.props.message}
-                </div>
-                <Button
-                    className={styles.alertRemoveButton}
-                    onClick={this.handleOnCloseAlert}
-                >
-                    {'x'}
-                </Button>
-            </Box>
-        );
-    }
-}
+const AlertComponent = ({
+    iconURL,
+    message,
+    onCloseAlert
+}) => (
+    <Box
+        className={styles.alert}
+    >
+        <div className={styles.alertMessage}>
+            {iconURL ? (
+                <img
+                    className={styles.alertIcon}
+                    src={iconURL}
+                />
+            ) : null}
+            {message}
+        </div>
+        <Button
+            className={styles.alertRemoveButton}
+            onClick={onCloseAlert}
+        >
+            {'x'}
+        </Button>
+    </Box>
+);
 
 AlertComponent.propTypes = {
     iconURL: PropTypes.string,
-    index: PropTypes.number,
     message: PropTypes.string,
     onCloseAlert: PropTypes.func.isRequired
 };

--- a/src/components/alerts/alert.jsx
+++ b/src/components/alerts/alert.jsx
@@ -1,51 +1,52 @@
-import classNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
+import bindAll from 'lodash.bindall';
 
 import Box from '../box/box.jsx';
 import Button from '../button/button.jsx';
 
 import styles from './alert.css';
 
-const Alerts = ({
-    alertsList,
-    className,
-    onCloseAlert
-}) => (
-    <Box
-        bounds="parent"
-        className={classNames(className)}
-    >
-        {alertsList.map((a, index) => (
+class AlertComponent extends React.Component {
+    constructor (props) {
+        super(props);
+        bindAll(this, [
+            'handleOnCloseAlert'
+        ]);
+    }
+    handleOnCloseAlert () {
+        this.props.onCloseAlert(this.props.index);
+    }
+    render () {
+        return (
             <Box
                 className={styles.alert}
-                key={index}
             >
                 <div className={styles.alertMessage}>
-                    {a.iconURL ? (
+                    {this.props.iconURL ? (
                         <img
                             className={styles.alertIcon}
-                            src={a.iconURL}
+                            src={this.props.iconURL}
                         />
                     ) : null}
-                    {a.message}
+                    {this.props.message}
                 </div>
                 <Button
                     className={styles.alertRemoveButton}
-                    key={index}
-                    onClick={onCloseAlert}
+                    onClick={this.handleOnCloseAlert}
                 >
                     {'x'}
                 </Button>
             </Box>
-        ))}
-    </Box>
-);
+        );
+    }
+}
 
-Alerts.propTypes = {
-    alertsList: PropTypes.arrayOf(PropTypes.object),
-    className: PropTypes.string,
+AlertComponent.propTypes = {
+    iconURL: PropTypes.string,
+    index: PropTypes.number,
+    message: PropTypes.string,
     onCloseAlert: PropTypes.func.isRequired
 };
 
-export default Alerts;
+export default AlertComponent;

--- a/src/components/alerts/alerts.jsx
+++ b/src/components/alerts/alerts.jsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import Box from '../box/box.jsx';
 import Button from '../button/button.jsx';
 
@@ -21,6 +22,9 @@ const Alerts = ({
                 key={index}
             >
                 <div className={styles.alertMessage}>
+                    <img
+                        src={a.iconURL}
+                    />
                     {a.message}
                 </div>
                 <Button

--- a/src/components/alerts/alerts.jsx
+++ b/src/components/alerts/alerts.jsx
@@ -8,33 +8,36 @@ import styles from './alert.css';
 
 const Alerts = ({
     className,
-    message,
+    alertsList,
     onCloseAlert
 }) => (
     <Box
         bounds="parent"
         className={classNames(className)}
     >
-        <Box
-            className={styles.alert}
-        >
-            <div className={styles.alertMessage}>
-                {message}
-            </div>
-            <Button
-                className={styles.alertRemoveButton}
-                onClick={onCloseAlert}
+        {alertsList.map((a, index) => (
+            <Box
+                className={styles.alert}
+                key={index}
             >
-                { /* eslint-disable react/jsx-no-literals */ }
-                x
-            </Button>
-        </Box>
+                <div className={styles.alertMessage}>
+                    {a.message}
+                </div>
+                <Button
+                    className={styles.alertRemoveButton}
+                    onClick={() => onCloseAlert(index)}
+                >
+                    { /* eslint-disable react/jsx-no-literals */ }
+                    x
+                </Button>
+            </Box>
+        ))}
     </Box>
 );
 
 Alerts.propTypes = {
+    alertsList: PropTypes.arrayOf(PropTypes.object),
     className: PropTypes.string,
-    message: PropTypes.string.isRequired,
     onCloseAlert: PropTypes.func.isRequired
 };
 

--- a/src/components/alerts/alerts.jsx
+++ b/src/components/alerts/alerts.jsx
@@ -22,10 +22,7 @@ const Alerts = ({
                 key={index}
             >
                 <div className={styles.alertMessage}>
-                    <img
-                        src={a.iconURL}
-                    />
-                    {a.message}
+                    <img className={styles.alertIcon} src={a.iconURL} /> {a.message} {a.name}.
                 </div>
                 <Button
                     className={styles.alertRemoveButton}

--- a/src/components/alerts/alerts.jsx
+++ b/src/components/alerts/alerts.jsx
@@ -8,8 +8,8 @@ import Button from '../button/button.jsx';
 import styles from './alert.css';
 
 const Alerts = ({
-    className,
     alertsList,
+    className,
     onCloseAlert
 }) => (
     <Box
@@ -22,14 +22,17 @@ const Alerts = ({
                 key={index}
             >
                 <div className={styles.alertMessage}>
-                    <img className={styles.alertIcon} src={a.iconURL} /> {a.message} {a.name}.
+                    <img
+                        className={styles.alertIcon}
+                        src={a.iconURL}
+                    /> {a.message} {a.name} {'.'}
                 </div>
                 <Button
                     className={styles.alertRemoveButton}
-                    onClick={() => onCloseAlert(index)}
+                    key={index}
+                    onClick={onCloseAlert}
                 >
-                    { /* eslint-disable react/jsx-no-literals */ }
-                    x
+                    {'x'}
                 </Button>
             </Box>
         ))}

--- a/src/components/alerts/alerts.jsx
+++ b/src/components/alerts/alerts.jsx
@@ -22,10 +22,13 @@ const Alerts = ({
                 key={index}
             >
                 <div className={styles.alertMessage}>
-                    <img
-                        className={styles.alertIcon}
-                        src={a.iconURL}
-                    /> {a.message} {a.name} {'.'}
+                    {a.iconURL ? (
+                        <img
+                            className={styles.alertIcon}
+                            src={a.iconURL}
+                        />
+                    ) : null}
+                    {a.message}
                 </div>
                 <Button
                     className={styles.alertRemoveButton}

--- a/src/containers/alert.jsx
+++ b/src/containers/alert.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import bindAll from 'lodash.bindall';
+import PropTypes from 'prop-types';
+
+import AlertComponent from '../components/alerts/alert.jsx';
+
+class Alert extends React.Component {
+    constructor (props) {
+        super(props);
+        bindAll(this, [
+            'handleOnCloseAlert'
+        ]);
+    }
+    handleOnCloseAlert () {
+        this.props.onCloseAlert(this.props.index);
+    }
+    render () {
+        return (
+            <AlertComponent
+                iconURL={this.props.iconURL}
+                message={this.props.message}
+                onCloseAlert={this.handleOnCloseAlert}
+            />
+        );
+    }
+}
+
+Alert.propTypes = {
+    iconURL: PropTypes.string,
+    index: PropTypes.number,
+    message: PropTypes.string,
+    onCloseAlert: PropTypes.func.isRequired
+};
+
+export default Alert;

--- a/src/containers/alerts.jsx
+++ b/src/containers/alerts.jsx
@@ -1,5 +1,5 @@
+import classNames from 'classnames';
 import React from 'react';
-import bindAll from 'lodash.bindall';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 
@@ -7,28 +7,29 @@ import {
     closeAlert
 } from '../reducers/alerts';
 
-import AlertsComponent from '../components/alerts/alerts.jsx';
+import Box from '../components/box/box.jsx';
+import AlertComponent from '../components/alerts/alert.jsx';
 
-class Alerts extends React.Component {
-    constructor (props) {
-        super(props);
-        bindAll(this, [
-            'handleOnCloseAlert'
-        ]);
-    }
-    handleOnCloseAlert (e) {
-        this.props.onCloseAlert(e.target.key);
-    }
-    render () {
-        return (
-            <AlertsComponent
-                alertsList={this.props.alertsList}
-                className={this.props.className}
-                onCloseAlert={this.handleOnCloseAlert}
+const Alerts = ({
+    alertsList,
+    className,
+    onCloseAlert
+}) => (
+    <Box
+        bounds="parent"
+        className={classNames(className)}
+    >
+        {alertsList.map((a, index) => (
+            <AlertComponent
+                iconURL={a.iconURL}
+                index={index}
+                key={index}
+                message={a.message}
+                onCloseAlert={onCloseAlert}
             />
-        );
-    }
-}
+        ))}
+    </Box>
+);
 
 Alerts.propTypes = {
     alertsList: PropTypes.arrayOf(PropTypes.object),

--- a/src/containers/alerts.jsx
+++ b/src/containers/alerts.jsx
@@ -8,7 +8,7 @@ import {
 } from '../reducers/alerts';
 
 import Box from '../components/box/box.jsx';
-import AlertComponent from '../components/alerts/alert.jsx';
+import Alert from '../containers/alert.jsx';
 
 const Alerts = ({
     alertsList,
@@ -20,7 +20,7 @@ const Alerts = ({
         className={classNames(className)}
     >
         {alertsList.map((a, index) => (
-            <AlertComponent
+            <Alert
                 iconURL={a.iconURL}
                 index={index}
                 key={index}

--- a/src/containers/alerts.jsx
+++ b/src/containers/alerts.jsx
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 
 import {
-    showAlert,
     closeAlert
 } from '../reducers/alerts';
 
@@ -38,12 +37,10 @@ Alerts.propTypes = {
 };
 
 const mapStateToProps = state => ({
-    visible: state.scratchGui.alerts.visible,
     alertsList: state.scratchGui.alerts.alertsList
 });
 
 const mapDispatchToProps = dispatch => ({
-    onShowAlert: () => dispatch(showAlert()),
     onCloseAlert: index => dispatch(closeAlert(index))
 });
 

--- a/src/containers/alerts.jsx
+++ b/src/containers/alerts.jsx
@@ -9,12 +9,13 @@ import AlertsComponent from '../components/alerts/alerts.jsx';
 
 const mapStateToProps = state => ({
     visible: state.scratchGui.alerts.visible,
-    message: state.scratchGui.alerts.message
+    message: state.scratchGui.alerts.message,
+    alertsList: state.scratchGui.alerts.alertsList
 });
 
 const mapDispatchToProps = dispatch => ({
     onShowAlert: () => dispatch(showAlert()),
-    onCloseAlert: () => dispatch(closeAlert())
+    onCloseAlert: index => dispatch(closeAlert(index))
 });
 
 export default connect(

--- a/src/containers/alerts.jsx
+++ b/src/containers/alerts.jsx
@@ -9,7 +9,6 @@ import AlertsComponent from '../components/alerts/alerts.jsx';
 
 const mapStateToProps = state => ({
     visible: state.scratchGui.alerts.visible,
-    message: state.scratchGui.alerts.message,
     alertsList: state.scratchGui.alerts.alertsList
 });
 

--- a/src/containers/alerts.jsx
+++ b/src/containers/alerts.jsx
@@ -1,3 +1,6 @@
+import React from 'react';
+import bindAll from 'lodash.bindall';
+import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 
 import {
@@ -6,6 +9,33 @@ import {
 } from '../reducers/alerts';
 
 import AlertsComponent from '../components/alerts/alerts.jsx';
+
+class Alerts extends React.Component {
+    constructor (props) {
+        super(props);
+        bindAll(this, [
+            'handleOnCloseAlert'
+        ]);
+    }
+    handleOnCloseAlert (e) {
+        this.props.onCloseAlert(e.target.key);
+    }
+    render () {
+        return (
+            <AlertsComponent
+                alertsList={this.props.alertsList}
+                className={this.props.className}
+                onCloseAlert={this.handleOnCloseAlert}
+            />
+        );
+    }
+}
+
+Alerts.propTypes = {
+    alertsList: PropTypes.arrayOf(PropTypes.object),
+    className: PropTypes.string,
+    onCloseAlert: PropTypes.func
+};
 
 const mapStateToProps = state => ({
     visible: state.scratchGui.alerts.visible,
@@ -20,4 +50,4 @@ const mapDispatchToProps = dispatch => ({
 export default connect(
     mapStateToProps,
     mapDispatchToProps
-)(AlertsComponent);
+)(Alerts);

--- a/src/lib/vm-listener-hoc.jsx
+++ b/src/lib/vm-listener-hoc.jsx
@@ -139,8 +139,8 @@ const vmListenerHOC = function (WrappedComponent) {
         onProjectRunStop: () => dispatch(setRunningState(false)),
         onTurboModeOn: () => dispatch(setTurboState(true)),
         onTurboModeOff: () => dispatch(setTurboState(false)),
-        onShowAlert: () => {
-            dispatch(showAlert('Scratch has lost connection to peripheral.'));
+        onShowAlert: data => {
+            dispatch(showAlert(data));
         }
     });
     return connect(

--- a/src/reducers/alerts.js
+++ b/src/reducers/alerts.js
@@ -43,6 +43,12 @@ const reducer = function (state, action) {
     }
 };
 
+/**
+ * Function to close an alert with the given index.
+ *
+ * @param {object} index - the index of the alert to close.
+ * @return {object} - an object to be passed to the reducer.
+ */
 const closeAlert = function (index) {
     return {
         type: CLOSE_ALERT,
@@ -50,6 +56,12 @@ const closeAlert = function (index) {
     };
 };
 
+/**
+ * Function to show an alert with the given input data.
+ *
+ * @param {object} data - data with the following props: {message, extensionId=null}
+ * @return {object} - an object to be passed to the reducer.
+ */
 const showAlert = function (data) {
     return {
         type: SHOW_ALERT,

--- a/src/reducers/alerts.js
+++ b/src/reducers/alerts.js
@@ -14,7 +14,7 @@ const reducer = function (state, action) {
     case SHOW_ALERT: {
         const newList = state.alertsList.slice();
         const newAlert = {message: action.data.message};
-        if (action.data.extensionId) {
+        if (action.data.extensionId) { // if it's an extension
             const extension = extensionData.find(ext => ext.extensionId === action.data.extensionId);
             if (extension && extension.name) {
                 newAlert.name = extension.name;
@@ -23,6 +23,7 @@ const reducer = function (state, action) {
                 newAlert.iconURL = extension.smallPeripheralImage;
             }
         }
+        // TODO: add cases for other kinds of alerts?
         newList.push(newAlert);
         return Object.assign({}, state, {
             alertsList: newList

--- a/src/reducers/alerts.js
+++ b/src/reducers/alerts.js
@@ -1,3 +1,5 @@
+import extensionData from '../lib/libraries/extensions/index.jsx';
+
 const CLOSE_ALERT = 'scratch-gui/alerts/CLOSE_ALERT';
 const SHOW_ALERT = 'scratch-gui/alerts/SHOW_ALERT';
 
@@ -11,7 +13,14 @@ const reducer = function (state, action) {
     switch (action.type) {
     case SHOW_ALERT: {
         const newList = state.alertsList.slice();
-        newList.push({message: action.message});
+        const newAlert = {message: action.data.message};
+        if (action.data.extensionId) {
+            const extension = extensionData.find(ext => ext.extensionId === action.data.extensionId);
+            if (extension && extension.smallPeripheralImage) {
+                newAlert.iconURL = extension.smallPeripheralImage;
+            }
+        }
+        newList.push(newAlert);
         return Object.assign({}, state, {
             alertsList: newList
         });
@@ -35,10 +44,10 @@ const closeAlert = function (index) {
     };
 };
 
-const showAlert = function (message) {
+const showAlert = function (data) {
     return {
         type: SHOW_ALERT,
-        message
+        data
     };
 };
 

--- a/src/reducers/alerts.js
+++ b/src/reducers/alerts.js
@@ -14,16 +14,18 @@ const reducer = function (state, action) {
     case SHOW_ALERT: {
         const newList = state.alertsList.slice();
         const newAlert = {message: action.data.message};
-        if (action.data.extensionId) { // if it's an extension
-            const extension = extensionData.find(ext => ext.extensionId === action.data.extensionId);
+        const extensionId = action.data.extensionId;
+        if (extensionId) { // if it's an extension
+            const extension = extensionData.find(ext => ext.extensionId === extensionId);
             if (extension && extension.name) {
-                newAlert.name = extension.name;
+                // TODO: is this the right place to assemble this message?
+                newAlert.message = `${newAlert.message} ${extension.name}.`;
             }
             if (extension && extension.smallPeripheralImage) {
                 newAlert.iconURL = extension.smallPeripheralImage;
             }
         }
-        // TODO: add cases for other kinds of alerts?
+        // TODO: add cases for other kinds of alerts here?
         newList.push(newAlert);
         return Object.assign({}, state, {
             alertsList: newList

--- a/src/reducers/alerts.js
+++ b/src/reducers/alerts.js
@@ -16,6 +16,9 @@ const reducer = function (state, action) {
         const newAlert = {message: action.data.message};
         if (action.data.extensionId) {
             const extension = extensionData.find(ext => ext.extensionId === action.data.extensionId);
+            if (extension && extension.name) {
+                newAlert.name = extension.name;
+            }
             if (extension && extension.smallPeripheralImage) {
                 newAlert.iconURL = extension.smallPeripheralImage;
             }

--- a/src/reducers/alerts.js
+++ b/src/reducers/alerts.js
@@ -2,29 +2,37 @@ const CLOSE_ALERT = 'scratch-gui/alerts/CLOSE_ALERT';
 const SHOW_ALERT = 'scratch-gui/alerts/SHOW_ALERT';
 
 const initialState = {
-    message: '',
-    visible: false
+    visible: true,
+    alertsList: []
 };
 
 const reducer = function (state, action) {
     if (typeof state === 'undefined') state = initialState;
     switch (action.type) {
-    case SHOW_ALERT:
+    case SHOW_ALERT: {
+        const newList = state.alertsList.slice();
+        newList.push({message: action.message});
         return Object.assign({}, state, {
-            visible: true,
-            message: action.message
+            alertsList: newList
         });
-    case CLOSE_ALERT:
+    }
+    case CLOSE_ALERT: {
+        const newList = state.alertsList.slice();
+        newList.splice(action.index, 1);
         return Object.assign({}, state, {
-            visible: false
+            alertsList: newList
         });
+    }
     default:
         return state;
     }
 };
 
-const closeAlert = function () {
-    return {type: CLOSE_ALERT};
+const closeAlert = function (index) {
+    return {
+        type: CLOSE_ALERT,
+        index
+    };
 };
 
 const showAlert = function (message) {


### PR DESCRIPTION
### Resolves

This is progress towards: https://github.com/LLK/scratch-gui/issues/2956.

### Proposed Changes

- Displays stacks of alerts vertically.
- Shows an icon in an alert if one is provided.

<img width="727" alt="screen shot 2018-09-22 at 5 40 22 pm" src="https://user-images.githubusercontent.com/699840/45922015-4e6a7300-be8f-11e8-811d-876884f9365e.png">

### Reason for Changes

To improve on previous alerts that displayed directly on top of each other, and to add further customizability with optional icons.

### Notes

- Is a prerequisite for this PR in scratch-vm: https://github.com/LLK/scratch-vm/pull/1607. 