### PR TITLE
Fix problem with updating cloud vars to zero.

### DIFF
--- a/src/lib/cloud-provider.js
+++ b/src/lib/cloud-provider.js
@@ -79,10 +79,13 @@ class CloudProvider {
         msg.user = this.username;
         msg.project_id = this.projectId;
 
+        // Optional string params can use simple falsey undefined check
         if (dataName) msg.name = dataName;
-        if (dataValue) msg.value = dataValue;
-        if (dataIndex) msg.index = dataIndex;
         if (dataNewName) msg.new_name = dataNewName;
+
+        // Optional number params need different undefined check
+        if (typeof dataValue !== 'undefined') msg.value = dataValue;
+        if (typeof dataValue !== 'undefined') msg.index = dataIndex;
 
         const dataToWrite = JSON.stringify(msg);
         this.sendCloudData(dataToWrite);

--- a/test/unit/util/cloud-provider.test.js
+++ b/test/unit/util/cloud-provider.test.js
@@ -1,0 +1,44 @@
+import CloudProvider from '../../../src/lib/cloud-provider';
+
+// Disable window.WebSocket
+global.WebSocket = null;
+
+describe('CloudProvider', () => {
+    let cloudProvider = null;
+    let sentMessage = null;
+
+    beforeEach(() => {
+        cloudProvider = new CloudProvider();
+        // Stub connection
+        cloudProvider.connection = {
+            send: msg => {
+                sentMessage = msg;
+            }
+        };
+    });
+
+    test('updateVariable', () => {
+        cloudProvider.updateVariable('hello', 1);
+        const obj = JSON.parse(sentMessage);
+        expect(obj.method).toEqual('set');
+        expect(obj.name).toEqual('hello');
+        expect(obj.value).toEqual(1);
+    });
+
+    test('updateVariable with falsey value', () => {
+        cloudProvider.updateVariable('hello', 0);
+        const obj = JSON.parse(sentMessage);
+        expect(obj.method).toEqual('set');
+        expect(obj.name).toEqual('hello');
+        expect(obj.value).toEqual(0);
+    });
+
+    test('writeToServer with falsey index value', () => {
+        cloudProvider.writeToServer('method', 'name', 5, 0);
+        const obj = JSON.parse(sentMessage);
+        expect(obj.method).toEqual('method');
+        expect(obj.name).toEqual('name');
+        expect(obj.value).toEqual(5);
+        expect(obj.index).toEqual(0);
+    });
+});


### PR DESCRIPTION
Fixes an issue where you cant set a cloud variable to zero, it shows up as undefined in 2.0 client. 

Added a unit test and covered the other case (not used) where you might be trying to update the index zero of a list.

On https://github.com/LLK/scratch-gui/issues/3647