### PR TITLE
added showComingSoon flag prop for gui

### DIFF
--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -92,9 +92,10 @@ const GUIComponent = props => {
         onSeeCommunity,
         onShare,
         previewInfoVisible,
-        targetIsStage,
+        showComingSoon,
         soundsTabVisible,
         stageSizeMode,
+        targetIsStage,
         tipsLibraryVisible,
         vm,
         ...componentProps
@@ -178,6 +179,7 @@ const GUIComponent = props => {
                     className={styles.menuBarPosition}
                     enableCommunity={enableCommunity}
                     renderLogin={renderLogin}
+                    showComingSoon={showComingSoon}
                     onClickAccountNav={onClickAccountNav}
                     onCloseAccountNav={onCloseAccountNav}
                     onLogOut={onLogOut}
@@ -351,6 +353,7 @@ GUIComponent.propTypes = {
     onUpdateProjectTitle: PropTypes.func,
     previewInfoVisible: PropTypes.bool,
     renderLogin: PropTypes.func,
+    showComingSoon: PropTypes.bool,
     soundsTabVisible: PropTypes.bool,
     stageSizeMode: PropTypes.oneOf(Object.keys(STAGE_SIZE_MODES)),
     targetIsStage: PropTypes.bool,
@@ -369,6 +372,7 @@ GUIComponent.defaultProps = {
     canSaveAsCopy: false,
     canShare: false,
     onUpdateProjectTitle: () => {},
+    showComingSoon: false,
     stageSizeMode: STAGE_SIZE_MODES.large
 };
 

--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -298,39 +298,39 @@ class MenuBar extends React.Component {
                                     >
                                         {newProjectMessage}
                                     </MenuItem>
-                                ) : (
+                                ) : (this.props.showComingSoon ? (
                                     <MenuItemTooltip
                                         id="new"
                                         isRtl={this.props.isRtl}
                                     >
                                         <MenuItem>{newProjectMessage}</MenuItem>
                                     </MenuItemTooltip>
-                                )}
+                                ) : [])}
                                 <MenuSection>
                                     {this.props.canSave ? (
                                         <MenuItem onClick={this.handleClickSave}>
                                             {saveNowMessage}
                                         </MenuItem>
-                                    ) : (
+                                    ) : (this.props.showComingSoon ? (
                                         <MenuItemTooltip
                                             id="save"
                                             isRtl={this.props.isRtl}
                                         >
                                             <MenuItem>{saveNowMessage}</MenuItem>
                                         </MenuItemTooltip>
-                                    )}
+                                    ) : [])}
                                     {this.props.canSaveAsCopy ? (
                                         <MenuItem onClick={this.handleClickSaveAsCopy}>
                                             {saveAsCopyMessage}
                                         </MenuItem>
-                                    ) : (
+                                    ) : (this.props.showComingSoon ? (
                                         <MenuItemTooltip
                                             id="copy"
                                             isRtl={this.props.isRtl}
                                         >
                                             <MenuItem>{saveAsCopyMessage}</MenuItem>
                                         </MenuItemTooltip>
-                                    )}
+                                    ) : [])}
                                 </MenuSection>
                                 <MenuSection>
                                     <SBFileUploader onUpdateProjectTitle={this.props.onUpdateProjectTitle}>
