### PR TITLE
Start Gui with Tutorials Library open

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import GUI from './containers/gui.jsx';
 import AppStateHOC from './lib/app-state-hoc.jsx';
-import GuiReducer, {guiInitialState, guiMiddleware, initFullScreen, initPlayer} from './reducers/gui';
+import {detectTutorialId} from './lib/tutorial-from-url';
+import GuiReducer, {guiInitialState, guiMiddleware, initFullScreen, initPlayer, initTutorialCard} from './reducers/gui';
 import LocalesReducer, {localesInitialState, initLocale} from './reducers/locales';
 import {ScratchPaintReducer} from 'scratch-paint';
 import {setFullScreen, setPlayer} from './reducers/mode';
@@ -24,5 +25,7 @@ export {
     initLocale,
     localesInitialState,
     setFullScreen,
-    setPlayer
+    setPlayer,
+    detectTutorialId,
+    initTutorialCard
 };

--- a/src/lib/app-state-hoc.jsx
+++ b/src/lib/app-state-hoc.jsx
@@ -70,7 +70,7 @@ const AppStateHOC = function (WrappedComponent, localesOnly) {
                     if (tutorialId !== null) {
                         // When loading a tutorial from the URL,
                         // load w/o preview modal
-                        // open requested tutorial card or tutorials mocal for 'all'
+                        // open requested tutorial card or tutorials library modal for 'all'
                         if (tutorialId === 'all') {
                             initializedGui = initTutorialLibrary(initializedGui);
                         } else {

--- a/src/lib/app-state-hoc.jsx
+++ b/src/lib/app-state-hoc.jsx
@@ -52,7 +52,8 @@ const AppStateHOC = function (WrappedComponent, localesOnly) {
                     guiMiddleware,
                     initFullScreen,
                     initPlayer,
-                    initTutorialCard
+                    initTutorialCard,
+                    initTutorialLibrary
                 } = guiRedux;
                 const {ScratchPaintReducer} = require('scratch-paint');
 
@@ -69,8 +70,12 @@ const AppStateHOC = function (WrappedComponent, localesOnly) {
                     if (tutorialId !== null) {
                         // When loading a tutorial from the URL,
                         // load w/o preview modal
-                        // open requested tutorial card
-                        initializedGui = initTutorialCard(initializedGui, tutorialId);
+                        // open requested tutorial card or tutorials mocal for 'all'
+                        if (tutorialId === 'all') {
+                            initializedGui = initTutorialLibrary(initializedGui);
+                        } else {
+                            initializedGui = initTutorialCard(initializedGui, tutorialId);
+                        }
                     }
                 }
                 reducers = {

--- a/src/lib/tutorial-from-url.js
+++ b/src/lib/tutorial-from-url.js
@@ -40,6 +40,7 @@ const detectTutorialId = () => {
         queryParams.tutorial[0] :
         queryParams.tutorial;
     if (typeof tutorialID === 'undefined') return null;
+    if (tutorialID === 'all') return tutorialID;
     return getDeckIdFromUrlId(tutorialID);
 };
 

--- a/src/reducers/gui.js
+++ b/src/reducers/gui.js
@@ -96,6 +96,19 @@ const initTutorialCard = function (currentState, deckId) {
     );
 };
 
+const initTutorialLibrary = function (currentState) {
+    return Object.assign(
+        {},
+        currentState,
+        {
+            modals: {
+                previewInfo: false,
+                tipsLibrary: true
+            }
+        }
+    );
+};
+
 const guiReducer = combineReducers({
     alerts: alertsReducer,
     assetDrag: assetDragReducer,
@@ -128,5 +141,6 @@ export {
     guiMiddleware,
     initFullScreen,
     initPlayer,
-    initTutorialCard
+    initTutorialCard,
+    initTutorialLibrary
 };

--- a/test/integration/tutorials-shortcut.test.js
+++ b/test/integration/tutorials-shortcut.test.js
@@ -1,0 +1,32 @@
+import path from 'path';
+import SeleniumHelper from '../helpers/selenium-helper';
+
+const {
+    clickText,
+    findByXpath,
+    getDriver,
+    loadUri
+} = new SeleniumHelper();
+
+const uri = path.resolve(__dirname, '../../build/index.html?tutorial=all');
+
+let driver;
+
+describe('Working with shortcut to Tutorials library', () => {
+    beforeAll(() => {
+        driver = getDriver();
+    });
+
+    afterAll(async () => {
+        await driver.quit();
+    });
+
+    test('opens with the Tutorial Library showing', async () => {
+        await loadUri(uri);
+        // make sure there is a tutorial visible that doesn't have a shortcut
+        await clickText('Switch costume');
+        await findByXpath('//div[contains(@class, "step-video")]');
+    });
+
+    // @todo navigating cards, etc.
+});

--- a/test/unit/util/tutorial-from-url.test.js
+++ b/test/unit/util/tutorial-from-url.test.js
@@ -36,7 +36,7 @@ test('returns null if no query param', () => {
     expect(detectTutorialId()).toBe(null);
 });
 
-test('returns null if non-numeric template', () => {
+test('returns null if unrecognized template', () => {
     window.location.search = '?tutorial=asdf';
     expect(detectTutorialId()).toBe(null);
 });
@@ -44,4 +44,9 @@ test('returns null if non-numeric template', () => {
 test('takes the first of multiple', () => {
     window.location.search = '?tutorial=one&tutorial=two';
     expect(detectTutorialId()).toBe('foo');
+});
+
+test('returns all for the tutorial library shortcut', () => {
+    window.location.search = '?tutorial=all';
+    expect(detectTutorialId()).toBe('all');
 });


### PR DESCRIPTION
### Resolves
- Resolves #3643

### Proposed Changes
Adds `?tutorial=all` as a recognized option. Gui opens without the preview modal, and with the Tutorials Library open.

Back button in the Tutorials Library takes you to the Editor (not back to referrer).

### Reason for Changes

The 2018 Hour of Code banner needs a link to all tutorials.

### Test Coverage
- added unit test for detecting 'all' as a valid tutorial id
- added integration test that checks for skipping the preview modal and having a tutorial available when the gui is loaded.

I'm having trouble with my chrome driver, so hopefully the tests run on travis.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
