### PR TITLE
Translate 2 strings on list monitor

### DIFF
--- a/src/components/monitor/list-monitor-scroller.jsx
+++ b/src/components/monitor/list-monitor-scroller.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import bindAll from 'lodash.bindall';
+import {FormattedMessage} from 'react-intl';
 
 import styles from './monitor.css';
 import {List} from 'react-virtualized';
@@ -21,7 +22,11 @@ class ListMonitorScroller extends React.Component {
     noRowsRenderer () {
         return (
             <div className={classNames(styles.listRow, styles.listEmpty)}>
-                {'(empty)' /* TODO waiting for design before translation */}
+                <FormattedMessage
+                    defaultMessage="(empty)"
+                    description="Text shown on a list monitor when a list is empty"
+                    id="gui.monitor.listMonitor.empty"
+                />
             </div>
         );
     }

--- a/src/components/monitor/list-monitor.jsx
+++ b/src/components/monitor/list-monitor.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import {defineMessages, formatMessage} from 'react-intl';
+import {defineMessages, injectIntl, intlShape} from 'react-intl';
 import styles from './monitor.css';
 import ListMonitorScroller from './list-monitor-scroller.jsx';
 
@@ -13,7 +13,7 @@ const messages = defineMessages({
     }
 });
 
-const ListMonitor = ({draggable, label, width, height, value, onResizeMouseDown, onAdd, ...rowProps}) => (
+const ListMonitor = ({draggable, intl, label, width, height, value, onResizeMouseDown, onAdd, ...rowProps}) => (
     <div
         className={styles.listMonitor}
         style={{
@@ -41,7 +41,7 @@ const ListMonitor = ({draggable, label, width, height, value, onResizeMouseDown,
                 {'+' /* TODO waiting on asset */}
             </div>
             <div className={styles.footerLength}>
-                {formatMessage(messages.listLength, {length: value.length})}
+                {intl.formatMessage(messages.listLength, {length: value.length})}
             </div>
             <div
                 className={classNames(draggable ? styles.resizeHandle : null, 'no-drag')}
@@ -59,6 +59,7 @@ ListMonitor.propTypes = {
     draggable: PropTypes.bool.isRequired,
     height: PropTypes.number,
     label: PropTypes.string.isRequired,
+    intl: intlShape.isRequired,
     onActivate: PropTypes.func,
     onAdd: PropTypes.func,
     onResizeMouseDown: PropTypes.func,
@@ -78,4 +79,4 @@ ListMonitor.defaultProps = {
     height: 200
 };
 
-export default ListMonitor;
+export default injectIntl(ListMonitor);

--- a/src/components/monitor/list-monitor.jsx
+++ b/src/components/monitor/list-monitor.jsx
@@ -34,9 +34,9 @@ const ListMonitor = ({draggable, label, width, height, value, onResizeMouseDown,
             </div>
             <div className={styles.footerLength}>
                 <FormattedMessage
-                    defaultMessage='length {length}'
-                    description='Length label on list monitors. DO NOT translate {length} (with brackets).'
-                    id='gui.monitor.listMonitor.listLength'
+                    defaultMessage="length {length}"
+                    description="Length label on list monitors. DO NOT translate {length} (with brackets)."
+                    id="gui.monitor.listMonitor.listLength"
                     values={{
                         length: value.length
                     }}

--- a/src/components/monitor/list-monitor.jsx
+++ b/src/components/monitor/list-monitor.jsx
@@ -1,19 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import {defineMessages, injectIntl, intlShape} from 'react-intl';
+import {FormattedMessage} from 'react-intl';
 import styles from './monitor.css';
 import ListMonitorScroller from './list-monitor-scroller.jsx';
 
-const messages = defineMessages({
-    listLength: {
-        defaultMessage: 'length {length}',
-        description: 'Length label on list monitors. DO NOT translate {length} (with brackets).',
-        id: 'gui.monitor.listMonitor.listLength'
-    }
-});
-
-const ListMonitor = ({draggable, intl, label, width, height, value, onResizeMouseDown, onAdd, ...rowProps}) => (
+const ListMonitor = ({draggable, label, width, height, value, onResizeMouseDown, onAdd, ...rowProps}) => (
     <div
         className={styles.listMonitor}
         style={{
@@ -41,7 +33,14 @@ const ListMonitor = ({draggable, intl, label, width, height, value, onResizeMous
                 {'+' /* TODO waiting on asset */}
             </div>
             <div className={styles.footerLength}>
-                {intl.formatMessage(messages.listLength, {length: value.length})}
+                <FormattedMessage
+                    defaultMessage='length {length}'
+                    description='Length label on list monitors. DO NOT translate {length} (with brackets).'
+                    id='gui.monitor.listMonitor.listLength'
+                    values={{
+                        length: value.length
+                    }}
+                />
             </div>
             <div
                 className={classNames(draggable ? styles.resizeHandle : null, 'no-drag')}
@@ -58,7 +57,6 @@ ListMonitor.propTypes = {
     categoryColor: PropTypes.string.isRequired,
     draggable: PropTypes.bool.isRequired,
     height: PropTypes.number,
-    intl: intlShape.isRequired,
     label: PropTypes.string.isRequired,
     onActivate: PropTypes.func,
     onAdd: PropTypes.func,
@@ -79,4 +77,4 @@ ListMonitor.defaultProps = {
     height: 200
 };
 
-export default injectIntl(ListMonitor);
+export default ListMonitor;

--- a/src/components/monitor/list-monitor.jsx
+++ b/src/components/monitor/list-monitor.jsx
@@ -1,8 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import {defineMessages, formatMessage} from 'react-intl';
 import styles from './monitor.css';
 import ListMonitorScroller from './list-monitor-scroller.jsx';
+
+const messages = defineMessages({
+    listLength: {
+        defaultMessage: 'length {length}',
+        description: 'Length label on list monitors. DO NOT translate {length} (with brackets).',
+        id: 'gui.monitor.listLength'
+    }
+});
 
 const ListMonitor = ({draggable, label, width, height, value, onResizeMouseDown, onAdd, ...rowProps}) => (
     <div
@@ -32,7 +41,7 @@ const ListMonitor = ({draggable, label, width, height, value, onResizeMouseDown,
                 {'+' /* TODO waiting on asset */}
             </div>
             <div className={styles.footerLength}>
-                {`length ${value.length}`}
+                {formatMessage(messages.listLength, {length: value.length})}
             </div>
             <div
                 className={classNames(draggable ? styles.resizeHandle : null, 'no-drag')}

--- a/src/components/monitor/list-monitor.jsx
+++ b/src/components/monitor/list-monitor.jsx
@@ -9,7 +9,7 @@ const messages = defineMessages({
     listLength: {
         defaultMessage: 'length {length}',
         description: 'Length label on list monitors. DO NOT translate {length} (with brackets).',
-        id: 'gui.monitor.listLength'
+        id: 'gui.monitor.listMonitor.listLength'
     }
 });
 
@@ -58,8 +58,8 @@ ListMonitor.propTypes = {
     categoryColor: PropTypes.string.isRequired,
     draggable: PropTypes.bool.isRequired,
     height: PropTypes.number,
-    label: PropTypes.string.isRequired,
     intl: intlShape.isRequired,
+    label: PropTypes.string.isRequired,
     onActivate: PropTypes.func,
     onAdd: PropTypes.func,
     onResizeMouseDown: PropTypes.func,


### PR DESCRIPTION
### Resolves
Fixes #3258

### Proposed Changes
Translate "empty" and "length".

### Reason for Changes
It's always in English!

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
