### PR TITLE
Create cloud vars

### DIFF
--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -69,6 +69,7 @@ const GUIComponent = props => {
         canSave,
         canCreateCopy,
         canShare,
+        canUseCloud,
         children,
         connectionModalVisible,
         costumeLibraryVisible,
@@ -262,6 +263,7 @@ const GUIComponent = props => {
                                 <TabPanel className={tabClassNames.tabPanel}>
                                     <Box className={styles.blocksWrapper}>
                                         <Blocks
+                                            canUseCloud={canUseCloud}
                                             grow={1}
                                             isVisible={blocksTabVisible}
                                             options={{
@@ -334,6 +336,7 @@ GUIComponent.propTypes = {
     canRemix: PropTypes.bool,
     canSave: PropTypes.bool,
     canShare: PropTypes.bool,
+    canUseCloud: PropTypes.bool,
     cardsVisible: PropTypes.bool,
     children: PropTypes.node,
     costumeLibraryVisible: PropTypes.bool,
@@ -378,6 +381,7 @@ GUIComponent.defaultProps = {
     canSave: false,
     canCreateCopy: false,
     canShare: false,
+    canUseCloud: false,
     enableCommunity: false,
     isShared: false,
     onUpdateProjectTitle: () => {},

--- a/src/components/prompt/prompt.css
+++ b/src/components/prompt/prompt.css
@@ -15,6 +15,10 @@
     margin: 0 0 0.75rem;
 }
 
+.disabled-label {
+    opacity: 0.5;
+}
+
 .variable-name-text-input {
     margin-bottom: 1.5rem;
     width: 100%;
@@ -68,35 +72,16 @@
     margin-right: 0.5rem;
 }
 
-.more-options {
+.cloud-option {
+    display:flex;
     border-top: 1px dashed hsla(0, 0%, 0%, .25);
     overflow: visible;
-    padding: 1rem;
+    padding: 1rem 0;
     text-align: center;
-    margin: 0 0 1rem;
-}
-
-.more-options-accordion {
-    width: 60%;
+    width: 100%;
     margin: 0 auto;
 }
 
-.more-options-text {
+.cloud-option-text {
     opacity: .5;
-}
-
-.more-options-icon {
-    width: .75rem;
-    height: .75rem;
-    vertical-align: middle;
-    padding-bottom: .2rem;
-    opacity: .5;
-}
-
-[dir="ltr"] .more-options-icon {
-    margin-left: .5rem;
-}
-
-[dir="rtl"] .more-options-icon {
-    margin-right: .5rem;
 }

--- a/src/components/prompt/prompt.jsx
+++ b/src/components/prompt/prompt.jsx
@@ -90,18 +90,19 @@ const PromptComponent = props => (
                                 />
                             </label>
                         </Box>}
-                    <Box className={classNames(styles.cloudOption)}>
-                        <label>
-                            <input
-                                checked={props.cloudSelected}
-                                type="checkbox"
-                                onChange={props.onCloudVarOptionChange}
-                            />
-                            <FormattedMessage
-                                {...messages.cloudVarOptionMessage}
-                            />
-                        </label>
-                    </Box>
+                    {props.canUseCloud ?
+                        <Box className={classNames(styles.cloudOption)}>
+                            <label>
+                                <input
+                                    checked={props.cloudSelected}
+                                    type="checkbox"
+                                    onChange={props.onCloudVarOptionChange}
+                                />
+                                <FormattedMessage
+                                    {...messages.cloudVarOptionMessage}
+                                />
+                            </label>
+                        </Box> : null}
                 </div> : null}
 
             <Box className={styles.buttonRow}>

--- a/src/components/prompt/prompt.jsx
+++ b/src/components/prompt/prompt.jsx
@@ -1,14 +1,13 @@
+import classNames from 'classnames';
 import {defineMessages, FormattedMessage} from 'react-intl';
 import PropTypes from 'prop-types';
 import React from 'react';
 
 import Box from '../box/box.jsx';
-import {ComingSoonTooltip} from '../coming-soon/coming-soon.jsx';
 import Modal from '../../containers/modal.jsx';
 
 import styles from './prompt.css';
 
-import dropdownIcon from './icon--dropdown-caret.svg';
 
 const messages = defineMessages({
     forAllSpritesMessage: {
@@ -21,10 +20,10 @@ const messages = defineMessages({
         description: 'Option message when creating a varaible for making it only available to the current sprite',
         id: 'gui.gui.variableScopeOptionSpriteOnly'
     },
-    moreOptionsMessage: {
-        defaultMessage: 'More Options',
-        description: 'Dropdown message for variable/list options',
-        id: 'gui.gui.variablePrompt'
+    cloudVarOptionMessage: {
+        defaultMessage: 'Cloud variable (stored on server)',
+        description: 'Option message when creating a variable for making it a cloud variable, a variable that is stored on the server', /* eslint-disable-line max-len */
+        id: 'gui.gui.cloudVariableOption'
     },
     availableToAllSpritesMessage: {
         defaultMessage: 'This variable will be available to all sprites.',
@@ -54,7 +53,7 @@ const PromptComponent = props => (
                     onKeyPress={props.onKeyPress}
                 />
             </Box>
-            {props.showMoreOptions ?
+            {props.showVariableOptions ?
                 <div>
                     {props.isStage ?
                         <div className={styles.infoMessage}>
@@ -65,44 +64,43 @@ const PromptComponent = props => (
                         <Box className={styles.optionsRow}>
                             <label>
                                 <input
-                                    defaultChecked
+                                    checked={props.globalSelected}
                                     name="variableScopeOption"
                                     type="radio"
                                     value="global"
-                                    onChange={props.onOptionSelection}
+                                    onChange={props.onScopeOptionSelection}
                                 />
                                 <FormattedMessage
                                     {...messages.forAllSpritesMessage}
                                 />
                             </label>
-                            <label>
+                            <label
+                                className={props.cloudSelected ? styles.disabledLabel : ''}
+                            >
                                 <input
+                                    checked={!props.globalSelected}
+                                    disabled={props.cloudSelected}
                                     name="variableScopeOption"
                                     type="radio"
                                     value="local"
-                                    onChange={props.onOptionSelection}
+                                    onChange={props.onScopeOptionSelection}
                                 />
                                 <FormattedMessage
                                     {...messages.forThisSpriteMessage}
                                 />
                             </label>
                         </Box>}
-                    <Box className={styles.moreOptions}>
-                        <ComingSoonTooltip
-                            className={styles.moreOptionsAccordion}
-                            place="right"
-                            tooltipId="variable-options-accordion"
-                        >
-                            <div className={styles.moreOptionsText}>
-                                <FormattedMessage
-                                    {...messages.moreOptionsMessage}
-                                />
-                                <img
-                                    className={styles.moreOptionsIcon}
-                                    src={dropdownIcon}
-                                />
-                            </div>
-                        </ComingSoonTooltip>
+                    <Box className={classNames(styles.cloudOption)}>
+                        <label>
+                            <input
+                                checked={props.cloudSelected}
+                                type="checkbox"
+                                onChange={props.onCloudVarOptionChange}
+                            />
+                            <FormattedMessage
+                                {...messages.cloudVarOptionMessage}
+                            />
+                        </label>
                     </Box>
                 </div> : null}
 
@@ -133,15 +131,18 @@ const PromptComponent = props => (
 );
 
 PromptComponent.propTypes = {
+    cloudSelected: PropTypes.bool.isRequired,
+    globalSelected: PropTypes.bool.isRequired,
     isStage: PropTypes.bool.isRequired,
     label: PropTypes.string.isRequired,
     onCancel: PropTypes.func.isRequired,
     onChange: PropTypes.func.isRequired,
+    onCloudVarOptionChange: PropTypes.func,
     onKeyPress: PropTypes.func.isRequired,
     onOk: PropTypes.func.isRequired,
-    onOptionSelection: PropTypes.func.isRequired,
+    onScopeOptionSelection: PropTypes.func.isRequired,
     placeholder: PropTypes.string,
-    showMoreOptions: PropTypes.bool.isRequired,
+    showVariableOptions: PropTypes.bool.isRequired,
     title: PropTypes.string.isRequired
 };
 

--- a/src/components/prompt/prompt.jsx
+++ b/src/components/prompt/prompt.jsx
@@ -75,7 +75,7 @@ const PromptComponent = props => (
                                 />
                             </label>
                             <label
-                                className={props.cloudSelected ? styles.disabledLabel : ''}
+                                className={classNames({[styles.disabledLabel]: props.cloudSelected})}
                             >
                                 <input
                                     checked={!props.globalSelected}
@@ -93,7 +93,7 @@ const PromptComponent = props => (
                     {props.showCloudOption ?
                         <Box className={classNames(styles.cloudOption)}>
                             <label
-                                className={props.canAddCloudVariable ? '' : styles.disabledLabel}
+                                className={classNames({[styles.disabledLabel]: !props.canAddCloudVariable})}
                             >
                                 <input
                                     checked={props.cloudSelected && props.canAddCloudVariable}

--- a/src/components/prompt/prompt.jsx
+++ b/src/components/prompt/prompt.jsx
@@ -90,11 +90,14 @@ const PromptComponent = props => (
                                 />
                             </label>
                         </Box>}
-                    {props.canUseCloud ?
+                    {props.showCloudOption ?
                         <Box className={classNames(styles.cloudOption)}>
-                            <label>
+                            <label
+                                className={props.canAddCloudVariable ? '' : styles.disabledLabel}
+                            >
                                 <input
-                                    checked={props.cloudSelected}
+                                    checked={props.cloudSelected && props.canAddCloudVariable}
+                                    disabled={!props.canAddCloudVariable}
                                     type="checkbox"
                                     onChange={props.onCloudVarOptionChange}
                                 />
@@ -132,6 +135,7 @@ const PromptComponent = props => (
 );
 
 PromptComponent.propTypes = {
+    canAddCloudVariable: PropTypes.bool.isRequired,
     cloudSelected: PropTypes.bool.isRequired,
     globalSelected: PropTypes.bool.isRequired,
     isStage: PropTypes.bool.isRequired,
@@ -143,6 +147,7 @@ PromptComponent.propTypes = {
     onOk: PropTypes.func.isRequired,
     onScopeOptionSelection: PropTypes.func.isRequired,
     placeholder: PropTypes.string,
+    showCloudOption: PropTypes.bool.isRequired,
     showVariableOptions: PropTypes.bool.isRequired,
     title: PropTypes.string.isRequired
 };

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -380,10 +380,12 @@ class Blocks extends React.Component {
             this.ScratchBlocks.Msg.VARIABLE_MODAL_TITLE;
         p.prompt.varType = typeof optVarType === 'string' ?
             optVarType : this.ScratchBlocks.SCALAR_VARIABLE_TYPE;
-        p.prompt.showMoreOptions =
+        p.prompt.showVariableOptions = // This flag means that we should show variable/list options about scope
             optVarType !== this.ScratchBlocks.BROADCAST_MESSAGE_VARIABLE_TYPE &&
             p.prompt.title !== this.ScratchBlocks.Msg.RENAME_VARIABLE_MODAL_TITLE &&
             p.prompt.title !== this.ScratchBlocks.Msg.RENAME_LIST_MODAL_TITLE;
+        // TODO CLOUD add flag about showing the cloud variable option, which will necessitate
+        // that the flag above is true, e.g. p.prompt.showVariableOptions && canUseCloudData
         this.setState(p);
     }
     handleConnectionModalStart (extensionId) {
@@ -449,11 +451,13 @@ class Blocks extends React.Component {
                     {...props}
                 />
                 {this.state.prompt ? (
+                    /* TODO add the following in the props below:
+                    showCloudOption={this.state.canUseCloudData */
                     <Prompt
                         isStage={vm.runtime.getEditingTarget().isStage}
                         label={this.state.prompt.message}
                         placeholder={this.state.prompt.defaultValue}
-                        showMoreOptions={this.state.prompt.showMoreOptions}
+                        showVariableOptions={this.state.prompt.showVariableOptions}
                         title={this.state.prompt.title}
                         onCancel={this.handlePromptClose}
                         onOk={this.handlePromptCallback}

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -397,11 +397,17 @@ class Blocks extends React.Component {
     handleOpenSoundRecorder () {
         this.props.onOpenSoundRecorder();
     }
-    handlePromptCallback (input, optionSelection) {
+
+    /*
+     * Pass along information about proposed name and variable options (scope and isCloud)
+     * and additional potentially conflicting variable names from the VM
+     * to the variable validation prompt callback used in scratch-blocks.
+     */
+    handlePromptCallback (input, variableOptions) {
         this.state.prompt.callback(
             input,
             this.props.vm.runtime.getAllVarNamesOfType(this.state.prompt.varType),
-            optionSelection);
+            variableOptions);
         this.handlePromptClose();
     }
     handlePromptClose () {

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -431,6 +431,7 @@ class Blocks extends React.Component {
         /* eslint-disable no-unused-vars */
         const {
             anyModalVisible,
+            canUseCloud,
             customProceduresVisible,
             extensionLibraryVisible,
             options,
@@ -460,6 +461,7 @@ class Blocks extends React.Component {
                     /* TODO add the following in the props below:
                     showCloudOption={this.state.canUseCloudData */
                     <Prompt
+                        canUseCloud={canUseCloud}
                         isStage={vm.runtime.getEditingTarget().isStage}
                         label={this.state.prompt.message}
                         placeholder={this.state.prompt.defaultValue}
@@ -491,6 +493,7 @@ class Blocks extends React.Component {
 
 Blocks.propTypes = {
     anyModalVisible: PropTypes.bool,
+    canUseCloud: PropTypes.bool,
     customProceduresVisible: PropTypes.bool,
     extensionLibraryVisible: PropTypes.bool,
     isRtl: PropTypes.bool,

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -384,8 +384,6 @@ class Blocks extends React.Component {
             optVarType !== this.ScratchBlocks.BROADCAST_MESSAGE_VARIABLE_TYPE &&
             p.prompt.title !== this.ScratchBlocks.Msg.RENAME_VARIABLE_MODAL_TITLE &&
             p.prompt.title !== this.ScratchBlocks.Msg.RENAME_LIST_MODAL_TITLE;
-        // TODO CLOUD add flag about showing the cloud variable option, which will necessitate
-        // that the flag above is true, e.g. p.prompt.showVariableOptions && canUseCloudData
         this.setState(p);
     }
     handleConnectionModalStart (extensionId) {

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -458,15 +458,14 @@ class Blocks extends React.Component {
                     {...props}
                 />
                 {this.state.prompt ? (
-                    /* TODO add the following in the props below:
-                    showCloudOption={this.state.canUseCloudData */
                     <Prompt
-                        canUseCloud={canUseCloud}
                         isStage={vm.runtime.getEditingTarget().isStage}
                         label={this.state.prompt.message}
                         placeholder={this.state.prompt.defaultValue}
+                        showCloudOption={canUseCloud}
                         showVariableOptions={this.state.prompt.showVariableOptions}
                         title={this.state.prompt.title}
+                        vm={vm}
                         onCancel={this.handlePromptClose}
                         onOk={this.handlePromptCallback}
                     />

--- a/src/containers/gui.jsx
+++ b/src/containers/gui.jsx
@@ -32,6 +32,7 @@ import ProjectSaverHOC from '../lib/project-saver-hoc.jsx';
 import storage from '../lib/storage';
 import vmListenerHOC from '../lib/vm-listener-hoc.jsx';
 import vmManagerHOC from '../lib/vm-manager-hoc.jsx';
+import cloudManagerHOC from '../lib/cloud-manager-hoc.jsx';
 
 import GUIComponent from '../components/gui/gui.jsx';
 
@@ -85,6 +86,7 @@ class GUI extends React.Component {
             projectId,
             projectTitle,
             /* eslint-enable no-unused-vars */
+            canUseCloud,
             children,
             fetchingProject,
             isLoading,
@@ -93,6 +95,7 @@ class GUI extends React.Component {
         } = this.props;
         return (
             <GUIComponent
+                canUseCloud={canUseCloud}
                 loading={fetchingProject || isLoading || loadingStateVisible}
                 {...componentProps}
             >
@@ -187,7 +190,8 @@ const WrappedGui = compose(
     ProjectFetcherHOC,
     ProjectSaverHOC,
     vmListenerHOC,
-    vmManagerHOC
+    vmManagerHOC,
+    cloudManagerHOC
 )(ConnectedGUI);
 
 WrappedGui.setAppElement = ReactModal.setAppElement;

--- a/src/containers/gui.jsx
+++ b/src/containers/gui.jsx
@@ -86,7 +86,6 @@ class GUI extends React.Component {
             projectId,
             projectTitle,
             /* eslint-enable no-unused-vars */
-            canUseCloud,
             children,
             fetchingProject,
             isLoading,
@@ -95,7 +94,6 @@ class GUI extends React.Component {
         } = this.props;
         return (
             <GUIComponent
-                canUseCloud={canUseCloud}
                 loading={fetchingProject || isLoading || loadingStateVisible}
                 {...componentProps}
             >

--- a/src/containers/prompt.jsx
+++ b/src/containers/prompt.jsx
@@ -39,6 +39,8 @@ class Prompt extends React.Component {
         this.setState({globalSelected: (e.target.value === 'global')});
     }
     handleCloudVariableOptionChange (e) {
+        if (!this.props.canUseCloud) return;
+
         const checked = e.target.checked;
         this.setState({cloudSelected: checked});
         if (checked) {
@@ -48,6 +50,7 @@ class Prompt extends React.Component {
     render () {
         return (
             <PromptComponent
+                canUseCloud={this.props.canUseCloud}
                 cloudSelected={this.state.cloudSelected}
                 globalSelected={this.state.globalSelected}
                 isStage={this.props.isStage}
@@ -67,6 +70,7 @@ class Prompt extends React.Component {
 }
 
 Prompt.propTypes = {
+    canUseCloud: PropTypes.bool.isRequired,
     isStage: PropTypes.bool.isRequired,
     label: PropTypes.string.isRequired,
     onCancel: PropTypes.func.isRequired,

--- a/src/containers/prompt.jsx
+++ b/src/containers/prompt.jsx
@@ -8,21 +8,24 @@ class Prompt extends React.Component {
         super(props);
         bindAll(this, [
             'handleOk',
-            'handleOptionSelection',
+            'handleScopeOptionSelection',
             'handleCancel',
             'handleChange',
-            'handleKeyPress'
+            'handleKeyPress',
+            'handleCloudVariableOptionChange'
         ]);
         this.state = {
             inputValue: '',
-            optionSelection: null
+            globalSelected: true,
+            cloudSelected: false
         };
     }
     handleKeyPress (event) {
         if (event.key === 'Enter') this.handleOk();
     }
     handleOk () {
-        this.props.onOk(this.state.inputValue, this.state.optionSelection);
+        // TODO CLOUD add cloud variable option info
+        this.props.onOk(this.state.inputValue, (this.state.globalSelected ? 'global' : 'local'));
     }
     handleCancel () {
         this.props.onCancel();
@@ -30,22 +33,32 @@ class Prompt extends React.Component {
     handleChange (e) {
         this.setState({inputValue: e.target.value});
     }
-    handleOptionSelection (e) {
-        this.setState({optionSelection: e.target.value});
+    handleScopeOptionSelection (e) {
+        this.setState({globalSelected: (e.target.value === 'global')});
+    }
+    handleCloudVariableOptionChange (e) {
+        const checked = e.target.checked;
+        this.setState({cloudSelected: checked});
+        if (checked) {
+            this.setState({globalSelected: true});
+        }
     }
     render () {
         return (
             <PromptComponent
+                cloudSelected={this.state.cloudSelected}
+                globalSelected={this.state.globalSelected}
                 isStage={this.props.isStage}
                 label={this.props.label}
                 placeholder={this.props.placeholder}
-                showMoreOptions={this.props.showMoreOptions}
+                showVariableOptions={this.props.showVariableOptions}
                 title={this.props.title}
                 onCancel={this.handleCancel}
                 onChange={this.handleChange}
+                onCloudVarOptionChange={this.handleCloudVariableOptionChange}
                 onKeyPress={this.handleKeyPress}
                 onOk={this.handleOk}
-                onOptionSelection={this.handleOptionSelection}
+                onScopeOptionSelection={this.handleScopeOptionSelection}
             />
         );
     }
@@ -57,7 +70,7 @@ Prompt.propTypes = {
     onCancel: PropTypes.func.isRequired,
     onOk: PropTypes.func.isRequired,
     placeholder: PropTypes.string,
-    showMoreOptions: PropTypes.bool.isRequired,
+    showVariableOptions: PropTypes.bool.isRequired,
     title: PropTypes.string.isRequired
 };
 

--- a/src/containers/prompt.jsx
+++ b/src/containers/prompt.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import bindAll from 'lodash.bindall';
 import PromptComponent from '../components/prompt/prompt.jsx';
+import VM from 'scratch-vm';
 
 class Prompt extends React.Component {
     constructor (props) {
@@ -17,7 +18,8 @@ class Prompt extends React.Component {
         this.state = {
             inputValue: '',
             globalSelected: true,
-            cloudSelected: false
+            cloudSelected: false,
+            canAddCloudVariable: (props.vm && props.vm.runtime.canAddCloudVariable()) || false
         };
     }
     handleKeyPress (event) {
@@ -39,7 +41,7 @@ class Prompt extends React.Component {
         this.setState({globalSelected: (e.target.value === 'global')});
     }
     handleCloudVariableOptionChange (e) {
-        if (!this.props.canUseCloud) return;
+        if (!this.props.showCloudOption) return;
 
         const checked = e.target.checked;
         this.setState({cloudSelected: checked});
@@ -50,12 +52,13 @@ class Prompt extends React.Component {
     render () {
         return (
             <PromptComponent
-                canUseCloud={this.props.canUseCloud}
+                canAddCloudVariable={this.state.canAddCloudVariable}
                 cloudSelected={this.state.cloudSelected}
                 globalSelected={this.state.globalSelected}
                 isStage={this.props.isStage}
                 label={this.props.label}
                 placeholder={this.props.placeholder}
+                showCloudOption={this.props.showCloudOption}
                 showVariableOptions={this.props.showVariableOptions}
                 title={this.props.title}
                 onCancel={this.handleCancel}
@@ -70,14 +73,15 @@ class Prompt extends React.Component {
 }
 
 Prompt.propTypes = {
-    canUseCloud: PropTypes.bool.isRequired,
     isStage: PropTypes.bool.isRequired,
     label: PropTypes.string.isRequired,
     onCancel: PropTypes.func.isRequired,
     onOk: PropTypes.func.isRequired,
     placeholder: PropTypes.string,
+    showCloudOption: PropTypes.bool.isRequired,
     showVariableOptions: PropTypes.bool.isRequired,
-    title: PropTypes.string.isRequired
+    title: PropTypes.string.isRequired,
+    vm: PropTypes.instanceOf(VM)
 };
 
 export default Prompt;

--- a/src/containers/prompt.jsx
+++ b/src/containers/prompt.jsx
@@ -24,8 +24,10 @@ class Prompt extends React.Component {
         if (event.key === 'Enter') this.handleOk();
     }
     handleOk () {
-        // TODO CLOUD add cloud variable option info
-        this.props.onOk(this.state.inputValue, (this.state.globalSelected ? 'global' : 'local'));
+        this.props.onOk(this.state.inputValue, {
+            scope: this.state.globalSelected ? 'global' : 'local',
+            isCloud: this.state.cloudSelected
+        });
     }
     handleCancel () {
         this.props.onCancel();

--- a/src/lib/cloud-manager-hoc.jsx
+++ b/src/lib/cloud-manager-hoc.jsx
@@ -26,6 +26,12 @@ const cloudManagerHOC = function (WrappedComponent) {
             }
         }
         componentDidUpdate (prevProps) {
+            // TODO add disconnection logic when loading a new project
+            // (and eventually move it out of the vm.clear function)
+            // e.g. was previously showingWithId but no longer, but we need
+            // to check that we don't disconnect when saving a project to the
+            // server.
+
             // If we couldn't use cloud data before, but now we can, try opening a cloud connection
             if (this.canUseCloud(this.props) && !this.canUseCloud(prevProps)) {
                 this.connectToCloud();

--- a/src/lib/cloud-manager-hoc.jsx
+++ b/src/lib/cloud-manager-hoc.jsx
@@ -1,0 +1,98 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import {connect} from 'react-redux';
+
+import VM from 'scratch-vm';
+import CloudProvider from '../lib/cloud-provider';
+
+import {
+    getIsShowingWithId
+} from '../reducers/project-state';
+
+/*
+ * Higher Order Component to manage the connection to the cloud dserver.
+ * @param {React.Component} WrappedComponent component to manage VM events for
+ * @returns {React.Component} connected component with vm events bound to redux
+ */
+const cloudManagerHOC = function (WrappedComponent) {
+    class CloudManager extends React.Component {
+        constructor (props) {
+            super(props);
+            this.cloudProvider = null;
+            this.canUseCloud = false;
+        }
+        componentDidUpdate (prevProps) {
+            // If any of the following are not true, do not open a cloud connection
+            const canUseCloud = this.props.cloudHost && this.props.username && this.props.isShowingWithId;
+
+            if (!canUseCloud) return;
+
+            // TODO add scratcher check
+            this.canUseCloud = canUseCloud;
+
+            if ((this.props.username !== prevProps.username) ||
+                (this.props.projectId !== prevProps.projectId) ||
+                (!this.cloudProvider) ||
+                (this.cloudProvider && !this.cloudProvider.connection)) {
+                // TODO need to add provisions for viewing someone
+                // else's project in editor mode
+                this.cloudProvider = new CloudProvider(
+                    this.props.cloudHost,
+                    this.props.vm,
+                    this.props.username,
+                    this.props.projectId);
+                this.props.vm.setCloudProvider(this.cloudProvider);
+            }
+        }
+        render () {
+            const {
+                /* eslint-disable no-unused-vars */
+                cloudHost,
+                projectId,
+                username,
+                isShowingWithId,
+                /* eslint-enable no-unused-vars */
+                vm,
+                ...componentProps
+            } = this.props;
+            return (
+                <WrappedComponent
+                    canUseCloud={this.canUseCloud}
+                    vm={vm}
+                    {...componentProps}
+                />
+            );
+        }
+    }
+
+    CloudManager.propTypes = {
+        cloudHost: PropTypes.string,
+        isShowingWithId: PropTypes.bool,
+        projectId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+        username: PropTypes.string,
+        vm: PropTypes.instanceOf(VM).isRequired
+    };
+
+    const mapStateToProps = state => {
+        const loadingState = state.scratchGui.projectState.loadingState;
+        return {
+            isShowingWithId: getIsShowingWithId(loadingState),
+            projectId: state.scratchGui.projectState.projectId
+        };
+    };
+
+    const mapDispatchToProps = () => ({});
+
+    // Allow incoming props to override redux-provided props. Used to mock in tests.
+    const mergeProps = (stateProps, dispatchProps, ownProps) => Object.assign(
+        {}, stateProps, dispatchProps, ownProps
+    );
+
+    return connect(
+        mapStateToProps,
+        mapDispatchToProps,
+        mergeProps
+    )(CloudManager);
+};
+
+export default cloudManagerHOC;

--- a/src/lib/cloud-provider.js
+++ b/src/lib/cloud-provider.js
@@ -139,7 +139,12 @@ class CloudProvider {
      * provider of references related to the cloud data project.
      */
     requestCloseConnection () {
-        this.connection.close();
+        if (this.connection &&
+            this.connection.readyState !== WebSocket.CLOSING &&
+            this.connection.readyState !== WebSocket.CLOSED) {
+
+            this.connection.close();
+        }
         this.clear();
     }
 

--- a/src/lib/cloud-provider.js
+++ b/src/lib/cloud-provider.js
@@ -38,6 +38,7 @@ class CloudProvider {
             log.error(`Websocket connection error: ${JSON.stringify(e)}`);
 
             // TODO Add re-connection attempt logic here
+            this.clear();
         };
 
         this.connection.onmessage = event => {

--- a/src/lib/cloud-provider.js
+++ b/src/lib/cloud-provider.js
@@ -45,7 +45,8 @@ class CloudProvider {
             const messageString = event.data;
             log.info(`Received websocket message: ${messageString}`);
             const message = JSON.parse(messageString);
-            this.parseMessage(message);
+            const parsedData = this.parseMessage(message);
+            this.vm.postIOData('cloud', parsedData);
         };
 
         this.connection.onopen = () => {
@@ -75,7 +76,7 @@ class CloudProvider {
             break;
         }
         }
-        this.vm.postIOData('cloud', varData);
+        return varData;
     }
 
     /**

--- a/src/lib/vm-manager-hoc.jsx
+++ b/src/lib/vm-manager-hoc.jsx
@@ -5,7 +5,6 @@ import {connect} from 'react-redux';
 
 import VM from 'scratch-vm';
 import AudioEngine from 'scratch-audio';
-import CloudProvider from '../lib/cloud-provider';
 
 import {
     LoadingStates,
@@ -47,18 +46,6 @@ const vmManagerHOC = function (WrappedComponent) {
             return this.props.vm.loadProject(this.props.projectData)
                 .then(() => {
                     this.props.onLoadedProject(this.props.loadingState, this.props.canSave);
-                    // If the cloud host exists, open a cloud connection and
-                    // set the vm's cloud provider.
-                    if (this.props.cloudHost) {
-                        // TODO check if we should actually
-                        // connect to cloud data based on info from the loaded project and
-                        // info about the user (e.g. scratcher status)
-                        this.props.vm.setCloudProvider(new CloudProvider(
-                            this.props.cloudHost,
-                            this.props.vm,
-                            this.props.username,
-                            this.props.projectId));
-                    }
                 })
                 .catch(e => {
                     this.props.onError(e);
@@ -67,14 +54,11 @@ const vmManagerHOC = function (WrappedComponent) {
         render () {
             const {
                 /* eslint-disable no-unused-vars */
-                cloudHost,
                 fontsLoaded,
                 loadingState,
                 onError: onErrorProp,
                 onLoadedProject: onLoadedProjectProp,
                 projectData,
-                projectId,
-                username,
                 /* eslint-enable no-unused-vars */
                 isLoadingWithId: isLoadingWithIdProp,
                 vm,

--- a/test/unit/util/cloud-manager-hoc.test.jsx
+++ b/test/unit/util/cloud-manager-hoc.test.jsx
@@ -1,0 +1,119 @@
+import 'web-audio-test-api';
+
+import React from 'react';
+import configureStore from 'redux-mock-store';
+import {mount} from 'enzyme';
+import VM from 'scratch-vm';
+import {LoadingState} from '../../../src/reducers/project-state';
+import CloudProvider from '../../../src/lib/cloud-provider';
+jest.mock('../../../src/lib/cloud-provider');
+
+import cloudManagerHOC from '../../../src/lib/cloud-manager-hoc.jsx';
+
+describe('CloudManagerHOC', () => {
+    const mockStore = configureStore();
+    let store;
+    let vm;
+    let stillLoadingStore;
+
+    beforeEach(() => {
+        store = mockStore({
+            scratchGui: {
+                projectState: {
+                    projectId: '1234',
+                    loadingState: LoadingState.SHOWING_WITH_ID
+                }
+            }
+        });
+        stillLoadingStore = mockStore({
+            scratchGui: {
+                projectState: {
+                    projectId: '1234',
+                    loadingState: LoadingState.LOADING_WITH_ID
+                }
+            }
+        });
+        vm = new VM();
+        vm.setCloudProvider = jest.fn();
+        CloudProvider.mockClear();
+    });
+    test('when it mounts, the cloud provider is set on the vm', () => {
+        const Component = () => (<div />);
+        const WrappedComponent = cloudManagerHOC(Component);
+        mount(
+            <WrappedComponent
+                cloudHost="nonEmpty"
+                store={store}
+                username="user"
+                vm={vm}
+            />
+        );
+        expect(vm.setCloudProvider.mock.calls.length).toBe(1);
+        expect(CloudProvider).toHaveBeenCalledTimes(1);
+    });
+
+    test('when cloudHost is missing, the cloud provider is not set on the vm', () => {
+        const Component = () => (<div />);
+        const WrappedComponent = cloudManagerHOC(Component);
+        mount(
+            <WrappedComponent
+                store={store}
+                username="user"
+                vm={vm}
+            />
+        );
+        expect(vm.setCloudProvider.mock.calls.length).toBe(0);
+        expect(CloudProvider).not.toHaveBeenCalled();
+
+    });
+
+    test('when projectID is missing, the cloud provider is not set on the vm', () => {
+
+        const Component = () => (<div />);
+        const WrappedComponent = cloudManagerHOC(Component);
+        mount(
+            <WrappedComponent
+                cloudHost="nonEmpty"
+                store={store}
+                vm={vm}
+            />
+        );
+        expect(vm.setCloudProvider.mock.calls.length).toBe(0);
+        expect(CloudProvider).not.toHaveBeenCalled();
+    });
+
+    test('when project is not showingWithId, the cloud provider is not set on the vm', () => {
+
+        const Component = () => (<div />);
+        const WrappedComponent = cloudManagerHOC(Component);
+        mount(
+            <WrappedComponent
+                cloudHost="nonEmpty"
+                store={stillLoadingStore}
+                username="user"
+                vm={vm}
+            />
+        );
+        expect(vm.setCloudProvider.mock.calls.length).toBe(0);
+        expect(CloudProvider).not.toHaveBeenCalled();
+    });
+
+    test('if the isShowingWithId prop becomes true, it sets the cloud provider on the vm', () => {
+        const Component = () => <div />;
+        const WrappedComponent = cloudManagerHOC(Component);
+        const mounted = mount(
+            <WrappedComponent
+                cloudHost="nonEmpty"
+                store={stillLoadingStore}
+                username="user"
+                vm={vm}
+            />
+        );
+        mounted.setProps({
+            isShowingWithId: true,
+            loadingState: LoadingState.SHOWING_WITH_ID
+        });
+        expect(vm.setCloudProvider.mock.calls.length).toBe(1);
+        expect(CloudProvider).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
### Resolves

Towards having fully functional cloud variables in 3.0.

### Proposed Changes

Adds the ability to create cloud variables in a 3.0 project.
- adds a cloud variable option to the variable modal
- refactors cloud data connection logic into a separate HOC. 

#### Known Issues/TODO
- There is still more logic to come (not in this PR) about checking whether the user is a scratcher and about handling the cases where the user is viewing someone else's cloud project in editor mode.
- Adding a tooltip for why the cloud option becomes disabled (e.g. notifying the user about the cloud variable limit)
- Adding alerts/info bubbles about cloud variable usage when creating the first cloud variable in a project (like in 2.0)


### Reason for Changes

Cloud variables!

### Test Coverage

Manual testing:

On a local scratch environment (api, scratchr2, www, projects, assets), create a new account (doesn't yet have to be a scratcher) and ensure the following:
- [ ] navigate to /preview/editor to create a new project, create a cloud variable using the variable modal, see that the cloud variable gets created
- [ ] You should not be able to create more than 8 cloud variables (cloud var option becomes disabled in menu)
- [ ] Create code to modify the cloud variable, save, and share the project.
- [ ] Create another account and interact with the cloud project and see that the value of the cloud variable updates on both accounts (use separate browsers)
- [ ] In one browser, sign out and try to interact with the project (the cloud variable should neither send updates so that they show up on other accounts, nor should they receive updates made from another account).
- [ ] In signed out mode, in the editor, the cloud variable option should not show up in the variable modal
- [ ] Renaming a cloud variable should append a cloud + space if not present at the front of the rename, and should not append an extra one if it is present
- [ ] Cloud variable option should not show up in the variable modal in standalone gui

### Related PRs
- LLK/scratch-vm#1755
- LLK/scratch-blocks#1782

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [x] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
