### PR TITLE
don't require onActivatedBlocksTab prop in TargetPane container

### DIFF
--- a/src/containers/target-pane.jsx
+++ b/src/containers/target-pane.jsx
@@ -231,6 +231,7 @@ class TargetPane extends React.Component {
 
 const {
     onSelectSprite, // eslint-disable-line no-unused-vars
+    onActivateBlocksTab, // eslint-disable-line no-unused-vars
     ...targetPaneProps
 } = TargetPaneComponent.propTypes;
 


### PR DESCRIPTION
This gets rid of a React console warning introduced by https://github.com/LLK/scratch-gui/pull/3596 .

Note that the proptypes inheritance that was put in place in `containers/target-pane.jsx` two years ago -- where the container duplicates its presentation component's proptypes -- is very confusing to me. I suspect this approach makes mistakes inevitable, and it seems to me to already include a dozen or two unused proptypes declarations.