### PR TITLE
correct wrong assetId prop name

### DIFF
--- a/src/containers/sprite-selector-item.jsx
+++ b/src/containers/sprite-selector-item.jsx
@@ -119,7 +119,7 @@ class SpriteSelectorItem extends React.Component {
     render () {
         const {
             /* eslint-disable no-unused-vars */
-            assetId,
+            asset,
             id,
             index,
             onClick,


### PR DESCRIPTION
Looks like https://github.com/LLK/scratch-gui/pull/3491 should have changed this old prop name, `assetId`, to `asset`