### PR TITLE
Resolves #3336: Prevent multiple peripheral alerts after language switch

### DIFF
--- a/src/lib/vm-listener-hoc.jsx
+++ b/src/lib/vm-listener-hoc.jsx
@@ -55,6 +55,7 @@ const vmListenerHOC = function (WrappedComponent) {
             }
         }
         componentWillUnmount () {
+            this.props.vm.removeListener('PERIPHERAL_DISCONNECT_ERROR', this.props.onShowAlert);
             if (this.props.attachKeyboardEvents) {
                 document.removeEventListener('keydown', this.handleKeyDown);
                 document.removeEventListener('keyup', this.handleKeyUp);


### PR DESCRIPTION
### Resolves

- Resolves #3666: Prevent multiple peripheral alerts after language has been switched

### Proposed Changes

Remove "peripheral disconnect" event listener when the component unmounts.
