### PR TITLE
Use target id in volume reporter block

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "scratch-render": "0.1.0-prerelease.20181029125804",
     "scratch-storage": "1.1.0",
     "scratch-svg-renderer": "0.2.0-prerelease.20181024192149",
-    "scratch-vm": "0.2.0-prerelease.20181101222423",
+    "scratch-vm": "0.2.0-prerelease.20181106161946",
     "selenium-webdriver": "3.6.0",
     "startaudiocontext": "1.2.1",
     "style-loader": "^0.23.0",

--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -312,7 +312,7 @@ const sound = function (isStage, targetId) {
                 </shadow>
             </value>
         </block>
-        <block id="volume" type="sound_volume"/>
+        <block id="${targetId}_volume" type="sound_volume"/>
         ${categorySeparator}
     </category>
     `;


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-gui/issues/3656

Depends on https://github.com/LLK/scratch-vm/pull/1730

### Proposed Changes

Use the target id on the volume reporter block.

### Reason for Changes

This is necessary to correctly show the sprite-specific volume monitor.