### PR TITLE
use can__ boolean properties to explicitly set user capabilities

### DIFF
--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -63,7 +63,6 @@ const GUIComponent = props => {
         cardsVisible,
         canCreateNew,
         canRemix,
-        canReport,
         canSave,
         canSaveAsCopy,
         canShare,
@@ -172,7 +171,6 @@ const GUIComponent = props => {
                     accountNavOpen={accountNavOpen}
                     canCreateNew={canCreateNew}
                     canRemix={canRemix}
-                    canReport={canReport}
                     canSave={canSave}
                     canSaveAsCopy={canSaveAsCopy}
                     canShare={canShare}
@@ -319,7 +317,6 @@ GUIComponent.propTypes = {
     blocksTabVisible: PropTypes.bool,
     canCreateNew: PropTypes.bool,
     canRemix: PropTypes.bool,
-    canReport: PropTypes.bool,
     canSave: PropTypes.bool,
     canSaveAsCopy: PropTypes.bool,
     canShare: PropTypes.bool,
@@ -362,9 +359,8 @@ GUIComponent.defaultProps = {
         visible: false
     },
     basePath: './',
-    canCreateNew: false,
+    canCreateNew: true,
     canRemix: false,
-    canReport: false,
     canSave: false,
     canSaveAsCopy: false,
     canShare: false,

--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -61,6 +61,12 @@ const GUIComponent = props => {
         backpackOptions,
         blocksTabVisible,
         cardsVisible,
+        canCreateNew,
+        canRemix,
+        canReport,
+        canSave,
+        canSaveAsCopy,
+        canShare,
         children,
         costumeLibraryVisible,
         costumesTabVisible,
@@ -164,6 +170,12 @@ const GUIComponent = props => {
                 ) : null}
                 <MenuBar
                     accountNavOpen={accountNavOpen}
+                    canCreateNew={canCreateNew}
+                    canRemix={canRemix}
+                    canReport={canReport}
+                    canSave={canSave}
+                    canSaveAsCopy={canSaveAsCopy}
+                    canShare={canShare}
                     className={styles.menuBarPosition}
                     enableCommunity={enableCommunity}
                     renderLogin={renderLogin}
@@ -305,6 +317,12 @@ GUIComponent.propTypes = {
     }),
     basePath: PropTypes.string,
     blocksTabVisible: PropTypes.bool,
+    canCreateNew: PropTypes.bool,
+    canRemix: PropTypes.bool,
+    canReport: PropTypes.bool,
+    canSave: PropTypes.bool,
+    canSaveAsCopy: PropTypes.bool,
+    canShare: PropTypes.bool,
     cardsVisible: PropTypes.bool,
     children: PropTypes.node,
     costumeLibraryVisible: PropTypes.bool,
@@ -344,6 +362,12 @@ GUIComponent.defaultProps = {
         visible: false
     },
     basePath: './',
+    canCreateNew: false,
+    canRemix: false,
+    canReport: false,
+    canSave: false,
+    canSaveAsCopy: false,
+    canShare: false,
     stageSizeMode: STAGE_SIZE_MODES.large
 };
 

--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -145,12 +145,11 @@ class MenuBar extends React.Component {
         }
     }
     handleClickNew () {
-        const canSave = this.props.canUpdateProject; // logged in
         // if canSave===true, it's safe to replace current project, since we will auto-save first
         const readyToReplaceProject =
-            canSave || confirm('Replace contents of the current project?'); // eslint-disable-line no-alert
+            this.props.canSave || confirm('Replace contents of the current project?'); // eslint-disable-line no-alert
         if (readyToReplaceProject) {
-            this.props.onClickNew(canSave);
+            this.props.onClickNew(this.props.canSave);
         }
     }
     handleClickSave () {
@@ -208,6 +207,13 @@ class MenuBar extends React.Component {
                 defaultMessage="Save now"
                 description="Menu bar item for saving now"
                 id="gui.menuBar.saveNow"
+            />
+        );
+        const saveAsCopyMessage = (
+            <FormattedMessage
+                defaultMessage="Save as a copy"
+                description="Menu bar item for saving as a copy"
+                id="gui.menuBar.saveAsCopy"
             />
         );
         const newProjectMessage = (
@@ -285,24 +291,23 @@ class MenuBar extends React.Component {
                                 place={this.props.isRtl ? 'left' : 'right'}
                                 onRequestClose={this.props.onRequestCloseFile}
                             >
-                                {/* for now, only enable New when there is no session */}
-                                {this.props.sessionExists ? (
-                                    <MenuItemTooltip
-                                        id="new"
-                                        isRtl={this.props.isRtl}
-                                    >
-                                        <MenuItem>{newProjectMessage}</MenuItem>
-                                    </MenuItemTooltip>
-                                ) : (
+                                {this.props.canCreateNew ? (
                                     <MenuItem
                                         isRtl={this.props.isRtl}
                                         onClick={this.handleClickNew}
                                     >
                                         {newProjectMessage}
                                     </MenuItem>
+                                ) : (
+                                    <MenuItemTooltip
+                                        id="new"
+                                        isRtl={this.props.isRtl}
+                                    >
+                                        <MenuItem>{newProjectMessage}</MenuItem>
+                                    </MenuItemTooltip>
                                 )}
                                 <MenuSection>
-                                    {this.props.canUpdateProject ? (
+                                    {this.props.canSave ? (
                                         <MenuItem onClick={this.handleClickSave}>
                                             {saveNowMessage}
                                         </MenuItem>
@@ -314,18 +319,18 @@ class MenuBar extends React.Component {
                                             <MenuItem>{saveNowMessage}</MenuItem>
                                         </MenuItemTooltip>
                                     )}
-                                    <MenuItemTooltip
-                                        id="copy"
-                                        isRtl={this.props.isRtl}
-                                    >
-                                        <MenuItem>
-                                            <FormattedMessage
-                                                defaultMessage="Save as a copy"
-                                                description="Menu bar item for saving as a copy"
-                                                id="gui.menuBar.saveAsCopy"
-                                            />
+                                    {this.props.canSaveAsCopy ? (
+                                        <MenuItem onClick={this.handleClickSaveAsCopy}>
+                                            {saveAsCopyMessage}
                                         </MenuItem>
-                                    </MenuItemTooltip>
+                                    ) : (
+                                        <MenuItemTooltip
+                                            id="copy"
+                                            isRtl={this.props.isRtl}
+                                        >
+                                            <MenuItem>{saveAsCopyMessage}</MenuItem>
+                                        </MenuItemTooltip>
+                                    )}
                                 </MenuSection>
                                 <MenuSection>
                                     <SBFileUploader>
@@ -432,7 +437,7 @@ class MenuBar extends React.Component {
                         </MenuBarItemTooltip>
                     </div>
                     <div className={classNames(styles.menuBarItem)}>
-                        {this.props.onShare ? shareButton : (
+                        {this.props.canShare ? shareButton : (
                             <MenuBarItemTooltip id="share-button">
                                 {shareButton}
                             </MenuBarItemTooltip>
@@ -615,7 +620,12 @@ class MenuBar extends React.Component {
 
 MenuBar.propTypes = {
     accountMenuOpen: PropTypes.bool,
-    canUpdateProject: PropTypes.bool,
+    canCreateNew: PropTypes.bool,
+    canRemix: PropTypes.bool,
+    canReport: PropTypes.bool,
+    canSave: PropTypes.bool,
+    canSaveAsCopy: PropTypes.bool,
+    canShare: PropTypes.bool,
     className: PropTypes.string,
     editMenuOpen: PropTypes.bool,
     enableCommunity: PropTypes.bool,
@@ -651,12 +661,15 @@ MenuBar.propTypes = {
     username: PropTypes.string
 };
 
+MenuBar.defaultProps = {
+    onShare: () => {}
+};
+
 const mapStateToProps = state => {
     const loadingState = state.scratchGui.projectState.loadingState;
     const user = state.session && state.session.session && state.session.session.user;
     return {
         accountMenuOpen: accountMenuOpen(state),
-        canUpdateProject: typeof user !== 'undefined',
         fileMenuOpen: fileMenuOpen(state),
         editMenuOpen: editMenuOpen(state),
         isRtl: state.locales.isRtl,

--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -622,7 +622,6 @@ MenuBar.propTypes = {
     accountMenuOpen: PropTypes.bool,
     canCreateNew: PropTypes.bool,
     canRemix: PropTypes.bool,
-    canReport: PropTypes.bool,
     canSave: PropTypes.bool,
     canSaveAsCopy: PropTypes.bool,
     canShare: PropTypes.bool,

--- a/src/playground/render-gui.jsx
+++ b/src/playground/render-gui.jsx
@@ -39,7 +39,6 @@ export default appTarget => {
 
     ReactDOM.render(
         <WrappedGui
-            canCreateNew
             backpackOptions={backpackOptions}
         />,
         appTarget);

--- a/src/playground/render-gui.jsx
+++ b/src/playground/render-gui.jsx
@@ -37,5 +37,14 @@ export default appTarget => {
         window.onbeforeunload = () => true;
     }
 
-    ReactDOM.render(<WrappedGui backpackOptions={backpackOptions} />, appTarget);
+    ReactDOM.render(
+        <WrappedGui
+            canCreateNew
+            backpackOptions={backpackOptions}
+            canRemix={false}
+            canSave={false}
+            canSaveAsCopy={false}
+            canShare={false}
+        />,
+        appTarget);
 };

--- a/src/playground/render-gui.jsx
+++ b/src/playground/render-gui.jsx
@@ -41,10 +41,6 @@ export default appTarget => {
         <WrappedGui
             canCreateNew
             backpackOptions={backpackOptions}
-            canRemix={false}
-            canSave={false}
-            canSaveAsCopy={false}
-            canShare={false}
         />,
         appTarget);
 };

--- a/test/integration/menu-bar.test.js
+++ b/test/integration/menu-bar.test.js
@@ -1,0 +1,60 @@
+import path from 'path';
+import SeleniumHelper from '../helpers/selenium-helper';
+
+const {
+    clickXpath,
+    findByXpath,
+    getDriver,
+    loadUri
+} = new SeleniumHelper();
+
+const uri = path.resolve(__dirname, '../../build/index.html');
+
+let driver;
+
+describe('Menu bar settings', () => {
+    beforeAll(() => {
+        driver = getDriver();
+    });
+
+    afterAll(async () => {
+        await driver.quit();
+    });
+
+    test('File->New should be enabled', async () => {
+        await loadUri(uri);
+        await clickXpath('//button[@title="Try It"]');
+        await clickXpath(
+            '//div[contains(@class, "menu-bar_menu-bar-item") and ' +
+            'contains(@class, "menu-bar_hoverable")][span[text()="File"]]'
+        );
+        await findByXpath('//*[li[span[text()="New"]] and not(@data-tip="tooltip")]');
+    });
+
+    test('File->Save now should NOT be enabled', async () => {
+        await loadUri(uri);
+        await clickXpath('//button[@title="Try It"]');
+        await clickXpath(
+            '//div[contains(@class, "menu-bar_menu-bar-item") and ' +
+            'contains(@class, "menu-bar_hoverable")][span[text()="File"]]'
+        );
+        await findByXpath('//*[li[span[text()="Save now"]] and @data-tip="tooltip"]');
+    });
+
+
+    test('File->Save as a copy should NOT be enabled', async () => {
+        await loadUri(uri);
+        await clickXpath('//button[@title="Try It"]');
+        await clickXpath(
+            '//div[contains(@class, "menu-bar_menu-bar-item") and ' +
+            'contains(@class, "menu-bar_hoverable")][span[text()="File"]]'
+        );
+        await findByXpath('//*[li[span[text()="Save as a copy"]] and @data-tip="tooltip"]');
+    });
+
+    test('Share button should NOT be enabled', async () => {
+        await loadUri(uri);
+        await clickXpath('//button[@title="Try It"]');
+        await findByXpath('//div[span[div[span[text()="Share"]]] and @data-tip="tooltip"]');
+    });
+});


### PR DESCRIPTION
### Resolves:

Resolves https://github.com/LLK/scratch-gui/issues/3322 (and related to https://github.com/LLK/scratch-www/issues/2168 )

### Changes:

sets and uses several variables:
```
canCreateNew
canRemix
canReport
canSave
canSaveAsCopy
canShare
```

Question: are there any booleans we should add? Do all of these make sense?

### Reason for Changes

We want embedding environments to be able to clearly communicate to GUI which capabilities the user should have, rather than have GUI contain knowledge about what various session statuses mean it should enable

### Test Coverage

Added several tests, in new test file `integration/menu-bar.test.js`

### Browser Coverage

Mac Chrome