### PR TITLE
Add a space after ‘apple’ in the join block

### DIFF
--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -589,7 +589,7 @@ const operators = function () {
         <block type="operator_join">
             <value name="STRING1">
                 <shadow type="text">
-                    <field name="TEXT">${apple}</field>
+                    <field name="TEXT">${apple} </field>
                 </shadow>
             </value>
             <value name="STRING2">

--- a/test/integration/blocks.test.js
+++ b/test/integration/blocks.test.js
@@ -34,7 +34,7 @@ describe('Working with the blocks', () => {
         await clickText('Operators', scope.blocksTab);
         await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for scroll animation
         await clickText('join', scope.blocksTab); // Click "join <hello> <world>" block
-        await findByText('applebanana', scope.reportedValue); // Tooltip with result
+        await findByText('apple banana', scope.reportedValue); // Tooltip with result
         const logs = await getLogs();
         await expect(logs).toEqual([]);
     });


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-gui/issues/3108

### Proposed Changes

Add a space at the end of the first default input to the `join` block, so that the result it reports is "apple banana".

### Reason for Changes

This makes the default behavior of the block more similar to the one in 2.0.