### PR TITLE
account menu messages are fully defined and inline

### DIFF
--- a/src/components/menu-bar/account-nav.jsx
+++ b/src/components/menu-bar/account-nav.jsx
@@ -64,27 +64,51 @@ const AccountNavComponent = ({
             onRequestClose={onClose}
         >
             <MenuItemContainer href={profileUrl}>
-                <FormattedMessage id="general.profile" />
+                <FormattedMessage
+                    defaultMessage="Profile"
+                    description="Text to link to my user profile, in the account navigation menu"
+                    id="gui.accountMenu.profile"
+                />
             </MenuItemContainer>
             <MenuItemContainer href="/mystuff/">
-                <FormattedMessage id="general.myStuff" />
+                <FormattedMessage
+                    defaultMessage="My Stuff"
+                    description="Text to link to list of my projects, in the account navigation menu"
+                    id="gui.accountMenu.myStuff"
+                />
             </MenuItemContainer>
             {isEducator ? (
                 <MenuItemContainer href="/educators/classes/">
-                    <FormattedMessage id="general.myClasses" />
+                    <FormattedMessage
+                        defaultMessage="My Classes"
+                        description="Text to link to my classes (if I am a teacher), in the account navigation menu"
+                        id="gui.accountMenu.myClasses"
+                    />
                 </MenuItemContainer>
             ) : null}
             {isStudent ? (
                 <MenuItemContainer href={`/classes/${classroomId}/`}>
-                    <FormattedMessage id="general.myClass" />
+                    <FormattedMessage
+                        defaultMessage="My Class"
+                        description="Text to link to my class (if I am a student), in the account navigation menu"
+                        id="gui.accountMenu.myClass"
+                    />
                 </MenuItemContainer>
             ) : null}
             <MenuItemContainer href="/accounts/settings/">
-                <FormattedMessage id="general.accountSettings" />
+                <FormattedMessage
+                    defaultMessage="Account settings"
+                    description="Text to link to my account settings, in the account navigation menu"
+                    id="gui.accountMenu.accountSettings"
+                />
             </MenuItemContainer>
             <MenuSection>
                 <MenuItemContainer onClick={onLogOut}>
-                    <FormattedMessage id="navigation.signOut" />
+                    <FormattedMessage
+                        defaultMessage="Sign out"
+                        description="Text to link to sign out, in the account navigation menu"
+                        id="gui.accountMenu.signOut"
+                    />
                 </MenuItemContainer>
             </MenuSection>
         </MenuBarMenu>


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-gui/issues/3536

### Proposed Changes

Instead of referencing translated messages a la www, define them inline a la gui.

### Reason for Changes

www-style translations were only working before because of the way www translations were inadvertently available to gui. This does the translation strings the right way.