### PR TITLE
send params in storage request body, so that remixing and saving as copy create links to original projects

### DIFF
--- a/src/lib/project-saver-hoc.jsx
+++ b/src/lib/project-saver-hoc.jsx
@@ -55,7 +55,8 @@ const ProjectSaverHOC = function (WrappedComponent) {
             if (this.props.isCreatingCopy && !prevProps.isCreatingCopy) {
                 this.storeProject(null, {
                     original_id: this.props.reduxProjectId,
-                    is_copy: 1
+                    is_copy: 1,
+                    title: this.props.reduxProjectTitle
                 })
                     .then(response => {
                         this.props.onCreatedProject(response.id.toString(), this.props.loadingState);
@@ -67,7 +68,8 @@ const ProjectSaverHOC = function (WrappedComponent) {
             if (this.props.isRemixing && !prevProps.isRemixing) {
                 this.storeProject(null, {
                     original_id: this.props.reduxProjectId,
-                    is_remix: 1
+                    is_remix: 1,
+                    title: this.props.reduxProjectTitle
                 })
                     .then(response => {
                         this.props.onCreatedProject(response.id.toString(), this.props.loadingState);
@@ -98,23 +100,27 @@ const ProjectSaverHOC = function (WrappedComponent) {
          * storeProject:
          * @param  {number|string|undefined} projectId - defined value will PUT/update; undefined/null will POST/create
          * @return {Promise} - resolves with json object containing project's existing or new id
-         * @param {?object} urlParams - object of params to add to querystring
+         * @param {?object} requestParams - object of params to add to request body
          */
-        storeProject (projectId, urlParams) {
+        storeProject (projectId, requestParams) {
             return this.props.vm.saveProjectSb3()
                 .then(content => {
                     const assetType = storage.AssetType.Project;
                     const dataFormat = storage.DataFormat.SB3;
                     const body = new FormData();
                     body.append('sb3_file', content, 'sb3_file');
+                    if (requestParams) {
+                        for (const key in requestParams) {
+                            body.append(key, requestParams[key]);
+                        }
+                    }
                     // when id is undefined or null, storage.store as we have
                     // configured it will create a new project with id
                     return storage.store(
                         assetType,
                         dataFormat,
                         body,
-                        projectId,
-                        urlParams
+                        projectId
                     );
                 });
         }
@@ -134,6 +140,7 @@ const ProjectSaverHOC = function (WrappedComponent) {
                 onUpdatedProject: onUpdatedProjectProp,
                 onUpdateProject: onUpdateProjectProp,
                 reduxProjectId,
+                reduxProjectTitle,
                 /* eslint-enable no-unused-vars */
                 ...componentProps
             } = this.props;
@@ -160,6 +167,7 @@ const ProjectSaverHOC = function (WrappedComponent) {
         onUpdateProject: PropTypes.func,
         onUpdatedProject: PropTypes.func,
         reduxProjectId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+        reduxProjectTitle: PropTypes.string,
         vm: PropTypes.instanceOf(VM).isRequired
     };
     const mapStateToProps = state => {
@@ -173,6 +181,7 @@ const ProjectSaverHOC = function (WrappedComponent) {
             isUpdating: getIsUpdating(loadingState),
             loadingState: loadingState,
             reduxProjectId: state.scratchGui.projectState.projectId,
+            reduxProjectTitle: state.scratchGui.projectTitle,
             vm: state.scratchGui.vm
         };
     };

--- a/src/lib/project-saver-hoc.jsx
+++ b/src/lib/project-saver-hoc.jsx
@@ -44,7 +44,7 @@ const ProjectSaverHOC = function (WrappedComponent) {
             }
             // TODO: distinguish between creating new, remixing, and saving as a copy
             if (this.props.isCreatingNew && !prevProps.isCreatingNew) {
-                this.storeProject()
+                this.storeProject(null)
                     .then(response => {
                         this.props.onCreatedProject(response.id.toString(), this.props.loadingState);
                     })
@@ -53,10 +53,9 @@ const ProjectSaverHOC = function (WrappedComponent) {
                     });
             }
             if (this.props.isCreatingCopy && !prevProps.isCreatingCopy) {
-                this.storeProject(undefined, {
+                this.storeProject(null, {
                     original_id: this.props.reduxProjectId,
-                    is_copy: 1,
-                    title: encodeURIComponent(this.props.reduxProjectTitle)
+                    is_copy: 1
                 })
                     .then(response => {
                         this.props.onCreatedProject(response.id.toString(), this.props.loadingState);
@@ -66,10 +65,9 @@ const ProjectSaverHOC = function (WrappedComponent) {
                     });
             }
             if (this.props.isRemixing && !prevProps.isRemixing) {
-                this.storeProject(undefined, {
+                this.storeProject(null, {
                     original_id: this.props.reduxProjectId,
-                    is_remix: 1,
-                    title: encodeURIComponent(this.props.reduxProjectTitle)
+                    is_remix: 1
                 })
                     .then(response => {
                         this.props.onCreatedProject(response.id.toString(), this.props.loadingState);
@@ -98,10 +96,11 @@ const ProjectSaverHOC = function (WrappedComponent) {
         }
         /**
          * storeProject:
-         * @param  {number|string|undefined} projectId defined value causes PUT/update; undefined causes POST/create
-         * @return {Promise} resolves with json object containing project's existing or new id
+         * @param  {number|string|undefined} projectId - defined value will PUT/update; undefined/null will POST/create
+         * @return {Promise} - resolves with json object containing project's existing or new id
+         * @param {?object} urlParams - object of params to add to querystring
          */
-        storeProject (projectId, urlOptions) {
+        storeProject (projectId, urlParams) {
             return this.props.vm.saveProjectSb3()
                 .then(content => {
                     const assetType = storage.AssetType.Project;
@@ -115,14 +114,16 @@ const ProjectSaverHOC = function (WrappedComponent) {
                         dataFormat,
                         body,
                         projectId,
-                        urlOptions
+                        urlParams
                     );
                 });
         }
         render () {
             const {
                 /* eslint-disable no-unused-vars */
-                isCreating: isCreatingProp,
+                isCreatingCopy: isCreatingCopyProp,
+                isCreatingNew: isCreatingNewProp,
+                isRemixing: isRemixingProp,
                 isShowingWithId: isShowingWithIdProp,
                 isShowingWithoutId: isShowingWithoutIdProp,
                 isUpdating: isUpdatingProp,
@@ -146,7 +147,9 @@ const ProjectSaverHOC = function (WrappedComponent) {
     ProjectSaverComponent.propTypes = {
         canCreateNew: PropTypes.bool,
         canSave: PropTypes.bool,
-        isCreating: PropTypes.bool,
+        isCreatingCopy: PropTypes.bool,
+        isCreatingNew: PropTypes.bool,
+        isRemixing: PropTypes.bool,
         isShowingWithId: PropTypes.bool,
         isShowingWithoutId: PropTypes.bool,
         isUpdating: PropTypes.bool,
@@ -157,7 +160,6 @@ const ProjectSaverHOC = function (WrappedComponent) {
         onUpdateProject: PropTypes.func,
         onUpdatedProject: PropTypes.func,
         reduxProjectId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-        reduxProjectTitle: PropTypes.string,
         vm: PropTypes.instanceOf(VM).isRequired
     };
     const mapStateToProps = state => {
@@ -171,7 +173,6 @@ const ProjectSaverHOC = function (WrappedComponent) {
             isUpdating: getIsUpdating(loadingState),
             loadingState: loadingState,
             reduxProjectId: state.scratchGui.projectState.projectId,
-            reduxProjectTitle: state.scratchGui.projectTitle,
             vm: state.scratchGui.vm
         };
     };

--- a/src/reducers/project-state.js
+++ b/src/reducers/project-state.js
@@ -54,10 +54,14 @@ const getIsLoadingWithId = loadingState => (
     loadingState === LoadingState.LOADING_VM_WITH_ID ||
     loadingState === LoadingState.LOADING_VM_NEW_DEFAULT
 );
-const getIsCreating = loadingState => (
-    loadingState === LoadingState.CREATING_NEW ||
-    loadingState === LoadingState.REMIXING ||
+const getIsCreatingNew = loadingState => (
+    loadingState === LoadingState.CREATING_NEW
+);
+const getIsCreatingCopy = loadingState => (
     loadingState === LoadingState.CREATING_COPY
+);
+const getIsRemixing = loadingState => (
+    loadingState === LoadingState.REMIXING
 );
 const getIsUpdating = loadingState => (
     loadingState === LoadingState.UPDATING ||
@@ -401,11 +405,13 @@ export {
     defaultProjectId,
     doneCreatingProject,
     doneUpdatingProject,
-    getIsCreating,
+    getIsCreatingCopy,
+    getIsCreatingNew,
     getIsError,
     getIsFetchingWithId,
     getIsFetchingWithoutId,
     getIsLoadingWithId,
+    getIsRemixing,
     getIsShowingProject,
     getIsShowingWithId,
     getIsShowingWithoutId,

--- a/test/unit/util/project-saver-hoc.test.jsx
+++ b/test/unit/util/project-saver-hoc.test.jsx
@@ -30,7 +30,7 @@ describe('projectSaverHOC', () => {
             <WrappedComponent
                 isShowingWithId
                 canSave={false}
-                isCreating={false}
+                isCreatingNew={false}
                 isShowingWithoutId={false}
                 isUpdating={false}
                 loadingState={LoadingState.SHOWING_WITH_ID}
@@ -52,7 +52,7 @@ describe('projectSaverHOC', () => {
         const mounted = mount(
             <WrappedComponent
                 canSave
-                isCreating={false}
+                isCreatingNew={false}
                 isShowingWithId={false}
                 isShowingWithoutId={false}
                 isUpdating={false}
@@ -78,7 +78,7 @@ describe('projectSaverHOC', () => {
             <WrappedComponent
                 isShowingWithoutId
                 canSave={false}
-                isCreating={false}
+                isCreatingNew={false}
                 isShowingWithId={false}
                 isUpdating={false}
                 loadingState={LoadingState.LOADING_VM_NEW_DEFAULT}
@@ -102,7 +102,7 @@ describe('projectSaverHOC', () => {
             <WrappedComponent
                 isShowingWithoutId
                 canCreateNew={false}
-                isCreating={false}
+                isCreatingNew={false}
                 isShowingWithId={false}
                 isUpdating={false}
                 loadingState={LoadingState.SHOWING_WITHOUT_ID}
@@ -124,7 +124,7 @@ describe('projectSaverHOC', () => {
         const mounted = mount(
             <WrappedComponent
                 canCreateNew
-                isCreating={false}
+                isCreatingNew={false}
                 isShowingWithId={false}
                 isShowingWithoutId={false}
                 isUpdating={false}
@@ -141,14 +141,16 @@ describe('projectSaverHOC', () => {
         expect(mockedCreateProject).toHaveBeenCalled();
     });
 
-    test('if we enter creating state, vm project should be requested', () => {
+    test('if we enter creating new state, vm project should be requested', () => {
         vm.saveProjectSb3 = jest.fn(() => Promise.resolve());
         const Component = () => <div />;
         const WrappedComponent = projectSaverHOC(Component);
         const mounted = mount(
             <WrappedComponent
                 canSave
-                isCreating={false}
+                isCreatingCopy={false}
+                isCreatingNew={false}
+                isRemixing={false}
                 isShowingWithId={false}
                 isShowingWithoutId={false}
                 isUpdating={false}
@@ -159,8 +161,61 @@ describe('projectSaverHOC', () => {
             />
         );
         mounted.setProps({
-            isCreating: true,
+            isCreatingNew: true,
             loadingState: LoadingState.CREATING_NEW
+        });
+        expect(vm.saveProjectSb3).toHaveBeenCalled();
+    });
+
+    test('if we enter remixing state, vm project should be requested', () => {
+        vm.saveProjectSb3 = jest.fn(() => Promise.resolve());
+        const Component = () => <div />;
+        const WrappedComponent = projectSaverHOC(Component);
+        const mounted = mount(
+            <WrappedComponent
+                canSave
+                isCreatingCopy={false}
+                isCreatingNew={false}
+                isRemixing={false}
+                isShowingWithId={false}
+                isShowingWithoutId={false}
+                isUpdating={false}
+                loadingState={LoadingState.SHOWING_WITH_ID}
+                reduxProjectId={'100'}
+                store={store}
+                vm={vm}
+            />
+        );
+        mounted.setProps({
+            isRemixing: true,
+            loadingState: LoadingState.REMIXING
+        });
+        expect(vm.saveProjectSb3).toHaveBeenCalled();
+    });
+
+
+    test('if we enter creating copy state, vm project should be requested', () => {
+        vm.saveProjectSb3 = jest.fn(() => Promise.resolve());
+        const Component = () => <div />;
+        const WrappedComponent = projectSaverHOC(Component);
+        const mounted = mount(
+            <WrappedComponent
+                canSave
+                isCreatingCopy={false}
+                isCreatingNew={false}
+                isRemixing={false}
+                isShowingWithId={false}
+                isShowingWithoutId={false}
+                isUpdating={false}
+                loadingState={LoadingState.SHOWING_WITH_ID}
+                reduxProjectId={'100'}
+                store={store}
+                vm={vm}
+            />
+        );
+        mounted.setProps({
+            isCreatingCopy: true,
+            loadingState: LoadingState.CREATING_COPY
         });
         expect(vm.saveProjectSb3).toHaveBeenCalled();
     });
@@ -172,7 +227,7 @@ describe('projectSaverHOC', () => {
         const mounted = mount(
             <WrappedComponent
                 canSave
-                isCreating={false}
+                isCreatingNew={false}
                 isShowingWithId={false}
                 isShowingWithoutId={false}
                 isUpdating={false}
@@ -197,7 +252,7 @@ describe('projectSaverHOC', () => {
             <WrappedComponent
                 canSave
                 isUpdating
-                isCreating={false}
+                isCreatingNew={false}
                 isShowingWithId={false}
                 isShowingWithoutId={false}
                 loadingState={LoadingState.UPDATING}


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-gui/issues/3197

### Proposed Changes

For remix project creation and save as a copy project creation, we need to add params to the POST request. 

The first version of this PR did this by passing an object of params to the scratch-storage library, and letting it assemble the request url.

The current version of this PR doesn't pass the object of params. Instead, it adds these params directly to the outgoing request body.

This requires scratch-projects PR https://github.com/LLK/scratch-projects/pull/83 .
