### PR TITLE
Fix expensive operation in mapStateToProps

### DIFF
--- a/src/containers/paint-editor-wrapper.jsx
+++ b/src/containers/paint-editor-wrapper.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import bindAll from 'lodash.bindall';
-import omit from 'lodash.omit';
 import VM from 'scratch-vm';
 import PaintEditor from 'scratch-paint';
 
@@ -46,12 +45,16 @@ class PaintEditorWrapper extends React.Component {
     }
     render () {
         if (!this.props.imageId) return null;
-        const componentProps = omit(this.props, ['selectedCostumeIndex', 'vm']);
+        const {
+            selectedCostumeIndex,
+            vm,
+            ...componentProps
+        } = this.props;
 
         return (
             <PaintEditor
                 {...componentProps}
-                image={this.props.vm.getCostume(this.props.selectedCostumeIndex)}
+                image={vm.getCostume(selectedCostumeIndex)}
                 onUpdateImage={this.handleUpdateImage}
                 onUpdateName={this.handleUpdateName}
             />

--- a/src/containers/paint-editor-wrapper.jsx
+++ b/src/containers/paint-editor-wrapper.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import bindAll from 'lodash.bindall';
+import omit from 'lodash.omit';
 import VM from 'scratch-vm';
 import PaintEditor from 'scratch-paint';
 
@@ -18,6 +19,11 @@ class PaintEditorWrapper extends React.Component {
     }
     componentDidMount () {
         analytics.pageview('/editors/paint');
+    }
+    shouldComponentUpdate (nextProps) {
+        return this.props.imageId !== nextProps.imageId ||
+            this.props.rtl !== nextProps.rtl ||
+            this.props.name !== nextProps.name;
     }
     handleUpdateName (name) {
         this.props.vm.renameCostume(this.props.selectedCostumeIndex, name);
@@ -40,9 +46,12 @@ class PaintEditorWrapper extends React.Component {
     }
     render () {
         if (!this.props.imageId) return null;
+        const componentProps = omit(this.props, ['selectedCostumeIndex', 'vm']);
+
         return (
             <PaintEditor
-                {...this.props}
+                {...componentProps}
+                image={this.props.vm.getCostume(this.props.selectedCostumeIndex)}
                 onUpdateImage={this.handleUpdateImage}
                 onUpdateName={this.handleUpdateName}
             />
@@ -74,8 +83,8 @@ const mapStateToProps = (state, {selectedCostumeIndex}) => {
         rotationCenterY: costume && costume.rotationCenterY,
         imageFormat: costume && costume.dataFormat,
         imageId: targetId && `${targetId}${costume.skinId}`,
-        image: state.scratchGui.vm.getCostume(index),
         rtl: state.locales.isRtl,
+        selectedCostumeIndex: index,
         vm: state.scratchGui.vm,
         zoomLevelId: targetId
     };


### PR DESCRIPTION
### Resolves
Fixes https://github.com/LLK/scratch-gui/issues/3235

### Proposed Changes
Move getCostume() out of mapStateToProps. mapStateToProps is called any time the state changes, and getCostume can be very expensive because it has to decode from storage. In addition, I added a shouldComponentUpdate to ignore the props that don't affect rendering.

### Reason for Changes
Projects could run very slowly when the paint editor was open

### Test Coverage
Tested [Space Giraffe](https://llk.github.io/scratch-gui/develop/#247578672) and [Geometry Dash](https://llk.github.io/scratch-gui/develop/#105500895)

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [x] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
