### PR TITLE
Revert "Blur language select focus when mouse leaves"

### DIFF
--- a/src/components/language-selector/language-selector.jsx
+++ b/src/components/language-selector/language-selector.jsx
@@ -7,11 +7,10 @@ import styles from './language-selector.css';
 // supported languages to exclude from the menu, but allow as a URL option
 const ignore = [];
 
-const LanguageSelector = ({componentRef, currentLocale, label, onChange}) => (
+const LanguageSelector = ({currentLocale, label, onChange}) => (
     <select
         aria-label={label}
         className={styles.languageSelect}
-        ref={componentRef}
         value={currentLocale}
         onChange={onChange}
     >
@@ -31,7 +30,6 @@ const LanguageSelector = ({componentRef, currentLocale, label, onChange}) => (
 );
 
 LanguageSelector.propTypes = {
-    componentRef: PropTypes.func,
     currentLocale: PropTypes.string,
     label: PropTypes.string,
     onChange: PropTypes.func

--- a/src/containers/language-selector.jsx
+++ b/src/containers/language-selector.jsx
@@ -11,30 +11,9 @@ class LanguageSelector extends React.Component {
     constructor (props) {
         super(props);
         bindAll(this, [
-            'handleChange',
-            'handleMouseOut',
-            'ref'
+            'handleChange'
         ]);
         document.documentElement.lang = props.currentLocale;
-    }
-    componentDidMount () {
-        this.addListeners();
-    }
-
-    componentWillUnmount () {
-        this.removeListeners();
-    }
-    addListeners () {
-        this.select.addEventListener('mouseout', this.handleMouseOut);
-    }
-    removeListeners () {
-        this.select.removeEventListener('mouseout', this.handleMouseOut);
-    }
-    handleMouseOut () {
-        this.select.blur();
-    }
-    ref (c) {
-        this.select = c;
     }
     handleChange (e) {
         const newLocale = e.target.value;
@@ -52,7 +31,6 @@ class LanguageSelector extends React.Component {
         } = this.props;
         return (
             <LanguageSelectorComponent
-                componentRef={this.ref}
                 onChange={this.handleChange}
                 {...props}
             >


### PR DESCRIPTION
Reverts LLK/scratch-gui#3583
Fixes #3613 

On firefox the mouse is considered to have "left" the select element as soon as it is no longer over the select menubar item. It doesn't treat the options as being part of the select. So this change completely breaks the language selector on Firefox.

Having the language selector keep keyboard focus if you don't select a language (you have to click twice outside the menu to reset focus) seems better than not working at all on Firefox. The permanent solution is https://github.com/LLK/scratch-gui/issues/3595