### PR TITLE
Filter for letters in the sprite/costumes libraries

### DIFF
--- a/src/lib/libraries/sprite-tags.js
+++ b/src/lib/libraries/sprite-tags.js
@@ -7,5 +7,6 @@ export default [
     {tag: 'music', intlLabel: messages.music},
     {tag: 'sports', intlLabel: messages.sports},
     {tag: 'food', intlLabel: messages.food},
-    {tag: 'fashion', intlLabel: messages.fashion}
+    {tag: 'fashion', intlLabel: messages.fashion},
+    {tag: 'letters', intlLabel: messages.letters}
 ];

--- a/src/lib/libraries/tag-messages.js
+++ b/src/lib/libraries/tag-messages.js
@@ -120,5 +120,10 @@ export default defineMessages({
         defaultMessage: 'Stories',
         description: 'Tag for filtering a library for stories',
         id: 'gui.libraryTags.stories'
+    },
+    letters: {
+        defaultMessage: 'Letters',
+        description: 'Tag for filtering a library for letters',
+        id: 'gui.libraryTags.letters'
     }
 });

--- a/test/integration/costumes.test.js
+++ b/test/integration/costumes.test.js
@@ -160,4 +160,19 @@ describe('Working with costumes', () => {
         const logs = await getLogs();
         await expect(logs).toEqual([]);
     });
+
+    test('Adding a letter costume through the Letters filter in the library', async () => {
+        await loadUri(uri);
+        await driver.manage()
+            .window()
+            .setSize(1244, 768); // Letters filter not visible at 1024 width
+        await clickXpath('//button[@title="Try It"]');
+        await clickText('Costumes');
+        await clickXpath('//button[@aria-label="Choose a Costume"]');
+        await clickText('Letters');
+        await clickText('Block-a', scope.modal); // Closes modal
+        await rightClickText('Block-a', scope.costumesTab); // Make sure it is there
+        const logs = await getLogs();
+        await expect(logs).toEqual([]);
+    });
 });

--- a/test/integration/sprites.test.js
+++ b/test/integration/sprites.test.js
@@ -109,4 +109,19 @@ describe('Working with sprites', () => {
         const logs = await getLogs();
         await expect(logs).toEqual([]);
     });
+
+    test('Adding a letter sprite through the Letters filter in the library', async () => {
+        await loadUri(uri);
+        await driver.manage()
+            .window()
+            .setSize(1244, 768); // Letters filter not visible at 1024 width
+        await clickXpath('//button[@title="Try It"]');
+        await clickText('Costumes');
+        await clickXpath('//button[@aria-label="Choose a Sprite"]');
+        await clickText('Letters');
+        await clickText('Block-B', scope.modal); // Closes modal
+        await rightClickText('Block-B', scope.spriteTile); // Make sure it is there
+        const logs = await getLogs();
+        await expect(logs).toEqual([]);
+    });
 });


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/LLK/scratch-gui/issues/3726

### Proposed Changes

_Describe what this Pull Request does_

Add a "Letters" filter to the sprite/costume libraries (they use the same tagging systems). 

### Reason for Changes

_Explain why these changes should be made_

### Test Coverage

_Please show how you have added tests to cover your changes_

Added integration tests to use the "Letters" filter in the sprite/costumes libraries.