### PR TITLE
Fix missing fonts in backpack thumbnails

### DIFF
--- a/src/lib/backpack/costume-payload.js
+++ b/src/lib/backpack/costume-payload.js
@@ -1,4 +1,5 @@
 import jpegThumbnail from './jpeg-thumbnail';
+import getCostumeUrl from '../get-costume-url';
 
 const costumePayload = costume => {
     // TODO is it ok to base64 encode SVGs? What about unicode text inside them?
@@ -26,8 +27,10 @@ const costumePayload = costume => {
         alert(`Cannot serialize for format: ${assetDataFormat}`); // eslint-disable-line
     }
 
-    // TODO we may be able to optimize by not actually generating thumbnails...
-    return jpegThumbnail(assetDataUrl).then(thumbnail => {
+    // Do not generate the thumbnail from the raw asset. Instead use the getCostumeUrl
+    // utility which inlines the fonts to make the thumbnail show the right fonts.
+    const inlinedFontDataUrl = getCostumeUrl(costume.asset);
+    return jpegThumbnail(inlinedFontDataUrl).then(thumbnail => {
         payload.thumbnail = thumbnail.replace('data:image/jpeg;base64,', '');
         return payload;
     });


### PR DESCRIPTION
Fixes an issue where the backpack thumbnails did not show with the correct fonts.

The solution is to use the `getCostumeUrl` utility, which takes care of inlining font-faces, which is exactly what is needed for this! Thanks @kchadha @fsih for making that utility!

