### PR TITLE
[Develop] Use names for tutorial URL ids

### DIFF
--- a/src/lib/libraries/decks/index.jsx
+++ b/src/lib/libraries/decks/index.jsx
@@ -126,7 +126,7 @@ export default {
             ]
         }
         ],
-        urlId: 'getting-started'
+        urlId: 'getStarted'
     },
 
     'say-it-out-loud': {
@@ -423,7 +423,7 @@ export default {
             ]
         }
         ],
-        urlId: 'animate-a-name'
+        urlId: 'name'
     },
     'Make-Music': {
         name: (
@@ -492,7 +492,7 @@ export default {
             ]
         }
         ],
-        urlId: 'make-music'
+        urlId: 'music'
     },
     'Make-A-Game': {
         name: (
@@ -833,7 +833,7 @@ export default {
                 'switch-costume'
             ]
         }],
-        urlId: 'hide-and-show'
+        urlId: 'hide'
     },
 
     'switch-costume': {

--- a/src/lib/libraries/decks/index.jsx
+++ b/src/lib/libraries/decks/index.jsx
@@ -126,7 +126,7 @@ export default {
             ]
         }
         ],
-        urlId: 1
+        urlId: 'getting-started'
     },
 
     'say-it-out-loud': {
@@ -237,7 +237,7 @@ export default {
             ]
         }
         ],
-        urlId: 16
+        urlId: 'animations-that-talk'
     },
 
     'cartoon-network': {
@@ -348,7 +348,7 @@ export default {
             ]
         }
         ],
-        urlId: 17
+        urlId: 'animate-an-adventure-game'
     },
     'animate-a-name': {
         name: (
@@ -423,7 +423,7 @@ export default {
             ]
         }
         ],
-        urlId: 2
+        urlId: 'animate-a-name'
     },
     'Make-Music': {
         name: (
@@ -492,7 +492,7 @@ export default {
             ]
         }
         ],
-        urlId: 3
+        urlId: 'make-music'
     },
     'Make-A-Game': {
         name: (
@@ -578,7 +578,7 @@ export default {
             ]
         }
         ],
-        urlId: 4
+        urlId: 'clicker-game'
     },
 
     'Chase-Game': {
@@ -682,7 +682,7 @@ export default {
             ]
         }
         ],
-        urlId: 5
+        urlId: 'chase-game'
     },
     'add-sprite': {
         name: (
@@ -712,7 +712,7 @@ export default {
                 ]
             }
         ],
-        urlId: 6
+        urlId: 'add-a-sprite'
     },
     'add-a-backdrop': {
         name: (
@@ -732,7 +732,7 @@ export default {
                 'switch-costume'
             ]
         }],
-        urlId: 7
+        urlId: 'add-a-backdrop'
     },
     'change-size': {
         name: (
@@ -752,7 +752,7 @@ export default {
                 'spin-video'
             ]
         }],
-        urlId: 8
+        urlId: 'change-size'
     },
     'glide-around': {
         name: (
@@ -772,7 +772,7 @@ export default {
                 'switch-costume'
             ]
         }],
-        urlId: 9
+        urlId: 'glide-around'
     },
 
     'record-a-sound': {
@@ -793,7 +793,7 @@ export default {
                 'switch-costume'
             ]
         }],
-        urlId: 10
+        urlId: 'record-a-sound'
     },
     'spin-video': {
         name: (
@@ -813,7 +813,7 @@ export default {
                 'switch-costume'
             ]
         }],
-        urlId: 11
+        urlId: 'make-it-spin'
     },
     'hide-and-show': {
         name: (
@@ -833,7 +833,7 @@ export default {
                 'switch-costume'
             ]
         }],
-        urlId: 12
+        urlId: 'hide-and-show'
     },
 
     'switch-costume': {
@@ -854,7 +854,7 @@ export default {
                 'add-effects'
             ]
         }],
