### PR TITLE
Add a hook for custom storage init

### DIFF
--- a/src/containers/gui.jsx
+++ b/src/containers/gui.jsx
@@ -29,6 +29,7 @@ import FontLoaderHOC from '../lib/font-loader-hoc.jsx';
 import LocalizationHOC from '../lib/localization-hoc.jsx';
 import ProjectFetcherHOC from '../lib/project-fetcher-hoc.jsx';
 import ProjectSaverHOC from '../lib/project-saver-hoc.jsx';
+import storage from '../lib/storage';
 import vmListenerHOC from '../lib/vm-listener-hoc.jsx';
 import vmManagerHOC from '../lib/vm-manager-hoc.jsx';
 
@@ -45,6 +46,7 @@ const messages = defineMessages({
 class GUI extends React.Component {
     componentDidMount () {
         this.setReduxTitle(this.props.projectTitle);
+        this.props.onStorageInit(storage);
     }
     componentDidUpdate (prevProps) {
         if (this.props.projectId !== prevProps.projectId && this.props.projectId !== null) {
@@ -75,6 +77,7 @@ class GUI extends React.Component {
             hideIntro,
             isError,
             isShowingProject,
+            onStorageInit,
             onUpdateProjectId,
             onUpdateReduxProjectTitle,
             projectHost,
@@ -111,6 +114,7 @@ GUI.propTypes = {
     isShowingProject: PropTypes.bool,
     loadingStateVisible: PropTypes.bool,
     onSeeCommunity: PropTypes.func,
+    onStorageInit: PropTypes.func,
     onUpdateProjectId: PropTypes.func,
     onUpdateProjectTitle: PropTypes.func,
     onUpdateReduxProjectTitle: PropTypes.func,
@@ -122,6 +126,7 @@ GUI.propTypes = {
 };
 
 GUI.defaultProps = {
+    onStorageInit: storageInstance => storageInstance.addOfficialScratchWebStores(),
     onUpdateProjectId: () => {}
 };
 

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -10,6 +10,8 @@ class Storage extends ScratchStorage {
     constructor () {
         super();
         this.cacheDefaultProject();
+    }
+    addOfficialScratchWebStores () {
         this.addWebStore(
             [this.AssetType.Project],
             this.getProjectGetConfig.bind(this),


### PR DESCRIPTION
### Proposed Changes

This change adds a way for a consumer of `scratch-gui` to customize the `scratch-storage` instance that the GUI creates and shares with the VM and the rest of the system. If the `onStorageInit` property is not provided, the default value makes everything work as it did before.

### Reason for Changes

This allows `scratch-desktop` to inject its own "Helper" to handle loading bundled assets through Electron.

### Test Coverage

The existing tests verify that this change doesn't break current behavior.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [x] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
