### PR TITLE
Fix backpack crashing the GUI when trying to store a cloud variable

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "immutable": "3.8.2",
     "intl": "1.2.5",
     "jest": "^21.0.0",
+    "js-base64": "2.4.9",
     "keymirror": "0.1.1",
     "lodash.bindall": "4.4.0",
     "lodash.debounce": "4.0.8",

--- a/src/lib/backpack/code-payload.js
+++ b/src/lib/backpack/code-payload.js
@@ -1,12 +1,15 @@
 import blockToImage from './block-to-image';
 import jpegThumbnail from './jpeg-thumbnail';
+import {Base64} from 'js-base64';
 
 const codePayload = ({blockObjects, topBlockId}) => {
     const payload = {
         type: 'script', // Needs to match backpack-server type name
         name: 'code', // All code currently gets the same name
         mime: 'application/json',
-        body: btoa(JSON.stringify(blockObjects)) // Base64 encode the json
+        // Backpack expects a base64 encoded string to store. Cannot use btoa because
+        // the code can contain characters outside the 0-255 code-point range supported by btoa
+        body: Base64.encode(JSON.stringify(blockObjects)) // Base64 encode the json
     };
 
     return blockToImage(topBlockId)

--- a/test/unit/util/code-payload.test.js
+++ b/test/unit/util/code-payload.test.js
@@ -1,0 +1,19 @@
+jest.mock('../../../src/lib/backpack/block-to-image', () => () => Promise.resolve('block-image'));
+jest.mock('../../../src/lib/backpack/jpeg-thumbnail', () => () => Promise.resolve('thumbnail'));
+
+import codePayload from '../../../src/lib/backpack/code-payload';
+import {Base64} from 'js-base64';
+
+describe('codePayload', () => {
+    test('base64 encodes the blocks as json', () => {
+        const blocks = '☁︎❤️🐻';
+        const payload = codePayload({
+            blockObjects: blocks
+        });
+        return payload.then(p => {
+            expect(
+                JSON.parse(Base64.decode(p.body))
+            ).toEqual(blocks);
+        });
+    });
+});


### PR DESCRIPTION
Converting string to b64 via window.btoa fails on characters outside codepoints 0-255, include the "cloud" in cloud variable names

Added a unit test that failed using the previous `btoa` implementation.