### PR TITLE
Cloud bugfixes

### DIFF
--- a/src/lib/cloud-manager-hoc.jsx
+++ b/src/lib/cloud-manager-hoc.jsx
@@ -34,7 +34,7 @@ const cloudManagerHOC = function (WrappedComponent) {
                 this.connectToCloud();
             }
 
-            if (this.shouldDisconnect(this.props) && !this.shouldDisconnect(prevProps)) {
+            if (this.shouldDisconnect(this.props, prevProps)) {
                 this.disconnectFromCloud();
             }
         }
@@ -49,12 +49,12 @@ const cloudManagerHOC = function (WrappedComponent) {
         shouldConnect (props) {
             return !this.isConnected() && this.canUseCloud(props) && props.isShowingWithId;
         }
-        shouldDisconnect (props) {
+        shouldDisconnect (props, prevProps) {
             return this.isConnected() &&
                 ( // Can no longer use cloud or cloud provider info is now stale
                     !this.canUseCloud(this.props) ||
-                    (this.cloudProvider.projectId !== props.projectId) ||
-                    (this.cloudProvider.username !== props.username)
+                    (props.projectId !== prevProps.projectId) ||
+                    (props.username !== prevProps.username)
                 );
             // TODO need to add provisions for viewing someone
             // else's project in editor mode

--- a/src/lib/cloud-manager-hoc.jsx
+++ b/src/lib/cloud-manager-hoc.jsx
@@ -74,6 +74,7 @@ const cloudManagerHOC = function (WrappedComponent) {
             if (this.cloudProvider) {
                 this.cloudProvider.requestCloseConnection();
                 this.cloudProvider = null;
+                this.props.vm.setCloudProvider(null);
             }
         }
         render () {

--- a/src/lib/cloud-manager-hoc.jsx
+++ b/src/lib/cloud-manager-hoc.jsx
@@ -21,54 +21,60 @@ const cloudManagerHOC = function (WrappedComponent) {
             this.cloudProvider = null;
         }
         componentDidMount () {
-            if (this.canUseCloud(this.props)) {
+            if (this.shouldConnect(this.props)) {
                 this.connectToCloud();
             }
         }
         componentDidUpdate (prevProps) {
-            // TODO add disconnection logic when loading a new project
+            // TODO need to add cloud provider disconnection logic and cloud data clearing logic
+            // when loading a new project e.g. via file upload
             // (and eventually move it out of the vm.clear function)
-            // e.g. was previously showingWithId but no longer, but we need
-            // to check that we don't disconnect when saving a project to the
-            // server.
 
-            // If we couldn't use cloud data before, but now we can, try opening a cloud connection
-            if (this.canUseCloud(this.props) && !this.canUseCloud(prevProps)) {
+            if (this.shouldConnect(this.props) && !this.shouldConnect(prevProps)) {
                 this.connectToCloud();
-                return;
             }
 
-            // TODO add scratcher check
-
-            if ((this.props.username !== prevProps.username) ||
-                (this.props.projectId !== prevProps.projectId)) {
-                this.connectToCloud();
+            if (this.shouldDisconnect(this.props) && !this.shouldDisconnect(prevProps)) {
+                this.disconnectFromCloud();
             }
         }
         componentWillUnmount () {
-            if (this.cloudProvider) {
-                this.cloudProvider.requestCloseConnection();
-                this.cloudProvider = null;
-            }
+            this.disconnectFromCloud();
         }
         canUseCloud (props) {
-            return props.cloudHost && props.username && props.isShowingWithId &&
-                props.vm && props.username && props.projectId;
+            // TODO add a canUseCloud to pass down to this HOC (e.g. from www) and also check that here.
+            // This should cover info about the website specifically, like scrather status
+            return !!(props.cloudHost && props.username && props.vm && props.projectId);
         }
-        connectToCloud () {
-            if (this.cloudProvider && this.cloudProvider.connection) {
-                // Already connected
-                return;
-            }
-
+        shouldConnect (props) {
+            return !this.isConnected() && this.canUseCloud(props) && props.isShowingWithId;
+        }
+        shouldDisconnect (props) {
+            return this.isConnected() &&
+                ( // Can no longer use cloud or cloud provider info is now stale
+                    !this.canUseCloud(this.props) ||
+                    (this.cloudProvider.projectId !== props.projectId) ||
+                    (this.cloudProvider.username !== props.username)
+                );
             // TODO need to add provisions for viewing someone
             // else's project in editor mode
+        }
+        isConnected () {
+            return this.cloudProvider && !!this.cloudProvider.connection;
+        }
+        connectToCloud () {
             this.cloudProvider = new CloudProvider(
                 this.props.cloudHost,
                 this.props.vm,
                 this.props.username,
                 this.props.projectId);
             this.props.vm.setCloudProvider(this.cloudProvider);
+        }
+        disconnectFromCloud () {
+            if (this.cloudProvider) {
+                this.cloudProvider.requestCloseConnection();
+                this.cloudProvider = null;
+            }
         }
         render () {
             const {

--- a/src/lib/cloud-provider.js
+++ b/src/lib/cloud-provider.js
@@ -51,8 +51,10 @@ class CloudProvider {
         log.info(`Received websocket message: ${messageString}`);
         // Multiple commands can be received, newline separated
         messageString.split('\n').forEach(message => {
-            const parsedData = this.parseMessage(JSON.parse(message));
-            this.vm.postIOData('cloud', parsedData);
+            if (message) { // .split can also contain '' in the array it returns
+                const parsedData = this.parseMessage(JSON.parse(message));
+                this.vm.postIOData('cloud', parsedData);
+            }
         });
     }
 

--- a/test/unit/util/cloud-manager-hoc.test.jsx
+++ b/test/unit/util/cloud-manager-hoc.test.jsx
@@ -50,6 +50,8 @@ describe('CloudManagerHOC', () => {
         );
         expect(vm.setCloudProvider.mock.calls.length).toBe(1);
         expect(CloudProvider).toHaveBeenCalledTimes(1);
+        const cloudProviderInstance = CloudProvider.mock.instances[0];
+        expect(vm.setCloudProvider).toHaveBeenCalledWith(cloudProviderInstance);
     });
 
     test('when cloudHost is missing, the cloud provider is not set on the vm', () => {
@@ -115,6 +117,8 @@ describe('CloudManagerHOC', () => {
         });
         expect(vm.setCloudProvider.mock.calls.length).toBe(1);
         expect(CloudProvider).toHaveBeenCalledTimes(1);
+        const cloudProviderInstance = CloudProvider.mock.instances[0];
+        expect(vm.setCloudProvider).toHaveBeenCalledWith(cloudProviderInstance);
     });
 
     test('projectId change should not trigger cloudProvider connection unless isShowingWithId becomes true', () => {
@@ -139,5 +143,32 @@ describe('CloudManagerHOC', () => {
         });
         expect(vm.setCloudProvider.mock.calls.length).toBe(1);
         expect(CloudProvider).toHaveBeenCalledTimes(1);
+        const cloudProviderInstance = CloudProvider.mock.instances[0];
+        expect(vm.setCloudProvider).toHaveBeenCalledWith(cloudProviderInstance);
+    });
+
+    test('when it unmounts, the cloud provider is set on the vm', () => {
+        const Component = () => (<div />);
+        const WrappedComponent = cloudManagerHOC(Component);
+        const mounted = mount(
+            <WrappedComponent
+                cloudHost="nonEmpty"
+                store={store}
+                username="user"
+                vm={vm}
+            />
+        );
+
+        expect(CloudProvider).toHaveBeenCalledTimes(1);
+        const cloudProviderInstance = CloudProvider.mock.instances[0];
+        const requestCloseConnection = cloudProviderInstance.requestCloseConnection;
+
+        mounted.unmount();
+
+        // vm.setCloudProvider is called twice,
+        // once during mount and once during unmount
+        expect(vm.setCloudProvider.mock.calls.length).toBe(2);
+        expect(vm.setCloudProvider).toHaveBeenCalledWith(null);
+        expect(requestCloseConnection).toHaveBeenCalledTimes(1);
     });
 });

--- a/test/unit/util/cloud-manager-hoc.test.jsx
+++ b/test/unit/util/cloud-manager-hoc.test.jsx
@@ -116,4 +116,28 @@ describe('CloudManagerHOC', () => {
         expect(vm.setCloudProvider.mock.calls.length).toBe(1);
         expect(CloudProvider).toHaveBeenCalledTimes(1);
     });
+
+    test('projectId change should not trigger cloudProvider connection unless isShowingWithId becomes true', () => {
+        const Component = () => <div />;
+        const WrappedComponent = cloudManagerHOC(Component);
+        const mounted = mount(
+            <WrappedComponent
+                cloudHost="nonEmpty"
+                store={stillLoadingStore}
+                username="user"
+                vm={vm}
+            />
+        );
+        mounted.setProps({
+            projectId: 'a different id'
+        });
+        expect(vm.setCloudProvider.mock.calls.length).toBe(0);
+        expect(CloudProvider).not.toHaveBeenCalled();
+        mounted.setProps({
+            isShowingWithId: true,
+            loadingState: LoadingState.SHOWING_WITH_ID
+        });
+        expect(vm.setCloudProvider.mock.calls.length).toBe(1);
+        expect(CloudProvider).toHaveBeenCalledTimes(1);
+    });
 });

--- a/test/unit/util/cloud-provider.test.js
+++ b/test/unit/util/cloud-provider.test.js
@@ -70,6 +70,16 @@ describe('CloudProvider', () => {
         expect(vmIOData[0].varUpdate.value).toEqual('value');
     });
 
+    test('onMessage with newline at the end', () => {
+        const msg1 = JSON.stringify({
+            method: 'set',
+            name: 'name1',
+            value: 'value'
+        });
+        cloudProvider.onMessage({data: `${msg1}\n`});
+        expect(vmIOData[0].varUpdate.name).toEqual('name1');
+    });
+
     test('onMessage with multiple commands', () => {
         const msg1 = JSON.stringify({
             method: 'set',


### PR DESCRIPTION
### Proposed Changes

Make cloud manager hoc cloud connection logic more robust. Namely, this fixes an issue where we were opening a cloud provider connection twice when creating a new project through /preview/editor.

Fix a bug where regular messages getting sent from the cloud server were resulting in an uncaught json parse error because `str.split('\n')` returns `['actual stuff', '']` if str ends in `'\n'`. Calling `JSON.parse` on `''` throws an error.

### Reason for Changes

There were bugs.

### Test Coverage

Added tests for the things that were previously failing. Both of these tests should fail on develop.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [x] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
