### PR TITLE
Fix dropdowns on backpack items being transparent

### DIFF
--- a/src/components/backpack/backpack.css
+++ b/src/components/backpack/backpack.css
@@ -71,5 +71,8 @@
 .backpack-item {
     min-width: 4rem;
     margin: 0 0.25rem;
+}
+
+.backpack-item img {
     mix-blend-mode: multiply; /* Make white transparent for thumnbnails */
 }


### PR DESCRIPTION
The blend-mode property was being set on the whole thing, rather than the image only
![image](https://user-images.githubusercontent.com/654102/47939236-f1fe6880-debc-11e8-9424-d4474faebb91.png)
