### PR TITLE
hide monitor overflow from going past stage boundary

### DIFF
--- a/src/components/monitor-list/monitor-list.css
+++ b/src/components/monitor-list/monitor-list.css
@@ -2,6 +2,7 @@
     /* Width/height are set by the component, margin: auto centers in fullscreen */
     margin: auto;
     pointer-events: none;
+    overflow: hidden;
 }
 
 .monitor-list-scaler {


### PR DESCRIPTION
### Resolves

- Resolves https://github.com/LLK/scratch-gui/issues/2933

### Proposed Changes

Use the `overflow: hidden` style to constrain monitors and keep them from overflowing stage in fullscreen mode

### Reason for Changes

It's bad to have stuff extend outside of the stage!