### PR TITLE
Restore IntlProvider for Internet Explorer

### DIFF
--- a/src/lib/app-state-hoc.jsx
+++ b/src/lib/app-state-hoc.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {Provider} from 'react-redux';
 import {createStore, combineReducers, compose} from 'redux';
+import ConnectedIntlProvider from './connected-intl-provider.jsx';
 
 import localesReducer, {initLocale, localesInitialState} from '../reducers/locales';
 
@@ -107,7 +108,9 @@ const AppStateHOC = function (WrappedComponent, localesOnly) {
             } = this.props;
             return (
                 <Provider store={this.store}>
-                    <WrappedComponent {...componentProps} />
+                    <ConnectedIntlProvider>
+                        <WrappedComponent {...componentProps} />
+                    </ConnectedIntlProvider>
                 </Provider>
             );
         }


### PR DESCRIPTION
Since https://github.com/LLK/scratch-gui/pull/3431 GUI includes its own Intl provider (react-intl supports nested intl providers) that works within the www intl provider.

This PR restores the app-state-hoc intl provider for the stand-alone gui so that IE can function enough to put up the unsupported browser.

This will permit adding localization to things outside what's exported by GUI. We should be very careful about adding localization to any GUI wrapper component because it will work in playground (because of this PR), but possibly break in www.
