### PR TITLE
Update to VM hotfix version

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "scratch-render": "0.1.0-prerelease.20181024220305",
     "scratch-storage": "1.1.0",
     "scratch-svg-renderer": "0.2.0-prerelease.20181024192149",
-    "scratch-vm": "0.2.0-prerelease.20181025092837",
+    "scratch-vm": "0.2.0-prerelease.20181101184114",
     "selenium-webdriver": "3.6.0",
     "startaudiocontext": "1.2.1",
     "style-loader": "^0.23.0",


### PR DESCRIPTION
Fix uploading images as sprites.

This version is a custom build of VM, which has only this change applied to the currently deployed version https://github.com/LLK/scratch-vm/pull/1719

This version should _not_ be pulled into `develop` or `smoke`. Instead we should merge https://github.com/LLK/scratch-vm/pull/1719 and let VM publish a new version on `latest`, and update to that version on `develop`/`smoke`.