### PR TITLE
moved z-index of alerts down around modal, loader levels

### DIFF
--- a/src/css/z-index.css
+++ b/src/css/z-index.css
@@ -13,7 +13,8 @@ $z-index-tooltip: 47; /* tooltips should go over add buttons if they overlap */
 $z-index-monitor: 48; /* monitors go over add buttons */
 /* Block drag z-index: 50; set in scratch-blocks */
 
-$z-index-card: 490;
+$z-index-card: 480;
+$z-index-alerts: 490;
 $z-index-loader: 500;
 $z-index-modal: 510;
 
@@ -25,7 +26,6 @@ $z-index-stage-color-picker-background: 2000;
 $z-index-stage-with-color-picker: 2010;
 $z-index-stage-header: 5000;
 $z-index-stage-wrapper-overlay: 5000;
-$z-index-alerts: 5010;
 
 /* in most interfaces, the context menu is always on top */
 $z-index-context-menu: 10000;


### PR DESCRIPTION
### Resolves

- Resolves https://github.com/LLK/scratch-gui/issues/3828

### Proposed Changes

Make alerts appear below modals and fullscreen view:

![image](https://user-images.githubusercontent.com/3431616/48674385-784fb700-eb19-11e8-91af-ac6da2fcf324.png)

![image](https://user-images.githubusercontent.com/3431616/48674386-7dad0180-eb19-11e8-9439-611aa5d761c4.png)

![image](https://user-images.githubusercontent.com/3431616/48674387-830a4c00-eb19-11e8-84e7-ba21e3d04c3c.png)

### Reason for Changes

Alerts feel out of place when they appear above modals and fullscreen.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
