### PR TITLE
Issue/hotfix project load

### DIFF
--- a/src/reducers/project-state.js
+++ b/src/reducers/project-state.js
@@ -172,6 +172,10 @@ const reducer = function (state, action) {
         }
         return state;
     case SET_PROJECT_ID:
+        // if the projectId hasn't actually changed do nothing
+        if (state.projectId === action.projectId) {
+            return state;
+        }
         // if setting the default project id, specifically fetch that project
         if (action.projectId === defaultProjectId) {
             return Object.assign({}, state, {


### PR DESCRIPTION
If you switch language after loading the default project it gets reloaded, losing any changes you may have made. 

This PR checks whether the project id is changing in the reducer, but I think there's a deeper root cause as changing locale should not cause a SET_PROJECT_ID dispatch.