### PR TITLE
Add pointer-events:none to sprite img to prevent dragging.

### DIFF
--- a/src/components/sprite-selector-item/sprite-selector-item.css
+++ b/src/components/sprite-selector-item/sprite-selector-item.css
@@ -42,6 +42,7 @@
 .sprite-image {
     margin: auto;
     user-select: none;
+    pointer-events: none;
     max-width: 32px;
     max-height: 32px;
 }


### PR DESCRIPTION
Fixes an issue @kathymakes saw where dragging sprite tiles by clicking on the image itself does not work well in firefox, because despite draggable=false on the image, it still drags :( boo firefox. 

@picklesrus I also think this could fix the angle picker on firefox problem