### PR TITLE
Handle ?tutorial= query in gui

### DIFF
--- a/src/containers/gui.jsx
+++ b/src/containers/gui.jsx
@@ -13,6 +13,8 @@ import {
     getIsShowingProject
 } from '../reducers/project-state';
 import {setProjectTitle} from '../reducers/project-title';
+import {detectTutorialId} from '../lib/tutorial-from-url';
+import {activateDeck} from '../reducers/cards';
 import {
     activateTab,
     BLOCKS_TAB_INDEX,
@@ -47,6 +49,7 @@ class GUI extends React.Component {
     componentDidMount () {
         this.setReduxTitle(this.props.projectTitle);
         this.props.onStorageInit(storage);
+        this.setActiveCards(detectTutorialId());
     }
     componentDidUpdate (prevProps) {
         if (this.props.projectId !== prevProps.projectId && this.props.projectId !== null) {
@@ -63,6 +66,11 @@ class GUI extends React.Component {
             );
         } else {
             this.props.onUpdateReduxProjectTitle(newTitle);
+        }
+    }
+    setActiveCards (tutorialId) {
+        if (tutorialId && tutorialId !== 'all') {
+            this.props.onUpdateReduxDeck(tutorialId);
         }
     }
     render () {
@@ -119,6 +127,7 @@ GUI.propTypes = {
     onStorageInit: PropTypes.func,
     onUpdateProjectId: PropTypes.func,
     onUpdateProjectTitle: PropTypes.func,
+    onUpdateReduxDeck: PropTypes.func,
     onUpdateReduxProjectTitle: PropTypes.func,
     previewInfoVisible: PropTypes.bool,
     projectHost: PropTypes.string,
@@ -169,6 +178,7 @@ const mapDispatchToProps = dispatch => ({
     onActivateSoundsTab: () => dispatch(activateTab(SOUNDS_TAB_INDEX)),
     onRequestCloseBackdropLibrary: () => dispatch(closeBackdropLibrary()),
     onRequestCloseCostumeLibrary: () => dispatch(closeCostumeLibrary()),
+    onUpdateReduxDeck: tutorialId => dispatch(activateDeck(tutorialId)),
     onUpdateReduxProjectTitle: title => dispatch(setProjectTitle(title))
 });
 

--- a/src/containers/gui.jsx
+++ b/src/containers/gui.jsx
@@ -88,6 +88,7 @@ class GUI extends React.Component {
             isShowingProject,
             onStorageInit,
             onUpdateProjectId,
+            onUpdateReduxDeck,
             onUpdateReduxProjectTitle,
             projectHost,
             projectId,

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 import GUI from './containers/gui.jsx';
 import AppStateHOC from './lib/app-state-hoc.jsx';
-import {detectTutorialId} from './lib/tutorial-from-url';
-import GuiReducer, {guiInitialState, guiMiddleware, initFullScreen, initPlayer, initTutorialCard} from './reducers/gui';
+import GuiReducer, {guiInitialState, guiMiddleware, initFullScreen, initPlayer} from './reducers/gui';
 import LocalesReducer, {localesInitialState, initLocale} from './reducers/locales';
 import {ScratchPaintReducer} from 'scratch-paint';
 import {setFullScreen, setPlayer} from './reducers/mode';
@@ -25,7 +24,5 @@ export {
     initLocale,
     localesInitialState,
     setFullScreen,
-    setPlayer,
-    detectTutorialId,
-    initTutorialCard
+    setPlayer
 };

--- a/src/lib/app-state-hoc.jsx
+++ b/src/lib/app-state-hoc.jsx
@@ -52,7 +52,6 @@ const AppStateHOC = function (WrappedComponent, localesOnly) {
                     guiMiddleware,
                     initFullScreen,
                     initPlayer,
-                    initTutorialCard,
                     initTutorialLibrary
                 } = guiRedux;
                 const {ScratchPaintReducer} = require('scratch-paint');
@@ -67,16 +66,10 @@ const AppStateHOC = function (WrappedComponent, localesOnly) {
                     }
                 } else {
                     const tutorialId = detectTutorialId();
-                    if (tutorialId !== null) {
-                        // When loading a tutorial from the URL,
-                        // load w/o preview modal
-                        // open requested tutorial card or tutorials library modal for 'all'
-                        if (tutorialId === 'all') {
-                            initializedGui = initTutorialLibrary(initializedGui);
-                        } else {
-                            initializedGui = initTutorialCard(initializedGui, tutorialId);
-                        }
-                    }
+                    // handle ?tutorial=all for beta
+                    // if we decide to keep this for www, functionality should move to
+                    // setActiveCards in the GUI container
+                    if (tutorialId === 'all') initializedGui = initTutorialLibrary(initializedGui);
                 }
                 reducers = {
                     locales: localesReducer,

--- a/src/lib/app-state-hoc.jsx
+++ b/src/lib/app-state-hoc.jsx
@@ -31,6 +31,10 @@ const AppStateHOC = function (WrappedComponent, localesOnly) {
             let reducers = {};
             let enhancer;
 
+            this.state = {
+                tutorial: false
+            };
+
             let initializedLocales = localesInitialState;
             const locale = detectLocale(Object.keys(locales));
             if (locale !== 'en') {
@@ -70,6 +74,7 @@ const AppStateHOC = function (WrappedComponent, localesOnly) {
                     // if we decide to keep this for www, functionality should move to
                     // setActiveCards in the GUI container
                     if (tutorialId === 'all') initializedGui = initTutorialLibrary(initializedGui);
+                    if (tutorialId) this.state.tutorial = true;
                 }
                 reducers = {
                     locales: localesReducer,
@@ -104,10 +109,13 @@ const AppStateHOC = function (WrappedComponent, localesOnly) {
                 isPlayerOnly, // eslint-disable-line no-unused-vars
                 ...componentProps
             } = this.props;
+            if (this.state.tutorial) componentProps.hideIntro = true;
             return (
                 <Provider store={this.store}>
                     <ConnectedIntlProvider>
-                        <WrappedComponent {...componentProps} />
+                        <WrappedComponent
+                            {...componentProps}
+                        />
                     </ConnectedIntlProvider>
                 </Provider>
             );


### PR DESCRIPTION
### Resolves
Prerequisite for https://github.com/LLK/scratch-www/issues/2281

### Proposed Changes

Moved the tutorial id handling into gui so it works when gui is embedded in www as well as standalone.

This seemed better than duplicating the query handling in www, in order to pass an id to gui.

Note, the `?tutorial=all` handling remains in app-state-hoc. Currently it’s only needed in standalone mode for Hour of Code. It’s easy to move into the gui container if we do want it in gui by default.

Question: are there going to be interactions with project save/new... that will lead to ignoring the query string, or otherwise not the results that users expect.

### Reason for Changes
Support opening with a tutorial loaded in www.

### Test Coverage
Current tests pass - it didn't change functionality, just where it was included so it's available in www.

Try it:
https://chrisgarrity.github.io/scratch-gui/issue/www-2281-tutorials/

Manual testing:
- [ ] `/?tutorial=getStarted` should open the getting started tutorial
- [ ] Other tutorials should open as well ('name', 'music', 'chase-game', 'clicker-game', 'animations-that-talk') 
- [ ] 'animate-an-adventure-game' should load with a default project
- [ ] `/?tutorial=all` should load with the tutorials library open
- [ ] if the tutorial isn't recognized it should be ignored


### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [x] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
