### PR TITLE
Hack to load a starter project for a specific tutorial

### DIFF
--- a/src/containers/tips-library.jsx
+++ b/src/containers/tips-library.jsx
@@ -35,6 +35,19 @@ class TipsLibrary extends React.PureComponent {
         ]);
     }
     handleItemSelect (item) {
+        /*
+            Support tutorials that require specific starter projects.
+            If a tutorial declares "requiredProjectId", check that the URL contains
+            it. If it is not, open a new page with this tutorial and project id.
+
+            TODO remove this at first opportunity. If this is still here after HOC2018,
+                 blame Eric R. Andrew is also on record saying "this is temporary".
+        */
+        if (item.requiredProjectId && window.location.href.indexOf(item.requiredProjectId) === -1) {
+            const urlParams = `?tutorial=${item.urlId}#${item.requiredProjectId}`;
+            return window.open(window.location.pathname + urlParams, '_blank');
+        }
+
         this.props.onActivateDeck(item.id);
         analytics.event({
             category: 'library',
@@ -48,7 +61,9 @@ class TipsLibrary extends React.PureComponent {
             id: id,
             name: decksLibraryContent[id].name,
             featured: true,
-            tags: decksLibraryContent[id].tags
+            tags: decksLibraryContent[id].tags,
+            urlId: decksLibraryContent[id].urlId,
+            requiredProjectId: decksLibraryContent[id].requiredProjectId
         }));
 
         if (!this.props.visible) return null;

--- a/src/lib/libraries/decks/index.jsx
+++ b/src/lib/libraries/decks/index.jsx
@@ -248,6 +248,7 @@ export default {
                 id="gui.howtos.cartoon-network"
             />
         ),
+        requiredProjectId: '249143200',
         img: libraryCartoonNetwork,
         steps: [{
             video: 'uz5oz5h9yg'


### PR DESCRIPTION
First of all, let me make clear that @paulkaplan bears no responsibility, moral, ethical, technical or otherwise, for the contents of this PR.

Also, thanks to @paulkaplan for writing the elegant and powerful code in this PR.

The new "Animate an Adventure Game" tutorial requires assets from a starter project. We will generally direct people to it using a URL that includes both the tutorial ID and starter project ID. But, because you can also get to the tutorial by opening it from the library, we need a way to direct people to the starter project. 

After considering several options, we decided to do the following: when you click on this particular tutorial, if your browser is already at a URL containing the starter project ID, open the tutorial as usual; if not, open a new browser window with both the tutorial and starter project open. 

This is a temporary solution, until we have a more robust way to provide assets or starter projects for tutorials.