### PR TITLE
Fix adding extension blocks from the backpack

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -414,8 +414,8 @@ class Blocks extends React.Component {
     handleDrop (dragInfo) {
         fetch(dragInfo.payload.bodyUrl)
             .then(response => response.json())
-            .then(blocks => {
-                this.props.vm.shareBlocksToTarget(blocks, this.props.vm.editingTarget.id);
+            .then(blocks => this.props.vm.shareBlocksToTarget(blocks, this.props.vm.editingTarget.id))
+            .then(() => {
                 this.props.vm.refreshWorkspace();
             });
     }


### PR DESCRIPTION
Wait for `vm.shareBlocksToTarget` before refreshing the workspace, so do not request a workspace refresh until after the sharing is completed.

@kchadha this does not strictly depend on https://github.com/LLK/scratch-vm/pull/1727, but will be needed once that is merged.
