### PR TITLE
Fixes cover tiles overlapping issue

### DIFF
--- a/src/components/asset-panel/selector.css
+++ b/src/components/asset-panel/selector.css
@@ -10,6 +10,11 @@
     background: $ui-tertiary;
 }
 
+.wrapper::after {
+    flex: 0 0 70px;
+    content: '';
+}
+
 .new-buttons {
     position: absolute;
     bottom: 0;
@@ -47,11 +52,11 @@ $fade-out-distance: 100px;
     /* Must have some height (recalculated by flex-grow) in order to scroll */
     height: 0;
     flex-grow: 1;
-    overflow-y: scroll;
+    overflow-y: auto;
     display: flex;
     flex-direction: column;
     /* Make sure there is room to scroll beyond the last tile */
-    padding-bottom: 70px;
+    /* padding-bottom: 70px; */
 }
 
 .list-item {


### PR DESCRIPTION
### Resolves

- Closes #2921

### Proposed Changes

To prevent tiles overlapping with the button on Firefox, bottom padding was added. Previous implementation was not a cross-browser code, this change supports all browsers. 

### Reason for Changes

To prevent tiles overlapping with the button on Firefox, bottom padding was added. Previous implementation was not a cross-browser code, this change supports all browsers. 

### Test Coverage

Firefox:
![image](https://user-images.githubusercontent.com/10993808/48684903-e78ce000-ebd9-11e8-8d21-63559993bce0.png)

Chrome:
![image](https://user-images.githubusercontent.com/10993808/48684928-fd9aa080-ebd9-11e8-9810-aae23a547631.png)

Edge:
![image](https://user-images.githubusercontent.com/10993808/48684940-0ab78f80-ebda-11e8-9f23-6f04eba52557.png)


### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [x] Chrome 
 * [x] Firefox 
 * [x] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome

