### PR TITLE
Update videoState to match default in rendered-target

### DIFF
--- a/src/lib/default-project/project-data.js
+++ b/src/lib/default-project/project-data.js
@@ -62,10 +62,7 @@ const projectData = translateFunction => {
                         md5ext: '83a9787d4cb6f3b7632b4ddfebf74367.wav'
                     }
                 ],
-                volume: 100,
-                tempo: 60,
-                videoTransparency: 50,
-                videoState: 'off'
+                volume: 100
             },
             {
                 isStage: false,


### PR DESCRIPTION
### Resolves

This will help with https://github.com/LLK/scratch-vm/issues/1635

### Proposed Changes

Set the default project's videoState to 'on'

### Reason for Changes

[Currently the default videoState in the VM is 'on',](https://github.com/LLK/scratch-vm/blob/develop/src/sprites/rendered-target.js#L154) which is helpful for making sure adding a video extension enables the camera by default. Setting the project default to 'on' in the GUI will make sure this default isn't overwritten for default SB3 projects. This change won't automatically turn on the video device, an extension will still need to be added for the video to turn on. 
