### PR TITLE
Costume selector RTL

### DIFF
--- a/src/components/sprite-selector-item/sprite-selector-item.jsx
+++ b/src/components/sprite-selector-item/sprite-selector-item.jsx
@@ -45,7 +45,12 @@ const SpriteSelectorItem = props => (
         <div className={styles.spriteInfo}>
             <div className={styles.spriteName}>{props.name}</div>
             {props.details ? (
-                <div className={styles.spriteDetails}>{props.details}</div>
+                <div
+                    className={styles.spriteDetails}
+                    dir="ltr"
+                >
+                    {props.details}
+                </div>
             ) : null}
         </div>
         {props.onDuplicateButtonClick || props.onDeleteButtonClick || props.onExportButtonClick ? (


### PR DESCRIPTION
### Resolves
Resolves #3128 

### Proposed Changes
Adds `dir=ltr` to SpriteSelectorItem

### Reason for Changes
In RTL texts, numbers should be still LTR.