### PR TITLE
removed save and save copy from beta; better menu section style handling

### DIFF
--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -337,37 +337,25 @@ class MenuBar extends React.Component {
                                 place={this.props.isRtl ? 'left' : 'right'}
                                 onRequestClose={this.props.onRequestCloseFile}
                             >
-                                <MenuItem
-                                    isRtl={this.props.isRtl}
-                                    onClick={this.handleClickNew}
-                                >
-                                    {newProjectMessage}
-                                </MenuItem>
+                                <MenuSection>
+                                    <MenuItem
+                                        isRtl={this.props.isRtl}
+                                        onClick={this.handleClickNew}
+                                    >
+                                        {newProjectMessage}
+                                    </MenuItem>
+                                </MenuSection>
                                 <MenuSection>
                                     {this.props.canSave ? (
                                         <MenuItem onClick={this.handleClickSave}>
                                             {saveNowMessage}
                                         </MenuItem>
-                                    ) : (this.props.showComingSoon ? (
-                                        <MenuItemTooltip
-                                            id="save"
-                                            isRtl={this.props.isRtl}
-                                        >
-                                            <MenuItem>{saveNowMessage}</MenuItem>
-                                        </MenuItemTooltip>
-                                    ) : [])}
+                                    ) : []}
                                     {this.props.canCreateCopy ? (
                                         <MenuItem onClick={this.handleClickSaveAsCopy}>
                                             {createCopyMessage}
                                         </MenuItem>
-                                    ) : (this.props.showComingSoon ? (
-                                        <MenuItemTooltip
-                                            id="copy"
-                                            isRtl={this.props.isRtl}
-                                        >
-                                            <MenuItem>{createCopyMessage}</MenuItem>
-                                        </MenuItemTooltip>
-                                    ) : [])}
+                                    ) : []}
                                     {this.props.canRemix ? (
                                         <MenuItem onClick={this.handleClickRemix}>
                                             {remixMessage}
@@ -376,8 +364,9 @@ class MenuBar extends React.Component {
                                 </MenuSection>
                                 <MenuSection>
                                     <SBFileUploader onUpdateProjectTitle={this.props.onUpdateProjectTitle}>
-                                        {(renderFileInput, loadProject) => (
+                                        {(className, renderFileInput, loadProject) => (
                                             <MenuItem
+                                                className={className}
                                                 onClick={loadProject}
                                             >
                                                 <FormattedMessage
@@ -391,8 +380,9 @@ class MenuBar extends React.Component {
                                             </MenuItem>
                                         )}
                                     </SBFileUploader>
-                                    <SB3Downloader>{downloadProject => (
+                                    <SB3Downloader>{(className, downloadProject) => (
                                         <MenuItem
+                                            className={className}
                                             onClick={this.handleCloseFileMenuAndThen(downloadProject)}
                                         >
                                             <FormattedMessage

--- a/src/components/menu/menu.jsx
+++ b/src/components/menu/menu.jsx
@@ -55,9 +55,10 @@ MenuItem.propTypes = {
 
 const addDividerClassToFirstChild = (child, id) => (
     React.cloneElement(child, {
-        className: classNames(child.className, {
-            [styles.menuSection]: id === 0
-        }),
+        className: classNames(
+            {[styles.menuSection]: id === 0},
+            child.className
+        ),
         key: id
     })
 );

--- a/src/components/menu/menu.jsx
+++ b/src/components/menu/menu.jsx
@@ -56,8 +56,8 @@ MenuItem.propTypes = {
 const addDividerClassToFirstChild = (child, id) => (
     React.cloneElement(child, {
         className: classNames(
-            {[styles.menuSection]: id === 0},
-            child.className
+            child.className,
+            {[styles.menuSection]: id === 0}
         ),
         key: id
     })

--- a/src/containers/sb-file-uploader.jsx
+++ b/src/containers/sb-file-uploader.jsx
@@ -107,13 +107,14 @@ class SBFileUploader extends React.Component {
         );
     }
     render () {
-        return this.props.children(this.renderFileInput, this.handleClick);
+        return this.props.children(this.props.className, this.renderFileInput, this.handleClick);
     }
 }
 
 SBFileUploader.propTypes = {
     canSave: PropTypes.bool, // eslint-disable-line react/no-unused-prop-types
     children: PropTypes.func,
+    className: PropTypes.string,
     intl: intlShape.isRequired,
     loadingState: PropTypes.oneOf(LoadingStates),
     onLoadingFinished: PropTypes.func,
@@ -122,6 +123,9 @@ SBFileUploader.propTypes = {
     vm: PropTypes.shape({
         loadProject: PropTypes.func
     })
+};
+SBFileUploader.defaultProps = {
+    className: ''
 };
 const mapStateToProps = state => ({
     loadingState: state.scratchGui.projectState.loadingState,

--- a/src/containers/sb3-downloader.jsx
+++ b/src/containers/sb3-downloader.jsx
@@ -52,6 +52,7 @@ class SB3Downloader extends React.Component {
             children
         } = this.props;
         return children(
+            this.props.className,
             this.downloadProject
         );
     }
@@ -67,9 +68,13 @@ const getProjectFilename = (curTitle, defaultTitle) => {
 
 SB3Downloader.propTypes = {
     children: PropTypes.func,
+    className: PropTypes.string,
     onSaveFinished: PropTypes.func,
     projectFilename: PropTypes.string,
     saveProjectSb3: PropTypes.func
+};
+SB3Downloader.defaultProps = {
+    className: ''
 };
 
 const mapStateToProps = state => ({

--- a/test/integration/menu-bar.test.js
+++ b/test/integration/menu-bar.test.js
@@ -31,25 +31,24 @@ describe('Menu bar settings', () => {
         await findByXpath('//*[li[span[text()="New"]] and not(@data-tip="tooltip")]');
     });
 
-    test('File->Save now should NOT be enabled', async () => {
+    test('File->Upload should be enabled', async () => {
         await loadUri(uri);
         await clickXpath('//button[@title="Try It"]');
         await clickXpath(
             '//div[contains(@class, "menu-bar_menu-bar-item") and ' +
             'contains(@class, "menu-bar_hoverable")][span[text()="File"]]'
         );
-        await findByXpath('//*[li[span[text()="Save now"]] and @data-tip="tooltip"]');
+        await findByXpath('//*[li[span[text()="Upload from your computer"]] and not(@data-tip="tooltip")]');
     });
 
-
-    test('File->Save as a copy should NOT be enabled', async () => {
+    test('File->Download should be enabled', async () => {
         await loadUri(uri);
         await clickXpath('//button[@title="Try It"]');
         await clickXpath(
             '//div[contains(@class, "menu-bar_menu-bar-item") and ' +
             'contains(@class, "menu-bar_hoverable")][span[text()="File"]]'
         );
-        await findByXpath('//*[li[span[text()="Save as a copy"]] and @data-tip="tooltip"]');
+        await findByXpath('//*[li[span[text()="Download to your computer"]] and not(@data-tip="tooltip")]');
     });
 
     test('Share button should NOT be enabled', async () => {


### PR DESCRIPTION
### Resolves

- Resolves #3617 

### Proposed Changes

* removes save and save copy from beta
* better menu section style handling, so that there is still a menu divider

### Reason for Changes

A disabled Save and Save copy make it seem like you can't save, and make users not realize that upload and download are how to "save"

