### PR TITLE
Pass onActivateBlocksTab to sprite library to switch tabs after adding.

### DIFF
--- a/src/components/target-pane/target-pane.jsx
+++ b/src/components/target-pane/target-pane.jsx
@@ -21,6 +21,7 @@ const TargetPane = ({
     fileInputRef,
     hoveredTarget,
     spriteLibraryVisible,
+    onActivateBlocksTab,
     onChangeSpriteDirection,
     onChangeSpriteName,
     onChangeSpriteRotationStyle,
@@ -92,6 +93,7 @@ const TargetPane = ({
                 {spriteLibraryVisible ? (
                     <SpriteLibrary
                         vm={vm}
+                        onActivateBlocksTab={onActivateBlocksTab}
                         onRequestClose={onRequestCloseSpriteLibrary}
                     />
                 ) : null}
@@ -128,6 +130,7 @@ TargetPane.propTypes = {
         hoveredSprite: PropTypes.string,
         receivedBlocks: PropTypes.bool
     }),
+    onActivateBlocksTab: PropTypes.func.isRequired,
     onChangeSpriteDirection: PropTypes.func,
     onChangeSpriteName: PropTypes.func,
     onChangeSpriteRotationStyle: PropTypes.func,

--- a/src/containers/target-pane.jsx
+++ b/src/containers/target-pane.jsx
@@ -202,6 +202,7 @@ class TargetPane extends React.Component {
             <TargetPaneComponent
                 {...componentProps}
                 fileInputRef={this.setFileInput}
+                onActivateBlocksTab={this.handleActivateBlocksTab}
                 onChangeSpriteDirection={this.handleChangeSpriteDirection}
                 onChangeSpriteName={this.handleChangeSpriteName}
                 onChangeSpriteRotationStyle={this.handleChangeSpriteRotationStyle}

--- a/test/integration/sprites.test.js
+++ b/test/integration/sprites.test.js
@@ -33,7 +33,7 @@ describe('Working with sprites', () => {
         await clickXpath('//button[@aria-label="Choose a Sprite"]');
         await clickText('Apple', scope.modal); // Closes modal
         await rightClickText('Apple', scope.spriteTile); // Make sure it is there
-        await findByText('Motion'); // Make sure we are back to the code tab
+        await clickText('Motion'); // Make sure we are back to the code tab
         const logs = await getLogs();
         await expect(logs).toEqual([]);
     });


### PR DESCRIPTION
Looks like I forgot to actually pass this function to the sprite library. My integration test was erroneously passing :(  Made the test fail, then fixed the issue.
I forgot that the integration test needs to try clicking, because finding text will find invisible text as well

Fixes the issue reported by @picklesrus where you would not get switched back to the code tab after adding a sprite from the library