### PR TITLE
automatically save on navigating from page; hide share and community buttons while creating

### DIFF
--- a/src/components/menu-bar/community-button.css
+++ b/src/components/menu-bar/community-button.css
@@ -1,0 +1,9 @@
+@import "../../css/colors.css";
+
+.community-button {
+    box-shadow: 0 0 0 1px $ui-black-transparent;
+}
+
+.community-button-icon {
+    height: 1.25rem;
+}

--- a/src/components/menu-bar/community-button.jsx
+++ b/src/components/menu-bar/community-button.jsx
@@ -1,0 +1,40 @@
+import classNames from 'classnames';
+import {FormattedMessage} from 'react-intl';
+import PropTypes from 'prop-types';
+import React from 'react';
+import Button from '../button/button.jsx';
+
+import communityIcon from './icon--see-community.svg';
+import styles from './community-button.css';
+
+const CommunityButton = ({
+    className,
+    onClick
+}) => (
+    <Button
+        className={classNames(
+            className,
+            styles.communityButton
+        )}
+        iconClassName={styles.communityButtonIcon}
+        iconSrc={communityIcon}
+        onClick={onClick}
+    >
+        <FormattedMessage
+            defaultMessage="See Community"
+            description="Label for see community button"
+            id="gui.menuBar.seeCommunity"
+        />
+    </Button>
+);
+
+CommunityButton.propTypes = {
+    className: PropTypes.string,
+    onClick: PropTypes.func
+};
+
+CommunityButton.defaultProps = {
+    onClick: () => {}
+};
+
+export default CommunityButton;

--- a/src/components/menu-bar/menu-bar.css
+++ b/src/components/menu-bar/menu-bar.css
@@ -130,22 +130,6 @@
     height: 2rem;
 }
 
-.share-button {
-    background: $data-primary;
-}
-
-.share-button-is-shared {
-    background: $ui-black-transparent;
-}
-
-.community-button {
-    box-shadow: 0 0 0 1px $ui-black-transparent;
-}
-
-.community-button-icon {
-    height: 1.25rem;
-}
-
 .remix-button {
     background-color: $pen-primary
 }

--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -7,10 +7,13 @@ import React from 'react';
 
 import Box from '../box/box.jsx';
 import Button from '../button/button.jsx';
+import CommunityButton from './community-button.jsx';
+import ShareButton from './share-button.jsx';
 import {ComingSoonTooltip} from '../coming-soon/coming-soon.jsx';
 import Divider from '../divider/divider.jsx';
 import LanguageSelector from '../../containers/language-selector.jsx';
 import SBFileUploader from '../../containers/sb-file-uploader.jsx';
+import ProjectWatcher from '../../containers/project-watcher.jsx';
 import MenuBarMenu from './menu-bar-menu.jsx';
 import {MenuItem, MenuSection} from '../menu/menu.jsx';
 import ProjectTitleInput from './project-title-input.jsx';
@@ -54,7 +57,6 @@ import helpIcon from '../../lib/assets/icon--tutorials.svg';
 import mystuffIcon from './icon--mystuff.png';
 import feedbackIcon from './icon--feedback.svg';
 import profileIcon from './icon--profile.png';
-import communityIcon from './icon--see-community.svg';
 import remixIcon from './icon--remix.svg';
 import dropdownCaret from './dropdown-caret.svg';
 import languageIcon from '../language-selector/language-icon.svg';
