### PR TITLE
Strip nbsp to fix serializing svg on safari

### DIFF
--- a/src/containers/backpack.jsx
+++ b/src/containers/backpack.jsx
@@ -114,8 +114,9 @@ class Backpack extends React.Component {
                         contents: [item].concat(this.state.contents)
                     });
                 })
-                .catch(() => {
+                .catch(error => {
                     this.setState({error: true, loading: false});
+                    throw error;
                 });
         });
     }
@@ -133,8 +134,9 @@ class Backpack extends React.Component {
                         contents: this.state.contents.filter(o => o.id !== id)
                     });
                 })
-                .catch(() => {
+                .catch(error => {
                     this.setState({error: true, loading: false});
+                    throw error;
                 });
         });
     }
@@ -155,8 +157,9 @@ class Backpack extends React.Component {
                             loading: false
                         });
                     })
-                    .catch(() => {
+                    .catch(error => {
                         this.setState({error: true, loading: false});
+                        throw error;
                     });
             });
         }

--- a/src/lib/backpack/block-to-image.js
+++ b/src/lib/backpack/block-to-image.js
@@ -15,6 +15,9 @@ export default function (blockId) {
     // blocking the drag end from finishing promptly.
     return new Promise(resolve => {
         setTimeout(() => {
+            // Strip &nbsp; entities that cannot be inlined
+            blockSvg.innerHTML = blockSvg.innerHTML.replace(/&nbsp;/g, ' ');
+
             // Create an <svg> element to put the cloned blockSvg inside
             const NS = 'http://www.w3.org/2000/svg';
             const svg = document.createElementNS(NS, 'svg');

--- a/src/lib/backpack/jpeg-thumbnail.js
+++ b/src/lib/backpack/jpeg-thumbnail.js
@@ -1,4 +1,4 @@
-const jpegThumbnail = dataUrl => new Promise(resolve => {
+const jpegThumbnail = dataUrl => new Promise((resolve, reject) => {
     const image = new Image();
     image.onload = () => {
         const canvas = document.createElement('canvas');
@@ -13,6 +13,9 @@ const jpegThumbnail = dataUrl => new Promise(resolve => {
         ctx.drawImage(image, 0, 0);
         // TODO we can play with the `quality` option here to optimize file size
         resolve(canvas.toDataURL('image/jpeg', 0.92 /* quality */)); // Default quality is 0.92
+    };
+    image.onerror = err => {
+        reject(err);
     };
     image.src = dataUrl;
 });


### PR DESCRIPTION
Fixes the issue @thisandagain saw with safari not serializing blocks sometimes, caused by html entities not serializing properly. 

Also made errors in image loading propagate back through the promise chain so it doesn't get stuck on "loading"