### PR TITLE
Add @babel/cli for generating translation strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react-dom": "^16.0.0"
   },
   "devDependencies": {
+    "@babel/cli": "^7.1.2",
     "@babel/core": "^7.1.2",
     "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
     "@babel/plugin-syntax-dynamic-import": "^7.0.0",


### PR DESCRIPTION
The recent change to update the version of babel requires a corresponding version of babel/cli to run the script that extracts translations. (The cli dependency was included in scratch-l10n, but now gui requires a different version, so it's better to just add the dependency here) 