### PR TITLE
Fix sprite-info pane for ‘wide’ languages

### DIFF
--- a/src/components/direction-picker/direction-picker.jsx
+++ b/src/components/direction-picker/direction-picker.jsx
@@ -52,6 +52,7 @@ const messages = defineMessages({
 const DirectionPicker = props => (
     <Label
         secondary
+        above={props.labelAbove}
         text={directionLabel}
     >
         <Popover
@@ -124,6 +125,7 @@ DirectionPicker.propTypes = {
     direction: PropTypes.number,
     disabled: PropTypes.bool.isRequired,
     intl: intlShape,
+    labelAbove: PropTypes.bool,
     onChangeDirection: PropTypes.func.isRequired,
     onClickAllAround: PropTypes.func.isRequired,
     onClickDontRotate: PropTypes.func.isRequired,
@@ -132,6 +134,10 @@ DirectionPicker.propTypes = {
     onOpenPopover: PropTypes.func.isRequired,
     popoverOpen: PropTypes.bool.isRequired,
     rotationStyle: PropTypes.string
+};
+
+DirectionPicker.defaultProps = {
+    labelAbove: false
 };
 
 const WrappedDirectionPicker = injectIntl(DirectionPicker);

--- a/src/components/forms/label.css
+++ b/src/components/forms/label.css
@@ -7,6 +7,16 @@
     align-items: center;
 }
 
+.input-group-column {
+    display: inline-flex;
+    flex-direction: column;
+    align-items: flex-start;
+}
+
+.input-group-column span {
+    margin-bottom: .25rem;
+}
+
 .input-label, .input-label-secondary {
     font-size: 0.625rem;
     user-select: none;
@@ -15,11 +25,11 @@
     white-space: nowrap;
 }
 
-[dir="ltr"] .input-label, .input-label-secondary {
+[dir="ltr"] .input-label, [dir="ltr"] .input-label-secondary {
     margin-right: .5rem;
 }
 
-[dir="rtl"] .input-label, .input-label-secondary {
+[dir="rtl"] .input-label, [dir="rtl"] .input-label-secondary {
     margin-left: .5rem;
 }
 

--- a/src/components/forms/label.jsx
+++ b/src/components/forms/label.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 import styles from './label.css';
 
 const Label = props => (
-    <label className={styles.inputGroup}>
+    <label className={props.above ? styles.inputGroupColumn : styles.inputGroup}>
         <span className={props.secondary ? styles.inputLabelSecondary : styles.inputLabel}>
             {props.text}
         </span>
@@ -13,12 +13,14 @@ const Label = props => (
 );
 
 Label.propTypes = {
+    above: PropTypes.bool,
     children: PropTypes.node,
     secondary: PropTypes.bool,
     text: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired
 };
 
 Label.defaultProps = {
+    above: false,
     secondary: false
 };
 

--- a/src/components/sprite-info/sprite-info.css
+++ b/src/components/sprite-info/sprite-info.css
@@ -2,7 +2,6 @@
 @import "../../css/colors.css";
 
 .sprite-info {
-    height: $sprite-info-height;
     padding: 0.75rem;
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
     background-color: white;
@@ -27,6 +26,16 @@
     display: inline-flex;
     flex-direction: row; /* makes columns, for each label/form group */
     align-items: center;
+}
+
+.column {
+    display: inline-flex;
+    flex-direction: column; /* put label above input */
+    align-items: flex-start;
+}
+
+.column span {
+    margin-bottom: .25rem;
 }
 
 .icon-wrapper {

--- a/src/components/sprite-info/sprite-info.jsx
+++ b/src/components/sprite-info/sprite-info.jsx
@@ -11,6 +11,8 @@ import DirectionPicker from '../../containers/direction-picker.jsx';
 import {injectIntl, intlShape, defineMessages, FormattedMessage} from 'react-intl';
 
 import {STAGE_DISPLAY_SIZES} from '../../lib/layout-constants.js';
+import {isWideLocale} from '../../lib/locale-utils.js';
+
 import styles from './sprite-info.css';
 
 import xIcon from './icon--x.svg';
@@ -69,9 +71,16 @@ class SpriteInfo extends React.Component {
             />
         );
 
+        const labelAbove = isWideLocale(this.props.intl.locale);
+
         const spriteNameInput = (
             <BufferedInput
-                className={styles.spriteInput}
+                className={classNames(
+                    styles.spriteInput,
+                    {
+                        [styles.columnInput]: labelAbove
+                    }
+                )}
                 disabled={this.props.disabled}
                 placeholder={this.props.intl.formatMessage(messages.spritePlaceholder)}
                 tabIndex="0"
@@ -155,7 +164,10 @@ class SpriteInfo extends React.Component {
             <Box className={styles.spriteInfo}>
                 <div className={classNames(styles.row, styles.rowPrimary)}>
                     <div className={styles.group}>
-                        <Label text={sprite}>
+                        <Label
+                            above={labelAbove}
+                            text={sprite}
+                        >
                             {spriteNameInput}
                         </Label>
                     </div>
@@ -163,7 +175,7 @@ class SpriteInfo extends React.Component {
                     {yPosition}
                 </div>
                 <div className={classNames(styles.row, styles.rowSecondary)}>
-                    <div className={styles.group}>
+                    <div className={labelAbove ? styles.column : styles.group}>
                         {
                             stageSize === STAGE_DISPLAY_SIZES.large ?
                                 <Label
@@ -216,6 +228,7 @@ class SpriteInfo extends React.Component {
                     <div className={classNames(styles.group, styles.largerInput)}>
                         <Label
                             secondary
+                            above={labelAbove}
                             text={sizeLabel}
                         >
                             <BufferedInput
@@ -233,6 +246,7 @@ class SpriteInfo extends React.Component {
                         <DirectionPicker
                             direction={this.props.direction}
                             disabled={this.props.disabled}
+                            labelAbove={labelAbove}
                             rotationStyle={this.props.rotationStyle}
                             onChangeDirection={this.props.onChangeDirection}
                             onChangeRotationStyle={this.props.onChangeRotationStyle}

--- a/src/components/sprite-selector/sprite-selector.jsx
+++ b/src/components/sprite-selector/sprite-selector.jsx
@@ -7,7 +7,7 @@ import SpriteInfo from '../../containers/sprite-info.jsx';
 import SpriteList from './sprite-list.jsx';
 import ActionMenu from '../action-menu/action-menu.jsx';
 import {STAGE_DISPLAY_SIZES} from '../../lib/layout-constants';
-import RtlLocales from '../../lib/rtl-locales';
+import {rtlLocales} from '../../lib/locale-utils';
 
 import styles from './sprite-selector.css';
 
@@ -140,7 +140,7 @@ const SpriteSelectorComponent = function (props) {
                     }
                 ]}
                 title={intl.formatMessage(messages.addSpriteFromLibrary)}
-                tooltipPlace={RtlLocales.indexOf(intl.locale) === -1 ? 'left' : 'right'}
+                tooltipPlace={rtlLocales.indexOf(intl.locale) === -1 ? 'left' : 'right'}
                 onClick={onNewSpriteClick}
             />
         </Box>

--- a/src/components/stage-selector/stage-selector.css
+++ b/src/components/stage-selector/stage-selector.css
@@ -78,6 +78,7 @@ $header-height: calc($stage-menu-height - 2px);
     font-size: 0.6rem;
     color: $text-primary;
     user-select: none;
+    text-align: center;
 }
 
 .costume-canvas {

--- a/src/containers/direction-picker.jsx
+++ b/src/containers/direction-picker.jsx
@@ -38,6 +38,7 @@ class DirectionPicker extends React.Component {
             <DirectionComponent
                 direction={this.props.direction}
                 disabled={this.props.disabled}
+                labelAbove={this.props.labelAbove}
                 popoverOpen={this.state.popoverOpen && !this.props.disabled}
                 rotationStyle={this.props.rotationStyle}
                 onChangeDirection={this.props.onChangeDirection}
@@ -54,6 +55,7 @@ class DirectionPicker extends React.Component {
 DirectionPicker.propTypes = {
     direction: PropTypes.number,
     disabled: PropTypes.bool,
+    labelAbove: PropTypes.bool,
     onChangeDirection: PropTypes.func,
     onChangeRotationStyle: PropTypes.func,
     rotationStyle: PropTypes.string

--- a/src/lib/locale-utils.js
+++ b/src/lib/locale-utils.js
@@ -1,0 +1,27 @@
+// TODO: this probably should be coming from scratch-l10n
+// Tracking in https://github.com/LLK/scratch-l10n/issues/32
+const rtlLocales = ['he'];
+
+const wideLocales = [
+    'ab',
+    'ca',
+    'de',
+    'el',
+    'it',
+    'ja',
+    'ja-Hira',
+    'ko',
+    'hu',
+    'ru',
+    'vi'
+];
+
+const isWideLocale = locale => (
+    wideLocales.indexOf(locale) !== -1
+);
+
+export {
+    rtlLocales,
+    wideLocales,
+    isWideLocale
+};

--- a/src/lib/rtl-locales.js
+++ b/src/lib/rtl-locales.js
@@ -1,3 +1,0 @@
-// TODO: this probably should be coming from scratch-l10n
-// Tracking in https://github.com/LLK/scratch-l10n/issues/32
-export default ['he'];

--- a/src/reducers/locales.js
+++ b/src/reducers/locales.js
@@ -2,7 +2,7 @@ import {addLocaleData} from 'react-intl';
 
 import {localeData} from 'scratch-l10n';
 import editorMessages from 'scratch-l10n/locales/editor-msgs';
-import RtlLocales from '../lib/rtl-locales';
+import {rtlLocales} from '../lib/locale-utils';
 
 addLocaleData(localeData);
 
@@ -21,7 +21,7 @@ const reducer = function (state, action) {
     switch (action.type) {
     case SELECT_LOCALE:
         return Object.assign({}, state, {
-            isRtl: RtlLocales.indexOf(action.locale) !== -1,
+            isRtl: rtlLocales.indexOf(action.locale) !== -1,
             locale: action.locale,
             messagesByLocale: state.messagesByLocale,
             messages: state.messagesByLocale[action.locale]
@@ -57,7 +57,7 @@ const initLocale = function (currentState, locale) {
             {},
             currentState,
             {
-                isRtl: RtlLocales.indexOf(locale) !== -1,
+                isRtl: rtlLocales.indexOf(locale) !== -1,
                 locale: locale,
                 messagesByLocale: currentState.messagesByLocale,
                 messages: currentState.messagesByLocale[locale]


### PR DESCRIPTION
### Resolves
- Resolves #2429 

### Proposed Changes
Move the labels above the inputs for languages that don’t fit in the width of the sprite-info pane.
<img width="409" alt="screen shot 2018-09-25 at 8 29 05 am" src="https://user-images.githubusercontent.com/399209/46014426-30725d80-c09d-11e8-83dc-cef65fbe8e3e.png">

Examples,
Abkhaz, Catalan, Greek...

renamed the `rtl-locales` lib file as `locale-utils` as  it’s doing more than rtl now. RTL should probably move into the scratch-l10n repo, but should the `wide-locales` setting? That seems like something that is gui specific. I don’t like having to hard code the specific languages that don’t fit, but there didn’t seem to be a better way to handle it right now.

I left aligned the labels as it seemed to look better most of the time. They are middle aligned horizontally - does that make sense? /cc @carljbowman 

### Reason for Changes

The translations of the sprite-info labels in some languages end up being too wide for the fixed width of the sprite-info pane. When this happens the stage info gets pushed off the screen.

### Test Coverage
Manually tested, current tests still run. It would probably be good to have someone else also look through all the languages to make sure I didn't miss any that should be in the 'wide' set.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [x] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
