### PR TITLE
Update monitor labels on the stage when language changes

### DIFF
--- a/src/containers/monitor-list.jsx
+++ b/src/containers/monitor-list.jsx
@@ -1,11 +1,13 @@
 import bindAll from 'lodash.bindall';
 import React from 'react';
 import PropTypes from 'prop-types';
+import {injectIntl, intlShape} from 'react-intl';
 
 import {connect} from 'react-redux';
 import {moveMonitorRect} from '../reducers/monitor-layout';
 
 import errorBoundaryHOC from '../lib/error-boundary-hoc.jsx';
+import OpcodeLabels from '../lib/opcode-labels';
 
 import MonitorListComponent from '../components/monitor-list/monitor-list.jsx';
 
@@ -15,6 +17,7 @@ class MonitorList extends React.Component {
         bindAll(this, [
             'handleMonitorChange'
         ]);
+        OpcodeLabels.setTranslatorFunction(props.intl.formatMessage);
     }
     handleMonitorChange (id, x, y) { // eslint-disable-line no-unused-vars
         this.props.moveMonitorRect(id, x, y);
@@ -30,6 +33,7 @@ class MonitorList extends React.Component {
 }
 
 MonitorList.propTypes = {
+    intl: intlShape.isRequired,
     moveMonitorRect: PropTypes.func.isRequired
 };
 const mapStateToProps = state => ({
@@ -40,8 +44,8 @@ const mapDispatchToProps = dispatch => ({
 });
 
 export default errorBoundaryHOC('Monitors')(
-    connect(
+    injectIntl(connect(
         mapStateToProps,
         mapDispatchToProps
-    )(MonitorList)
+    )(MonitorList))
 );

--- a/src/lib/monitor-adapter.js
+++ b/src/lib/monitor-adapter.js
@@ -17,7 +17,7 @@ const isUndefined = a => typeof a === 'undefined';
 export default function ({id, spriteName, opcode, params, value, vm}) {
     // Extension monitors get their labels from the Runtime through `getLabelForOpcode`.
     // Other monitors' labels are hard-coded in `OpcodeLabels`.
-    let {label, category, labelFn} = (vm && vm.runtime.getLabelForOpcode(opcode)) || OpcodeLabels(opcode);
+    let {label, category, labelFn} = (vm && vm.runtime.getLabelForOpcode(opcode)) || OpcodeLabels.getLabel(opcode);
 
     // Use labelFn if provided for dynamic labelling (e.g. variables)
     if (!isUndefined(labelFn)) label = labelFn(params);

--- a/src/lib/opcode-labels.js
+++ b/src/lib/opcode-labels.js
@@ -1,126 +1,247 @@
-import ScratchBlocks from 'scratch-blocks';
+import {defineMessages} from 'react-intl';
 
-const opcodeMap = {
-    // Motion
+const messages = defineMessages({
     motion_direction: {
-        category: 'motion',
-        labelFn: () => ScratchBlocks.ScratchMsgs.translate('MOTION_DIRECTION', 'direction')
+        defaultMessage: 'direction',
+        description: 'Label for the direction monitor when shown on the stage',
+        id: 'gui.opcodeLabels.direction'
     },
     motion_xposition: {
-        category: 'motion',
-        labelFn: () => ScratchBlocks.ScratchMsgs.translate('MOTION_XPOSITION', 'x postion')
+        defaultMessage: 'x postion',
+        description: 'Label for the x position monitor when shown on the stage',
+        id: 'gui.opcodeLabels.xposition'
     },
     motion_yposition: {
-        category: 'motion',
-        labelFn: () => ScratchBlocks.ScratchMsgs.translate('MOTION_YPOSITION', 'y postion')
+        defaultMessage: 'y postion',
+        description: 'Label for the y position monitor when shown on the stage',
+        id: 'gui.opcodeLabels.yposition'
     },
 
     // Looks
     looks_size: {
-        category: 'looks',
-        labelFn: () => ScratchBlocks.ScratchMsgs.translate('LOOKS_SIZE', 'size')
+        defaultMessage: 'size',
+        description: 'Label for the size monitor when shown on the stage',
+        id: 'gui.opcodeLabels.size'
     },
-    looks_costumenumbername: {
-        category: 'looks',
-        labelFn: params => {
-            let label = ScratchBlocks.ScratchMsgs.translate(
-                'LOOKS_COSTUMENUMBERNAME',
-                'costume %1'
-            );
-            if (params.NUMBER_NAME === 'number') {
-                label = label.replace(/%1/, ScratchBlocks.ScratchMsgs.translate(
-                    'LOOKS_NUMBERNAME_NUMBER', 'number'));
-            } else {
-                label = label.replace(/%1/, ScratchBlocks.ScratchMsgs.translate(
-                    'LOOKS_NUMBERNAME_NAME', 'name'));
-            }
-            return label;
-        }
+    looks_costumename: {
+        defaultMessage: 'costume name',
+        description: 'Label for the costume name monitor when shown on the stage',
+        id: 'gui.opcodeLabels.costumename'
     },
-    looks_backdropnumbername: {
-        category: 'looks',
-        labelFn: params => {
-            let label = ScratchBlocks.ScratchMsgs.translate(
-                'LOOKS_BACKDROPNUMBERNAME',
-                'costume %1'
-            );
-            if (params.NUMBER_NAME === 'number') {
-                label = label.replace(/%1/, ScratchBlocks.ScratchMsgs.translate(
-                    'LOOKS_NUMBERNAME_NUMBER', 'number'));
-            } else {
-                label = label.replace(/%1/, ScratchBlocks.ScratchMsgs.translate(
-                    'LOOKS_NUMBERNAME_NAME', 'name'));
-            }
-            return label;
-        }
+    looks_costumenumber: {
+        defaultMessage: 'costume number',
+        description: 'Label for the costume number monitor when shown on the stage',
+        id: 'gui.opcodeLabels.costumenumber'
     },
     looks_backdropname: {
-        category: 'looks',
-        labelFn: () => ScratchBlocks.ScratchMsgs.translate('LOOKS_BACKDROPNAME', 'backdrop name')
+        defaultMessage: 'backdrop name',
+        description: 'Label for the backdrop name monitor when shown on the stage',
+        id: 'gui.opcodeLabels.backdropname'
+    },
+    looks_backdropnumber: {
+        defaultMessage: 'backdrop number',
+        description: 'Label for the backdrop number monitor when shown on the stage',
+        id: 'gui.opcodeLabels.backdropnumber'
     },
 
-    // Data
-    data_variable: {
-        category: 'data',
-        labelFn: params => params.VARIABLE
-    },
-    data_listcontents: {
-        category: 'list',
-        labelFn: params => params.LIST
-    },
 
     // Sound
     sound_volume: {
-        category: 'sound',
-        labelFn: () => ScratchBlocks.ScratchMsgs.translate('SOUND_VOLUME', 'volume')
+        defaultMessage: 'volume',
+        description: 'Label for the volume monitor when shown on the stage',
+        id: 'gui.opcodeLabels.volume'
     },
     sound_tempo: {
-        category: 'sound',
-        labelFn: () => ScratchBlocks.ScratchMsgs.translate('SOUND_TEMPO', 'tempo')
+        defaultMessage: 'tempo',
+        description: 'Label for the tempo monitor when shown on the stage',
+        id: 'gui.opcodeLabels.tempo'
     },
 
     // Sensing
     sensing_answer: {
-        category: 'sensing',
-        labelFn: () => ScratchBlocks.ScratchMsgs.translate('SENSING_ANSWER', 'answer')
+        defaultMessage: 'answer',
+        description: 'Label for the answer monitor when shown on the stage',
+        id: 'gui.opcodeLabels.answer'
     },
     sensing_loudness: {
-        category: 'sensing',
-        labelFn: () => ScratchBlocks.ScratchMsgs.translate('SENSING_LOUDNESS', 'loudness')
+        defaultMessage: 'loudness',
+        description: 'Label for the loudness monitor when shown on the stage',
+        id: 'gui.opcodeLabels.loudness'
     },
     sensing_username: {
-        category: 'sensing',
-        labelFn: () => ScratchBlocks.ScratchMsgs.translate('SENSING_USERNAME', 'username')
+        defaultMessage: 'username',
+        description: 'Label for the username monitor when shown on the stage',
+        id: 'gui.opcodeLabels.username'
     },
-    sensing_current: {
-        category: 'sensing',
-        labelFn: params => {
-            let currentMenu = params.CURRENTMENU.toUpperCase();
-            currentMenu = ScratchBlocks.ScratchMsgs.translate(
-                `SENSING_CURRENT_${currentMenu}`,
-                currentMenu.toLowerCase()
-            );
-            if (currentMenu === 'dayofweek') {
-                currentMenu = 'day of week';
-            }
-            return currentMenu;
-        }
+    sensing_current_year: {
+        defaultMessage: 'year',
+        description: 'Label for the current year monitor when shown on the stage',
+        id: 'gui.opcodeLabels.year'
+    },
+    sensing_current_month: {
+        defaultMessage: 'month',
+        description: 'Label for the current month monitor when shown on the stage.',
+        id: 'gui.opcodeLabels.month'
+    },
+    sensing_current_date: {
+        defaultMessage: 'date',
+        description: 'Label for the current date monitor when shown on the stage. Shows the current day of the month',
+        id: 'gui.opcodeLabels.date'
+    },
+    sensing_current_dayofweek: {
+        defaultMessage: 'dayofweek',
+        description: 'Label for the current dayofweek monitor when shown on the stage',
+        id: 'gui.opcodeLabels.dayofweek'
+    },
+    sensing_current_hour: {
+        defaultMessage: 'hour',
+        description: 'Label for the current hour monitor when shown on the stage',
+        id: 'gui.opcodeLabels.hour'
+    },
+    sensing_current_minute: {
+        defaultMessage: 'minute',
+        description: 'Label for the current minute monitor when shown on the stage',
+        id: 'gui.opcodeLabels.minute'
+    },
+    sensing_current_second: {
+        defaultMessage: 'second',
+        description: 'Label for the current second monitor when shown on the stage',
+        id: 'gui.opcodeLabels.second'
     },
     sensing_timer: {
-        category: 'sensing',
-        labelFn: () => ScratchBlocks.ScratchMsgs.translate('SENSING_TIMER', 'timer')
+        defaultMessage: 'timer',
+        description: 'Label for the timer monitor when shown on the stage',
+        id: 'gui.opcodeLabels.timer'
     }
-};
+});
 
-/**
- * Get the label for an opcode
- * @param {string} opcode the opcode you want a label for
- * @return {object} object with label and category
- */
-export default function (opcode) {
-    if (opcode in opcodeMap) return opcodeMap[opcode];
-    return {
-        category: 'data',
-        label: opcode
-    };
+class OpcodeLabels {
+    constructor () {
+        /**
+         * Translation function for labels. By default just return the defaultMessage
+         * @private
+         * @param {object} message A message object compatible with react-intl formatMessage
+         * @return {string} Return the default string initially
+         */
+        this._translator = message => message.defaultMessage;
+
+        /**
+         * Initial opcode map, with categories defined
+         * @private
+         */
+        this._opcodeMap = {
+            // Motion
+            motion_direction: {category: 'motion'},
+            motion_xposition: {category: 'motion'},
+            motion_yposition: {category: 'motion'},
+
+            // Looks
+            looks_size: {category: 'looks'},
+            looks_costumenumbername: {category: 'looks'},
+            looks_backdropnumbername: {category: 'looks'},
+            looks_backdropname: {category: 'looks'},
+
+            // Data
+            data_variable: {category: 'data'},
+            data_listcontents: {category: 'list'},
+
+            // Sound
+            sound_volume: {category: 'sound'},
+            sound_tempo: {category: 'sound'},
+
+            // Sensing
+            sensing_answer: {category: 'sensing'},
+            sensing_loudness: {category: 'sensing'},
+            sensing_username: {category: 'sensing'},
+            sensing_current: {category: 'sensing'},
+            sensing_timer: {category: 'sensing'}
+        };
+
+        // Initialize opcodeMap with default strings
+        this._refreshOpcodeMap();
+    }
+
+    /**
+     * Set the translation function for monitor labels. The function should accept
+     * a message object as defined by react-intl defineMessages
+     * @param {function} translator the function to use for localization
+     */
+    setTranslatorFunction (translator) {
+        this._translator = translator;
+        this._refreshOpcodeMap();
+    }
+
+    /**
+     * Internal function to update opcode Map when translation function is defined
+     * @private
+     */
+    _refreshOpcodeMap () {
+        // Motion
+        this._opcodeMap.motion_direction.labelFn = () => this._translator(messages.motion_direction);
+        this._opcodeMap.motion_xposition.labelFn = () => this._translator(messages.motion_xposition);
+        this._opcodeMap.motion_yposition.labelFn = () => this._translator(messages.motion_yposition);
+
+        // Looks
+        this._opcodeMap.looks_size.labelFn = () => this._translator(messages.looks_size);
+        this._opcodeMap.looks_costumenumbername.labelFn = params => {
+            if (params.NUMBER_NAME === 'number') {
+                return this._translator(messages.looks_costumenumber);
+            }
+            return this._translator(messages.looks_costumename);
+        };
+        this._opcodeMap.looks_backdropnumbername.labelFn = params => {
+            if (params.NUMBER_NAME === 'number') {
+                return this._translator(messages.looks_backdropnumber);
+            }
+            return this._translator(messages.looks_backdropname);
+        };
+        this._opcodeMap.looks_backdropname.labelFn = () => this._translator(messages.looks_backdropname);
+
+        // Data
+        this._opcodeMap.data_variable.labelFn = params => params.VARIABLE;
+        this._opcodeMap.data_listcontents.labelFn = params => params.LIST;
+
+        // Sound
+        this._opcodeMap.sound_volume.labelFn = () => this._translator(messages.sound_volume);
+        this._opcodeMap.sound_tempo.labelFn = () => this._translator(messages.sound_tempo);
+
+        // Sensing
+        this._opcodeMap.sensing_answer.labelFn = () => this._translator(messages.sensing_answer);
+        this._opcodeMap.sensing_loudness.labelFn = () => this._translator(messages.sensing_loudness);
+        this._opcodeMap.sensing_username.labelFn = () => this._translator(messages.sensing_username);
+        this._opcodeMap.sensing_current.labelFn = params => {
+            switch (params.CURRENTMENU) {
+            case 'year':
+                return this._translator(messages.sensing_current_year);
+            case 'month':
+                return this._translator(messages.sensing_current_month);
+            case 'date':
+                return this._translator(messages.sensing_current_date);
+            case 'dayofweek':
+                return this._translator(messages.sensing_current_dayofweek);
+            case 'hour':
+                return this._translator(messages.sensing_current_hour);
+            case 'minute':
+                return this._translator(messages.sensing_current_minute);
+            case 'second':
+                return this._translator(messages.sensing_current_second);
+            }
+        };
+        this._opcodeMap.sensing_timer.labelFn = () => this._translator(messages.sensing_timer);
+    }
+
+    /**
+     * Return the label for an opcode
+     * @param {string} opcode the opcode you want a label for
+     * @return {object} object with  label and category
+     */
+    getLabel (opcode) {
+        if (opcode in this._opcodeMap) return this._opcodeMap[opcode];
+        return {
+            category: 'data',
+            label: opcode
+        };
+    }
 }
+
+export default new OpcodeLabels();


### PR DESCRIPTION
### Resolves

- Resolves https://github.com/LLK/scratch-vm/issues/1279

### Proposed Changes

A complete rewrite of OpcodeLabels. Instead of a function, it’s a class that maintains a current translator function, and updates the opcode labelFn for each opcode when a new translator function is set. The new function `getLabel` provides the original functionality, to return the object with `category` and `labelFn` based on the opcode.

Wrap MonitorList with the `InjectIntl` HOC so that it has access to the intl object. Then pass `intl.formatMessage` as the translator function to `OpcodeLabels`.

### Reason for Changes

Monitors on the stage don't update language correctly when switching language. It seemed worth figuring out how to update the language using the GUI (react-intl) framework instead of ScratchBlocks.ScratchMsgs. It uses the same strategy as storage (passing an translation function) for the default project.

### Test Coverage

Try it: https://chrisgarrity.github.io/scratch-gui/issue/vm1279-monitor-label/

Note: All of the strings are new translation ids in gui. So none of them will be translated until we go through a translation cycle. You can check that it's really using the new ids by looking for a message like `[React Intl] Missing message: "gui.opcodeLabels.costumenumber" for locale: "fr", using default message as fallback.` in the console.

Since most of the strings have already been translated for blocks, they should automatically be translated for gui once they're added. I'd like to add an integration test once we have some known translations.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [x] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
