### PR TITLE
Don't publish playground or test files to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,9 +8,11 @@ npm-*
 # Testing
 /.nyc_output
 /coverage
+/test
 
 # Build
 /.opt-in
+/build
 
 # generated translation files
 /translations


### PR DESCRIPTION
The package is too large to publish to NPM. These aren't necessary for other packages using scratch-gui as a module.

(does same as https://github.com/LLK/scratch-gui/pull/3528 , but to smoke branch)

### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves GUI not being published to NPM since 2018-10-23

### Proposed Changes

_Describe what this Pull Request does_
Excludes the test and build directories from the package published to NPM

### Reason for Changes

_Explain why these changes should be made_
We can't publish to NPM currently because the archive is too large.

### Test Coverage

_Please show how you have added tests to cover your changes_
N/A

### Browser Coverage
N/A