### PR TITLE
disable onShare button

### DIFF
--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -683,8 +683,7 @@ const mapDispatchToProps = dispatch => ({
     onRequestCloseLogin: () => dispatch(closeLoginMenu()),
     onClickNew: canSave => dispatch(requestNewProject(canSave)),
     onClickSave: () => dispatch(saveProject()),
-    onSeeCommunity: () => dispatch(setPlayer(true)),
-    onShare: () => {} // NOTE: implement this
+    onSeeCommunity: () => dispatch(setPlayer(true))
 });
 
 export default injectIntl(connect(


### PR DESCRIPTION
by putting in an empty default onShare function, I had inadvertently made the button appear enabled in beta/standalone.