### PR TITLE
welcome modal doesn't appear when a project is loaded directly

### DIFF
--- a/src/lib/hash-parser-hoc.jsx
+++ b/src/lib/hash-parser-hoc.jsx
@@ -33,6 +33,7 @@ const HashParserHOC = function (WrappedComponent) {
         render () {
             return (
                 <WrappedComponent
+                    hideIntro={this.state.projectId && this.state.projectId !== 0}
                     projectId={this.state.projectId}
                     {...this.props}
                 />

--- a/test/integration/project-loading.test.js
+++ b/test/integration/project-loading.test.js
@@ -71,7 +71,6 @@ describe('Loading scratch gui', () => {
 
             const projectId = '96708228';
             await loadUri(`${uri}#${projectId}`);
-            await clickXpath('//button[@title="Try It"]');
             await new Promise(resolve => setTimeout(resolve, 3000));
             await clickXpath('//img[@title="Go"]');
             await new Promise(resolve => setTimeout(resolve, 2000));
@@ -93,7 +92,6 @@ describe('Loading scratch gui', () => {
                 .setSize(1920, 1080);
             const projectId = '96708228';
             await loadUri(`${uri}#${projectId}`);
-            await clickXpath('//button[@title="Try It"]');
             await new Promise(resolve => setTimeout(resolve, 2000));
             await clickXpath('//img[@title="Full Screen Control"]');
             await clickXpath('//img[@title="Go"]');


### PR DESCRIPTION
### Resolves
#2981 

### Proposed Changes
Pass property hideModal when projectId is given

### Test Coverage
npm tests don't pass :/
tested in MacOS, Chrome

### Test Cases
- [ ] when loading a project directly using #projectid it will not show the welcome modal 
- [ ] if just loading the GUI via standalone it shows the welcome modal