### PR TITLE
Support multiple commands from cloud data server

### DIFF
--- a/test/unit/util/cloud-provider.test.js
+++ b/test/unit/util/cloud-provider.test.js
@@ -6,13 +6,21 @@ global.WebSocket = null;
 describe('CloudProvider', () => {
     let cloudProvider = null;
     let sentMessage = null;
+    let vmIOData = [];
 
     beforeEach(() => {
+        vmIOData = [];
         cloudProvider = new CloudProvider();
         // Stub connection
         cloudProvider.connection = {
             send: msg => {
                 sentMessage = msg;
+            }
+        };
+        // Stub vm
+        cloudProvider.vm = {
+            postIOData: (_namespace, data) => {
+                vmIOData.push(data);
             }
         };
     });
@@ -40,5 +48,40 @@ describe('CloudProvider', () => {
         expect(obj.name).toEqual('name');
         expect(obj.value).toEqual(5);
         expect(obj.index).toEqual(0);
+    });
+
+    test('onMessage ack', () => {
+        const msg = JSON.stringify({
+            method: 'ack',
+            name: 'name'
+        });
+        cloudProvider.onMessage({data: msg});
+        expect(vmIOData[0].varCreate.name).toEqual('name');
+    });
+
+    test('onMessage set', () => {
+        const msg = JSON.stringify({
+            method: 'set',
+            name: 'name',
+            value: 'value'
+        });
+        cloudProvider.onMessage({data: msg});
+        expect(vmIOData[0].varUpdate.name).toEqual('name');
+        expect(vmIOData[0].varUpdate.value).toEqual('value');
+    });
+
+    test('onMessage with multiple commands', () => {
+        const msg1 = JSON.stringify({
+            method: 'set',
+            name: 'name1',
+            value: 'value'
+        });
+        const msg2 = JSON.stringify({
+            method: 'ack',
+            name: 'name2'
+        });
+        cloudProvider.onMessage({data: `${msg1}\n${msg2}`});
+        expect(vmIOData[0].varUpdate.name).toEqual('name1');
+        expect(vmIOData[1].varCreate.name).toEqual('name2');
     });
 });


### PR DESCRIPTION
Fix an issue where the cloud data server sends multiple newline separated commands that each look like JSON, rather than a single JSON-parseable object

/cc @colbygk @kchadha 