### PR TITLE
Open sound recorder from sound block menu

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -21,8 +21,13 @@ import {STAGE_DISPLAY_SIZES} from '../lib/layout-constants';
 import {connect} from 'react-redux';
 import {updateToolbox} from '../reducers/toolbox';
 import {activateColorPicker} from '../reducers/color-picker';
-import {closeExtensionLibrary} from '../reducers/modals';
+import {closeExtensionLibrary, openSoundRecorder} from '../reducers/modals';
 import {activateCustomProcedures, deactivateCustomProcedures} from '../reducers/custom-procedures';
+
+import {
+    activateTab,
+    SOUNDS_TAB_INDEX
+} from '../reducers/editor-tab';
 
 const addFunctionListener = (object, property, callback) => {
     const oldFn = object[property];
@@ -44,6 +49,7 @@ class Blocks extends React.Component {
             'handleConnectionModalStart',
             'handleConnectionModalClose',
             'handleStatusButtonUpdate',
+            'handleOpenSoundRecorder',
             'handlePromptStart',
             'handlePromptCallback',
             'handlePromptClose',
@@ -63,6 +69,8 @@ class Blocks extends React.Component {
         ]);
         this.ScratchBlocks.prompt = this.handlePromptStart;
         this.ScratchBlocks.statusButtonCallback = this.handleConnectionModalStart;
+        this.ScratchBlocks.recordSoundCallback = this.handleOpenSoundRecorder;
+
         this.state = {
             workspaceMetrics: {},
             prompt: null,
@@ -395,6 +403,9 @@ class Blocks extends React.Component {
     handleStatusButtonUpdate () {
         this.ScratchBlocks.refreshStatusButtons(this.workspace);
     }
+    handleOpenSoundRecorder () {
+        this.props.onOpenSoundRecorder();
+    }
     handlePromptCallback (input, optionSelection) {
         this.state.prompt.callback(
             input,
@@ -423,6 +434,7 @@ class Blocks extends React.Component {
             isRtl,
             isVisible,
             onActivateColorPicker,
+            onOpenSoundRecorder,
             updateToolboxState,
             onActivateCustomProcedures,
             onRequestCloseExtensionLibrary,
@@ -486,6 +498,7 @@ Blocks.propTypes = {
     messages: PropTypes.objectOf(PropTypes.string),
     onActivateColorPicker: PropTypes.func,
     onActivateCustomProcedures: PropTypes.func,
+    onOpenSoundRecorder: PropTypes.func,
     onRequestCloseCustomProcedures: PropTypes.func,
     onRequestCloseExtensionLibrary: PropTypes.func,
     options: PropTypes.shape({
@@ -565,6 +578,10 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = dispatch => ({
     onActivateColorPicker: callback => dispatch(activateColorPicker(callback)),
     onActivateCustomProcedures: (data, callback) => dispatch(activateCustomProcedures(data, callback)),
+    onOpenSoundRecorder: () => {
+        dispatch(activateTab(SOUNDS_TAB_INDEX));
+        dispatch(openSoundRecorder());
+    },
     onRequestCloseExtensionLibrary: () => {
         dispatch(closeExtensionLibrary());
     },

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -54,7 +54,7 @@ export default function (vm) {
         }
         menu.push([
             ScratchBlocks.ScratchMsgs.translate('SOUND_RECORD', 'record...'),
-            ScratchBlocks.SOUND_RECORD_ID
+            ScratchBlocks.recordSoundCallback
         ]);
         return menu;
     };

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -7,12 +7,12 @@ import ScratchBlocks from 'scratch-blocks';
  */
 export default function (vm) {
 
-    const jsonForMenuBlock = function (name, menuOptionsFn, colors, start, fieldType = 'field_dropdown') {
+    const jsonForMenuBlock = function (name, menuOptionsFn, colors, start) {
         return {
             message0: '%1',
             args0: [
                 {
-                    type: fieldType,
+                    type: 'field_dropdown',
                     name: name,
                     options: function () {
                         return start.concat(menuOptionsFn());
@@ -128,7 +128,7 @@ export default function (vm) {
     const eventColors = ScratchBlocks.Colours.event;
 
     ScratchBlocks.Blocks.sound_sounds_menu.init = function () {
-        const json = jsonForMenuBlock('SOUND_MENU', soundsMenu, soundColors, [], 'field_sounddropdown');
+        const json = jsonForMenuBlock('SOUND_MENU', soundsMenu, soundColors, []);
         this.jsonInit(json);
     };
 

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -7,12 +7,12 @@ import ScratchBlocks from 'scratch-blocks';
  */
 export default function (vm) {
 
-    const jsonForMenuBlock = function (name, menuOptionsFn, colors, start) {
+    const jsonForMenuBlock = function (name, menuOptionsFn, colors, start, fieldType = 'field_dropdown') {
         return {
             message0: '%1',
             args0: [
                 {
-                    type: 'field_dropdown',
+                    type: fieldType,
                     name: name,
                     options: function () {
                         return start.concat(menuOptionsFn());
@@ -123,7 +123,7 @@ export default function (vm) {
     const eventColors = ScratchBlocks.Colours.event;
 
     ScratchBlocks.Blocks.sound_sounds_menu.init = function () {
-        const json = jsonForMenuBlock('SOUND_MENU', soundsMenu, soundColors, []);
+        const json = jsonForMenuBlock('SOUND_MENU', soundsMenu, soundColors, [], 'field_sounddropdown');
         this.jsonInit(json);
     };
 

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -52,7 +52,10 @@ export default function (vm) {
         if (vm.editingTarget && vm.editingTarget.sprite.sounds.length > 0) {
             menu = vm.editingTarget.sprite.sounds.map(sound => [sound.name, sound.name]);
         }
-        menu.push(['record...', '_record_']);
+        menu.push([
+            ScratchBlocks.ScratchMsgs.translate('SOUND_RECORD', 'record...'),
+            ScratchBlocks.SOUND_RECORD_ID
+        ]);
         return menu;
     };
 

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -48,10 +48,12 @@ export default function (vm) {
     };
 
     const soundsMenu = function () {
+        let menu = [['', '']];
         if (vm.editingTarget && vm.editingTarget.sprite.sounds.length > 0) {
-            return vm.editingTarget.sprite.sounds.map(sound => [sound.name, sound.name]);
+            menu = vm.editingTarget.sprite.sounds.map(sound => [sound.name, sound.name]);
         }
-        return [['', '']];
+        menu.push(['record...', '_record_']);
+        return menu;
     };
 
     const costumesMenu = function () {

--- a/test/integration/blocks.test.js
+++ b/test/integration/blocks.test.js
@@ -157,4 +157,17 @@ describe('Working with the blocks', () => {
         const logs = await getLogs();
         await expect(logs).toEqual([]);
     });
+
+    test('Record option from sound block menu opens sound recorder', async () => {
+        await loadUri(uri);
+        await clickXpath('//button[@title="Try It"]');
+        await clickText('Code');
+        await clickText('Sound', scope.blocksTab);
+        await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for scroll animation
+        await clickText('Meow', scope.blocksTab); // Click "play sound <Meow> until done" block
+        await clickText('record'); // Click "record..." option in the block's sound menu
+        await findByText('Record Sound'); // Sound recorder is open
+        const logs = await getLogs();
+        await expect(logs).toEqual([]);
+    });
 });


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-gui/issues/1368
(we can add "add sound..." as a follow-up maybe)

Depends on https://github.com/LLK/scratch-blocks/pull/1731

### Proposed Changes

- When the contents of the sounds menu are generated, append a 'record...' option
- Add a callback triggered by this option to make it switch to the sounds tab and open the sound recorder. 

### Reason for Changes

We'd like to make it more obvious that you can record your own sound, and make the process accessible directly from the play sound blocks themselves (as in Scratch 2.0).

### Test Coverage

Added an integration test

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
