### PR TITLE
avoid create/save/error loops

### DIFF
--- a/src/lib/alerts/index.jsx
+++ b/src/lib/alerts/index.jsx
@@ -48,6 +48,7 @@ const alerts = [
     },
     {
         alertId: 'creatingError',
+        clearList: ['creating', 'createSuccess'],
         content: (
             <FormattedMessage
                 defaultMessage="Could not create the project. Please try again!"
@@ -59,6 +60,7 @@ const alerts = [
     },
     {
         alertId: 'savingError',
+        clearList: ['saving', 'saveSuccess'],
         content: (
             <FormattedMessage
                 defaultMessage="Could not save the project. Please try again!"


### PR DESCRIPTION
### Resolves

- Resolves https://github.com/LLK/scratch-gui/issues/3836

### Proposed Changes

* avoid false success alerts:
  * throws an error if saving assets or project encounters an error (previously, error was being intercepted and not passed on)
  * call to display success alert comes *after* we dispatch success action itself, not before
* do not try to create or save twice in a row (avoids infinite loop of retries)

### Test Coverage

None currently

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
