### PR TITLE
handle many modes of new project creation

### DIFF
--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -656,7 +656,6 @@ MenuBar.propTypes = {
     onUpdateProjectTitle: PropTypes.func,
     renderLogin: PropTypes.func,
     sessionExists: PropTypes.bool,
-    startSaving: PropTypes.func,
     username: PropTypes.string
 };
 

--- a/src/containers/sb-file-uploader.jsx
+++ b/src/containers/sb-file-uploader.jsx
@@ -112,6 +112,7 @@ class SBFileUploader extends React.Component {
 }
 
 SBFileUploader.propTypes = {
+    canSave: PropTypes.bool, // eslint-disable-line react/no-unused-prop-types
     children: PropTypes.func,
     intl: intlShape.isRequired,
     loadingState: PropTypes.oneOf(LoadingStates),
@@ -127,9 +128,9 @@ const mapStateToProps = state => ({
     vm: state.scratchGui.vm
 });
 
-const mapDispatchToProps = dispatch => ({
+const mapDispatchToProps = (dispatch, ownProps) => ({
     onLoadingFinished: loadingState => {
-        dispatch(onLoadedProject(loadingState));
+        dispatch(onLoadedProject(loadingState, ownProps.canSave));
         dispatch(closeLoadingProject());
     },
     onLoadingStarted: () => {

--- a/src/lib/project-fetcher-hoc.jsx
+++ b/src/lib/project-fetcher-hoc.jsx
@@ -7,8 +7,8 @@ import {connect} from 'react-redux';
 import {
     LoadingStates,
     defaultProjectId,
-    onFetchedProjectData,
     getIsFetchingWithId,
+    onFetchedProjectData,
     setProjectId
 } from '../reducers/project-state';
 
@@ -102,6 +102,7 @@ const ProjectFetcherHOC = function (WrappedComponent) {
     }
     ProjectFetcherComponent.propTypes = {
         assetHost: PropTypes.string,
+        canSave: PropTypes.bool,
         intl: intlShape.isRequired,
         isFetchingWithId: PropTypes.bool,
         loadingState: PropTypes.oneOf(LoadingStates),

--- a/src/lib/vm-manager-hoc.jsx
+++ b/src/lib/vm-manager-hoc.jsx
@@ -42,13 +42,13 @@ const vmManagerHOC = function (WrappedComponent) {
             // and they weren't both that way until now... load project!
             if (this.props.isLoadingWithId && this.props.fontsLoaded &&
                 (!prevProps.isLoadingWithId || !prevProps.fontsLoaded)) {
-                this.loadProject(this.props.projectData, this.props.loadingState);
+                this.loadProject();
             }
         }
-        loadProject (projectData, loadingState) {
-            return this.props.vm.loadProject(projectData)
+        loadProject () {
+            return this.props.vm.loadProject(this.props.projectData)
                 .then(() => {
-                    this.props.onLoadedProject(loadingState);
+                    this.props.onLoadedProject(this.props.loadingState, this.props.canSave);
                 })
                 .catch(e => {
                     // Need to catch this error and update component state so that
@@ -82,6 +82,7 @@ const vmManagerHOC = function (WrappedComponent) {
     }
 
     VMManager.propTypes = {
+        canSave: PropTypes.bool,
         fontsLoaded: PropTypes.bool,
         isLoadingWithId: PropTypes.bool,
         loadingState: PropTypes.oneOf(LoadingStates),
@@ -102,7 +103,8 @@ const vmManagerHOC = function (WrappedComponent) {
     };
 
     const mapDispatchToProps = dispatch => ({
-        onLoadedProject: loadingState => dispatch(onLoadedProject(loadingState))
+        onLoadedProject: (loadingState, canSave) =>
+            dispatch(onLoadedProject(loadingState, canSave))
     });
 
     // Allow incoming props to override redux-provided props. Used to mock in tests.

--- a/test/unit/reducers/project-state-reducer.test.js
+++ b/test/unit/reducers/project-state-reducer.test.js
@@ -67,24 +67,22 @@ test('onFetchedProjectData new loads project data into vm', () => {
     expect(resultState.projectData).toBe('1010101');
 });
 
-test('onFetchedProjectData new, to save loads project data into vm, prepares to save next', () => {
-    const initialState = {
-        projectData: null,
-        loadingState: LoadingState.FETCHING_NEW_DEFAULT_TO_SAVE
-    };
-    const action = onFetchedProjectData('1010101', initialState.loadingState);
-    const resultState = projectStateReducer(initialState, action);
-    expect(resultState.loadingState).toBe(LoadingState.LOADING_VM_NEW_DEFAULT_TO_SAVE);
-    expect(resultState.projectData).toBe('1010101');
-});
-
-test('onLoadedProject upload shows without id', () => {
+test('onLoadedProject upload, with canSave false, shows without id', () => {
     const initialState = {
         loadingState: LoadingState.LOADING_VM_FILE_UPLOAD
     };
-    const action = onLoadedProject(initialState.loadingState);
+    const action = onLoadedProject(initialState.loadingState, false);
     const resultState = projectStateReducer(initialState, action);
     expect(resultState.loadingState).toBe(LoadingState.SHOWING_WITHOUT_ID);
+});
+
+test('onLoadedProject upload, with canSave true, prepares to save', () => {
+    const initialState = {
+        loadingState: LoadingState.LOADING_VM_FILE_UPLOAD
+    };
+    const action = onLoadedProject(initialState.loadingState, true);
+    const resultState = projectStateReducer(initialState, action);
+    expect(resultState.loadingState).toBe(LoadingState.SAVING_WITH_ID);
 });
 
 test('onLoadedProject with id shows with id', () => {
@@ -105,13 +103,13 @@ test('onLoadedProject new shows without id', () => {
     expect(resultState.loadingState).toBe(LoadingState.SHOWING_WITHOUT_ID);
 });
 
-test('onLoadedProject new, to save shows with id', () => {
+test('onLoadedProject new, to save shows without id', () => {
     const initialState = {
-        loadingState: LoadingState.LOADING_VM_NEW_DEFAULT_TO_SAVE
+        loadingState: LoadingState.LOADING_VM_NEW_DEFAULT
     };
     const action = onLoadedProject(initialState.loadingState);
     const resultState = projectStateReducer(initialState, action);
-    expect(resultState.loadingState).toBe(LoadingState.SHOWING_WITH_ID);
+    expect(resultState.loadingState).toBe(LoadingState.SHOWING_WITHOUT_ID);
 });
 
 test('onUpdated with id shows with id', () => {
@@ -129,7 +127,7 @@ test('onUpdated with id, before new, fetches default project', () => {
     };
     const action = onUpdated(initialState.loadingState);
     const resultState = projectStateReducer(initialState, action);
-    expect(resultState.loadingState).toBe(LoadingState.FETCHING_NEW_DEFAULT_TO_SAVE);
+    expect(resultState.loadingState).toBe(LoadingState.FETCHING_NEW_DEFAULT);
 });
 
 test('setProjectId, with same id as before, should show with id, not fetch', () => {
@@ -219,15 +217,26 @@ test('saveProject should prepare to save', () => {
     expect(resultState.loadingState).toBe(LoadingState.SAVING_WITH_ID);
 });
 
-test('onError from unloaded state should show error', () => {
-    const initialState = {
-        errStr: null,
-        loadingState: LoadingState.NOT_LOADED
-    };
-    const action = onError('Error string');
-    const resultState = projectStateReducer(initialState, action);
-    expect(resultState.loadingState).toBe(LoadingState.ERROR);
-    expect(resultState.errStr).toBe('Error string');
+test('onError from various states should show error', () => {
+    const startStates = [
+        LoadingState.LOADING_VM_NEW_DEFAULT,
+        LoadingState.LOADING_VM_WITH_ID,
+        LoadingState.FETCHING_WITH_ID,
+        LoadingState.FETCHING_NEW_DEFAULT,
+        LoadingState.SAVING_WITH_ID,
+        LoadingState.SAVING_WITH_ID_BEFORE_NEW,
+        LoadingState.CREATING_NEW
+    ];
+    for (const startState of startStates) {
+        const initialState = {
+            errStr: null,
+            loadingState: startState
+        };
+        const action = onError('Error string');
+        const resultState = projectStateReducer(initialState, action);
+        expect(resultState.loadingState).toBe(LoadingState.ERROR);
+        expect(resultState.errStr).toBe('Error string');
+    }
 });
 
 test('onError from showing project should show error', () => {

--- a/test/unit/util/project-saver-hoc.test.jsx
+++ b/test/unit/util/project-saver-hoc.test.jsx
@@ -1,0 +1,257 @@
+import 'web-audio-test-api';
+
+import React from 'react';
+import configureStore from 'redux-mock-store';
+import {mount} from 'enzyme';
+import {LoadingState} from '../../../src/reducers/project-state';
+import VM from 'scratch-vm';
+
+import projectSaverHOC from '../../../src/lib/project-saver-hoc.jsx';
+
+describe('projectSaverHOC', () => {
+    const mockStore = configureStore();
+    let store;
+    let vm;
+
+    beforeEach(() => {
+        store = mockStore({
+            scratchGui: {
+                projectState: {}
+            }
+        });
+        vm = new VM();
+    });
+
+    test('if canSave becomes true when showing a project with an id, project will be saved', () => {
+        const mockedSaveProject = jest.fn();
+        const Component = () => <div />;
+        const WrappedComponent = projectSaverHOC(Component);
+        const mounted = mount(
+            <WrappedComponent
+                isShowingWithId
+                canSave={false}
+                isCreating={false}
+                isShowingWithoutId={false}
+                isUpdating={false}
+                loadingState={LoadingState.SHOWING_WITH_ID}
+                saveProject={mockedSaveProject}
+                store={store}
+                vm={vm}
+            />
+        );
+        mounted.setProps({
+            canSave: true
+        });
+        expect(mockedSaveProject).toHaveBeenCalled();
+    });
+
+    test('if canSave is alreatdy true and we show a project with an id, project will NOT be saved', () => {
+        const mockedSaveProject = jest.fn();
+        const Component = () => <div />;
+        const WrappedComponent = projectSaverHOC(Component);
+        const mounted = mount(
+            <WrappedComponent
+                canSave
+                isCreating={false}
+                isShowingWithId={false}
+                isShowingWithoutId={false}
+                isUpdating={false}
+                loadingState={LoadingState.LOADING_VM_WITH_ID}
+                saveProject={mockedSaveProject}
+                store={store}
+                vm={vm}
+            />
+        );
+        mounted.setProps({
+            canSave: true,
+            isShowingWithId: true,
+            loadingState: LoadingState.SHOWING_WITH_ID
+        });
+        expect(mockedSaveProject).not.toHaveBeenCalled();
+    });
+
+    test('if canSave is false when showing a project without an id, project will NOT be created', () => {
+        const mockedCreateProject = jest.fn();
+        const Component = () => <div />;
+        const WrappedComponent = projectSaverHOC(Component);
+        const mounted = mount(
+            <WrappedComponent
+                isShowingWithoutId
+                canSave={false}
+                createProject={mockedCreateProject}
+                isCreating={false}
+                isShowingWithId={false}
+                isUpdating={false}
+                loadingState={LoadingState.LOADING_VM_NEW_DEFAULT}
+                store={store}
+                vm={vm}
+            />
+        );
+        mounted.setProps({
+            isShowingWithoutId: true,
+            loadingState: LoadingState.SHOWING_WITHOUT_ID
+        });
+        expect(mockedCreateProject).not.toHaveBeenCalled();
+    });
+
+    test('if canSave becomes true when showing a project without an id, project will be created', () => {
+        const mockedCreateProject = jest.fn();
+        const Component = () => <div />;
+        const WrappedComponent = projectSaverHOC(Component);
+        const mounted = mount(
+            <WrappedComponent
+                isShowingWithoutId
+                canSave={false}
+                createProject={mockedCreateProject}
+                isCreating={false}
+                isShowingWithId={false}
+                isUpdating={false}
+                loadingState={LoadingState.SHOWING_WITHOUT_ID}
+                store={store}
+                vm={vm}
+            />
+        );
+        mounted.setProps({
+            canSave: true
+        });
+        expect(mockedCreateProject).toHaveBeenCalled();
+    });
+
+    test('if canSave is true and we transition to showing new project, project will be created', () => {
+        const mockedCreateProject = jest.fn();
+        const Component = () => <div />;
+        const WrappedComponent = projectSaverHOC(Component);
+        const mounted = mount(
+            <WrappedComponent
+                canSave
+                createProject={mockedCreateProject}
+                isCreating={false}
+                isShowingWithId={false}
+                isShowingWithoutId={false}
+                isUpdating={false}
+                loadingState={LoadingState.LOADING_VM_NEW_DEFAULT}
+                store={store}
+                vm={vm}
+            />
+        );
+        mounted.setProps({
+            isShowingWithoutId: true,
+            loadingState: LoadingState.SHOWING_WITHOUT_ID
+        });
+        expect(mockedCreateProject).toHaveBeenCalled();
+    });
+
+    test('if we enter creating state, vm project should be requested', () => {
+        vm.saveProjectSb3 = jest.fn(() => Promise.resolve());
+        const Component = () => <div />;
+        const WrappedComponent = projectSaverHOC(Component);
+        const mounted = mount(
+            <WrappedComponent
+                canSave
+                isCreating={false}
+                isShowingWithId={false}
+                isShowingWithoutId={false}
+                isUpdating={false}
+                loadingState={LoadingState.LOADING_VM_NEW_DEFAULT}
+                reduxProjectId={'100'}
+                store={store}
+                vm={vm}
+            />
+        );
+        mounted.setProps({
+            isCreating: true,
+            loadingState: LoadingState.CREATING_NEW
+        });
+        expect(vm.saveProjectSb3).toHaveBeenCalled();
+    });
+
+    test('if we enter updating/saving state, vm project shold be requested', () => {
+        vm.saveProjectSb3 = jest.fn(() => Promise.resolve());
+        const Component = () => <div />;
+        const WrappedComponent = projectSaverHOC(Component);
+        const mounted = mount(
+            <WrappedComponent
+                canSave
+                isCreating={false}
+                isShowingWithId={false}
+                isShowingWithoutId={false}
+                isUpdating={false}
+                loadingState={LoadingState.LOADING_VM_WITH_ID}
+                reduxProjectId={'100'}
+                store={store}
+                vm={vm}
+            />
+        );
+        mounted.setProps({
+            isUpdating: true,
+            loadingState: LoadingState.SAVING_WITH_ID
+        });
+        expect(vm.saveProjectSb3).toHaveBeenCalled();
+    });
+
+    test('if we are already in updating/saving state, vm project shold be NOT requested', () => {
+        vm.saveProjectSb3 = jest.fn(() => Promise.resolve());
+        const Component = () => <div />;
+        const WrappedComponent = projectSaverHOC(Component);
+        const mounted = mount(
+            <WrappedComponent
+                canSave
+                isUpdating
+                isCreating={false}
+                isShowingWithId={false}
+                isShowingWithoutId={false}
+                loadingState={LoadingState.SAVING_WITH_ID}
+                reduxProjectId={'100'}
+                store={store}
+                vm={vm}
+            />
+        );
+        mounted.setProps({
+            isUpdating: true,
+            loadingState: LoadingState.SAVING_WITH_ID,
+            reduxProjectId: '99' // random change to force a re-render and componentDidUpdate
+        });
+        expect(vm.saveProjectSb3).not.toHaveBeenCalled();
+    });
+
+    // test('template', () => {
+    //     vm.saveProjectSb3 = jest.fn(() => Promise.resolve());
+    //     const mockedCreateProject = jest.fn();
+    //     const mockedOnCreated = jest.fn();
+    //     const mockedOnError = jest.fn();
+    //     const mockedOnUpdated = jest.fn();
+    //     const mockedSaveProject = jest.fn();
+    //
+    //     const Component = () => <div />;
+    //     const WrappedComponent = projectSaverHOC(Component);
+    //     const mounted = mount(
+    //         <WrappedComponent
+    //             canSave={false}
+    //             createProject={mockedCreateProject}
+    //             isCreating={false}
+    //             isShowingWithId={false}
+    //             isShowingWithoutId={false}
+    //             isUpdating={false}
+    //             loadingState={LoadingState.NOT_LOADED}
+    //             reduxProjectId={'100'}
+    //             saveProject={mockedSaveProject}
+    //             store={store}
+    //             vm={vm}
+    //             onCreated={mockedOnCreated}
+    //             onError={mockedOnError}
+    //             onUpdated={mockedOnUpdated}
+    //         />
+    //     );
+    //     mounted.setProps({
+    //         canSave: true,
+    //         isShowingWithId: true,
+    //         loadingState: LoadingState.SHOWING_WITH_ID,
+    //         projectData: '100'
+    //     });
+    //     expect(vm.loadProject).toHaveBeenLastCalledWith('100');
+    //     // nextTick needed since vm.loadProject is async, and we have to wait for it :/
+    //     process.nextTick(() => (
+    //         expect(mockedCreateProject).toHaveBeenCalled()
+    //     ));
+    // });
+});

--- a/test/unit/util/project-saver-hoc.test.jsx
+++ b/test/unit/util/project-saver-hoc.test.jsx
@@ -213,45 +213,4 @@ describe('projectSaverHOC', () => {
         });
         expect(vm.saveProjectSb3).not.toHaveBeenCalled();
     });
-
-    // test('template', () => {
-    //     vm.saveProjectSb3 = jest.fn(() => Promise.resolve());
-    //     const mockedCreateProject = jest.fn();
-    //     const mockedOnCreated = jest.fn();
-    //     const mockedOnError = jest.fn();
-    //     const mockedOnUpdated = jest.fn();
-    //     const mockedSaveProject = jest.fn();
-    //
-    //     const Component = () => <div />;
-    //     const WrappedComponent = projectSaverHOC(Component);
-    //     const mounted = mount(
-    //         <WrappedComponent
-    //             canSave={false}
-    //             createProject={mockedCreateProject}
-    //             isCreating={false}
-    //             isShowingWithId={false}
-    //             isShowingWithoutId={false}
-    //             isUpdating={false}
-    //             loadingState={LoadingState.NOT_LOADED}
-    //             reduxProjectId={'100'}
-    //             saveProject={mockedSaveProject}
-    //             store={store}
-    //             vm={vm}
-    //             onCreated={mockedOnCreated}
-    //             onError={mockedOnError}
-    //             onUpdated={mockedOnUpdated}
-    //         />
-    //     );
-    //     mounted.setProps({
-    //         canSave: true,
-    //         isShowingWithId: true,
-    //         loadingState: LoadingState.SHOWING_WITH_ID,
-    //         projectData: '100'
-    //     });
-    //     expect(vm.loadProject).toHaveBeenLastCalledWith('100');
-    //     // nextTick needed since vm.loadProject is async, and we have to wait for it :/
-    //     process.nextTick(() => (
-    //         expect(mockedCreateProject).toHaveBeenCalled()
-    //     ));
-    // });
 });

--- a/test/unit/util/vm-manager-hoc.test.jsx
+++ b/test/unit/util/vm-manager-hoc.test.jsx
@@ -93,13 +93,16 @@ describe('VMManagerHOC', () => {
             />
         );
         mounted.setProps({
+            canSave: false,
             fontsLoaded: true,
             loadingState: LoadingState.LOADING_VM_WITH_ID,
             projectData: '100'
         });
         expect(vm.loadProject).toHaveBeenLastCalledWith('100');
         // nextTick needed since vm.loadProject is async, and we have to wait for it :/
-        process.nextTick(() => expect(mockedOnLoadedProject).toHaveBeenLastCalledWith(LoadingState.LOADING_VM_WITH_ID));
+        process.nextTick(() => (
+            expect(mockedOnLoadedProject).toHaveBeenLastCalledWith(LoadingState.LOADING_VM_WITH_ID, false)
+        ));
     });
     test('if the fontsLoaded prop is false, project data is never loaded', () => {
         vm.loadProject = jest.fn(() => Promise.resolve());

--- a/test/unit/util/vm-manager-hoc.test.jsx
+++ b/test/unit/util/vm-manager-hoc.test.jsx
@@ -68,13 +68,16 @@ describe('VMManagerHOC', () => {
             />
         );
         mounted.setProps({
+            canSave: true,
             isLoadingWithId: true,
             loadingState: LoadingState.LOADING_VM_WITH_ID,
             projectData: '100'
         });
         expect(vm.loadProject).toHaveBeenLastCalledWith('100');
         // nextTick needed since vm.loadProject is async, and we have to wait for it :/
-        process.nextTick(() => expect(mockedOnLoadedProject).toHaveBeenLastCalledWith(LoadingState.LOADING_VM_WITH_ID));
+        process.nextTick(() => (
+            expect(mockedOnLoadedProject).toHaveBeenLastCalledWith(LoadingState.LOADING_VM_WITH_ID, true)
+        ));
     });
     test('if the fontsLoaded prop becomes true, it loads project data into the vm', () => {
         vm.loadProject = jest.fn(() => Promise.resolve());


### PR DESCRIPTION
Needs https://github.com/LLK/scratch-www/pull/2197 to work

Handles several states in which the user should be able to create a new project:
1. standalone player/beta: file->new just replaces current project data with default data
2. in www, logged in, viewing your project: file->new saves your project, replaces current project data with default data, then saves that data and gets a new id, then informs containing code of the change
3. in www, logged in, viewing someone else’s project:  file->new replaces current project data with default data, then saves that data and gets a new id, then informs containing code of the change
4. in www, not logged in, viewing whatever project:  file->new replaces current project data with default data, then informs containing code of the change
5. in www, logged in, clicking “create” from front page; or, going straight to projects/editor: loads default data, then saves that data and gets a new id, then informs containing code of the change
6. in www, not logged in, clicking “create” from front page: loads default data
7. After #4, when you log in or register while still in the editor, saves current data and gets a new id, then informs containing code of the change