### PR TITLE
sb-file-uploader gets title of any sb.* file; calls onUpdateProjectTitle

### DIFF
--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -368,6 +368,7 @@ GUIComponent.defaultProps = {
     canSave: false,
     canSaveAsCopy: false,
     canShare: false,
+    onUpdateProjectTitle: () => {},
     stageSizeMode: STAGE_SIZE_MODES.large
 };
 

--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -333,7 +333,7 @@ class MenuBar extends React.Component {
                                     )}
                                 </MenuSection>
                                 <MenuSection>
-                                    <SBFileUploader>
+                                    <SBFileUploader onUpdateProjectTitle={this.props.onUpdateProjectTitle}>
                                         {(renderFileInput, loadProject) => (
                                             <MenuItem
                                                 onClick={loadProject}

--- a/src/containers/sb-file-uploader.jsx
+++ b/src/containers/sb-file-uploader.jsx
@@ -41,6 +41,7 @@ class SBFileUploader extends React.Component {
     constructor (props) {
         super(props);
         bindAll(this, [
+            'getProjectTitleFromFilename',
             'renderFileInput',
             'setFileInput',
             'handleChange',

--- a/src/containers/sb-file-uploader.jsx
+++ b/src/containers/sb-file-uploader.jsx
@@ -6,7 +6,6 @@ import {defineMessages, injectIntl, intlShape} from 'react-intl';
 
 import analytics from '../lib/analytics';
 import log from '../lib/log';
-import {setProjectTitle} from '../reducers/project-title';
 import {LoadingStates, onLoadedProject, onProjectUploadStarted} from '../reducers/project-state';
 
 import {
@@ -79,13 +78,11 @@ class SBFileUploader extends React.Component {
             reader.readAsArrayBuffer(thisFileInput.files[0]);
             // extract the title from the file and set it as current project title
             if (thisFileInput.files[0].name) {
-                const matches = thisFileInput.files[0].name.match(/^(.*?)(\.sb[23]?)?$/);
+                // only parse title from files like "filename.sb2" or "filename.sb3"
+                const matches = thisFileInput.files[0].name.match(/^(.*)\.sb[23]$/);
                 if (matches) {
                     const truncatedProjectTitle = matches[1].substring(0, 100);
-                    this.props.onSetReduxProjectTitle(truncatedProjectTitle);
-                    if (this.props.onUpdateProjectTitle) {
-                        this.props.onUpdateProjectTitle(truncatedProjectTitle);
-                    }
+                    this.props.onUpdateProjectTitle(truncatedProjectTitle);
                 }
             }
         }
@@ -119,7 +116,6 @@ SBFileUploader.propTypes = {
     loadingState: PropTypes.oneOf(LoadingStates),
     onLoadingFinished: PropTypes.func,
     onLoadingStarted: PropTypes.func,
-    onSetReduxProjectTitle: PropTypes.func,
     onUpdateProjectTitle: PropTypes.func,
     vm: PropTypes.shape({
         loadProject: PropTypes.func
@@ -135,7 +131,6 @@ const mapDispatchToProps = dispatch => ({
         dispatch(onLoadedProject(loadingState));
         dispatch(closeLoadingProject());
     },
-    onSetReduxProjectTitle: title => dispatch(setProjectTitle(title)),
     onLoadingStarted: () => {
         dispatch(openLoadingProject());
         dispatch(onProjectUploadStarted());

--- a/src/containers/sb-file-uploader.jsx
+++ b/src/containers/sb-file-uploader.jsx
@@ -47,6 +47,13 @@ class SBFileUploader extends React.Component {
             'handleClick'
         ]);
     }
+    getProjectTitleFromFilename (fileInputFilename) {
+        if (!fileInputFilename) return '';
+        // only parse title from files like "filename.sb2" or "filename.sb3"
+        const matches = fileInputFilename.match(/^(.*)\.sb[23]$/);
+        if (!matches) return '';
+        return matches[1].substring(0, 100); // truncate project title to max 100 chars
+    }
     // called when user has finished selecting a file to upload
     handleChange (e) {
         // Remove the hash if any (without triggering a hash change event or a reload)
@@ -76,15 +83,8 @@ class SBFileUploader extends React.Component {
         if (thisFileInput.files) { // Don't attempt to load if no file was selected
             this.props.onLoadingStarted();
             reader.readAsArrayBuffer(thisFileInput.files[0]);
-            // extract the title from the file and set it as current project title
-            if (thisFileInput.files[0].name) {
-                // only parse title from files like "filename.sb2" or "filename.sb3"
-                const matches = thisFileInput.files[0].name.match(/^(.*)\.sb[23]$/);
-                if (matches) {
-                    const truncatedProjectTitle = matches[1].substring(0, 100);
-                    this.props.onUpdateProjectTitle(truncatedProjectTitle);
-                }
-            }
+            const uploadedProjectTitle = this.getProjectTitleFromFilename(thisFileInput.files[0].name);
+            this.props.onUpdateProjectTitle(uploadedProjectTitle);
         }
     }
     handleClick () {
@@ -137,7 +137,13 @@ const mapDispatchToProps = dispatch => ({
     }
 });
 
+// Allow incoming props to override redux-provided props. Used to mock in tests.
+const mergeProps = (stateProps, dispatchProps, ownProps) => Object.assign(
+    {}, stateProps, dispatchProps, ownProps
+);
+
 export default connect(
     mapStateToProps,
-    mapDispatchToProps
+    mapDispatchToProps,
+    mergeProps
 )(injectIntl(SBFileUploader));

--- a/src/containers/sb-file-uploader.jsx
+++ b/src/containers/sb-file-uploader.jsx
@@ -79,10 +79,13 @@ class SBFileUploader extends React.Component {
             reader.readAsArrayBuffer(thisFileInput.files[0]);
             // extract the title from the file and set it as current project title
             if (thisFileInput.files[0].name) {
-                const matches = thisFileInput.files[0].name.match(/^(.*)\.sb3$/);
+                const matches = thisFileInput.files[0].name.match(/^(.*?)(\.sb[23]?)?$/);
                 if (matches) {
                     const truncatedProjectTitle = matches[1].substring(0, 100);
-                    this.props.onSetProjectTitle(truncatedProjectTitle);
+                    this.props.onSetReduxProjectTitle(truncatedProjectTitle);
+                    if (this.props.onUpdateProjectTitle) {
+                        this.props.onUpdateProjectTitle(truncatedProjectTitle);
+                    }
                 }
             }
         }
@@ -116,7 +119,8 @@ SBFileUploader.propTypes = {
     loadingState: PropTypes.oneOf(LoadingStates),
     onLoadingFinished: PropTypes.func,
     onLoadingStarted: PropTypes.func,
-    onSetProjectTitle: PropTypes.func,
+    onSetReduxProjectTitle: PropTypes.func,
+    onUpdateProjectTitle: PropTypes.func,
     vm: PropTypes.shape({
         loadProject: PropTypes.func
     })
@@ -131,7 +135,7 @@ const mapDispatchToProps = dispatch => ({
         dispatch(onLoadedProject(loadingState));
         dispatch(closeLoadingProject());
     },
-    onSetProjectTitle: title => dispatch(setProjectTitle(title)),
+    onSetReduxProjectTitle: title => dispatch(setProjectTitle(title)),
     onLoadingStarted: () => {
         dispatch(openLoadingProject());
         dispatch(onProjectUploadStarted());

--- a/test/unit/containers/sb-file-uploader.test.jsx
+++ b/test/unit/containers/sb-file-uploader.test.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import {Provider} from 'react-redux';
+import {mount, shallow} from 'enzyme';
+
 import {mountWithIntl, shallowWithIntl, componentWithIntl} from '../../helpers/intl-helpers.jsx';
 import configureStore from 'redux-mock-store';
 import SBFileUploader from '../../../src/containers/sb-file-uploader';
@@ -17,19 +19,17 @@ describe('SBFileUploader Container', () => {
     // Wrap this in a function so it gets test specific states and can be reused.
     const getContainer = function () {
         return (
-            <Provider store={store}>
-                <SBFileUploader
-                    onLoadingFinished={onLoadingFinished}
-                    onLoadingStarted={onLoadingStarted}
-                    onUpdateProjectTitle={onUpdateProjectTitle}
-                >
-                    {(renderFileInput, loadProject) => (
-                        <div
-                            onClick={loadProject}
-                        />
-                    )}
-                </SBFileUploader>
-            </Provider>
+            <SBFileUploader
+                onLoadingFinished={onLoadingFinished}
+                onLoadingStarted={onLoadingStarted}
+                onUpdateProjectTitle={onUpdateProjectTitle}
+            >
+                {(renderFileInput, loadProject) => (
+                    <div
+                        onClick={loadProject}
+                    />
+                )}
+            </SBFileUploader>
         );
     };
 
@@ -48,28 +48,42 @@ describe('SBFileUploader Container', () => {
     });
 
     test('correctly sets title with .sb3 filename', () => {
-        const wrapper = mountWithIntl(getContainer());
-        const instance = wrapper.find(SBFileUploader).component();
-        expect(instance).toBe(true);
+        const wrapper = shallowWithIntl(getContainer(), {context: {store}});
+        const instance = wrapper
+            .dive() // unwrap redux Connect(InjectIntl(SBFileUploader))
+            .dive() // unwrap InjectIntl(SBFileUploader)
+            .instance(); // SBFileUploader
         const projectName = instance.getProjectTitleFromFilename('my project is great.sb3');
         expect(projectName).toBe('my project is great');
     });
 
-    // test('correctly sets title with .sb3 filename', () => {
-    //     const component = componentWithIntl(getContainer());
-    //     const projectName = component.getProjectTitleFromFilename('my project is great.sb3');
-    //     expect(projectName).toBe('my project is great');
-    // });
-    //
-    // test('sets blank title with .sb filename', () => {
-    //     const component = componentWithIntl(getContainer());
-    //     const projectName = component.getProjectTitleFromFilename('my project is great.sb');
-    //     expect(projectName).toBe('');
-    // });
-    //
-    // test('sets blank title with filename with no extension', () => {
-    //     const component = componentWithIntl(getContainer());
-    //     const projectName = component.getProjectTitleFromFilename('my project is great');
-    //     expect(projectName).toBe('');
-    // });
+    test('correctly sets title with .sb2 filename', () => {
+        const wrapper = shallowWithIntl(getContainer(), {context: {store}});
+        const instance = wrapper
+            .dive() // unwrap redux Connect(InjectIntl(SBFileUploader))
+            .dive() // unwrap InjectIntl(SBFileUploader)
+            .instance(); // SBFileUploader
+        const projectName = instance.getProjectTitleFromFilename('my project is great.sb2');
+        expect(projectName).toBe('my project is great');
+    });
+
+    test('sets blank title with .sb filename', () => {
+        const wrapper = shallowWithIntl(getContainer(), {context: {store}});
+        const instance = wrapper
+            .dive() // unwrap redux Connect(InjectIntl(SBFileUploader))
+            .dive() // unwrap InjectIntl(SBFileUploader)
+            .instance(); // SBFileUploader
+        const projectName = instance.getProjectTitleFromFilename('my project is great.sb');
+        expect(projectName).toBe('');
+    });
+
+    test('sets blank title with filename with no extension', () => {
+        const wrapper = shallowWithIntl(getContainer(), {context: {store}});
+        const instance = wrapper
+            .dive() // unwrap redux Connect(InjectIntl(SBFileUploader))
+            .dive() // unwrap InjectIntl(SBFileUploader)
+            .instance(); // SBFileUploader
+        const projectName = instance.getProjectTitleFromFilename('my project is great');
+        expect(projectName).toBe('');
+    });
 });

--- a/test/unit/containers/sb-file-uploader.test.jsx
+++ b/test/unit/containers/sb-file-uploader.test.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
-import {Provider} from 'react-redux';
-import {mount, shallow} from 'enzyme';
 
-import {mountWithIntl, shallowWithIntl, componentWithIntl} from '../../helpers/intl-helpers.jsx';
+import {shallowWithIntl} from '../../helpers/intl-helpers.jsx';
 import configureStore from 'redux-mock-store';
 import SBFileUploader from '../../../src/containers/sb-file-uploader';
 import {LoadingState} from '../../../src/reducers/project-state';

--- a/test/unit/containers/sb-file-uploader.test.jsx
+++ b/test/unit/containers/sb-file-uploader.test.jsx
@@ -2,9 +2,12 @@ import React from 'react';
 import {Provider} from 'react-redux';
 import {mountWithIntl, shallowWithIntl, componentWithIntl} from '../../helpers/intl-helpers.jsx';
 import configureStore from 'redux-mock-store';
-import SBFileUploader from '../../../src/containers/sb-file-uploader.jsx';
+import SBFileUploader from '../../../src/containers/sb-file-uploader';
+import {LoadingState} from '../../../src/reducers/project-state';
 
-describe('SBFileUploader', () => {
+jest.mock('react-ga'); // must mock this entire library, or lib/analytics causes error
+
+describe('SBFileUploader Container', () => {
     const mockStore = configureStore();
     let onLoadingFinished;
     let onLoadingStarted;
@@ -14,25 +17,29 @@ describe('SBFileUploader', () => {
     // Wrap this in a function so it gets test specific states and can be reused.
     const getContainer = function () {
         return (
-            <SBFileUploader
-                store={store}
-                onLoadingFinished={onLoadingFinished}
-                onLoadingStarted={onLoadingStarted}
-                onUpdateProjectTitle={onUpdateProjectTitle}
-            >
-                {(renderFileInput, loadProject) => (
-                    <div
-                        onClick={loadProject}
-                    />
-                )}
-            </SBFileUploader>
+            <Provider store={store}>
+                <SBFileUploader
+                    onLoadingFinished={onLoadingFinished}
+                    onLoadingStarted={onLoadingStarted}
+                    onUpdateProjectTitle={onUpdateProjectTitle}
+                >
+                    {(renderFileInput, loadProject) => (
+                        <div
+                            onClick={loadProject}
+                        />
+                    )}
+                </SBFileUploader>
+            </Provider>
         );
     };
 
     beforeEach(() => {
         store = mockStore({
             scratchGui: {
-                projectState: {}
+                projectState: {
+                    loadingState: LoadingState.SHOWING_WITH_ID
+                },
+                vm: {}
             }
         });
         onUpdateProjectTitle = jest.fn();
@@ -41,27 +48,28 @@ describe('SBFileUploader', () => {
     });
 
     test('correctly sets title with .sb3 filename', () => {
-        const component = mountWithIntl(getContainer());
-        const instance = component.instance();
+        const wrapper = mountWithIntl(getContainer());
+        const instance = wrapper.find(SBFileUploader).component();
+        expect(instance).toBe(true);
         const projectName = instance.getProjectTitleFromFilename('my project is great.sb3');
         expect(projectName).toBe('my project is great');
     });
 
-    test('correctly sets title with .sb3 filename', () => {
-        const component = componentWithIntl(getContainer());
-        const projectName = component.getProjectTitleFromFilename('my project is great.sb3');
-        expect(projectName).toBe('my project is great');
-    });
-
-    test('sets blank title with .sb filename', () => {
-        const component = componentWithIntl(getContainer());
-        const projectName = component.getProjectTitleFromFilename('my project is great.sb');
-        expect(projectName).toBe('');
-    });
-
-    test('sets blank title with filename with no extension', () => {
-        const component = componentWithIntl(getContainer());
-        const projectName = component.getProjectTitleFromFilename('my project is great');
-        expect(projectName).toBe('');
-    });
+    // test('correctly sets title with .sb3 filename', () => {
+    //     const component = componentWithIntl(getContainer());
+    //     const projectName = component.getProjectTitleFromFilename('my project is great.sb3');
+    //     expect(projectName).toBe('my project is great');
+    // });
+    //
+    // test('sets blank title with .sb filename', () => {
+    //     const component = componentWithIntl(getContainer());
+    //     const projectName = component.getProjectTitleFromFilename('my project is great.sb');
+    //     expect(projectName).toBe('');
+    // });
+    //
+    // test('sets blank title with filename with no extension', () => {
+    //     const component = componentWithIntl(getContainer());
+    //     const projectName = component.getProjectTitleFromFilename('my project is great');
+    //     expect(projectName).toBe('');
+    // });
 });

--- a/test/unit/containers/sb-file-uploader.test.jsx
+++ b/test/unit/containers/sb-file-uploader.test.jsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import {Provider} from 'react-redux';
+import {mountWithIntl, shallowWithIntl, componentWithIntl} from '../../helpers/intl-helpers.jsx';
+import configureStore from 'redux-mock-store';
+import SBFileUploader from '../../../src/containers/sb-file-uploader.jsx';
+
+describe('SBFileUploader', () => {
+    const mockStore = configureStore();
+    let onLoadingFinished;
+    let onLoadingStarted;
+    let onUpdateProjectTitle;
+    let store;
+
+    // Wrap this in a function so it gets test specific states and can be reused.
+    const getContainer = function () {
+        return (
+            <SBFileUploader
+                store={store}
+                onLoadingFinished={onLoadingFinished}
+                onLoadingStarted={onLoadingStarted}
+                onUpdateProjectTitle={onUpdateProjectTitle}
+            >
+                {(renderFileInput, loadProject) => (
+                    <div
+                        onClick={loadProject}
+                    />
+                )}
+            </SBFileUploader>
+        );
+    };
+
+    beforeEach(() => {
+        store = mockStore({
+            scratchGui: {
+                projectState: {}
+            }
+        });
+        onUpdateProjectTitle = jest.fn();
+        onLoadingFinished = jest.fn();
+        onLoadingStarted = jest.fn();
+    });
+
+    test('correctly sets title with .sb3 filename', () => {
+        const component = mountWithIntl(getContainer());
+        const instance = component.instance();
+        const projectName = instance.getProjectTitleFromFilename('my project is great.sb3');
+        expect(projectName).toBe('my project is great');
+    });
+
+    test('correctly sets title with .sb3 filename', () => {
+        const component = componentWithIntl(getContainer());
+        const projectName = component.getProjectTitleFromFilename('my project is great.sb3');
+        expect(projectName).toBe('my project is great');
+    });
+
+    test('sets blank title with .sb filename', () => {
+        const component = componentWithIntl(getContainer());
+        const projectName = component.getProjectTitleFromFilename('my project is great.sb');
+        expect(projectName).toBe('');
+    });
+
+    test('sets blank title with filename with no extension', () => {
+        const component = componentWithIntl(getContainer());
+        const projectName = component.getProjectTitleFromFilename('my project is great');
+        expect(projectName).toBe('');
+    });
+});


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-gui/issues/3339 and https://github.com/LLK/scratch-gui/issues/3140

### Proposed Changes

* Handles/shows title of a 2.0 project (and will work for 1.0 projects, and projects missing extension, if it needs to) when one is loaded in 3.0.

* calls the onUpdateProjectTitle passed to it from `MenuBar` with the new title, if it exists. This allows code that encloses or embeds GUI to be notified of the title change when a file is uploaded.

### Reason for Changes

* sb2 file uploads were having titles ignored, for no good reason!
* uploading a Scratch file when editor is under preview/project page should update the title of the project!

### Test Coverage

None. Unclear how to test this well?

### Browser Coverage

tested in Mac Chrome