### PR TITLE
Layer extension button and monitors below block drag surface

### DIFF
--- a/src/css/z-index.css
+++ b/src/css/z-index.css
@@ -3,11 +3,12 @@
     In other words, z-index values that are "inside" a component are not added here.
     This prevents conflicts between identical z-index values in different components.
 */
+$z-index-toolbox: 40;
+$z-index-extension-button: 45;
+$z-index-monitor: 45; /* Below block drags, confined to stage, never meets extension button */
+$z-index-block-drag: 50;
 
-$z-index-extension-button: 50; /* Force extension button above the ScratchBlocks flyout */
-$z-index-menu-bar: 50; /* blocklyToolboxDiv is 40 */
-
-$z-index-monitor: 100;
+$z-index-menu-bar: 60;
 $z-index-stage-indicator: 110;
 $z-index-add-button: 120;
 $z-index-tooltip: 130; /* tooltips should go over add buttons if they overlap */

--- a/src/css/z-index.css
+++ b/src/css/z-index.css
@@ -3,15 +3,15 @@
     In other words, z-index values that are "inside" a component are not added here.
     This prevents conflicts between identical z-index values in different components.
 */
-$z-index-toolbox: 40;
-$z-index-extension-button: 45;
-$z-index-monitor: 45; /* Below block drags, confined to stage, never meets extension button */
-$z-index-block-drag: 50;
 
-$z-index-menu-bar: 60;
-$z-index-stage-indicator: 110;
-$z-index-add-button: 120;
-$z-index-tooltip: 130; /* tooltips should go over add buttons if they overlap */
+/* Toolbox z-index: 40; set in scratch-blocks */
+$z-index-menu-bar: 41;
+$z-index-extension-button: 42;
+$z-index-stage-indicator: 45;
+$z-index-add-button: 46;
+$z-index-tooltip: 47; /* tooltips should go over add buttons if they overlap */
+$z-index-monitor: 48; /* monitors go over add buttons */
+/* Block drag z-index: 50; set in scratch-blocks */
 
 $z-index-card: 490;
 $z-index-loader: 500;


### PR DESCRIPTION
![block-drag-index](https://user-images.githubusercontent.com/654102/47939607-4eae5300-debe-11e8-982e-0c33d52478ed.gif)

Fixes issue reported by @carljbowman 
> Blocks that being dragged appear below the Add buttons (e.g. Add Extensions) and monitors