### PR TITLE
Fix monitor labels for (current [v year]) block.

### DIFF
--- a/src/lib/opcode-labels.js
+++ b/src/lib/opcode-labels.js
@@ -210,7 +210,7 @@ class OpcodeLabels {
         this._opcodeMap.sensing_loudness.labelFn = () => this._translator(messages.sensing_loudness);
         this._opcodeMap.sensing_username.labelFn = () => this._translator(messages.sensing_username);
         this._opcodeMap.sensing_current.labelFn = params => {
-            switch (params.CURRENTMENU) {
+            switch (params.CURRENTMENU.toLowerCase()) {
             case 'year':
                 return this._translator(messages.sensing_current_year);
             case 'month':


### PR DESCRIPTION
### Resolves

Fixes a regression introduced by #3320 where the monitor labels for the `(current [v year])` block wasn't displaying.

### Proposed Changes

The sensing_current block has its field values in all caps. The changes in #3320 were no longer calling toLowerCase on them before matching on it.

### Reason for Changes

The monitor label for that block (with all its various arguments) is currently broken.

### Test Coverage

Tested manually.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [x] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome

cc/ @paulkaplan, @picklesrus 