### PR TITLE
Fix monitor label for day of week block.

### DIFF
--- a/src/lib/opcode-labels.js
+++ b/src/lib/opcode-labels.js
@@ -89,8 +89,8 @@ const messages = defineMessages({
         id: 'gui.opcodeLabels.date'
     },
     sensing_current_dayofweek: {
-        defaultMessage: 'dayofweek',
-        description: 'Label for the current dayofweek monitor when shown on the stage',
+        defaultMessage: 'day of week',
+        description: 'Label for the current day of week monitor when shown on the stage',
         id: 'gui.opcodeLabels.dayofweek'
     },
     sensing_current_hour: {

--- a/test/unit/util/opcode-labels.test.js
+++ b/test/unit/util/opcode-labels.test.js
@@ -1,0 +1,15 @@
+import opcodeLabels from '../../../src/lib/opcode-labels';
+
+describe('Opcode Labels', () => {
+    test('day of week label', () => {
+        const labelFun = opcodeLabels.getLabel('sensing_current').labelFn;
+        expect(labelFun({CURRENTMENU: 'dayofweek'})).toBe('day of week');
+        expect(labelFun({CURRENTMENU: 'DAYOFWEEK'})).toBe('day of week');
+    });
+
+    test('unspecified opcodes default to extension category and opcode as label', () => {
+        const labelInfo = opcodeLabels.getLabel('music_getTempo');
+        expect(labelInfo.label).toBe('music_getTempo');
+        expect(labelInfo.category).toBe('extension');
+    });
+});


### PR DESCRIPTION
### Resolves

Fixes an issue found in bug hunt on 11/16/18:

@ericrosenbaum notes:
> Monitor label for “day or week” has no spaces - it shows up as “dayofweek”

### Proposed Changes

Change default message (and description) of day of week option for the sensing_current block. This fixes the monitor label in English. @chrisgarrity, I was wondering if this will end up showing up as a changed string on transifex and if that's desired?

### Reason for Changes

Monitor label was not user friendly before.

### Test Coverage

Added unit tests for the monitor label, the capitalization issue fixed in a previous PR, and the fact that unknown opcodes get their category set as "extension" and their label set as their opcode.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [x] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
