### PR TITLE
fixed mapDispatchToProps error

### DIFF
--- a/src/containers/project-watcher.jsx
+++ b/src/containers/project-watcher.jsx
@@ -56,7 +56,7 @@ const mapStateToProps = state => {
     };
 };
 
-const mapDispatchToProps = () => {};
+const mapDispatchToProps = () => ({});
 
 export default connect(
     mapStateToProps,


### PR DESCRIPTION
### Resolves

Gets rid of console error: `mapDispatchToProps() in Connect(ProjectWatcher) must return a plain object. Instead received undefined.`

...which was an unintentional side effect of https://github.com/LLK/scratch-gui/pull/3638
