### PR TITLE
Make sure to switch back to code when adding new sprites

### DIFF
--- a/src/containers/sprite-library.jsx
+++ b/src/containers/sprite-library.jsx
@@ -39,7 +39,9 @@ class SpriteLibrary extends React.PureComponent {
         clearInterval(this.intervalId);
     }
     handleItemSelect (item) {
-        this.props.vm.addSprite(JSON.stringify(item.json));
+        this.props.vm.addSprite(JSON.stringify(item.json)).then(() => {
+            this.props.onActivateBlocksTab();
+        });
         analytics.event({
             category: 'library',
             action: 'Select Sprite',
@@ -95,6 +97,7 @@ class SpriteLibrary extends React.PureComponent {
 
 SpriteLibrary.propTypes = {
     intl: intlShape.isRequired,
+    onActivateBlocksTab: PropTypes.func.isRequired,
     onRequestClose: PropTypes.func,
     vm: PropTypes.instanceOf(VM).isRequired
 };

--- a/src/containers/target-pane.jsx
+++ b/src/containers/target-pane.jsx
@@ -9,7 +9,7 @@ import {
     closeSpriteLibrary
 } from '../reducers/modals';
 
-import {activateTab, COSTUMES_TAB_INDEX} from '../reducers/editor-tab';
+import {activateTab, COSTUMES_TAB_INDEX, BLOCKS_TAB_INDEX} from '../reducers/editor-tab';
 import {setReceivedBlocks} from '../reducers/hovered-target';
 import {setRestore} from '../reducers/restore-deletion';
 import DragConstants from '../lib/drag-constants';
@@ -23,6 +23,7 @@ class TargetPane extends React.Component {
     constructor (props) {
         super(props);
         bindAll(this, [
+            'handleActivateBlocksTab',
             'handleBlockDragEnd',
             'handleChangeSpriteRotationStyle',
             'handleChangeSpriteDirection',
@@ -109,7 +110,8 @@ class TargetPane extends React.Component {
     }
     handleSurpriseSpriteClick () {
         const item = spriteLibraryContent[Math.floor(Math.random() * spriteLibraryContent.length)];
-        this.props.vm.addSprite(JSON.stringify(item.json));
+        this.props.vm.addSprite(JSON.stringify(item.json))
+            .then(this.handleActivateBlocksTab);
     }
     handlePaintSpriteClick () {
         const formatMessage = this.props.intl.formatMessage;
@@ -124,8 +126,12 @@ class TargetPane extends React.Component {
             });
         });
     }
+    handleActivateBlocksTab () {
+        this.props.onActivateTab(BLOCKS_TAB_INDEX);
+    }
     handleNewSprite (spriteJSONString) {
-        this.props.vm.addSprite(spriteJSONString);
+        this.props.vm.addSprite(spriteJSONString)
+            .then(this.handleActivateBlocksTab);
     }
     handleFileUploadClick () {
         this.fileInput.click();

--- a/test/integration/sprites.test.js
+++ b/test/integration/sprites.test.js
@@ -33,6 +33,7 @@ describe('Working with sprites', () => {
         await clickXpath('//button[@aria-label="Choose a Sprite"]');
         await clickText('Apple', scope.modal); // Closes modal
         await rightClickText('Apple', scope.spriteTile); // Make sure it is there
+        await findByText('Motion'); // Make sure we are back to the code tab
         const logs = await getLogs();
         await expect(logs).toEqual([]);
     });
@@ -45,6 +46,19 @@ describe('Working with sprites', () => {
             .perform();
         await driver.sleep(500); // Wait for thermometer menu to come up
         await clickXpath('//button[@aria-label="Surprise"]');
+        const logs = await getLogs();
+        await expect(logs).toEqual([]);
+    });
+
+    test('Adding a sprite by paint button', async () => {
+        await loadUri(uri);
+        await clickXpath('//button[@title="Try It"]');
+        const el = await findByXpath('//button[@aria-label="Choose a Sprite"]');
+        await driver.actions().mouseMove(el)
+            .perform();
+        await driver.sleep(500); // Wait for thermometer menu to come up
+        await clickXpath('//button[@aria-label="Paint"]');
+        await findByText('Convert to Bitmap'); // Make sure we are on the paint editor
         const logs = await getLogs();
         await expect(logs).toEqual([]);
     });


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/LLK/scratch-gui/issues/3440

### Proposed Changes

_Describe what this Pull Request does_

Make the sprite library, surprise sprite and file upload sprite switch to code tab once the sprite is added. Adds an integration test to make sure it does that. Also check that the "paint a sprite" switches to the costume tab

### Reason for Changes

_Explain why these changes should be made_

### Test Coverage

_Please show how you have added tests to cover your changes_

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
