### PR TITLE
Add HOC tracking pixels

### DIFF
--- a/src/components/cards/card.css
+++ b/src/components/cards/card.css
@@ -267,3 +267,6 @@
     background: $ui-white;
     box-shadow: 0px 0px 0px 2px $ui-black-transparent;
 }
+.tracking-pixel {
+    display: none;
+}

--- a/src/components/cards/cards.jsx
+++ b/src/components/cards/cards.jsx
@@ -276,6 +276,7 @@ const Cards = props => {
                                 />
                             )
                         )}
+                        {steps[step].trackingPixel && steps[step].trackingPixel}
                     </div>
                     <NextPrevButtons
                         isRtl={isRtl}

--- a/src/components/cards/cards.jsx
+++ b/src/components/cards/cards.jsx
@@ -276,7 +276,11 @@ const Cards = props => {
                                 />
                             )
                         )}
-                        {steps[step].trackingPixel && steps[step].trackingPixel}
+                        {steps[step].trackingPixel ? (
+                            <div className={styles.trackingPixel}>
+                                {steps[step].trackingPixel}
+                            </div>
+                        ) : null}
                     </div>
                     <NextPrevButtons
                         isRtl={isRtl}

--- a/src/lib/libraries/decks/index.jsx
+++ b/src/lib/libraries/decks/index.jsx
@@ -139,7 +139,10 @@ export default {
         ),
         img: libraryTXTSpeech,
         steps: [{
-            video: 'k54n8uwcty'
+            video: 'k54n8uwcty',
+            trackingPixel: (
+                <img src="http://code.org/api/hour/scratch_talk.png" />
+            )
         }, {
             title: (
                 <FormattedMessage
@@ -251,7 +254,10 @@ export default {
         requiredProjectId: '249143200',
         img: libraryCartoonNetwork,
         steps: [{
-            video: 'uz5oz5h9yg'
+            video: 'uz5oz5h9yg',
+            trackingPixel: (
+                <img src="http://code.org/api/hour/scratch_adventure.png" />
+            )
         }, {
             title: (
                 <FormattedMessage

--- a/src/lib/libraries/decks/index.jsx
+++ b/src/lib/libraries/decks/index.jsx
@@ -141,7 +141,7 @@ export default {
         steps: [{
             video: 'k54n8uwcty',
             trackingPixel: (
-                <img src="http://code.org/api/hour/scratch_talk.png" />
+                <img src="https://code.org/api/hour/scratch_talk.png" />
             )
         }, {
             title: (
@@ -256,7 +256,7 @@ export default {
         steps: [{
             video: 'uz5oz5h9yg',
             trackingPixel: (
-                <img src="http://code.org/api/hour/scratch_adventure.png" />
+                <img src="https://code.org/api/hour/scratch_adventure.png" />
             )
         }, {
             title: (


### PR DESCRIPTION
Add tracking pixels from code.org to the first page of our two Hour of Code tutorials, "Create Animations That Talk" and "Animate an Adventure Game."

We are now hiding the tracking pixel so that we don't see a broken image, because the pixels are still 404ing.