### PR TITLE
when user clickes File->New, only save if user can save

### DIFF
--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -150,12 +150,13 @@ class MenuBar extends React.Component {
         }
     }
     handleClickNew () {
-        // if canCreateNew===true, it's safe to replace current project, since we will auto-save first.
+        // if canSave===true, it's safe to replace current project, since we will auto-save first.
         // else confirm first.
-        const readyToReplaceProject = this.props.canCreateNew ||
+        const readyToReplaceProject = this.props.canSave ||
             confirm('Replace contents of the current project?'); // eslint-disable-line no-alert
+        this.props.onRequestCloseFile();
         if (readyToReplaceProject) {
-            this.props.onClickNew(this.props.canCreateNew);
+            this.props.onClickNew(this.props.canSave && this.props.canCreateNew);
         }
     }
     handleClickRemix () {
@@ -752,7 +753,7 @@ const mapDispatchToProps = dispatch => ({
     onRequestCloseLanguage: () => dispatch(closeLanguageMenu()),
     onClickLogin: () => dispatch(openLoginMenu()),
     onRequestCloseLogin: () => dispatch(closeLoginMenu()),
-    onClickNew: canCreateNew => dispatch(requestNewProject(canCreateNew)),
+    onClickNew: needSave => dispatch(requestNewProject(needSave)),
     onClickRemix: () => dispatch(remixProject()),
     onClickSave: () => dispatch(updateProject()),
     onClickSaveAsCopy: () => dispatch(saveProjectAsCopy()),

--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -150,9 +150,9 @@ class MenuBar extends React.Component {
         }
     }
     handleClickNew () {
-        // if canSave===true, it's safe to replace current project, since we will auto-save first.
-        // else confirm first.
-        const readyToReplaceProject = this.props.canSave ||
+        // if canSave===true and canCreateNew===true, it's safe to replace current project,
+        // since we will auto-save first. Else, confirm first.
+        const readyToReplaceProject = (this.props.canSave && this.props.canCreateNew) ||
             confirm('Replace contents of the current project?'); // eslint-disable-line no-alert
         this.props.onRequestCloseFile();
         if (readyToReplaceProject) {

--- a/src/reducers/project-state.js
+++ b/src/reducers/project-state.js
@@ -379,8 +379,8 @@ const setProjectId = id => ({
     projectId: id
 });
 
-const requestNewProject = canCreateNew => {
-    if (canCreateNew) return {type: START_UPDATING_BEFORE_CREATING_NEW};
+const requestNewProject = needSave => {
+    if (needSave) return {type: START_UPDATING_BEFORE_CREATING_NEW};
     return {type: START_FETCHING_NEW};
 };
 


### PR DESCRIPTION
### Resolves

- Resolves #3615 

### Proposed Changes

Instead of using `canCreateNew` to decide whether or not to save current project when you click `File->New`, use `canSave && canCreateNew`.

### Reason for Changes

Saving the current project is bad (or trying) when you do not own the current project!

### Test coverage

Not sure how to test this?