@@ -136,6 +138,8 @@ class MenuBar extends React.Component {
             'handleClickRemix',
             'handleClickSave',
             'handleClickSaveAsCopy',
+            'handleClickSeeCommunity',
+            'handleClickShare',
             'handleCloseFileMenuAndThen',
             'handleLanguageMouseUp',
             'handleRestoreOption',
@@ -164,6 +168,21 @@ class MenuBar extends React.Component {
     handleClickSaveAsCopy () {
         this.props.onClickSaveAsCopy();
         this.props.onRequestCloseFile();
+    }
+    handleClickSeeCommunity (requestSeeCommunity) {
+        if (this.props.canSave) { // save before transitioning to project page
+            this.props.onClickSave();
+        }
+        requestSeeCommunity(); // queue the transition to project page
+    }
+    handleClickShare (requestSeeCommunity) {
+        if (this.props.canSave && !this.props.isShared) { // save before transitioning to project page
+            this.props.onClickSave();
+        }
+        if (this.props.canShare && !this.props.isShared) { // save before transitioning to project page
+            this.props.onShare();
+            requestSeeCommunity(); // queue the transition to project page
+        }
     }
     handleRestoreOption (restoreFun) {
         return () => {
@@ -239,32 +258,6 @@ class MenuBar extends React.Component {
                 description="Menu bar item for creating a new project"
                 id="gui.menuBar.new"
             />
-        );
-        const shareMessage = (
-            <FormattedMessage
-                defaultMessage="Share"
-                description="Label for project share button"
-                id="gui.menuBar.share"
-            />
-        );
-        const isSharedMessage = (
-            <FormattedMessage
-                defaultMessage="Shared"
-                description="Label for shared project"
-                id="gui.menuBar.isShared"
-            />
-        );
-        const shareButton = (
-            <Button
-                className={classNames(
-                    styles.menuBarButton,
-                    styles.shareButton,
-                    {[styles.shareButtonIsShared]: this.props.isShared}
-                )}
-                onClick={this.props.onShare}
-            >
-                {this.props.isShared ? isSharedMessage : shareMessage}
-            </Button>
         );
         const remixButton = (
             <Button
@@ -467,10 +460,30 @@ class MenuBar extends React.Component {
                         </MenuBarItemTooltip>
                     </div>
                     <div className={classNames(styles.menuBarItem)}>
-                        {this.props.canShare ? shareButton : (
+                        {this.props.canShare ? (
+                            (this.props.isShowingProject || this.props.isUpdating) && (
+                                <ProjectWatcher
+                                    onShowingWithId={this.props.onSeeCommunity}
+                                >
+                                    {
+                                        setRequesting => (
+                                            <ShareButton
+                                                className={styles.menuBarButton}
+                                                isShared={this.props.isShared}
+                                                /* eslint-disable react/jsx-no-bind */
+                                                onClick={() => {
+                                                    this.handleClickShare(setRequesting);
+                                                }}
+                                                /* eslint-enable react/jsx-no-bind */
+                                            />
+                                        )
+                                    }
+                                </ProjectWatcher>
+                            )
+                        ) : (
                             this.props.showComingSoon ? (
                                 <MenuBarItemTooltip id="share-button">
-                                    {shareButton}
+                                    <ShareButton className={styles.menuBarButton} />
                                 </MenuBarItemTooltip>
                             ) : []
                         )}
@@ -478,37 +491,27 @@ class MenuBar extends React.Component {
                     </div>
                     <div className={classNames(styles.menuBarItem, styles.communityButtonWrapper)}>
                         {this.props.enableCommunity ? (
-                            <Button
-                                className={classNames(
-                                    styles.menuBarButton,
-                                    styles.communityButton
-                                )}
-                                iconClassName={styles.communityButtonIcon}
-                                iconSrc={communityIcon}
-                                onClick={this.props.onSeeCommunity}
-                            >
-                                <FormattedMessage
-                                    defaultMessage="See Community"
-                                    description="Label for see community button"
-                                    id="gui.menuBar.seeCommunity"
-                                />
-                            </Button>
+                            (this.props.isShowingProject || this.props.isUpdating) && (
+                                <ProjectWatcher
+                                    onShowingWithId={this.props.onSeeCommunity}
+                                >
+                                    {
+                                        setRequesting => (
+                                            <CommunityButton
+                                                className={styles.menuBarButton}
+                                                /* eslint-disable react/jsx-no-bind */
+                                                onClick={() => {
+                                                    this.handleClickSeeCommunity(setRequesting);
+                                                }}
+                                                /* eslint-enable react/jsx-no-bind */
+                                            />
+                                        )
+                                    }
+                                </ProjectWatcher>
+                            )
                         ) : (this.props.showComingSoon ? (
                             <MenuBarItemTooltip id="community-button">
-                                <Button
-                                    className={classNames(
-                                        styles.menuBarButton,
-                                        styles.communityButton
-                                    )}
-                                    iconClassName={styles.communityButtonIcon}
-                                    iconSrc={communityIcon}
-                                >
-                                    <FormattedMessage
-                                        defaultMessage="See Community"
-                                        description="Label for see community button"
-                                        id="gui.menuBar.seeCommunity"
-                                    />
-                                </Button>
+                                <CommunityButton className={styles.menuBarButton} />
                             </MenuBarItemTooltip>
                         ) : [])}
                     </div>

--- a/src/components/menu-bar/share-button.css
+++ b/src/components/menu-bar/share-button.css
@@ -1,0 +1,10 @@
+@import "../../css/colors.css";
+
+.share-button {
+    background: $data-primary;
+}
+
+.share-button-is-shared {
+    background: $ui-black-transparent;
+    cursor: default;
+}

--- a/src/components/menu-bar/share-button.jsx
+++ b/src/components/menu-bar/share-button.jsx
@@ -1,0 +1,48 @@
+import classNames from 'classnames';
+import {FormattedMessage} from 'react-intl';
+import PropTypes from 'prop-types';
+import React from 'react';
+import Button from '../button/button.jsx';
+
+import styles from './share-button.css';
+
+const ShareButton = ({
+    className,
+    isShared,
+    onClick
+}) => (
+    <Button
+        className={classNames(
+            className,
+            styles.shareButton,
+            {[styles.shareButtonIsShared]: isShared}
+        )}
+        onClick={onClick}
+    >
+        {isShared ? (
+            <FormattedMessage
+                defaultMessage="Shared"
+                description="Label for shared project"
+                id="gui.menuBar.isShared"
+            />
+        ) : (
+            <FormattedMessage
+                defaultMessage="Share"
+                description="Label for project share button"
+                id="gui.menuBar.share"
+            />
+        )}
+    </Button>
+);
+
+ShareButton.propTypes = {
+    className: PropTypes.string,
+    isShared: PropTypes.bool,
+    onClick: PropTypes.func
+};
+
+ShareButton.defaultProps = {
+    onClick: () => {}
+};
+
+export default ShareButton;

--- a/src/containers/project-watcher.jsx
+++ b/src/containers/project-watcher.jsx
@@ -1,0 +1,64 @@
+import bindAll from 'lodash.bindall';
+import PropTypes from 'prop-types';
+import React from 'react';
+import {connect} from 'react-redux';
+
+import {
+    getIsShowingWithId
+} from '../reducers/project-state';
+
+class ProjectWatcher extends React.Component {
+    constructor (props) {
+        super(props);
+        bindAll(this, [
+            'setRequesting'
+        ]);
+
+        this.state = {
+            requesting: false
+        };
+    }
+    componentDidUpdate (prevProps) {
+        if (this.state.requesting && this.props.isShowingWithId && !prevProps.isShowingWithId) {
+            this.props.onShowingWithId();
+            this.setState({ // eslint-disable-line react/no-did-update-set-state
+                requesting: false
+            });
+        }
+
+    }
+    setRequesting () {
+        this.setState({
+            requesting: true
+        });
+    }
+    render () {
+        return this.props.children(
+            this.setRequesting
+        );
+    }
+}
+
+ProjectWatcher.propTypes = {
+    children: PropTypes.func,
+    isShowingWithId: PropTypes.bool,
+    onShowingWithId: PropTypes.func
+};
+
+ProjectWatcher.defaultProps = {
+    onShowingWithId: () => {}
+};
+
+const mapStateToProps = state => {
+    const loadingState = state.scratchGui.projectState.loadingState;
+    return {
+        isShowingWithId: getIsShowingWithId(loadingState)
+    };
+};
+
+const mapDispatchToProps = () => {};
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(ProjectWatcher);


### PR DESCRIPTION
This mostly resolves https://github.com/LLK/scratch-www/issues/2278

This change makes it so that:
* clicking the Share button triggers a save; once the save completes, user is navigated to the project page
* clicking the See Community button triggers a save; once the save completes, user is navigated to the project page
* navigating away from your project in any other way triggers a save (though this may not complete; it's unclear how effective this is); and
* Share and Community buttons are hidden while project fetching, project loading, and project creation happen (they are shown when the project is showing normally, or when saving)

The biggest outstanding problems are:
* navigating away can't be totally stopped until the save request is sent. So clicking "My Stuff" or the Scratch logo may not send the save request in time before javascript on the page is completely stopped.
* when you do a more complex action that involves saving/creation, such as creating a new project, saving as a copy, or remixing, and you navigate away before that operation has finished (not so unrealistic, on slow connections), you can get into weird states. I somewhat avoid these by hiding the Share and Community buttons while these operations are happening. 

(Of course, there are other ways to navigate away! But since Share and Community will show you the Project Page, these are the ones that can get you into an unexpected state with respect to what's loaded in the vm.)

I wrote up the outstanding problems at: https://github.com/LLK/scratch-gui/issues/3639
