### PR TITLE
Add rename and delete functionality for cloud variables

### DIFF
--- a/src/lib/cloud-provider.js
+++ b/src/lib/cloud-provider.js
@@ -113,10 +113,9 @@ class CloudProvider {
      * @param {string} methodName The message method, indicating the action to perform.
      * @param {string} dataName The name of the cloud variable this message pertains to
      * @param {string | number} dataValue The value to set the cloud variable to
-     * @param {number} dataIndex The index of the item to update (for cloud lists)
      * @param {string} dataNewName The new name for the cloud variable (if renaming)
      */
-    writeToServer (methodName, dataName, dataValue, dataIndex, dataNewName) {
+    writeToServer (methodName, dataName, dataValue, dataNewName) {
         const msg = {};
         msg.method = methodName;
         msg.user = this.username;
@@ -127,8 +126,7 @@ class CloudProvider {
         if (dataNewName) msg.new_name = dataNewName;
 
         // Optional number params need different undefined check
-        if (typeof dataValue !== 'undefined') msg.value = dataValue;
-        if (typeof dataValue !== 'undefined') msg.index = dataIndex;
+        if (typeof dataValue !== 'undefined' && dataValue !== null) msg.value = dataValue;
 
         const dataToWrite = JSON.stringify(msg);
         this.sendCloudData(dataToWrite);
@@ -161,6 +159,25 @@ class CloudProvider {
      */
     updateVariable (name, value) {
         this.writeToServer('set', name, value);
+    }
+
+    /**
+     * Provides an API for the VM's cloud IO device to rename
+     * a cloud variable on the server.
+     * @param {string} oldName The old name of the variable to rename
+     * @param {string} newName The new name for the cloud variable.
+     */
+    renameVariable (oldName, newName) {
+        this.writeToServer('rename', oldName, null, newName);
+    }
+
+    /**
+     * Provides an API for the VM's cloud IO device to delete
+     * a cloud variable on the server.
+     * @param {string} name The name of the variable to delete
+     */
+    deleteVariable (name) {
+        this.writeToServer('delete', name);
     }
 
     /**

--- a/test/unit/util/cloud-provider.test.js
+++ b/test/unit/util/cloud-provider.test.js
@@ -43,6 +43,14 @@ describe('CloudProvider', () => {
         cloudProvider.randomizeDuration = t => t;
     });
 
+    test('createVariable', () => {
+        cloudProvider.createVariable('hello', 1);
+        const obj = JSON.parse(cloudProvider.connection._sentMessages[0]);
+        expect(obj.method).toEqual('create');
+        expect(obj.name).toEqual('hello');
+        expect(obj.value).toEqual(1);
+    });
+
     test('updateVariable', () => {
         cloudProvider.updateVariable('hello', 1);
         const obj = JSON.parse(cloudProvider.connection._sentMessages[0]);
@@ -59,13 +67,21 @@ describe('CloudProvider', () => {
         expect(obj.value).toEqual(0);
     });
 
-    test('writeToServer with falsey index value', () => {
-        cloudProvider.writeToServer('method', 'name', 5, 0);
+    test('renameVariable', () => {
+        cloudProvider.renameVariable('oldName', 'newName');
         const obj = JSON.parse(cloudProvider.connection._sentMessages[0]);
-        expect(obj.method).toEqual('method');
-        expect(obj.name).toEqual('name');
-        expect(obj.value).toEqual(5);
-        expect(obj.index).toEqual(0);
+        expect(obj.method).toEqual('rename');
+        expect(obj.name).toEqual('oldName');
+        expect(typeof obj.value).toEqual('undefined');
+        expect(obj.new_name).toEqual('newName');
+    });
+
+    test('deleteVariable', () => {
+        cloudProvider.deleteVariable('hello');
+        const obj = JSON.parse(cloudProvider.connection._sentMessages[0]);
+        expect(obj.method).toEqual('delete');
+        expect(obj.name).toEqual('hello');
+        expect(typeof obj.value).toEqual('undefined');
     });
 
     test('onMessage ack', () => {


### PR DESCRIPTION
### Proposed Changes

Allows renaming and deleting cloud variables and for those changes to persist on the cloud.

### Reason for Changes

Exists in 2.0.

### Test Coverage

Added unit tests. Manually tested.

### Related PRs
LLK/scratch-vm#1775

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [x] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
