### PR TITLE
Fixes Close button overlap issue

### DIFF
--- a/src/components/sprite-selector-item/sprite-selector-item.css
+++ b/src/components/sprite-selector-item/sprite-selector-item.css
@@ -80,7 +80,7 @@
 .delete-button {
     position: absolute;
     top: 0.125rem;
-    z-index: 1;
+    z-index: auto;
 }
 
 [dir="ltr"] .delete-button {


### PR DESCRIPTION
### Resolves

- Resolves #3024

### Proposed Changes

Z-index of the x-sprite on thumbnail was changed from 1 to 'auto' as the parent elements had 'auto' z-index.

### Reason for Changes

Thermometer menu, if open should cover the x for deleting a sprite on the selected sprite.

### Test Coverage

Chrome:
![image](https://user-images.githubusercontent.com/10993808/47840776-628c8300-ddf2-11e8-8b76-2588e8eebb29.png)

Firefox:
![image](https://user-images.githubusercontent.com/10993808/47840806-746e2600-ddf2-11e8-9bb8-9397c91a1d16.png)


### Browser Coverage

Windows
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Edge

