### PR TITLE
project-watcher can request eventual callback, or immediately call ca…

### DIFF
--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -171,24 +171,24 @@ class MenuBar extends React.Component {
         this.props.onClickSaveAsCopy();
         this.props.onRequestCloseFile();
     }
-    handleClickSeeCommunity (requestSeeCommunity) {
+    handleClickSeeCommunity (waitForUpdate) {
         if (this.props.canSave) { // save before transitioning to project page
             this.props.autoSave();
-            requestSeeCommunity(true); // queue the transition to project page
+            waitForUpdate(true); // queue the transition to project page
         } else {
-            requestSeeCommunity(false); // immediately transition to project page
+            waitForUpdate(false); // immediately transition to project page
         }
     }
-    handleClickShare (requestSeeCommunity) {
+    handleClickShare (waitForUpdate) {
         if (!this.props.isShared) {
             if (this.props.canShare) { // save before transitioning to project page
                 this.props.onShare();
             }
             if (this.props.canSave) { // save before transitioning to project page
                 this.props.autoSave();
-                requestSeeCommunity(true); // queue the transition to project page
+                waitForUpdate(true); // queue the transition to project page
             } else {
-                requestSeeCommunity(false); // immediately transition to project page
+                waitForUpdate(false); // immediately transition to project page
             }
         }
     }
@@ -480,17 +480,15 @@ class MenuBar extends React.Component {
                     <div className={classNames(styles.menuBarItem)}>
                         {this.props.canShare ? (
                             (this.props.isShowingProject || this.props.isUpdating) && (
-                                <ProjectWatcher
-                                    onShowingWithId={this.props.onSeeCommunity}
-                                >
+                                <ProjectWatcher onDoneUpdating={this.props.onSeeCommunity}>
                                     {
-                                        setRequesting => (
+                                        waitForUpdate => (
                                             <ShareButton
                                                 className={styles.menuBarButton}
                                                 isShared={this.props.isShared}
                                                 /* eslint-disable react/jsx-no-bind */
                                                 onClick={() => {
-                                                    this.handleClickShare(setRequesting);
+                                                    this.handleClickShare(waitForUpdate);
                                                 }}
                                                 /* eslint-enable react/jsx-no-bind */
                                             />
@@ -510,16 +508,14 @@ class MenuBar extends React.Component {
                     <div className={classNames(styles.menuBarItem, styles.communityButtonWrapper)}>
                         {this.props.enableCommunity ? (
                             (this.props.isShowingProject || this.props.isUpdating) && (
-                                <ProjectWatcher
-                                    onShowingWithId={this.props.onSeeCommunity}
-                                >
+                                <ProjectWatcher onDoneUpdating={this.props.onSeeCommunity}>
                                     {
-                                        setRequesting => (
+                                        waitForUpdate => (
                                             <CommunityButton
                                                 className={styles.menuBarButton}
                                                 /* eslint-disable react/jsx-no-bind */
                                                 onClick={() => {
-                                                    this.handleClickSeeCommunity(setRequesting);
+                                                    this.handleClickSeeCommunity(waitForUpdate);
                                                 }}
                                                 /* eslint-enable react/jsx-no-bind */
                                             />

--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -173,7 +173,7 @@ class MenuBar extends React.Component {
     }
     handleClickSeeCommunity (waitForUpdate) {
         if (this.props.canSave) { // save before transitioning to project page
-            this.props.autoSave();
+            this.props.autoUpdateProject();
             waitForUpdate(true); // queue the transition to project page
         } else {
             waitForUpdate(false); // immediately transition to project page
@@ -185,7 +185,7 @@ class MenuBar extends React.Component {
                 this.props.onShare();
             }
             if (this.props.canSave) { // save before transitioning to project page
-                this.props.autoSave();
+                this.props.autoUpdateProject();
                 waitForUpdate(true); // queue the transition to project page
             } else {
                 waitForUpdate(false); // immediately transition to project page
@@ -753,7 +753,7 @@ const mapStateToProps = state => {
 };
 
 const mapDispatchToProps = dispatch => ({
-    autoSave: () => dispatch(autoUpdateProject()),
+    autoUpdateProject: () => dispatch(autoUpdateProject()),
     onOpenTipLibrary: () => dispatch(openTipsLibrary()),
     onClickAccount: () => dispatch(openAccountMenu()),
     onRequestCloseAccount: () => dispatch(closeAccountMenu()),

--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -27,6 +27,7 @@ import TurboMode from '../../containers/turbo-mode.jsx';
 import {openTipsLibrary} from '../../reducers/modals';
 import {setPlayer} from '../../reducers/mode';
 import {
+    autoUpdateProject,
     getIsUpdating,
     getIsShowingProject,
     manualUpdateProject,
@@ -172,17 +173,23 @@ class MenuBar extends React.Component {
     }
     handleClickSeeCommunity (requestSeeCommunity) {
         if (this.props.canSave) { // save before transitioning to project page
-            this.props.onClickSave();
+            this.props.autoSave();
+            requestSeeCommunity(true); // queue the transition to project page
+        } else {
+            requestSeeCommunity(false); // immediately transition to project page
         }
-        requestSeeCommunity(); // queue the transition to project page
     }
     handleClickShare (requestSeeCommunity) {
-        if (this.props.canSave && !this.props.isShared) { // save before transitioning to project page
-            this.props.onClickSave();
-        }
-        if (this.props.canShare && !this.props.isShared) { // save before transitioning to project page
-            this.props.onShare();
-            requestSeeCommunity(); // queue the transition to project page
+        if (!this.props.isShared) {
+            if (this.props.canShare) { // save before transitioning to project page
+                this.props.onShare();
+            }
+            if (this.props.canSave) { // save before transitioning to project page
+                this.props.autoSave();
+                requestSeeCommunity(true); // queue the transition to project page
+            } else {
+                requestSeeCommunity(false); // immediately transition to project page
+            }
         }
     }
     handleRestoreOption (restoreFun) {
@@ -681,6 +688,7 @@ MenuBar.propTypes = {
     authorId: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
     authorThumbnailUrl: PropTypes.string,
     authorUsername: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+    autoUpdateProject: PropTypes.func,
     canCreateCopy: PropTypes.bool,
     canCreateNew: PropTypes.bool,
     canEditTitle: PropTypes.bool,
@@ -749,6 +757,7 @@ const mapStateToProps = state => {
 };
 
 const mapDispatchToProps = dispatch => ({
+    autoSave: () => dispatch(autoUpdateProject()),
     onOpenTipLibrary: () => dispatch(openTipsLibrary()),
     onClickAccount: () => dispatch(openAccountMenu()),
     onRequestCloseAccount: () => dispatch(closeAccountMenu()),

--- a/src/containers/project-watcher.jsx
+++ b/src/containers/project-watcher.jsx
@@ -20,17 +20,23 @@ class ProjectWatcher extends React.Component {
     }
     componentDidUpdate (prevProps) {
         if (this.state.requesting && this.props.isShowingWithId && !prevProps.isShowingWithId) {
-            this.props.onShowingWithId();
-            this.setState({ // eslint-disable-line react/no-did-update-set-state
-                requesting: false
-            });
+            this.fulfillRequest();
         }
-
     }
-    setRequesting () {
-        this.setState({
-            requesting: true
+    fulfillRequest () {
+        this.props.onShowingWithId();
+        this.setState({ // eslint-disable-line react/no-did-update-set-state
+            requesting: false
         });
+    }
+    setRequesting (waitForRequest) {
+        if (waitForRequest) {
+            this.setState({
+                requesting: true
+            });
+        } else { // fulfill immediately
+            this.fulfillRequest();
+        }
     }
     render () {
         return this.props.children(

--- a/src/containers/project-watcher.jsx
+++ b/src/containers/project-watcher.jsx
@@ -7,6 +7,14 @@ import {
     getIsShowingWithId
 } from '../reducers/project-state';
 
+/**
+ * Watches for project to finish updating before taking some action.
+ *
+ * To use ProjectWatcher, pass it a callback function using the onDoneUpdating prop.
+ * ProjectWatcher passes a waitForUpdate function to its children, which they can call
+ * to set ProjectWatcher to request that it call the onDoneUpdating callback when
+ * project is no longer updating.
+ */
 class ProjectWatcher extends React.Component {
     constructor (props) {
         super(props);
@@ -29,8 +37,8 @@ class ProjectWatcher extends React.Component {
             waiting: false
         });
     }
-    waitForSaving (isSaving) {
-        if (isSaving) {
+    waitForUpdate (isUpdating) {
+        if (isUpdating) {
             this.setState({
                 waiting: true
             });
@@ -40,7 +48,7 @@ class ProjectWatcher extends React.Component {
     }
     render () {
         return this.props.children(
-            this.waitForSaving
+            this.waitForUpdate
         );
     }
 }

--- a/src/containers/project-watcher.jsx
+++ b/src/containers/project-watcher.jsx
@@ -11,28 +11,28 @@ class ProjectWatcher extends React.Component {
     constructor (props) {
         super(props);
         bindAll(this, [
-            'setRequesting'
+            'waitForSaving'
         ]);
 
         this.state = {
-            requesting: false
+            waiting: false
         };
     }
     componentDidUpdate (prevProps) {
-        if (this.state.requesting && this.props.isShowingWithId && !prevProps.isShowingWithId) {
+        if (this.state.waiting && this.props.isShowingWithId && !prevProps.isShowingWithId) {
             this.fulfillRequest();
         }
     }
     fulfillRequest () {
-        this.props.onShowingWithId();
+        this.props.onDoneUpdating();
         this.setState({ // eslint-disable-line react/no-did-update-set-state
-            requesting: false
+            waiting: false
         });
     }
-    setRequesting (waitForRequest) {
-        if (waitForRequest) {
+    waitForSaving (isSaving) {
+        if (isSaving) {
             this.setState({
-                requesting: true
+                waiting: true
             });
         } else { // fulfill immediately
             this.fulfillRequest();
@@ -40,7 +40,7 @@ class ProjectWatcher extends React.Component {
     }
     render () {
         return this.props.children(
-            this.setRequesting
+            this.waitForSaving
         );
     }
 }
@@ -48,11 +48,11 @@ class ProjectWatcher extends React.Component {
 ProjectWatcher.propTypes = {
     children: PropTypes.func,
     isShowingWithId: PropTypes.bool,
-    onShowingWithId: PropTypes.func
+    onDoneUpdating: PropTypes.func
 };
 
 ProjectWatcher.defaultProps = {
-    onShowingWithId: () => {}
+    onDoneUpdating: () => {}
 };
 
 const mapStateToProps = state => {

--- a/src/containers/project-watcher.jsx
+++ b/src/containers/project-watcher.jsx
@@ -19,7 +19,7 @@ class ProjectWatcher extends React.Component {
     constructor (props) {
         super(props);
         bindAll(this, [
-            'waitForSaving'
+            'waitForUpdate'
         ]);
 
         this.state = {
@@ -28,10 +28,10 @@ class ProjectWatcher extends React.Component {
     }
     componentDidUpdate (prevProps) {
         if (this.state.waiting && this.props.isShowingWithId && !prevProps.isShowingWithId) {
-            this.fulfillRequest();
+            this.fulfill();
         }
     }
-    fulfillRequest () {
+    fulfill () {
         this.props.onDoneUpdating();
         this.setState({ // eslint-disable-line react/no-did-update-set-state
             waiting: false
@@ -43,7 +43,7 @@ class ProjectWatcher extends React.Component {
                 waiting: true
             });
         } else { // fulfill immediately
-            this.fulfillRequest();
+            this.fulfill();
         }
     }
     render () {


### PR DESCRIPTION
Addresses a bug introduced in https://github.com/LLK/scratch-gui/pull/3638 where user cannot click on See Community button to transition from editor to project page, if user does now own project.

Revises `ProjectWatcher` component so that it can be set to callback a function after waiting for project to finish saving, *or* to immediately call the callback.

Also ensures that saves before transition are auto-saves, not manual saves.