### PR TITLE
Blur language select focus when mouse leaves

### DIFF
--- a/src/components/language-selector/language-selector.jsx
+++ b/src/components/language-selector/language-selector.jsx
@@ -7,10 +7,11 @@ import styles from './language-selector.css';
 // supported languages to exclude from the menu, but allow as a URL option
 const ignore = [];
 
-const LanguageSelector = ({currentLocale, label, onChange}) => (
+const LanguageSelector = ({componentRef, currentLocale, label, onChange}) => (
     <select
         aria-label={label}
         className={styles.languageSelect}
+        ref={componentRef}
         value={currentLocale}
         onChange={onChange}
     >
@@ -30,6 +31,7 @@ const LanguageSelector = ({currentLocale, label, onChange}) => (
 );
 
 LanguageSelector.propTypes = {
+    componentRef: PropTypes.func,
     currentLocale: PropTypes.string,
     label: PropTypes.string,
     onChange: PropTypes.func

--- a/src/containers/language-selector.jsx
+++ b/src/containers/language-selector.jsx
@@ -11,9 +11,30 @@ class LanguageSelector extends React.Component {
     constructor (props) {
         super(props);
         bindAll(this, [
-            'handleChange'
+            'handleChange',
+            'handleMouseLeave',
+            'ref'
         ]);
         document.documentElement.lang = props.currentLocale;
+    }
+    componentDidMount () {
+        this.addListeners();
+    }
+
+    componentWillUnmount () {
+        this.removeListeners();
+    }
+    addListeners () {
+        this.select.addEventListener('mouseleave', this.handleMouseLeave);
+    }
+    removeListeners () {
+        this.select.removeEventListener('mouseleave', this.handleMouseLeave);
+    }
+    handleMouseLeave () {
+        this.select.blur();
+    }
+    ref (c) {
+        this.select = c;
     }
     handleChange (e) {
         const newLocale = e.target.value;
@@ -31,6 +52,7 @@ class LanguageSelector extends React.Component {
         } = this.props;
         return (
             <LanguageSelectorComponent
+                componentRef={this.ref}
                 onChange={this.handleChange}
                 {...props}
             >

--- a/src/containers/language-selector.jsx
+++ b/src/containers/language-selector.jsx
@@ -12,7 +12,7 @@ class LanguageSelector extends React.Component {
         super(props);
         bindAll(this, [
             'handleChange',
-            'handleMouseLeave',
+            'handleMouseOut',
             'ref'
         ]);
         document.documentElement.lang = props.currentLocale;
@@ -25,12 +25,12 @@ class LanguageSelector extends React.Component {
         this.removeListeners();
     }
     addListeners () {
-        this.select.addEventListener('mouseleave', this.handleMouseLeave);
+        this.select.addEventListener('mouseout', this.handleMouseOut);
     }
     removeListeners () {
-        this.select.removeEventListener('mouseleave', this.handleMouseLeave);
+        this.select.removeEventListener('mouseout', this.handleMouseOut);
     }
-    handleMouseLeave () {
+    handleMouseOut () {
         this.select.blur();
     }
     ref (c) {


### PR DESCRIPTION
### Resolves

- Resolves #3302 

### Proposed Changes
Blur the language select when the user clicks outside the select so that arrow keys go to the stage instead of the select.

### Reason for Changes

Language-select was keeping keyboard focus for arrow keys when it shouldn't

### Test Coverage

Current tests run 

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [x] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
