### PR TITLE
use project state error for project state related errors

### DIFF
--- a/src/containers/gui.jsx
+++ b/src/containers/gui.jsx
@@ -66,7 +66,7 @@ class GUI extends React.Component {
     render () {
         if (this.props.isError) {
             throw new Error(
-                `Failed to load project from server [id=${window.location.hash}]: ${this.props.error}`);
+                `Error in Scratch GUI [location=${window.location}]: ${this.props.error}`);
         }
         const {
             /* eslint-disable no-unused-vars */
@@ -101,7 +101,7 @@ class GUI extends React.Component {
 GUI.propTypes = {
     assetHost: PropTypes.string,
     children: PropTypes.node,
-    error: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+    error: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
     fetchingProject: PropTypes.bool,
     hideIntro: PropTypes.bool,
     importInfoVisible: PropTypes.bool,

--- a/src/containers/gui.jsx
+++ b/src/containers/gui.jsx
@@ -9,6 +9,7 @@ import {defineMessages, injectIntl, intlShape} from 'react-intl';
 import ErrorBoundaryHOC from '../lib/error-boundary-hoc.jsx';
 import {openExtensionLibrary} from '../reducers/modals';
 import {
+    getIsError,
     getIsShowingProject
 } from '../reducers/project-state';
 import {setProjectTitle} from '../reducers/project-title';
@@ -63,16 +64,16 @@ class GUI extends React.Component {
         }
     }
     render () {
-        if (this.props.loadingError) {
+        if (this.props.isError) {
             throw new Error(
-                `Failed to load project from server [id=${window.location.hash}]: ${this.props.errorMessage}`);
+                `Failed to load project from server [id=${window.location.hash}]: ${this.props.errStr}`);
         }
         const {
             /* eslint-disable no-unused-vars */
             assetHost,
-            errorMessage,
+            errStr,
             hideIntro,
-            loadingError,
+            isError,
             isShowingProject,
             onUpdateProjectId,
             onUpdateReduxProjectTitle,
@@ -100,14 +101,14 @@ class GUI extends React.Component {
 GUI.propTypes = {
     assetHost: PropTypes.string,
     children: PropTypes.node,
-    errorMessage: PropTypes.string,
+    errStr: PropTypes.string,
     fetchingProject: PropTypes.bool,
     hideIntro: PropTypes.bool,
     importInfoVisible: PropTypes.bool,
+    isError: PropTypes.bool,
     intl: intlShape,
     isLoading: PropTypes.bool,
     isShowingProject: PropTypes.bool,
-    loadingError: PropTypes.bool,
     loadingStateVisible: PropTypes.bool,
     onChangeProjectInfo: PropTypes.func,
     onSeeCommunity: PropTypes.func,
@@ -135,7 +136,9 @@ const mapStateToProps = (state, ownProps) => {
         cardsVisible: state.scratchGui.cards.visible,
         costumeLibraryVisible: state.scratchGui.modals.costumeLibrary,
         costumesTabVisible: state.scratchGui.editorTab.activeTabIndex === COSTUMES_TAB_INDEX,
+        errStr: state.scratchGui.projectState.errStr,
         importInfoVisible: state.scratchGui.modals.importInfo,
+        isError: getIsError(loadingState),
         isPlayerOnly: state.scratchGui.mode.isPlayerOnly,
         isRtl: state.locales.isRtl,
         isShowingProject: getIsShowingProject(loadingState),

--- a/src/containers/gui.jsx
+++ b/src/containers/gui.jsx
@@ -66,12 +66,12 @@ class GUI extends React.Component {
     render () {
         if (this.props.isError) {
             throw new Error(
-                `Failed to load project from server [id=${window.location.hash}]: ${this.props.errorMessage}`);
+                `Failed to load project from server [id=${window.location.hash}]: ${this.props.error}`);
         }
         const {
             /* eslint-disable no-unused-vars */
             assetHost,
-            errorMessage,
+            error,
             hideIntro,
             isError,
             isShowingProject,
@@ -101,7 +101,7 @@ class GUI extends React.Component {
 GUI.propTypes = {
     assetHost: PropTypes.string,
     children: PropTypes.node,
-    errorMessage: PropTypes.string,
+    error: PropTypes.object, // eslint-disable-line react/forbid-prop-types
     fetchingProject: PropTypes.bool,
     hideIntro: PropTypes.bool,
     importInfoVisible: PropTypes.bool,
@@ -136,7 +136,7 @@ const mapStateToProps = (state, ownProps) => {
         cardsVisible: state.scratchGui.cards.visible,
         costumeLibraryVisible: state.scratchGui.modals.costumeLibrary,
         costumesTabVisible: state.scratchGui.editorTab.activeTabIndex === COSTUMES_TAB_INDEX,
-        errorMessage: state.scratchGui.projectState.errorMessage,
+        error: state.scratchGui.projectState.error,
         importInfoVisible: state.scratchGui.modals.importInfo,
         isError: getIsError(loadingState),
         isPlayerOnly: state.scratchGui.mode.isPlayerOnly,

--- a/src/containers/gui.jsx
+++ b/src/containers/gui.jsx
@@ -66,12 +66,12 @@ class GUI extends React.Component {
     render () {
         if (this.props.isError) {
             throw new Error(
-                `Failed to load project from server [id=${window.location.hash}]: ${this.props.errStr}`);
+                `Failed to load project from server [id=${window.location.hash}]: ${this.props.errorMessage}`);
         }
         const {
             /* eslint-disable no-unused-vars */
             assetHost,
-            errStr,
+            errorMessage,
             hideIntro,
             isError,
             isShowingProject,
@@ -101,12 +101,12 @@ class GUI extends React.Component {
 GUI.propTypes = {
     assetHost: PropTypes.string,
     children: PropTypes.node,
-    errStr: PropTypes.string,
+    errorMessage: PropTypes.string,
     fetchingProject: PropTypes.bool,
     hideIntro: PropTypes.bool,
     importInfoVisible: PropTypes.bool,
-    isError: PropTypes.bool,
     intl: intlShape,
+    isError: PropTypes.bool,
     isLoading: PropTypes.bool,
     isShowingProject: PropTypes.bool,
     loadingStateVisible: PropTypes.bool,
@@ -136,7 +136,7 @@ const mapStateToProps = (state, ownProps) => {
         cardsVisible: state.scratchGui.cards.visible,
         costumeLibraryVisible: state.scratchGui.modals.costumeLibrary,
         costumesTabVisible: state.scratchGui.editorTab.activeTabIndex === COSTUMES_TAB_INDEX,
-        errStr: state.scratchGui.projectState.errStr,
+        errorMessage: state.scratchGui.projectState.errorMessage,
         importInfoVisible: state.scratchGui.modals.importInfo,
         isError: getIsError(loadingState),
         isPlayerOnly: state.scratchGui.mode.isPlayerOnly,

--- a/src/lib/project-fetcher-hoc.jsx
+++ b/src/lib/project-fetcher-hoc.jsx
@@ -83,11 +83,12 @@ const ProjectFetcherHOC = function (WrappedComponent) {
             const {
                 /* eslint-disable no-unused-vars */
                 assetHost,
-                onFetchedProjectData: onFetchedProjectDataProp,
                 intl,
+                loadingState,
+                onError: onErrorProp,
+                onFetchedProjectData: onFetchedProjectDataProp,
                 projectHost,
                 projectId,
-                loadingState,
                 reduxProjectId,
                 setProjectId: setProjectIdProp,
                 /* eslint-enable no-unused-vars */

--- a/src/lib/project-fetcher-hoc.jsx
+++ b/src/lib/project-fetcher-hoc.jsx
@@ -8,6 +8,7 @@ import {
     LoadingStates,
     defaultProjectId,
     getIsFetchingWithId,
+    onError,
     onFetchedProjectData,
     setProjectId
 } from '../reducers/project-state';
@@ -74,6 +75,7 @@ const ProjectFetcherHOC = function (WrappedComponent) {
                     }
                 })
                 .catch(err => {
+                    this.props.onError(`Saving the project failed with error: ${err}`);
                     log.error(err);
                 });
         }
@@ -106,6 +108,7 @@ const ProjectFetcherHOC = function (WrappedComponent) {
         intl: intlShape.isRequired,
         isFetchingWithId: PropTypes.bool,
         loadingState: PropTypes.oneOf(LoadingStates),
+        onError: PropTypes.func,
         onFetchedProjectData: PropTypes.func,
         projectHost: PropTypes.string,
         projectId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
@@ -123,6 +126,7 @@ const ProjectFetcherHOC = function (WrappedComponent) {
         reduxProjectId: state.scratchGui.projectState.projectId
     });
     const mapDispatchToProps = dispatch => ({
+        onError: errStr => dispatch(onError(errStr)),
         onFetchedProjectData: (projectData, loadingState) =>
             dispatch(onFetchedProjectData(projectData, loadingState)),
         setProjectId: projectId => dispatch(setProjectId(projectId))

--- a/src/lib/project-fetcher-hoc.jsx
+++ b/src/lib/project-fetcher-hoc.jsx
@@ -127,7 +127,7 @@ const ProjectFetcherHOC = function (WrappedComponent) {
         reduxProjectId: state.scratchGui.projectState.projectId
     });
     const mapDispatchToProps = dispatch => ({
-        onError: errorMessage => dispatch(onError(errorMessage)),
+        onError: error => dispatch(onError(error)),
         onFetchedProjectData: (projectData, loadingState) =>
             dispatch(onFetchedProjectData(projectData, loadingState)),
         setProjectId: projectId => dispatch(setProjectId(projectId))

--- a/src/lib/project-fetcher-hoc.jsx
+++ b/src/lib/project-fetcher-hoc.jsx
@@ -126,7 +126,7 @@ const ProjectFetcherHOC = function (WrappedComponent) {
         reduxProjectId: state.scratchGui.projectState.projectId
     });
     const mapDispatchToProps = dispatch => ({
-        onError: errStr => dispatch(onError(errStr)),
+        onError: errorMessage => dispatch(onError(errorMessage)),
         onFetchedProjectData: (projectData, loadingState) =>
             dispatch(onFetchedProjectData(projectData, loadingState)),
         setProjectId: projectId => dispatch(setProjectId(projectId))

--- a/src/lib/project-fetcher-hoc.jsx
+++ b/src/lib/project-fetcher-hoc.jsx
@@ -75,7 +75,7 @@ const ProjectFetcherHOC = function (WrappedComponent) {
                     }
                 })
                 .catch(err => {
-                    this.props.onError(`Saving the project failed with error: ${err}`);
+                    this.props.onError(err);
                     log.error(err);
                 });
         }

--- a/src/lib/project-saver-hoc.jsx
+++ b/src/lib/project-saver-hoc.jsx
@@ -90,14 +90,14 @@ const ProjectSaverHOC = function (WrappedComponent) {
             const {
                 /* eslint-disable no-unused-vars */
                 createProject: createProjectProp,
-                onCreated: onCreatedProp,
-                onUpdated: onUpdatedProp,
-                onError: onErrorProp,
                 isCreating: isCreatingProp,
                 isShowingWithId: isShowingWithIdProp,
                 isShowingWithoutId: isShowingWithoutIdProp,
                 isUpdating: isUpdatingProp,
                 loadingState,
+                onCreated: onCreatedProp,
+                onError: onErrorProp,
+                onUpdated: onUpdatedProp,
                 reduxProjectId,
                 saveProject: saveProjectProp,
                 /* eslint-enable no-unused-vars */

--- a/src/lib/project-saver-hoc.jsx
+++ b/src/lib/project-saver-hoc.jsx
@@ -141,7 +141,7 @@ const ProjectSaverHOC = function (WrappedComponent) {
         createProject: () => dispatch(createProject()),
         onCreated: projectId => dispatch(onCreated(projectId)),
         onUpdated: (projectId, loadingState) => dispatch(onUpdated(projectId, loadingState)),
-        onError: errorMessage => dispatch(onError(errorMessage)),
+        onError: error => dispatch(onError(error)),
         saveProject: () => dispatch(saveProject())
     });
     // Allow incoming props to override redux-provided props. Used to mock in tests.

--- a/src/lib/project-saver-hoc.jsx
+++ b/src/lib/project-saver-hoc.jsx
@@ -141,7 +141,7 @@ const ProjectSaverHOC = function (WrappedComponent) {
         createProject: () => dispatch(createProject()),
         onCreated: projectId => dispatch(onCreated(projectId)),
         onUpdated: (projectId, loadingState) => dispatch(onUpdated(projectId, loadingState)),
-        onError: errStr => dispatch(onError(errStr)),
+        onError: errorMessage => dispatch(onError(errorMessage)),
         saveProject: () => dispatch(saveProject())
     });
     // Allow incoming props to override redux-provided props. Used to mock in tests.

--- a/src/lib/vm-manager-hoc.jsx
+++ b/src/lib/vm-manager-hoc.jsx
@@ -48,7 +48,7 @@ const vmManagerHOC = function (WrappedComponent) {
                     this.props.onLoadedProject(this.props.loadingState, this.props.canSave);
                 })
                 .catch(e => {
-                    this.props.onError(`vm-manager-hoc error: ${e}`);
+                    this.props.onError(e);
                 });
         }
         render () {
@@ -98,7 +98,7 @@ const vmManagerHOC = function (WrappedComponent) {
     };
 
     const mapDispatchToProps = dispatch => ({
-        onError: errorMessage => dispatch(onError(errorMessage)),
+        onError: error => dispatch(onError(error)),
         onLoadedProject: (loadingState, canSave) =>
             dispatch(onLoadedProject(loadingState, canSave))
     });

--- a/src/lib/vm-manager-hoc.jsx
+++ b/src/lib/vm-manager-hoc.jsx
@@ -8,6 +8,7 @@ import AudioEngine from 'scratch-audio';
 
 import {
     LoadingStates,
+    onError,
     onLoadedProject,
     getIsLoadingWithId
 } from '../reducers/project-state';
@@ -24,10 +25,6 @@ const vmManagerHOC = function (WrappedComponent) {
             bindAll(this, [
                 'loadProject'
             ]);
-            this.state = {
-                loadingError: false,
-                errorMessage: ''
-            };
         }
         componentDidMount () {
             if (this.props.vm.initialized) return;
@@ -51,9 +48,7 @@ const vmManagerHOC = function (WrappedComponent) {
                     this.props.onLoadedProject(this.props.loadingState, this.props.canSave);
                 })
                 .catch(e => {
-                    // Need to catch this error and update component state so that
-                    // error page gets rendered if project failed to load
-                    this.setState({loadingError: true, errorMessage: e});
+                    this.props.onError(e);
                 });
         }
         render () {
@@ -71,9 +66,7 @@ const vmManagerHOC = function (WrappedComponent) {
             } = this.props;
             return (
                 <WrappedComponent
-                    errorMessage={this.state.errorMessage}
                     isLoading={isLoadingWithIdProp}
-                    loadingError={this.state.loadingError}
                     vm={vm}
                     {...componentProps}
                 />
@@ -86,6 +79,7 @@ const vmManagerHOC = function (WrappedComponent) {
         fontsLoaded: PropTypes.bool,
         isLoadingWithId: PropTypes.bool,
         loadingState: PropTypes.oneOf(LoadingStates),
+        onError: PropTypes.func,
         onLoadedProject: PropTypes.func,
         projectData: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
         projectId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
@@ -103,6 +97,7 @@ const vmManagerHOC = function (WrappedComponent) {
     };
 
     const mapDispatchToProps = dispatch => ({
+        onError: errStr => dispatch(onError(errStr)),
         onLoadedProject: (loadingState, canSave) =>
             dispatch(onLoadedProject(loadingState, canSave))
     });

--- a/src/lib/vm-manager-hoc.jsx
+++ b/src/lib/vm-manager-hoc.jsx
@@ -48,17 +48,18 @@ const vmManagerHOC = function (WrappedComponent) {
                     this.props.onLoadedProject(this.props.loadingState, this.props.canSave);
                 })
                 .catch(e => {
-                    this.props.onError(e);
+                    this.props.onError(`vm-manager-hoc error: ${e}`);
                 });
         }
         render () {
             const {
                 /* eslint-disable no-unused-vars */
                 fontsLoaded,
+                loadingState,
+                onError: onErrorProp,
                 onLoadedProject: onLoadedProjectProp,
                 projectData,
                 projectId,
-                loadingState,
                 /* eslint-enable no-unused-vars */
                 isLoadingWithId: isLoadingWithIdProp,
                 vm,

--- a/src/lib/vm-manager-hoc.jsx
+++ b/src/lib/vm-manager-hoc.jsx
@@ -97,7 +97,7 @@ const vmManagerHOC = function (WrappedComponent) {
     };
 
     const mapDispatchToProps = dispatch => ({
-        onError: errStr => dispatch(onError(errStr)),
+        onError: errorMessage => dispatch(onError(errorMessage)),
         onLoadedProject: (loadingState, canSave) =>
             dispatch(onLoadedProject(loadingState, canSave))
     });

--- a/src/reducers/project-state.js
+++ b/src/reducers/project-state.js
@@ -65,6 +65,9 @@ const getIsShowingWithId = loadingState => (
 const getIsShowingWithoutId = loadingState => (
     loadingState === LoadingState.SHOWING_WITHOUT_ID
 );
+const getIsError = loadingState => (
+    loadingState === LoadingState.ERROR
+);
 
 const initialState = {
     errStr: null,
@@ -326,6 +329,7 @@ export {
     createProject,
     defaultProjectId,
     getIsCreating,
+    getIsError,
     getIsFetchingWithoutId,
     getIsFetchingWithId,
     getIsLoadingWithId,

--- a/src/reducers/project-state.js
+++ b/src/reducers/project-state.js
@@ -70,7 +70,7 @@ const getIsError = loadingState => (
 );
 
 const initialState = {
-    errStr: null,
+    errorMessage: null,
     projectData: null,
     projectId: null,
     loadingState: LoadingState.NOT_LOADED
@@ -224,7 +224,7 @@ const reducer = function (state, action) {
         ].includes(state.loadingState)) {
             return Object.assign({}, state, {
                 loadingState: LoadingState.ERROR,
-                errStr: action.errStr
+                errorMessage: action.errorMessage
             });
         }
         return state;
@@ -298,9 +298,9 @@ const onUpdated = loadingState => {
     }
 };
 
-const onError = errStr => ({
+const onError = errorMessage => ({
     type: GO_TO_ERROR_STATE,
-    errStr: errStr
+    errorMessage: errorMessage
 });
 
 const setProjectId = id => ({

--- a/src/reducers/project-state.js
+++ b/src/reducers/project-state.js
@@ -70,7 +70,7 @@ const getIsError = loadingState => (
 );
 
 const initialState = {
-    errorMessage: null,
+    error: null,
     projectData: null,
     projectId: null,
     loadingState: LoadingState.NOT_LOADED
@@ -224,7 +224,7 @@ const reducer = function (state, action) {
         ].includes(state.loadingState)) {
             return Object.assign({}, state, {
                 loadingState: LoadingState.ERROR,
-                errorMessage: action.errorMessage
+                error: action.error
             });
         }
         return state;
@@ -298,9 +298,9 @@ const onUpdated = loadingState => {
     }
 };
 
-const onError = errorMessage => ({
+const onError = error => ({
     type: GO_TO_ERROR_STATE,
-    errorMessage: errorMessage
+    error: error
 });
 
 const setProjectId = id => ({

--- a/test/unit/reducers/project-state-reducer.test.js
+++ b/test/unit/reducers/project-state-reducer.test.js
@@ -17,7 +17,7 @@ test('initialState', () => {
     let defaultState;
     /* projectStateReducer(state, action) */
     expect(projectStateReducer(defaultState, {type: 'anything'})).toBeDefined();
-    expect(projectStateReducer(defaultState, {type: 'anything'}).errorMessage).toBe(null);
+    expect(projectStateReducer(defaultState, {type: 'anything'}).error).toBe(null);
     expect(projectStateReducer(defaultState, {type: 'anything'}).projectData).toBe(null);
     expect(projectStateReducer(defaultState, {type: 'anything'}).projectId).toBe(null);
     expect(projectStateReducer(defaultState, {type: 'anything'}).loadingState).toBe(LoadingState.NOT_LOADED);
@@ -229,23 +229,23 @@ test('onError from various states should show error', () => {
     ];
     for (const startState of startStates) {
         const initialState = {
-            errorMessage: null,
+            error: null,
             loadingState: startState
         };
-        const action = onError('Error string');
+        const action = onError({message: 'Error string'});
         const resultState = projectStateReducer(initialState, action);
         expect(resultState.loadingState).toBe(LoadingState.ERROR);
-        expect(resultState.errorMessage).toBe('Error string');
+        expect(resultState.error).toEqual({message: 'Error string'});
     }
 });
 
 test('onError from showing project should show error', () => {
     const initialState = {
-        errorMessage: null,
+        error: null,
         loadingState: LoadingState.FETCHING_WITH_ID
     };
-    const action = onError('Error string');
+    const action = onError({message: 'Error string'});
     const resultState = projectStateReducer(initialState, action);
     expect(resultState.loadingState).toBe(LoadingState.ERROR);
-    expect(resultState.errorMessage).toBe('Error string');
+    expect(resultState.error).toEqual({message: 'Error string'});
 });

--- a/test/unit/reducers/project-state-reducer.test.js
+++ b/test/unit/reducers/project-state-reducer.test.js
@@ -17,7 +17,7 @@ test('initialState', () => {
     let defaultState;
     /* projectStateReducer(state, action) */
     expect(projectStateReducer(defaultState, {type: 'anything'})).toBeDefined();
-    expect(projectStateReducer(defaultState, {type: 'anything'}).errStr).toBe(null);
+    expect(projectStateReducer(defaultState, {type: 'anything'}).errorMessage).toBe(null);
     expect(projectStateReducer(defaultState, {type: 'anything'}).projectData).toBe(null);
     expect(projectStateReducer(defaultState, {type: 'anything'}).projectId).toBe(null);
     expect(projectStateReducer(defaultState, {type: 'anything'}).loadingState).toBe(LoadingState.NOT_LOADED);
@@ -229,23 +229,23 @@ test('onError from various states should show error', () => {
     ];
     for (const startState of startStates) {
         const initialState = {
-            errStr: null,
+            errorMessage: null,
             loadingState: startState
         };
         const action = onError('Error string');
         const resultState = projectStateReducer(initialState, action);
         expect(resultState.loadingState).toBe(LoadingState.ERROR);
-        expect(resultState.errStr).toBe('Error string');
+        expect(resultState.errorMessage).toBe('Error string');
     }
 });
 
 test('onError from showing project should show error', () => {
     const initialState = {
-        errStr: null,
+        errorMessage: null,
         loadingState: LoadingState.FETCHING_WITH_ID
     };
     const action = onError('Error string');
     const resultState = projectStateReducer(initialState, action);
     expect(resultState.loadingState).toBe(LoadingState.ERROR);
-    expect(resultState.errStr).toBe('Error string');
+    expect(resultState.errorMessage).toBe('Error string');
 });


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-gui/issues/3435

### Proposed Changes

Uses project-state error state and string instead of vm-manager's error state; adds handling to project-fetcher-hoc

### Reason for Changes

single central project error display system

### Test Coverage

Already put error state test into project-state-reducer.test.js

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
