### PR TITLE
Prevent crash after deleting sprite that had been highlighted

### DIFF
--- a/src/containers/target-highlight.jsx
+++ b/src/containers/target-highlight.jsx
@@ -32,7 +32,8 @@ class TargetHighlight extends React.Component {
             vm
         } = this.props;
 
-        if (!(highlightedTargetId && vm && vm.renderer)) return null;
+        if (!(highlightedTargetId && vm && vm.renderer &&
+            vm.runtime.getTargetById(highlightedTargetId))) return null;
 
         const target = vm.runtime.getTargetById(highlightedTargetId);
         const bounds = vm.renderer.getBounds(target.drawableID);

--- a/test/integration/stage-size.test.js
+++ b/test/integration/stage-size.test.js
@@ -1,0 +1,47 @@
+import path from 'path';
+import SeleniumHelper from '../helpers/selenium-helper';
+
+const {
+    clickText,
+    clickXpath,
+    rightClickText,
+    getDriver,
+    getLogs,
+    loadUri,
+    scope
+} = new SeleniumHelper();
+
+const uri = path.resolve(__dirname, '../../build/index.html');
+
+let driver;
+
+describe('Loading scratch gui', () => {
+    beforeAll(() => {
+        driver = getDriver();
+    });
+
+    afterAll(async () => {
+        await driver.quit();
+    });
+
+    test('Switching small/large stage after highlighting and deleting sprite', async () => {
+        await loadUri(uri);
+        await clickXpath('//button[@title="Try It"]');
+
+        // Highlight the sprite
+        await clickText('Sprite1', scope.spriteTile);
+
+        // Delete it
+        await rightClickText('Sprite1', scope.spriteTile);
+        await clickText('delete', scope.spriteTile);
+
+        // Go to small stage mode
+        await clickXpath('//img[@alt="Switch to small stage"]');
+
+        // Confirm app still working
+        await clickXpath('//img[@alt="Switch to large stage"]');
+
+        const logs = await getLogs();
+        await expect(logs).toEqual([]);
+    });
+});


### PR DESCRIPTION
@ericrosenbaum fixes the crashing problem you found. The problem was that the highlight component gets rerendered when you switch stage mode, but the highlightedTargetId may not still be available.

The real change here is just checking that the target still exists.

Adds an integration test also, using the simplest repo I could find:
1. Click a sprite
2. Delete that sprite
3. Click "Small stage mode"

/cc @BryceLTaylor I think we may want to hotfix this to master