### PR TITLE
Fix CSS issues that appear when integrated with WWW

### DIFF
--- a/src/components/language-selector/language-selector.css
+++ b/src/components/language-selector/language-selector.css
@@ -10,6 +10,8 @@
     user-select: none;
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
     font-size: .875rem;
+    color: $text-primary;
+    background: $ui-white;
 }
 
 [dir="ltr"] .language-select {

--- a/src/components/loader/loader.css
+++ b/src/components/loader/loader.css
@@ -154,6 +154,12 @@
   }
 }
 
+.title {
+    font-size: 2rem;
+    font-weight: bold;
+    margin: 0.75rem 0;
+}
+
 .message-container-outer {
     height: 30px;
     overflow: hidden;

--- a/src/components/loader/loader.jsx
+++ b/src/components/loader/loader.jsx
@@ -147,13 +147,13 @@ class LoaderComponent extends React.Component {
                             src={bottomBlock}
                         />
                     </div>
-                    <h1 className={styles.title}>
+                    <div className={styles.title}>
                         <FormattedMessage
                             defaultMessage="Loading Project"
                             description="Main loading message"
                             id="gui.loader.headline"
                         />
-                    </h1>
+                    </div>
                     <div className={styles.messageContainerOuter}>
                         <div
                             className={styles.messageContainerInner}

--- a/src/components/menu-bar/menu-bar.css
+++ b/src/components/menu-bar/menu-bar.css
@@ -55,6 +55,7 @@
 }
 
 .language-menu {
+    box-sizing: border-box;
     display: inline-flex;
     width: $language-selector-width;
 }

--- a/src/components/menu/menu.css
+++ b/src/components/menu/menu.css
@@ -27,6 +27,9 @@
     line-height: 34px;
     white-space: nowrap;
     padding: 0 10px;
+    font-size: .75rem;
+    margin: 0;
+    font-weight: bold;
 }
 
 .menu-item.active,


### PR DESCRIPTION
Changes a few CSS things, including:
- Making the font-size properties more specific to the element, avoiding the giant menu item problem (a result of having a font-size set for all `ul li` in www)
- Forcing a box-sizing property when using explicit width + padding, since www does not have the same global preference for box sizing
- Do not rely on browser stylesheets for styling something that isn't really an "h1", and avoid the collision with h1 styling that comes from www
- Do not rely on browser stylesheet for styling `select`s, this is basically our fault in GUI for not acknowledging the fact that select components act differently in different OSs (i.e. actually have a background/color in non-mac OS)

Non of this requires overrides, just a bit of extra specification on selectors. 

This addresses the issues listed on https://github.com/LLK/scratch-www/issues/2096 and one extra one (loading screen wrong color), but does not implement a long term fix, so I don't think it should be considered to close that issue.

Tested using a chromebook (for the select menu) and the other issues exist on all browsers.