### PR TITLE
Fix language selector alignment

### DIFF
--- a/src/components/language-selector/language-selector.css
+++ b/src/components/language-selector/language-selector.css
@@ -1,10 +1,6 @@
 @import "../../css/colors.css";
 @import "../../css/units.css";
 
-.language-icon {
-    height:  1.5rem;
-}
-
 /* Position the language select over the language icon, and make it transparent */
 .language-select {
     position: absolute;

--- a/src/components/menu-bar/menu-bar.css
+++ b/src/components/menu-bar/menu-bar.css
@@ -101,6 +101,10 @@
     padding: 0 0.75rem;
 }
 
+.menu-bar-item.language-menu {
+    padding: 0 0.5rem;
+}
+
 .menu-bar-menu {
     margin-top: $menu-bar-height;
     z-index: $z-index-menu-bar;

--- a/src/components/menu-bar/menu-bar.css
+++ b/src/components/menu-bar/menu-bar.css
@@ -47,10 +47,11 @@
 
 .language-icon {
     height:  1.5rem;
+    vertical-align: middle;
 }
 
 .language-caret {
-    margin-bottom: .625rem;
+    margin: 0 .125rem;
 }
 
 .language-menu {


### PR DESCRIPTION
### Resolves

- Resolves ##3301 

### Proposed Changes

* Adjust language icon and caret in menu-bar
  * add slight margin on left and and right (works for both LTR and RTL languages)
* remove unused style from `language-selector.css`

### Reason for Changes

Align language icon with Scratch logo and tutorials icon

### Test Coverage

Current tests run

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