@@ -438,13 +438,15 @@ class MenuBar extends React.Component {
                     </div>
                     <div className={classNames(styles.menuBarItem)}>
                         {this.props.canShare ? shareButton : (
-                            <MenuBarItemTooltip id="share-button">
-                                {shareButton}
-                            </MenuBarItemTooltip>
+                            this.props.showComingSoon ? (
+                                <MenuBarItemTooltip id="share-button">
+                                    {shareButton}
+                                </MenuBarItemTooltip>
+                            ) : []
                         )}
                     </div>
                     <div className={classNames(styles.menuBarItem, styles.communityButtonWrapper)}>
-                        {this.props.enableCommunity ?
+                        {this.props.enableCommunity ? (
                             <Button
                                 className={classNames(styles.communityButton)}
                                 iconClassName={styles.communityButtonIcon}
@@ -456,7 +458,8 @@ class MenuBar extends React.Component {
                                     description="Label for see community button"
                                     id="gui.menuBar.seeCommunity"
                                 />
-                            </Button> :
+                            </Button>
+                        ) : (this.props.showComingSoon ? (
                             <MenuBarItemTooltip id="community-button">
                                 <Button
                                     className={classNames(styles.communityButton)}
@@ -470,7 +473,7 @@ class MenuBar extends React.Component {
                                     />
                                 </Button>
                             </MenuBarItemTooltip>
-                        }
+                        ) : [])}
                     </div>
                 </div>
 
@@ -572,44 +575,48 @@ class MenuBar extends React.Component {
                                     </Button>
                                 </a>
                             </div>
-                            <MenuBarItemTooltip id="mystuff">
-                                <div
-                                    className={classNames(
-                                        styles.menuBarItem,
-                                        styles.hoverable,
-                                        styles.mystuffButton
-                                    )}
-                                >
-                                    <img
-                                        className={styles.mystuffIcon}
-                                        src={mystuffIcon}
-                                    />
-                                </div>
-                            </MenuBarItemTooltip>
-                            <MenuBarItemTooltip
-                                id="account-nav"
-                                place={this.props.isRtl ? 'right' : 'left'}
-                            >
-                                <div
-                                    className={classNames(
-                                        styles.menuBarItem,
-                                        styles.hoverable,
-                                        styles.accountNavMenu
-                                    )}
-                                >
-                                    <img
-                                        className={styles.profileIcon}
-                                        src={profileIcon}
-                                    />
-                                    <span>
-                                        {'scratch-cat'}
-                                    </span>
-                                    <img
-                                        className={styles.dropdownCaretIcon}
-                                        src={dropdownCaret}
-                                    />
-                                </div>
-                            </MenuBarItemTooltip>
+                            {this.props.showComingSoon ? (
+                                <React.Fragment>
+                                    <MenuBarItemTooltip id="mystuff">
+                                        <div
+                                            className={classNames(
+                                                styles.menuBarItem,
+                                                styles.hoverable,
+                                                styles.mystuffButton
+                                            )}
+                                        >
+                                            <img
+                                                className={styles.mystuffIcon}
+                                                src={mystuffIcon}
+                                            />
+                                        </div>
+                                    </MenuBarItemTooltip>
+                                    <MenuBarItemTooltip
+                                        id="account-nav"
+                                        place={this.props.isRtl ? 'right' : 'left'}
+                                    >
+                                        <div
+                                            className={classNames(
+                                                styles.menuBarItem,
+                                                styles.hoverable,
+                                                styles.accountNavMenu
+                                            )}
+                                        >
+                                            <img
+                                                className={styles.profileIcon}
+                                                src={profileIcon}
+                                            />
+                                            <span>
+                                                {'scratch-cat'}
+                                            </span>
+                                            <img
+                                                className={styles.dropdownCaretIcon}
+                                                src={dropdownCaret}
+                                            />
+                                        </div>
+                                    </MenuBarItemTooltip>
+                                </React.Fragment>
+                            ) : []}
                         </React.Fragment>
                     )}
                 </div>
@@ -656,6 +663,7 @@ MenuBar.propTypes = {
     onUpdateProjectTitle: PropTypes.func,
     renderLogin: PropTypes.func,
     sessionExists: PropTypes.bool,
+    showComingSoon: PropTypes.bool,
     username: PropTypes.string
 };
 

--- a/src/containers/gui.jsx
+++ b/src/containers/gui.jsx
@@ -109,7 +109,6 @@ GUI.propTypes = {
     isShowingProject: PropTypes.bool,
     loadingError: PropTypes.bool,
     loadingStateVisible: PropTypes.bool,
-    onChangeProjectInfo: PropTypes.func,
     onSeeCommunity: PropTypes.func,
     onUpdateProjectId: PropTypes.func,
     onUpdateProjectTitle: PropTypes.func,

--- a/src/playground/render-gui.jsx
+++ b/src/playground/render-gui.jsx
@@ -39,6 +39,7 @@ export default appTarget => {
 
     ReactDOM.render(
         <WrappedGui
+            showComingSoon
             backpackOptions={backpackOptions}
         />,
         appTarget);


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-gui/issues/3444

### Proposed Changes

introduce the showComingSoon prop on GUI, which indicates whether to show "coming soon" tooltips on grayed-out menu options (and header menu bar items); if false, we simply hide them.

### Reason for Changes

In Beta, plenty of stuff is "coming soon". But embedded in www -- or, for that matter, in other players -- we are now able to use the user's session status and project ownership to determine what menu items we do and do not enable.

### Test Coverage

None

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
