### PR TITLE
Library 100% height fix

### DIFF
--- a/src/components/library/library.css
+++ b/src/components/library/library.css
@@ -10,7 +10,7 @@
     flex-grow: 1;
     flex-wrap: wrap;
     overflow-y: auto;
-    height: calc(100% - $library-header-height);
+    height: auto;
     padding: 0.5rem;
 }
 


### PR DESCRIPTION
### Resolves

- Resolves #3825: Extension library item tiles are too tall in a single row.