### PR TITLE
Fixing library item height stretch only for extensions.

### DIFF
--- a/src/components/library-item/library-item.css
+++ b/src/components/library-item/library-item.css
@@ -3,12 +3,10 @@
 
 .library-item {
     display: flex;
-    align-self: stretch;
     flex-direction: column;
     align-items: center;
     justify-content: flex-start;
     flex-basis: 160px;
-    max-width: 160px;
     height: 160px;
     margin: $space;
     padding: 1rem 1rem 0 1rem;
@@ -21,6 +19,10 @@
     border-radius: $space;
     text-align: center;
     cursor: pointer;
+}
+
+.library-item-extension {
+    align-self: stretch;
 }
 
 .library-item:hover {

--- a/src/components/library-item/library-item.jsx
+++ b/src/components/library-item/library-item.jsx
@@ -54,7 +54,8 @@ class LibraryItem extends React.PureComponent {
                     styles.featuredItem,
                     {
                         [styles.disabled]: this.props.disabled
-                    }
+                    },
+                    this.props.extensionId ? styles.libraryItemExtension : null
                 )}
                 onClick={this.handleClick}
             >


### PR DESCRIPTION
### Resolves

- Resolves #3790: Tutorials library displays incorrectly when "music" filter is selected
