### PR TITLE
Add sprite/stage watermark to the blocks workspace.

### DIFF
--- a/src/components/gui/gui.css
+++ b/src/components/gui/gui.css
@@ -279,6 +279,20 @@ $fade-out-distance: 15px;
     margin-top: 0;
 }
 
+/* Sprite Selection Watermark */
+.watermark {
+    position: absolute;
+    top: 1.25rem;
+}
+
+[dir="ltr"] .watermark {
+    right: 1.25rem;
+}
+
+[dir="rtl"] .watermark {
+    left: 1.25rem;
+}
+
 /* Menu */
 
 .menu-bar-position {

--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -20,6 +20,7 @@ import Box from '../box/box.jsx';
 import MenuBar from '../menu-bar/menu-bar.jsx';
 import CostumeLibrary from '../../containers/costume-library.jsx';
 import BackdropLibrary from '../../containers/backdrop-library.jsx';
+import Watermark from '../../containers/watermark.jsx';
 
 import Backpack from '../../containers/backpack.jsx';
 import PreviewModal from '../../containers/preview-modal.jsx';
@@ -260,6 +261,9 @@ const GUIComponent = props => {
                                                 src={addExtensionIcon}
                                             />
                                         </button>
+                                    </Box>
+                                    <Box className={styles.watermark}>
+                                        <Watermark />
                                     </Box>
                                 </TabPanel>
                                 <TabPanel className={tabClassNames.tabPanel}>

--- a/src/components/watermark/watermark.css
+++ b/src/components/watermark/watermark.css
@@ -1,0 +1,9 @@
+
+.sprite-image {
+    margin: auto;
+    user-select: none;
+    max-width: 48px;
+    max-height: 48px;
+    opacity: 0.35;
+    pointer-events: none;
+}

--- a/src/components/watermark/watermark.jsx
+++ b/src/components/watermark/watermark.jsx
@@ -1,0 +1,17 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import styles from './watermark.css';
+
+const Watermark = props => (
+    <img
+        className={styles.spriteImage}
+        src={props.costumeURL}
+    />
+);
+
+Watermark.propTypes = {
+    costumeURL: PropTypes.string
+};
+
+export default Watermark;

--- a/src/containers/sprite-selector-item.jsx
+++ b/src/containers/sprite-selector-item.jsx
@@ -46,15 +46,7 @@ class SpriteSelectorItem extends React.Component {
         if (this.props.costumeURL) return this.props.costumeURL;
         if (!this.props.assetId) return null;
 
-        if (this.decodedAssetId === this.props.assetId) {
-            // @todo consider caching more than one URL.
-            return this.cachedUrl;
-        }
-
-        this.decodedAssetId = this.props.assetId;
-        this.cachedUrl = getCostumeUrl(this.props.assetId, this.props.vm);
-
-        return this.cachedUrl;
+        return getCostumeUrl(this.props.assetId, this.props.vm);
     }
     handleMouseUp () {
         this.initialOffset = null;

--- a/src/containers/watermark.jsx
+++ b/src/containers/watermark.jsx
@@ -1,0 +1,83 @@
+import bindAll from 'lodash.bindall';
+import PropTypes from 'prop-types';
+import React from 'react';
+import {connect} from 'react-redux';
+
+import VM from 'scratch-vm';
+import getCostumeUrl from '../lib/get-costume-url';
+
+import WatermarkComponent from '../components/watermark/watermark.jsx';
+
+class Watermark extends React.Component {
+    constructor (props) {
+        super(props);
+        bindAll(this, [
+            'getCostumeData'
+        ]);
+        // Asset ID of the current sprite's current costume
+        this.decodedAssetId = null;
+    }
+
+    getCostumeData () {
+        if (!this.props.assetId) return null;
+
+        if (this.decodedAssetId === this.props.assetId) {
+            return this.cachedUrl;
+        }
+
+        this.decodedAssetId = this.props.assetId;
+        this.cachedUrl = getCostumeUrl(this.props.assetId, this.props.vm);
+
+        return this.cachedUrl;
+    }
+
+    render () {
+        const {
+            /* eslint-disable no-unused-vars */
+            assetId,
+            vm,
+            /* eslint-enable no-unused-vars */
+            ...props
+        } = this.props;
+        return (
+            <WatermarkComponent
+                costumeURL={this.getCostumeData()}
+                {...props}
+            />
+        );
+    }
+}
+
+Watermark.propTypes = {
+    assetId: PropTypes.string,
+    vm: PropTypes.instanceOf(VM).isRequired
+};
+
+const mapStateToProps = state => {
+    const targets = state.scratchGui.targets;
+    const currentTargetId = targets.editingTarget;
+
+    let assetId;
+    if (currentTargetId) {
+        if (targets.stage.id === currentTargetId) {
+            assetId = targets.stage.costume.assetId;
+        } else if (targets.sprites.hasOwnProperty(currentTargetId)) {
+            const currentSprite = targets.sprites[currentTargetId];
+            assetId = currentSprite.costume.assetId;
+        }
+    }
+
+    return {
+        vm: state.scratchGui.vm,
+        assetId: assetId
+    };
+};
+
+const mapDispatchToProps = () => ({});
+
+const ConnectedComponent = connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(Watermark);
+
+export default ConnectedComponent;

--- a/src/containers/watermark.jsx
+++ b/src/containers/watermark.jsx
@@ -1,4 +1,5 @@
 import bindAll from 'lodash.bindall';
+import omit from 'lodash.omit';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
@@ -21,28 +22,15 @@ class Watermark extends React.Component {
     getCostumeData () {
         if (!this.props.assetId) return null;
 
-        if (this.decodedAssetId === this.props.assetId) {
-            return this.cachedUrl;
-        }
-
-        this.decodedAssetId = this.props.assetId;
-        this.cachedUrl = getCostumeUrl(this.props.assetId, this.props.vm);
-
-        return this.cachedUrl;
+        return getCostumeUrl(this.props.assetId, this.props.vm);
     }
 
     render () {
-        const {
-            /* eslint-disable no-unused-vars */
-            assetId,
-            vm,
-            /* eslint-enable no-unused-vars */
-            ...props
-        } = this.props;
+        const componentProps = omit(this.props, ['assetId', 'vm']);
         return (
             <WatermarkComponent
                 costumeURL={this.getCostumeData()}
-                {...props}
+                {...componentProps}
             />
         );
     }
@@ -73,11 +61,8 @@ const mapStateToProps = state => {
     };
 };
 
-const mapDispatchToProps = () => ({});
-
 const ConnectedComponent = connect(
-    mapStateToProps,
-    mapDispatchToProps
+    mapStateToProps
 )(Watermark);
 
 export default ConnectedComponent;

--- a/src/lib/get-costume-url.js
+++ b/src/lib/get-costume-url.js
@@ -3,27 +3,37 @@ import {SVGRenderer} from 'scratch-svg-renderer';
 // Contains 'font-family', but doesn't only contain 'font-family="none"'
 const HAS_FONT_REGEXP = 'font-family(?!="none")';
 
-const getCostumeUrl = function (assetId, vm) {
+const getCostumeUrl = (function () {
+    let cachedAssetId;
+    let cachedUrl;
 
-    const storage = vm.runtime.storage;
-    const asset = storage.get(assetId);
-    // If the SVG refers to fonts, they must be inlined in order to display correctly in the img tag.
-    // Avoid parsing the SVG when possible, since it's expensive.
-    if (asset.assetType === storage.AssetType.ImageVector) {
-        // If the asset ID has not changed, no need to re-parse
+    return function (assetId, vm) {
 
-        const svgRenderer = new SVGRenderer();
-
-        const svgString = vm.runtime.storage.get(assetId).decodeText();
-        if (svgString.match(HAS_FONT_REGEXP)) {
-            svgRenderer.loadString(svgString);
-            const svgText = svgRenderer.toString(true /* shouldInjectFonts */);
-            return `data:image/svg+xml;utf8,${encodeURIComponent(svgText)}`;
+        if (cachedAssetId === assetId) {
+            return cachedUrl;
         }
-        return vm.runtime.storage.get(assetId).encodeDataURI();
-    }
-    return vm.runtime.storage.get(assetId).encodeDataURI();
-};
+
+        cachedAssetId = assetId;
+
+        const storage = vm.runtime.storage;
+        const asset = storage.get(assetId);
+        // If the SVG refers to fonts, they must be inlined in order to display correctly in the img tag.
+        // Avoid parsing the SVG when possible, since it's expensive.
+        if (asset.assetType === storage.AssetType.ImageVector) {
+            const svgString = vm.runtime.storage.get(assetId).decodeText();
+            if (svgString.match(HAS_FONT_REGEXP)) {
+                const svgRenderer = new SVGRenderer();
+                svgRenderer.loadString(svgString);
+                const svgText = svgRenderer.toString(true /* shouldInjectFonts */);
+                cachedUrl = `data:image/svg+xml;utf8,${encodeURIComponent(svgText)}`;
+            }
+            cachedUrl = vm.runtime.storage.get(assetId).encodeDataURI();
+        }
+        cachedUrl = vm.runtime.storage.get(assetId).encodeDataURI();
+
+        return cachedUrl;
+    };
+}());
 
 export {
     getCostumeUrl as default,

--- a/src/lib/get-costume-url.js
+++ b/src/lib/get-costume-url.js
@@ -1,0 +1,28 @@
+import {SVGRenderer} from 'scratch-svg-renderer';
+
+// Contains 'font-family', but doesn't only contain 'font-family="none"'
+const HAS_FONT_REGEXP = 'font-family(?!="none")';
+
+const getCostumeUrl = function (assetId, vm) {
+
+    const storage = vm.runtime.storage;
+    const asset = storage.get(assetId);
+    // If the SVG refers to fonts, they must be inlined in order to display correctly in the img tag.
+    // Avoid parsing the SVG when possible, since it's expensive.
+    if (asset.assetType === storage.AssetType.ImageVector) {
+        // If the asset ID has not changed, no need to re-parse
+
+        const svgRenderer = new SVGRenderer();
+
+        const svgString = vm.runtime.storage.get(assetId).decodeText();
+        if (svgString.match(HAS_FONT_REGEXP)) {
+            svgRenderer.loadString(svgString);
+            const svgText = svgRenderer.toString(true /* shouldInjectFonts */);
+            return `data:image/svg+xml;utf8,${encodeURIComponent(svgText)}`;
+        }
+        return vm.runtime.storage.get(assetId).encodeDataURI();
+    }
+    return vm.runtime.storage.get(assetId).encodeDataURI();
+};
+
+export default getCostumeUrl;

--- a/src/lib/get-costume-url.js
+++ b/src/lib/get-costume-url.js
@@ -25,4 +25,7 @@ const getCostumeUrl = function (assetId, vm) {
     return vm.runtime.storage.get(assetId).encodeDataURI();
 };
 
-export default getCostumeUrl;
+export {
+    getCostumeUrl as default,
+    HAS_FONT_REGEXP
+};

--- a/test/unit/containers/sprite-selector-item.test.jsx
+++ b/test/unit/containers/sprite-selector-item.test.jsx
@@ -4,7 +4,6 @@ import configureStore from 'redux-mock-store';
 import {Provider} from 'react-redux';
 
 import SpriteSelectorItem from '../../../src/containers/sprite-selector-item';
-import {HAS_FONT_REGEXP} from '../../../src/containers/sprite-selector-item';
 import CloseButton from '../../../src/components/close-button/close-button';
 
 describe('SpriteSelectorItem Container', () => {
@@ -55,13 +54,5 @@ describe('SpriteSelectorItem Container', () => {
         const wrapper = mountWithIntl(getContainer());
         wrapper.find(CloseButton).simulate('click');
         expect(onDeleteButtonClick).toHaveBeenCalledWith(1337);
-    });
-
-    test('Has font regexp works', () => {
-        expect('font-family="Sans Serif"'.match(HAS_FONT_REGEXP)).toBeTruthy();
-        expect('font-family="none" font-family="Sans Serif"'.match(HAS_FONT_REGEXP)).toBeTruthy();
-        expect('font-family = "Sans Serif"'.match(HAS_FONT_REGEXP)).toBeTruthy();
-
-        expect('font-family="none"'.match(HAS_FONT_REGEXP)).toBeFalsy();
     });
 });

--- a/test/unit/util/get-costume-url.test.js
+++ b/test/unit/util/get-costume-url.test.js
@@ -1,0 +1,11 @@
+import {HAS_FONT_REGEXP} from '../../../src/lib/get-costume-url';
+
+describe('SVG Font Parsing', () => {
+    test('Has font regexp works', () => {
+        expect('font-family="Sans Serif"'.match(HAS_FONT_REGEXP)).toBeTruthy();
+        expect('font-family="none" font-family="Sans Serif"'.match(HAS_FONT_REGEXP)).toBeTruthy();
+        expect('font-family = "Sans Serif"'.match(HAS_FONT_REGEXP)).toBeTruthy();
+
+        expect('font-family="none"'.match(HAS_FONT_REGEXP)).toBeFalsy();
+    });
+});


### PR DESCRIPTION
### Resolves

Resolves #2826.

### Proposed Changes

Adds a translucent sprite/stage watermark to the blocks workspace to indicated the selected target. @paulkaplan, thanks for your help on this!

Refactors code to get the costume source url out of sprite-selector-item so that it can be shared with the new watermark container.

### Test Coverage

Changes can be tested at https://llk.github.io/scratch-gui/watermark

[ ] Test that watermark appears on the workspace
[ ] Test that the watermark updates when a different sprite (or the stage) is selected
[ ] Test that watermark updates when new backdrops / costumes are added
[ ] Test layout in RTL
[ ] Test changing costume in paint editor and returning to workspace


#### Difference from Scratch 2.0
- In scratch 2.0 the watermark does not update if the current costume of the selected sprite is dynamically changed (e.g. `next costume` block). In Scratch 3.0, the watermark does update in this case. @carljbowman I'm interested to hear your thoughts on this...