### PR TITLE
Fix block direction in loading animation for RTL

### DIFF
--- a/src/components/loader/loader.css
+++ b/src/components/loader/loader.css
@@ -100,7 +100,7 @@
   }
 }
 
-@keyframes top-slide-in {
+@keyframes top-slide-in-rtl {
   0% {
     transform: translateY(50px) rotateY(180deg);
     opacity: 0;
@@ -112,7 +112,7 @@
   }
 }
 
-@keyframes middle-slide-in {
+@keyframes middle-slide-in-rtl {
   0% {
     transform: translateY(50px) rotateY(180deg);
     opacity: 0;
@@ -129,7 +129,7 @@
   }
 }
 
-@keyframes bottom-slide-in {
+@keyframes bottom-slide-in-rtl {
   0% {
     transform: translateY(50px) rotateY(180deg);
     opacity: 0;

--- a/src/components/loader/loader.css
+++ b/src/components/loader/loader.css
@@ -102,46 +102,54 @@
 
 @keyframes top-slide-in-rtl {
   0% {
-    transform: translateY(50px) rotateY(180deg);
+    transform: translateY(50px) scaleX(-1);
     opacity: 0;
   }
 
   33% {
-    transform: translateY(0px) rotateY(180deg);
+    transform: translateY(0px) scaleX(-1);
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(0px) scaleX(-1);
     opacity: 1;
   }
 }
 
 @keyframes middle-slide-in-rtl {
   0% {
-    transform: translateY(50px) rotateY(180deg);
+    transform: translateY(50px) scaleX(-1);
     opacity: 0;
   }
 
   33% {
-    transform: translateY(50px) rotateY(180deg);
+    transform: translateY(50px) scaleX(-1);
     opacity: 0;
   }
 
   66% {
-    transform: translateY(0px) rotateY(180deg);
+    transform: translateY(0px) scaleX(-1);
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(0px) scaleX(-1);
     opacity: 1;
   }
 }
 
 @keyframes bottom-slide-in-rtl {
   0% {
-    transform: translateY(50px) rotateY(180deg);
+    transform: translateY(50px) scaleX(-1);
     opacity: 0;
   }
 
   66% {
-    transform: translateY(50px) rotateY(180deg);
+    transform: translateY(50px) scaleX(-1);
     opacity: 0;
   }
 
   100% {
-    transform: translateY(0px) rotateY(180deg);
+    transform: translateY(0px) scaleX(-1);
     opacity: 1;
   }
 }

--- a/src/components/loader/loader.css
+++ b/src/components/loader/loader.css
@@ -42,6 +42,18 @@
     animation: bottom-slide-in 1.5s ease infinite;
 }
 
+[dir="rtl"] .top-block {
+    animation: top-slide-in-rtl 1.5s ease infinite;
+}
+
+[dir="rtl"] .middle-block {
+    animation: middle-slide-in-rtl 1.5s ease infinite;
+}
+
+[dir="rtl"] .bottom-block {
+    animation: bottom-slide-in-rtl 1.5s ease infinite;
+}
+
 @keyframes top-slide-in {
   0% {
     transform: translateY(50px);
@@ -84,6 +96,52 @@
 
   100% {
     transform: translateY(0px);
+    opacity: 1;
+  }
+}
+
+@keyframes top-slide-in {
+  0% {
+    transform: translateY(50px) rotateY(180deg);
+    opacity: 0;
+  }
+
+  33% {
+    transform: translateY(0px) rotateY(180deg);
+    opacity: 1;
+  }
+}
+
+@keyframes middle-slide-in {
+  0% {
+    transform: translateY(50px) rotateY(180deg);
+    opacity: 0;
+  }
+
+  33% {
+    transform: translateY(50px) rotateY(180deg);
+    opacity: 0;
+  }
+
+  66% {
+    transform: translateY(0px) rotateY(180deg);
+    opacity: 1;
+  }
+}
+
+@keyframes bottom-slide-in {
+  0% {
+    transform: translateY(50px) rotateY(180deg);
+    opacity: 0;
+  }
+
+  66% {
+    transform: translateY(50px) rotateY(180deg);
+    opacity: 0;
+  }
+
+  100% {
+    transform: translateY(0px) rotateY(180deg);
     opacity: 1;
   }
 }


### PR DESCRIPTION
### Resolves

- Resolves #3311

### Proposed Changes

This pull request flips the direction of the loading blocks on right-to-left languages

### Reason for Changes

This makes the blocks not look strange, and also look more like the real RTL blocks.

### Test Coverage

![image](https://user-images.githubusercontent.com/31634240/46606807-a084d880-cacc-11e8-9e68-0ddcf19e7f7f.png)


### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [x] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
