### PR TITLE
Fix a couple areas where we are rendering too much

### DIFF
--- a/src/containers/language-selector.jsx
+++ b/src/containers/language-selector.jsx
@@ -17,7 +17,7 @@ class LanguageSelector extends React.Component {
     }
     handleChange (e) {
         const newLocale = e.target.value;
-        if (this.props.supportedLocales.includes(newLocale)) {
+        if (this.props.messagesByLocale[newLocale]) {
             this.props.onChangeLanguage(newLocale);
             document.documentElement.lang = newLocale;
         }
@@ -25,7 +25,7 @@ class LanguageSelector extends React.Component {
     render () {
         const {
             onChangeLanguage, // eslint-disable-line no-unused-vars
-            supportedLocales, // eslint-disable-line no-unused-vars
+            messagesByLocale, // eslint-disable-line no-unused-vars
             children,
             ...props
         } = this.props;
@@ -43,13 +43,14 @@ class LanguageSelector extends React.Component {
 LanguageSelector.propTypes = {
     children: PropTypes.node,
     currentLocale: PropTypes.string.isRequired,
-    onChangeLanguage: PropTypes.func.isRequired,
-    supportedLocales: PropTypes.arrayOf(PropTypes.string)
+    // Only checking key presence for messagesByLocale, no need to be more specific than object
+    messagesByLocale: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+    onChangeLanguage: PropTypes.func.isRequired
 };
 
 const mapStateToProps = state => ({
     currentLocale: state.locales.locale,
-    supportedLocales: Object.keys(state.locales.messagesByLocale)
+    messagesByLocale: state.locales.messagesByLocale
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/containers/sprite-selector-item.jsx
+++ b/src/containers/sprite-selector-item.jsx
@@ -55,13 +55,15 @@ class SpriteSelectorItem extends React.Component {
         window.removeEventListener('mousemove', this.handleMouseMove);
         window.removeEventListener('touchend', this.handleMouseUp);
         window.removeEventListener('touchmove', this.handleMouseMove);
-        this.props.onDrag({
-            img: null,
-            currentOffset: null,
-            dragging: false,
-            dragType: null,
-            index: null
-        });
+        if (this.props.dragging) {
+            this.props.onDrag({
+                img: null,
+                currentOffset: null,
+                dragging: false,
+                dragType: null,
+                index: null
+            });
+        }
         setTimeout(() => {
             this.noClick = false;
         });
@@ -156,6 +158,7 @@ SpriteSelectorItem.propTypes = {
         body: PropTypes.string
     }),
     dragType: PropTypes.string,
+    dragging: PropTypes.bool,
     id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     index: PropTypes.number,
     name: PropTypes.string,


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves an issue where we were causing re-renders to happen on components that did not need to rerender

Each commit fixes a different problem. one for the backpack / any droppable area, and one for the language selector


![too-many-renders](https://user-images.githubusercontent.com/654102/47858212-e5e1b080-ddc1-11e8-8f7e-a2e20a0a0f13.gif)


After
![too-many-renders-fixed](https://user-images.githubusercontent.com/654102/47858217-e7ab7400-ddc1-11e8-8d9d-d1165ce6cc21.gif)
