### PR TITLE
Use storage for library icons

### DIFF
--- a/src/components/library-item/library-item.jsx
+++ b/src/components/library-item/library-item.jsx
@@ -13,6 +13,13 @@ import internetConnectionIconURL from './internet-connection.svg';
 class LibraryItem extends React.PureComponent {
     constructor (props) {
         super(props);
+        this.state = {
+            iconURL: null
+        };
+        Promise.resolve(props.iconURL)
+            .then(url => this.setState({
+                iconURL: url
+            }));
         bindAll(this, [
             'handleBlur',
             'handleClick',
@@ -72,7 +79,7 @@ class LibraryItem extends React.PureComponent {
                     ) : null}
                     <img
                         className={styles.featuredImage}
-                        src={this.props.iconURL}
+                        src={this.state.iconURL}
                     />
                 </div>
                 {this.props.insetIconURL ? (
@@ -158,7 +165,7 @@ class LibraryItem extends React.PureComponent {
                     <Box className={styles.libraryItemImageContainer}>
                         <img
                             className={styles.libraryItemImage}
-                            src={this.props.iconURL}
+                            src={this.state.iconURL}
                         />
                     </Box>
                 </Box>
@@ -179,7 +186,10 @@ LibraryItem.propTypes = {
     extensionId: PropTypes.string,
     featured: PropTypes.bool,
     hidden: PropTypes.bool,
-    iconURL: PropTypes.string,
+    iconURL: PropTypes.oneOfType([
+        PropTypes.string, // URL
+        PropTypes.instanceOf(Promise) // Promise for URL
+    ]),
     id: PropTypes.number.isRequired,
     insetIconURL: PropTypes.string,
     internetConnectionRequired: PropTypes.bool,

--- a/src/components/library-item/library-item.jsx
+++ b/src/components/library-item/library-item.jsx
@@ -10,16 +10,9 @@ import classNames from 'classnames';
 import bluetoothIconURL from './bluetooth.svg';
 import internetConnectionIconURL from './internet-connection.svg';
 
-class LibraryItem extends React.PureComponent {
+class LibraryItemComponent extends React.PureComponent {
     constructor (props) {
         super(props);
-        this.state = {
-            iconURL: null
-        };
-        Promise.resolve(props.iconURL)
-            .then(url => this.setState({
-                iconURL: url
-            }));
         bindAll(this, [
             'handleBlur',
             'handleClick',
@@ -79,7 +72,7 @@ class LibraryItem extends React.PureComponent {
                     ) : null}
                     <img
                         className={styles.featuredImage}
-                        src={this.state.iconURL}
+                        src={this.props.iconURI}
                     />
                 </div>
                 {this.props.insetIconURL ? (
@@ -165,7 +158,7 @@ class LibraryItem extends React.PureComponent {
                     <Box className={styles.libraryItemImageContainer}>
                         <img
                             className={styles.libraryItemImage}
-                            src={this.state.iconURL}
+                            src={this.props.iconURI}
                         />
                     </Box>
                 </Box>
@@ -175,7 +168,7 @@ class LibraryItem extends React.PureComponent {
     }
 }
 
-LibraryItem.propTypes = {
+LibraryItemComponent.propTypes = {
     bluetoothRequired: PropTypes.bool,
     collaborator: PropTypes.string,
     description: PropTypes.oneOfType([
@@ -186,10 +179,7 @@ LibraryItem.propTypes = {
     extensionId: PropTypes.string,
     featured: PropTypes.bool,
     hidden: PropTypes.bool,
-    iconURL: PropTypes.oneOfType([
-        PropTypes.string, // URL
-        PropTypes.instanceOf(Promise) // Promise for URL
-    ]),
+    iconURI: PropTypes.string,
     id: PropTypes.number.isRequired,
     insetIconURL: PropTypes.string,
     internetConnectionRequired: PropTypes.bool,
@@ -204,8 +194,8 @@ LibraryItem.propTypes = {
     onSelect: PropTypes.func.isRequired
 };
 
-LibraryItem.defaultProps = {
+LibraryItemComponent.defaultProps = {
     disabled: false
 };
 
-export default LibraryItem;
+export default LibraryItemComponent;

--- a/src/components/library-item/library-item.jsx
+++ b/src/components/library-item/library-item.jsx
@@ -1,4 +1,3 @@
-import bindAll from 'lodash.bindall';
 import {FormattedMessage} from 'react-intl';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -11,41 +10,6 @@ import bluetoothIconURL from './bluetooth.svg';
 import internetConnectionIconURL from './internet-connection.svg';
 
 class LibraryItemComponent extends React.PureComponent {
-    constructor (props) {
-        super(props);
-        bindAll(this, [
-            'handleBlur',
-            'handleClick',
-            'handleFocus',
-            'handleKeyPress',
-            'handleMouseEnter',
-            'handleMouseLeave'
-        ]);
-    }
-    handleBlur () {
-        this.props.onBlur(this.props.id);
-    }
-    handleFocus () {
-        this.props.onFocus(this.props.id);
-    }
-    handleClick (e) {
-        if (!this.props.disabled) {
-            this.props.onSelect(this.props.id);
-        }
-        e.preventDefault();
-    }
-    handleKeyPress (e) {
-        if (e.key === ' ' || e.key === 'Enter') {
-            e.preventDefault();
-            this.props.onSelect(this.props.id);
-        }
-    }
-    handleMouseEnter () {
-        this.props.onMouseEnter(this.props.id);
-    }
-    handleMouseLeave () {
-        this.props.onMouseLeave(this.props.id);
-    }
     render () {
         return this.props.featured ? (
             <div
@@ -58,7 +22,7 @@ class LibraryItemComponent extends React.PureComponent {
                     this.props.extensionId ? styles.libraryItemExtension : null,
                     this.props.hidden ? styles.hidden : null
                 )}
-                onClick={this.handleClick}
+                onClick={this.props.onClick}
             >
                 <div className={styles.featuredImageContainer}>
                     {this.props.disabled ? (
@@ -146,12 +110,12 @@ class LibraryItemComponent extends React.PureComponent {
                 )}
                 role="button"
                 tabIndex="0"
-                onBlur={this.handleBlur}
-                onClick={this.handleClick}
-                onFocus={this.handleFocus}
-                onKeyPress={this.handleKeyPress}
-                onMouseEnter={this.handleMouseEnter}
-                onMouseLeave={this.handleMouseLeave}
+                onBlur={this.props.onBlur}
+                onClick={this.props.onClick}
+                onFocus={this.props.onFocus}
+                onKeyPress={this.props.onKeyPress}
+                onMouseEnter={this.props.onMouseEnter}
+                onMouseLeave={this.props.onMouseLeave}
             >
                 {/* Layers of wrapping is to prevent layout thrashing on animation */}
                 <Box className={styles.libraryItemImageContainerWrapper}>
@@ -180,7 +144,6 @@ LibraryItemComponent.propTypes = {
     featured: PropTypes.bool,
     hidden: PropTypes.bool,
     iconURI: PropTypes.string,
-    id: PropTypes.number.isRequired,
     insetIconURL: PropTypes.string,
     internetConnectionRequired: PropTypes.bool,
     name: PropTypes.oneOfType([
@@ -188,10 +151,11 @@ LibraryItemComponent.propTypes = {
         PropTypes.node
     ]),
     onBlur: PropTypes.func,
+    onClick: PropTypes.func,
     onFocus: PropTypes.func,
-    onMouseEnter: PropTypes.func.isRequired,
-    onMouseLeave: PropTypes.func.isRequired,
-    onSelect: PropTypes.func.isRequired
+    onKeyPress: PropTypes.func,
+    onMouseEnter: PropTypes.func,
+    onMouseLeave: PropTypes.func
 };
 
 LibraryItemComponent.defaultProps = {

--- a/src/components/library/library.jsx
+++ b/src/components/library/library.jsx
@@ -4,13 +4,12 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {defineMessages, injectIntl, intlShape} from 'react-intl';
 
-import LibraryItem from '../library-item/library-item.jsx';
+import LibraryItem from '../../containers/library-item.jsx';
 import Modal from '../../containers/modal.jsx';
 import Divider from '../divider/divider.jsx';
 import Filter from '../filter/filter.jsx';
 import TagButton from '../../containers/tag-button.jsx';
 import analytics from '../../lib/analytics';
-import storage from '../../lib/storage';
 
 import styles from './library.css';
 
@@ -29,23 +28,6 @@ const messages = defineMessages({
 
 const ALL_TAG = {tag: 'all', intlLabel: messages.allTag};
 const tagListPrefix = [ALL_TAG];
-
-/**
- * @param {string} extension - the extension to look up.
- * @returns {AssetType} - the AssetType corresponding to the extension, if any.
- */
-const getAssetTypeForExtension = function (extension) {
-    const compareOptions = {
-        sensitivity: 'accent',
-        usage: 'search'
-    };
-    for (const assetTypeId of Object.keys(storage.AssetType)) {
-        const assetType = storage.AssetType[assetTypeId];
-        if (extension.localeCompare(assetType.runtimeFormat, compareOptions) === 0) {
-            return assetType;
-        }
-    }
-};
 
 class LibraryComponent extends React.Component {
     constructor (props) {
@@ -190,41 +172,29 @@ class LibraryComponent extends React.Component {
                     })}
                     ref={this.setFilteredDataRef}
                 >
-                    {this.getFilteredData().map((dataItem, index) => {
-                        let iconURL;
-                        if (dataItem.md5) {
-                            // TODO: adjust libraries to be more storage-friendly; don't use split() here.
-                            const [md5, ext] = dataItem.md5.split('.');
-                            const assetType = getAssetTypeForExtension(ext);
-                            iconURL = storage.load(assetType, md5)
-                                .then(asset => asset.encodeDataURI());
-                        } else {
-                            iconURL = dataItem.rawURL;
-                        }
-
-                        return (
-                            <LibraryItem
-                                bluetoothRequired={dataItem.bluetoothRequired}
-                                collaborator={dataItem.collaborator}
-                                description={dataItem.description}
-                                disabled={dataItem.disabled}
-                                extensionId={dataItem.extensionId}
-                                featured={dataItem.featured}
-                                hidden={dataItem.hidden}
-                                iconURL={iconURL}
-                                id={index}
-                                insetIconURL={dataItem.insetIconURL}
-                                internetConnectionRequired={dataItem.internetConnectionRequired}
-                                key={`item_${index}`}
-                                name={dataItem.name}
-                                onBlur={this.handleBlur}
-                                onFocus={this.handleFocus}
-                                onMouseEnter={this.handleMouseEnter}
-                                onMouseLeave={this.handleMouseLeave}
-                                onSelect={this.handleSelect}
-                            />
-                        );
-                    })}
+                    {this.getFilteredData().map((dataItem, index) => (
+                        <LibraryItem
+                            bluetoothRequired={dataItem.bluetoothRequired}
+                            collaborator={dataItem.collaborator}
+                            description={dataItem.description}
+                            disabled={dataItem.disabled}
+                            extensionId={dataItem.extensionId}
+                            featured={dataItem.featured}
+                            hidden={dataItem.hidden}
+                            iconMD5={dataItem.md5} // either this or iconURL must be defined
+                            iconURL={dataItem.rawURL} // either this or iconMD5 must be defined
+                            id={index}
+                            insetIconURL={dataItem.insetIconURL}
+                            internetConnectionRequired={dataItem.internetConnectionRequired}
+                            key={`item_${index}`}
+                            name={dataItem.name}
+                            onBlur={this.handleBlur}
+                            onFocus={this.handleFocus}
+                            onMouseEnter={this.handleMouseEnter}
+                            onMouseLeave={this.handleMouseLeave}
+                            onSelect={this.handleSelect}
+                        />
+                    ))}
                 </div>
             </Modal>
         );

--- a/src/containers/library-item.jsx
+++ b/src/containers/library-item.jsx
@@ -1,0 +1,74 @@
+import React from 'react';
+
+import LibraryItemComponent from '../components/library-item/library-item.jsx';
+import storage from '../lib/storage';
+
+/**
+ * @param {string} extension - the extension to look up.
+ * @returns {AssetType} - the AssetType corresponding to the extension, if any.
+ */
+const getAssetTypeForExtension = function (extension) {
+    const compareOptions = {
+        sensitivity: 'accent',
+        usage: 'search'
+    };
+    for (const assetTypeId of Object.keys(storage.AssetType)) {
+        const assetType = storage.AssetType[assetTypeId];
+        if (extension.localeCompare(assetType.runtimeFormat, compareOptions) === 0) {
+            return assetType;
+        }
+    }
+};
+
+class LibraryItem extends React.PureComponent {
+    constructor (props) {
+        super(props);
+        this.state = Object.assign(this.state || {}, {
+            iconURI: props.iconURL // may be undefined if we're using iconMD5 instead
+        });
+    }
+    componentWillReceiveProps (nextProps) {
+        if (nextProps.iconURL) {
+            this.setState({iconURI: nextProps.iconURL});
+        } else if ((!this.state.iconURI) || nextProps.iconMD5 !== this.props.iconMD5) {
+            // TODO: adjust libraries to be more storage-friendly; don't use split() here.
+            const [md5, ext] = nextProps.iconMD5.split('.');
+            const assetType = getAssetTypeForExtension(ext);
+            storage.load(assetType, md5)
+                .then(asset => {
+                    this.setState({iconURI: asset.encodeDataURI()});
+                });
+        }
+    }
+    render () {
+        const {iconMD5: _iconMD5, iconURL: _iconURL, ...childProps} = this.props;
+        return (<LibraryItemComponent
+            iconURI={this.state.iconURI}
+            {...childProps}
+        />);
+    }
+}
+
+LibraryItem.requireUrlOrMD5 = function (props) {
+    if (typeof props.iconMD5 === 'string' && typeof props.iconURL === 'undefined') {
+        return;
+    }
+    if (typeof props.iconMD5 === 'undefined' && typeof props.iconURL === 'string') {
+        return;
+    }
+    return new Error('Exactly one of iconURL or iconMD5 must be set and the value must be a string.');
+};
+
+LibraryItem.propTypes = Object.assign({},
+    (() => {
+        // copy all props EXCEPT iconURI from LibraryItemComponent
+        const {iconURI: _iconURI, ...otherProps} = LibraryItemComponent.propTypes;
+        return otherProps;
+    })(),
+    {
+        iconMD5: LibraryItem.requireUrlOrMD5,
+        iconURL: LibraryItem.requireUrlOrMD5
+    }
+);
+
+export default LibraryItem;

--- a/src/containers/library-item.jsx
+++ b/src/containers/library-item.jsx
@@ -1,3 +1,5 @@
+import bindAll from 'lodash.bindall';
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import LibraryItemComponent from '../components/library-item/library-item.jsx';
@@ -23,6 +25,14 @@ const getAssetTypeForExtension = function (extension) {
 class LibraryItem extends React.PureComponent {
     constructor (props) {
         super(props);
+        bindAll(this, [
+            'handleBlur',
+            'handleClick',
+            'handleFocus',
+            'handleKeyPress',
+            'handleMouseEnter',
+            'handleMouseLeave'
+        ]);
         this.state = Object.assign(this.state || {}, {
             iconURI: props.iconURL // may be undefined if we're using iconMD5 instead
         });
@@ -40,10 +50,50 @@ class LibraryItem extends React.PureComponent {
                 });
         }
     }
+    handleBlur () {
+        this.props.onBlur(this.props.id);
+    }
+    handleFocus () {
+        this.props.onFocus(this.props.id);
+    }
+    handleClick (e) {
+        if (!this.props.disabled) {
+            this.props.onSelect(this.props.id);
+        }
+        e.preventDefault();
+    }
+    handleKeyPress (e) {
+        if (e.key === ' ' || e.key === 'Enter') {
+            e.preventDefault();
+            this.props.onSelect(this.props.id);
+        }
+    }
+    handleMouseEnter () {
+        this.props.onMouseEnter(this.props.id);
+    }
+    handleMouseLeave () {
+        this.props.onMouseLeave(this.props.id);
+    }
     render () {
-        const {iconMD5: _iconMD5, iconURL: _iconURL, ...childProps} = this.props;
+        const {
+            iconMD5: _iconMD5,
+            iconURL: _iconURL,
+            id: _id,
+            onBlur: _onBlur,
+            onFocus: _onFocus,
+            onMouseEnter: _onMouseEnter,
+            onMouseLeave: _onMouseLeave,
+            onSelect: _onSelect,
+            ...childProps
+        } = this.props;
         return (<LibraryItemComponent
             iconURI={this.state.iconURI}
+            onBlur={this.props.onBlur && this.handleBlur}
+            onClick={this.handleClick}
+            onFocus={this.props.onFocus && this.handleFocus}
+            onKeyPress={this.handleKeyPress}
+            onMouseEnter={this.props.onMouseEnter && this.handleMouseEnter}
+            onMouseLeave={this.props.onMouseLeave && this.handleMouseLeave}
             {...childProps}
         />);
     }
@@ -61,13 +111,20 @@ LibraryItem.requireUrlOrMD5 = function (props) {
 
 LibraryItem.propTypes = Object.assign({},
     (() => {
-        // copy all props EXCEPT iconURI from LibraryItemComponent
-        const {iconURI: _iconURI, ...otherProps} = LibraryItemComponent.propTypes;
-        return otherProps;
+        // copy all prop types EXCEPT these from LibraryItemComponent
+        const {
+            iconURI: _iconURI,
+            onClick: _onClick,
+            onKeyPress: _onKeyPress,
+            ...otherPropTypes
+        } = LibraryItemComponent.propTypes;
+        return otherPropTypes;
     })(),
     {
+        id: PropTypes.number.isRequired,
         iconMD5: LibraryItem.requireUrlOrMD5,
-        iconURL: LibraryItem.requireUrlOrMD5
+        iconURL: LibraryItem.requireUrlOrMD5,
+        onSelect: PropTypes.func.isRequired
     }
 );
 

--- a/src/containers/library-item.jsx
+++ b/src/containers/library-item.jsx
@@ -6,17 +6,18 @@ import LibraryItemComponent from '../components/library-item/library-item.jsx';
 import storage from '../lib/storage';
 
 /**
- * @param {string} extension - the extension to look up.
+ * Find the AssetType which corresponds to a particular file extension. For example, 'png' => AssetType.ImageBitmap.
+ * @param {string} fileExtension - the file extension to look up.
  * @returns {AssetType} - the AssetType corresponding to the extension, if any.
  */
-const getAssetTypeForExtension = function (extension) {
+const getAssetTypeForFileExtension = function (fileExtension) {
     const compareOptions = {
         sensitivity: 'accent',
         usage: 'search'
     };
     for (const assetTypeId of Object.keys(storage.AssetType)) {
         const assetType = storage.AssetType[assetTypeId];
-        if (extension.localeCompare(assetType.runtimeFormat, compareOptions) === 0) {
+        if (fileExtension.localeCompare(assetType.runtimeFormat, compareOptions) === 0) {
             return assetType;
         }
     }
@@ -58,7 +59,7 @@ class LibraryItem extends React.PureComponent {
         if (this.state.lastRequestedMD5 !== props.iconMD5) {
             // TODO: adjust libraries to be more storage-friendly; don't use split() here.
             const [md5, ext] = props.iconMD5.split('.');
-            const assetType = getAssetTypeForExtension(ext);
+            const assetType = getAssetTypeForFileExtension(ext);
             storage.load(assetType, md5)
                 .then(asset => {
                     this.setState({

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -202,7 +202,7 @@ module.exports = [
                         loader: 'file-loader',
                         options: {
                             outputPath: 'static/assets/',
-                            publicPath: '/static/assets/'
+                            publicPath: 'static/assets/'
                         }
                     }
                 ])


### PR DESCRIPTION
### Proposed Changes

The `LibraryItem` component is now capable of loading its icon through `scratch-storage`, allowing the sprite and costume libraries to work correctly without a connection to our asset server. The component still supports a static URL, as before, for cases like the extension library or sound library where icons come from assets under the `static/` path.

As part of this effort `LibraryItem` was split into two parts: `src/components/library-item/library-item.jsx` handles presentation while `src/containers/library-item.jsx` handles input events and making `scratch-storage` requests.

### Reason for Changes

These changes allow `scratch-desktop` to correctly load all libraries even when there is no active Internet connection.

### Test Coverage

No change in test coverage: all libraries should behave as they did before, and any tests which operate on the libraries should require no changes.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 
Windows
 * [x] Chrome 
 