### PR TITLE
Get costume url bugfix

### DIFF
--- a/src/components/gui/gui.css
+++ b/src/components/gui/gui.css
@@ -283,6 +283,7 @@ $fade-out-distance: 15px;
 .watermark {
     position: absolute;
     top: 1.25rem;
+    pointer-events: none;
 }
 
 [dir="ltr"] .watermark {

--- a/src/components/watermark/watermark.css
+++ b/src/components/watermark/watermark.css
@@ -5,5 +5,4 @@
     max-width: 48px;
     max-height: 48px;
     opacity: 0.35;
-    pointer-events: none;
 }

--- a/src/lib/get-costume-url.js
+++ b/src/lib/get-costume-url.js
@@ -26,10 +26,12 @@ const getCostumeUrl = (function () {
                 svgRenderer.loadString(svgString);
                 const svgText = svgRenderer.toString(true /* shouldInjectFonts */);
                 cachedUrl = `data:image/svg+xml;utf8,${encodeURIComponent(svgText)}`;
+            } else {
+                cachedUrl = vm.runtime.storage.get(assetId).encodeDataURI();
             }
+        } else {
             cachedUrl = vm.runtime.storage.get(assetId).encodeDataURI();
         }
-        cachedUrl = vm.runtime.storage.get(assetId).encodeDataURI();
 
         return cachedUrl;
     };


### PR DESCRIPTION
### Proposed Changes

Fix minor issues with watermark:

- Font wasn't actually getting injected into costumes because cachedUrl was getting replaced. This is no longer broken:

![image](https://user-images.githubusercontent.com/1786240/47116678-5a4c1980-d230-11e8-9f69-7c2b9a9d2354.png)

- Fix issue where watermark could be dragged.