-        urlId: 13
+        urlId: 'animate-a-sprite'
     },
 
     'move-around-with-arrow-keys': {
@@ -875,7 +875,7 @@ export default {
                 'switch-costume'
             ]
         }],
-        urlId: 14
+        urlId: 'arrow-keys'
     },
     'add-effects': {
         name: (
@@ -896,6 +896,6 @@ export default {
                 'switch-costume'
             ]
         }],
-        urlId: 15
+        urlId: 'add-effects'
     }
 };

--- a/src/lib/tutorial-from-url.js
+++ b/src/lib/tutorial-from-url.js
@@ -36,15 +36,10 @@ const getDeckIdFromUrlId = urlId => {
  */
 const detectTutorialId = () => {
     const queryParams = queryString.parse(location.search);
-    const tutorialID = Number(
-        Array.isArray(queryParams.tutorial) ?
-            queryParams.tutorial[0] :
-            queryParams.tutorial
-    );
-    if (!isNaN(tutorialID)) {
-        return getDeckIdFromUrlId(tutorialID);
-    }
-    return null;
+    const tutorialID = Array.isArray(queryParams.tutorial) ?
+        queryParams.tutorial[0] :
+        queryParams.tutorial;
+    return getDeckIdFromUrlId(tutorialID);
 };
 
 export {

--- a/src/lib/tutorial-from-url.js
+++ b/src/lib/tutorial-from-url.js
@@ -39,6 +39,7 @@ const detectTutorialId = () => {
     const tutorialID = Array.isArray(queryParams.tutorial) ?
         queryParams.tutorial[0] :
         queryParams.tutorial;
+    if (typeof tutorialID === 'undefined') return null;
     return getDeckIdFromUrlId(tutorialID);
 };
 

--- a/test/unit/util/tutorial-from-url.test.js
+++ b/test/unit/util/tutorial-from-url.test.js
@@ -3,7 +3,7 @@ jest.mock('../../../src/lib/analytics.js', () => ({
 }));
 
 jest.mock('../../../src/lib/libraries/decks/index.jsx', () => ({
-    foo: {urlId: 1}
+    foo: {urlId: 'one'}
 }));
 
 import {detectTutorialId} from '../../../src/lib/tutorial-from-url.js';
@@ -15,7 +15,7 @@ Object.defineProperty(
 );
 
 test('returns the tutorial ID if the urlId matches', () => {
-    window.location.search = '?tutorial=1';
+    window.location.search = '?tutorial=one';
     expect(detectTutorialId()).toBe('foo');
 });
 
@@ -35,6 +35,6 @@ test('returns null if non-numeric template', () => {
 });
 
 test('takes the first of multiple', () => {
-    window.location.search = '?tutorial=1&tutorial=2';
+    window.location.search = '?tutorial=one&tutorial=two';
     expect(detectTutorialId()).toBe('foo');
 });

--- a/test/unit/util/tutorial-from-url.test.js
+++ b/test/unit/util/tutorial-from-url.test.js
@@ -3,7 +3,9 @@ jest.mock('../../../src/lib/analytics.js', () => ({
 }));
 
 jest.mock('../../../src/lib/libraries/decks/index.jsx', () => ({
-    foo: {urlId: 'one'}
+    noUrlId: {},
+    foo: {urlId: 'one'},
+    noUrlIdSandwich: {}
 }));
 
 import {detectTutorialId} from '../../../src/lib/tutorial-from-url.js';
@@ -26,6 +28,11 @@ test('returns null if no matching urlId', () => {
 
 test('returns null if empty template', () => {
     window.location.search = '?tutorial=';
+    expect(detectTutorialId()).toBe(null);
+});
+
+test('returns null if no query param', () => {
+    window.location.search = '';
     expect(detectTutorialId()).toBe(null);
 });
 


### PR DESCRIPTION
To make URLs more friendly, use e.g., `tutorial=getting-started` instead of `tutorial=1`.  This will also help with some URL handling we're doing for the new project page.
