### PR TITLE
hide watermark and any other overflow from tab panel

### DIFF
--- a/src/components/gui/gui.css
+++ b/src/components/gui/gui.css
@@ -172,6 +172,7 @@
     position: relative;
     flex-grow: 1;
     display: none;
+    overflow: hidden;
 }
 
 .tab-panel.is-selected {


### PR DESCRIPTION
Tiny fix to a problem I noticed, when the screen height is very low:

Before:
<img width="154" alt="screen shot 2018-11-04 at 9 22 36 pm" src="https://user-images.githubusercontent.com/3431616/47974627-7cd79280-e078-11e8-8904-a54875ba93bf.png">

After:
<img width="139" alt="screen shot 2018-11-04 at 9 22 42 pm" src="https://user-images.githubusercontent.com/3431616/47974630-8103b000-e078-11e8-9c7d-031ab4d3ba93.png">

FYI, somewhat related: https://github.com/LLK/scratch-gui/issues/3449