### PR TITLE
define login dropdown messages, so www component will render with readable text

### DIFF
--- a/src/components/menu-bar/login-dropdown.jsx
+++ b/src/components/menu-bar/login-dropdown.jsx
@@ -16,22 +16,22 @@ import styles from './login-dropdown.css';
 // these are here as a hack to get them translated, so that equivalent messages will be translated
 // when passed in from www via gui's renderLogin() function
 const LoginDropdownMessages = defineMessages({ // eslint-disable-line no-unused-vars
-    backdrop: {
+    username: {
         defaultMessage: 'Username',
         description: 'Label for login username input',
         id: 'general.username'
     },
-    costume: {
+    password: {
         defaultMessage: 'Password',
         description: 'Label for login password input',
         id: 'general.password'
     },
-    sprite: {
+    signin: {
         defaultMessage: 'Sign in',
         description: 'Button text for user to sign in',
         id: 'general.signIn'
     },
-    pop: {
+    needhelp: {
         defaultMessage: 'Need Help?',
         description: 'Button text for user to indicate that they need help',
         id: 'login.needHelp'

--- a/src/components/menu-bar/login-dropdown.jsx
+++ b/src/components/menu-bar/login-dropdown.jsx
@@ -7,10 +7,37 @@ eventually be consolidated.
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
+import {defineMessages} from 'react-intl';
 
 import MenuBarMenu from './menu-bar-menu.jsx';
 
 import styles from './login-dropdown.css';
+
+// these are here as a hack to get them translated, so that equivalent messages will be translated
+// when passed in from www via gui's renderLogin() function
+const LoginDropdownMessages = defineMessages({ // eslint-disable-line no-unused-vars
+    backdrop: {
+        defaultMessage: 'Username',
+        description: 'Label for login username input',
+        id: 'general.username'
+    },
+    costume: {
+        defaultMessage: 'Password',
+        description: 'Label for login password input',
+        id: 'general.password'
+    },
+    sprite: {
+        defaultMessage: 'Sign in',
+        description: 'Button text for user to sign in',
+        id: 'general.signIn'
+    },
+    pop: {
+        defaultMessage: 'Need Help?',
+        description: 'Button text for user to indicate that they need help',
+        id: 'login.needHelp'
+    }
+});
+
 
 const LoginDropdown = ({
     className,


### PR DESCRIPTION
### Resolves

- Resolves https://github.com/LLK/scratch-gui/issues/3601

### Proposed Changes

Define login dropdown messages in gui's `login-dropdown.jsx` file, so they will be translated in the gui context; then, when www passes its login component to gui via the `renderLogin()` function, they will (hopefully!) translate.

### Reason for Changes

Need readable login text, not weird id strings!
