### PR TITLE
Add basic "show more" pagination for the backpack

### DIFF
--- a/src/components/backpack/backpack.css
+++ b/src/components/backpack/backpack.css
@@ -76,3 +76,16 @@
 .backpack-item img {
     mix-blend-mode: multiply; /* Make white transparent for thumnbnails */
 }
+
+.more {
+    background: $motion-primary;
+    color: $ui-white;
+    border: none;
+    outline: none;
+    font-weight: bold;
+    border-radius: 0.5rem;
+    font-size: 0.85rem;
+    padding: 0.5rem;
+    margin: 0.5rem;
+    cursor: pointer;
+}

--- a/src/components/backpack/backpack.jsx
+++ b/src/components/backpack/backpack.jsx
@@ -25,10 +25,12 @@ const Backpack = ({
     error,
     expanded,
     loading,
+    showMore,
     onToggle,
     onDelete,
     onMouseEnter,
-    onMouseLeave
+    onMouseLeave,
+    onMore
 }) => (
     <div className={styles.backpackContainer}>
         <div
@@ -98,6 +100,18 @@ const Backpack = ({
                                         onDeleteButtonClick={onDelete}
                                     />
                                 ))}
+                                {showMore && (
+                                    <button
+                                        className={styles.more}
+                                        onClick={onMore}
+                                    >
+                                        <FormattedMessage
+                                            defaultMessage="More"
+                                            description="Load more from backpack"
+                                            id="gui.backpack.more"
+                                        />
+                                    </button>
+                                )}
                             </div>
                         ) : (
                             <div className={styles.statusMessage}>
@@ -129,6 +143,7 @@ Backpack.propTypes = {
     expanded: PropTypes.bool,
     loading: PropTypes.bool,
     onDelete: PropTypes.func,
+    onMore: PropTypes.func,
     onMouseEnter: PropTypes.func,
     onMouseLeave: PropTypes.func,
     onToggle: PropTypes.func
@@ -140,6 +155,8 @@ Backpack.defaultProps = {
     dragOver: false,
     expanded: false,
     loading: false,
+    showMore: false,
+    onMore: null,
     onToggle: null
 };
 

--- a/src/components/backpack/backpack.jsx
+++ b/src/components/backpack/backpack.jsx
@@ -146,7 +146,8 @@ Backpack.propTypes = {
     onMore: PropTypes.func,
     onMouseEnter: PropTypes.func,
     onMouseLeave: PropTypes.func,
-    onToggle: PropTypes.func
+    onToggle: PropTypes.func,
+    showMore: PropTypes.bool
 };
 
 Backpack.defaultProps = {

--- a/src/lib/backpack-api.js
+++ b/src/lib/backpack-api.js
@@ -4,6 +4,14 @@ import soundPayload from './backpack/sound-payload';
 import spritePayload from './backpack/sprite-payload';
 import codePayload from './backpack/code-payload';
 
+// Add a new property for the full thumbnail url, which includes the host.
+// Also include a full body url for loading sprite zips
+// TODO retreiving the images through storage would allow us to remove this.
+const includeFullUrls = (item, host) => Object.assign({}, item, {
+    thumbnailUrl: `${host}/${item.thumbnail}`,
+    bodyUrl: `${host}/${item.body}`
+});
+
 const getBackpackContents = ({
     host,
     username,
@@ -20,15 +28,7 @@ const getBackpackContents = ({
         if (error || response.statusCode !== 200) {
             return reject();
         }
-        // Add a new property for the full thumbnail url, which includes the host.
-        // Also include a full body url for loading sprite zips
-        // TODO retreiving the images through storage would allow us to remove this.
-        return resolve(response.body.map(item => (
-            Object.assign({}, item, {
-                thumbnailUrl: `${host}/${item.thumbnail}`,
-                bodyUrl: `${host}/${item.body}`
-            })
-        )));
+        return resolve(response.body.map(item => includeFullUrls(item, host)));
     });
 });
 
@@ -51,7 +51,7 @@ const saveBackpackObject = ({
         if (error || response.statusCode !== 200) {
             return reject();
         }
-        return resolve(response.body);
+        return resolve(includeFullUrls(response.body, host));
     });
 });
 


### PR DESCRIPTION
Load more than just the first page of backpack items! A "show more" button will be shown, using the same heuristic from the comments page (if you have loaded a whole "page" of results, assume there is another page after to load.

There is also a change to the way deleted/inserted items are handled: instead of trying to reload the whole backpack after each modification, just make the single modification to the list we know is needed. This prevents those operations from interfering with the pagination.