### PR TITLE
Add exponential backoff for cloud provider.

### DIFF
--- a/src/lib/cloud-provider.js
+++ b/src/lib/cloud-provider.js
@@ -79,7 +79,7 @@ class CloudProvider {
     }
 
     setTimeout (fn, time) {
-        log.info(`Reconnecting in ${time}ms, attempt ${this.connectionAttempts}`);
+        log.info(`Reconnecting in ${Math.floor(time / 1000)}s, attempt ${this.connectionAttempts}`);
         this._connectionTimeout = window.setTimeout(fn, time);
     }
 

--- a/src/lib/cloud-provider.js
+++ b/src/lib/cloud-provider.js
@@ -58,20 +58,16 @@ class CloudProvider {
     }
 
     onOpen () {
-        this.connectionAttempts = 1; // Reset because we successfully connected
+        this.connectionAttempts = 0; // Reset because we successfully connected
         this.writeToServer('handshake');
         log.info(`Successfully connected to clouddata server.`);
     }
 
     onClose () {
         log.info(`Closed connection to websocket`);
+        this.connectionAttempts += 1;
         const randomizedTimeout = this.randomizeDuration(this.exponentialTimeout());
-        this.setTimeout(this.reconnectNow.bind(this), randomizedTimeout);
-    }
-
-    reconnectNow () {
-        this.connectionAttempts = this.connectionAttempts + 1;
-        this.openConnection();
+        this.setTimeout(this.openConnection.bind(this), randomizedTimeout);
     }
 
     exponentialTimeout () {

--- a/src/playground/render-gui.jsx
+++ b/src/playground/render-gui.jsx
@@ -31,6 +31,11 @@ export default appTarget => {
     if (process.env.NODE_ENV === 'production' && typeof window === 'object') {
         // Warn before navigating away
         window.onbeforeunload = () => true;
+    } else {
+        window.onerror = e => {
+            alert('Uncaught error occurred–check the console'); // eslint-disable-line
+            throw e;
+        };
     }
 
     ReactDOM.render(

--- a/src/playground/render-gui.jsx
+++ b/src/playground/render-gui.jsx
@@ -31,11 +31,6 @@ export default appTarget => {
     if (process.env.NODE_ENV === 'production' && typeof window === 'object') {
         // Warn before navigating away
         window.onbeforeunload = () => true;
-    } else {
-        window.onerror = e => {
-            alert('Uncaught error occurred–check the console'); // eslint-disable-line
-            throw e;
-        };
     }
 
     ReactDOM.render(

--- a/test/unit/util/cloud-provider.test.js
+++ b/test/unit/util/cloud-provider.test.js
@@ -141,12 +141,17 @@ describe('CloudProvider', () => {
         cloudProvider.connection.close();
         expect(timeout).toEqual(31 * 1000); // 2^5 - 1
         expect(websocketConstructorCount).toBe(6);
-        expect(cloudProvider.connectionAttempts).toBe(5); // Maxed at 5
+        expect(cloudProvider.connectionAttempts).toBe(6);
 
         cloudProvider.connection.close();
         expect(timeout).toEqual(31 * 1000); // maxed out at 2^5 - 1
         expect(websocketConstructorCount).toBe(7);
-        expect(cloudProvider.connectionAttempts).toBe(5); // Maxed at 5
+        expect(cloudProvider.connectionAttempts).toBe(7);
+    });
+
+    test('exponentialTimeout caps connection attempt number', () => {
+        cloudProvider.connectionAttempts = 1000;
+        expect(cloudProvider.exponentialTimeout()).toEqual(31 * 1000);
     });
 
     test('requestCloseConnection does not try to reconnect', () => {

--- a/test/unit/util/cloud-provider.test.js
+++ b/test/unit/util/cloud-provider.test.js
@@ -103,50 +103,45 @@ describe('CloudProvider', () => {
         expect(vmIOData[1].varCreate.name).toEqual('name2');
     });
 
-    test('connecting sets connnection attempts back to 1', () => {
+    test('connecting sets connnection attempts back to 0', () => {
         expect(cloudProvider.connectionAttempts).toBe(0);
         cloudProvider.connectionAttempts = 10;
         cloudProvider.connection._open();
-        expect(cloudProvider.connectionAttempts).toBe(1);
+        expect(cloudProvider.connectionAttempts).toBe(0);
     });
 
     test('disconnect waits for a period equal to 2^k-1 before trying again', () => {
-        websocketConstructorCount = 1; // This is global, so set it back to 1 to start
-
-        // Connection attempts should still be 0 because connection hasn't opened yet
-        expect(cloudProvider.connectionAttempts).toBe(0);
-        cloudProvider.connection._open();
-        expect(cloudProvider.connectionAttempts).toBe(1);
+        websocketConstructorCount = 0; // This is global, so set it back to 0 to start
 
         cloudProvider.connection.close();
         expect(timeout).toEqual(1 * 1000); // 2^1 - 1
+        expect(websocketConstructorCount).toBe(1);
+        expect(cloudProvider.connectionAttempts).toBe(1);
+
+        cloudProvider.connection.close();
+        expect(timeout).toEqual(3 * 1000); // 2^2 - 1
         expect(websocketConstructorCount).toBe(2);
         expect(cloudProvider.connectionAttempts).toBe(2);
 
         cloudProvider.connection.close();
-        expect(timeout).toEqual(3 * 1000); // 2^2 - 1
+        expect(timeout).toEqual(7 * 1000); // 2^3 - 1
         expect(websocketConstructorCount).toBe(3);
         expect(cloudProvider.connectionAttempts).toBe(3);
 
         cloudProvider.connection.close();
-        expect(timeout).toEqual(7 * 1000); // 2^3 - 1
+        expect(timeout).toEqual(15 * 1000); // 2^4 - 1
         expect(websocketConstructorCount).toBe(4);
         expect(cloudProvider.connectionAttempts).toBe(4);
 
         cloudProvider.connection.close();
-        expect(timeout).toEqual(15 * 1000); // 2^4 - 1
+        expect(timeout).toEqual(31 * 1000); // 2^5 - 1
         expect(websocketConstructorCount).toBe(5);
         expect(cloudProvider.connectionAttempts).toBe(5);
 
         cloudProvider.connection.close();
-        expect(timeout).toEqual(31 * 1000); // 2^5 - 1
+        expect(timeout).toEqual(31 * 1000); // maxed out at 2^5 - 1
         expect(websocketConstructorCount).toBe(6);
         expect(cloudProvider.connectionAttempts).toBe(6);
-
-        cloudProvider.connection.close();
-        expect(timeout).toEqual(31 * 1000); // maxed out at 2^5 - 1
-        expect(websocketConstructorCount).toBe(7);
-        expect(cloudProvider.connectionAttempts).toBe(7);
     });
 
     test('exponentialTimeout caps connection attempt number', () => {

--- a/test/unit/util/cloud-provider.test.js
+++ b/test/unit/util/cloud-provider.test.js
@@ -1,33 +1,51 @@
 import CloudProvider from '../../../src/lib/cloud-provider';
 
-// Disable window.WebSocket
-global.WebSocket = null;
+let websocketConstructorCount = 0;
+
+// Stub the global websocket so we can call open/close/error/send on it
+global.WebSocket = function (url) {
+    this._url = url;
+    this._sentMessages = [];
+
+    // These are not real websocket methods, but used to trigger callbacks
+    this._open = () => this.onopen();
+    this._error = e => this.onerror(e);
+    this._receive = msg => this.onmessage(msg);
+
+    // Stub the real websocket.send to store sent messages
+    this.send = msg => this._sentMessages.push(msg);
+    this.close = () => this.onclose();
+
+    websocketConstructorCount++;
+};
+global.WebSocket.CLOSING = 'CLOSING';
+global.WebSocket.CLOSED = 'CLOSED';
 
 describe('CloudProvider', () => {
     let cloudProvider = null;
-    let sentMessage = null;
     let vmIOData = [];
-
+    let timeout = 0;
     beforeEach(() => {
         vmIOData = [];
         cloudProvider = new CloudProvider();
-        // Stub connection
-        cloudProvider.connection = {
-            send: msg => {
-                sentMessage = msg;
-            }
-        };
         // Stub vm
         cloudProvider.vm = {
             postIOData: (_namespace, data) => {
                 vmIOData.push(data);
             }
         };
+        // Stub setTimeout so this can run instantly.
+        cloudProvider.setTimeout = (fn, after) => {
+            timeout = after;
+            fn();
+        };
+        // Stub randomize to make it consistent for testing.
+        cloudProvider.randomizeDuration = t => t;
     });
 
     test('updateVariable', () => {
         cloudProvider.updateVariable('hello', 1);
-        const obj = JSON.parse(sentMessage);
+        const obj = JSON.parse(cloudProvider.connection._sentMessages[0]);
         expect(obj.method).toEqual('set');
         expect(obj.name).toEqual('hello');
         expect(obj.value).toEqual(1);
@@ -35,7 +53,7 @@ describe('CloudProvider', () => {
 
     test('updateVariable with falsey value', () => {
         cloudProvider.updateVariable('hello', 0);
-        const obj = JSON.parse(sentMessage);
+        const obj = JSON.parse(cloudProvider.connection._sentMessages[0]);
         expect(obj.method).toEqual('set');
         expect(obj.name).toEqual('hello');
         expect(obj.value).toEqual(0);
@@ -43,7 +61,7 @@ describe('CloudProvider', () => {
 
     test('writeToServer with falsey index value', () => {
         cloudProvider.writeToServer('method', 'name', 5, 0);
-        const obj = JSON.parse(sentMessage);
+        const obj = JSON.parse(cloudProvider.connection._sentMessages[0]);
         expect(obj.method).toEqual('method');
         expect(obj.name).toEqual('name');
         expect(obj.value).toEqual(5);
@@ -55,7 +73,7 @@ describe('CloudProvider', () => {
             method: 'ack',
             name: 'name'
         });
-        cloudProvider.onMessage({data: msg});
+        cloudProvider.connection._receive({data: msg});
         expect(vmIOData[0].varCreate.name).toEqual('name');
     });
 
@@ -65,7 +83,7 @@ describe('CloudProvider', () => {
             name: 'name',
             value: 'value'
         });
-        cloudProvider.onMessage({data: msg});
+        cloudProvider.connection._receive({data: msg});
         expect(vmIOData[0].varUpdate.name).toEqual('name');
         expect(vmIOData[0].varUpdate.value).toEqual('value');
     });
@@ -80,8 +98,60 @@ describe('CloudProvider', () => {
             method: 'ack',
             name: 'name2'
         });
-        cloudProvider.onMessage({data: `${msg1}\n${msg2}`});
+        cloudProvider.connection._receive({data: `${msg1}\n${msg2}`});
         expect(vmIOData[0].varUpdate.name).toEqual('name1');
         expect(vmIOData[1].varCreate.name).toEqual('name2');
+    });
+
+    test('connecting sets connnection attempts back to 1', () => {
+        expect(cloudProvider.connectionAttempts).toBe(0);
+        cloudProvider.connectionAttempts = 10;
+        cloudProvider.connection._open();
+        expect(cloudProvider.connectionAttempts).toBe(1);
+    });
+
+    test('disconnect waits for a period equal to 2^k-1 before trying again', () => {
+        websocketConstructorCount = 1; // This is global, so set it back to 1 to start
+
+        // Connection attempts should still be 0 because connection hasn't opened yet
+        expect(cloudProvider.connectionAttempts).toBe(0);
+        cloudProvider.connection._open();
+        expect(cloudProvider.connectionAttempts).toBe(1);
+
+        cloudProvider.connection.close();
+        expect(timeout).toEqual(1 * 1000); // 2^1 - 1
+        expect(websocketConstructorCount).toBe(2);
+        expect(cloudProvider.connectionAttempts).toBe(2);
+
+        cloudProvider.connection.close();
+        expect(timeout).toEqual(3 * 1000); // 2^2 - 1
+        expect(websocketConstructorCount).toBe(3);
+        expect(cloudProvider.connectionAttempts).toBe(3);
+
+        cloudProvider.connection.close();
+        expect(timeout).toEqual(7 * 1000); // 2^3 - 1
+        expect(websocketConstructorCount).toBe(4);
+        expect(cloudProvider.connectionAttempts).toBe(4);
+
+        cloudProvider.connection.close();
+        expect(timeout).toEqual(15 * 1000); // 2^4 - 1
+        expect(websocketConstructorCount).toBe(5);
+        expect(cloudProvider.connectionAttempts).toBe(5);
+
+        cloudProvider.connection.close();
+        expect(timeout).toEqual(31 * 1000); // 2^5 - 1
+        expect(websocketConstructorCount).toBe(6);
+        expect(cloudProvider.connectionAttempts).toBe(5); // Maxed at 5
+
+        cloudProvider.connection.close();
+        expect(timeout).toEqual(31 * 1000); // maxed out at 2^5 - 1
+        expect(websocketConstructorCount).toBe(7);
+        expect(cloudProvider.connectionAttempts).toBe(5); // Maxed at 5
+    });
+
+    test('requestCloseConnection does not try to reconnect', () => {
+        websocketConstructorCount = 1; // This is global, so set it back to 1 to start
+        cloudProvider.requestCloseConnection();
+        expect(websocketConstructorCount).toBe(1); // No reconnection attempts
     });
 });


### PR DESCRIPTION
Uses randomized duration between [0, 2^k-1] where k is the connection attempt number, maxed out at 5.

I had to rework the tests quite a bit to make this easy to test, to work around the timeouts and the randomization.


