### PR TITLE
only prompt user to save if project has changed and won’t autosave

### DIFF
--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -159,7 +159,10 @@ class MenuBar extends React.Component {
     handleClickNew () {
         let readyToReplaceProject = true;
         // if the project is dirty, and user owns the project, we will autosave.
-        // but if they don't own this project, user should consider downloading first.
+        // but if they are not logged in and can't save, user should consider
+        // downloading or logging in first.
+        // Note that if user is logged in and editing someone else's project,
+        // they'll lose their work.
         if (this.props.projectChanged && !this.props.canCreateNew) {
             readyToReplaceProject = confirm( // eslint-disable-line no-alert
                 this.props.intl.formatMessage(messages.confirmNav)

--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -157,10 +157,15 @@ class MenuBar extends React.Component {
         ]);
     }
     handleClickNew () {
-        // if canSave===true and canCreateNew===true, it's safe to replace current project,
-        // since we will auto-save first. Else, confirm first.
-        const readyToReplaceProject = (this.props.canSave && this.props.canCreateNew) ||
-            confirm(this.props.intl.formatMessage(messages.confirmNav)); // eslint-disable-line no-alert
+        let readyToReplaceProject = true;
+        // if the project is dirty, and user owns the project, we will autosave.
+        // but if they don't own this project, user should consider downloading first.
+        if (this.props.projectChanged && !this.props.canCreateNew) {
+            readyToReplaceProject = confirm( // eslint-disable-line no-alert
+                this.props.intl.formatMessage(messages.confirmNav)
+            );
+        }
+        this.props.onRequestCloseFile();
         if (readyToReplaceProject) {
             this.props.onClickNew(this.props.canSave && this.props.canCreateNew);
         }
@@ -734,6 +739,7 @@ MenuBar.propTypes = {
     onShare: PropTypes.func,
     onToggleLoginOpen: PropTypes.func,
     onUpdateProjectTitle: PropTypes.func,
+    projectChanged: PropTypes.bool,
     projectTitle: PropTypes.string,
     renderLogin: PropTypes.func,
     sessionExists: PropTypes.bool,
@@ -757,6 +763,7 @@ const mapStateToProps = state => {
         isShowingProject: getIsShowingProject(loadingState),
         languageMenuOpen: languageMenuOpen(state),
         loginMenuOpen: loginMenuOpen(state),
+        projectChanged: state.scratchGui.projectChanged,
         projectTitle: state.scratchGui.projectTitle,
         sessionExists: state.session && typeof state.session.session !== 'undefined',
         username: user ? user.username : null

--- a/test/integration/project-loading.test.js
+++ b/test/integration/project-loading.test.js
@@ -115,13 +115,48 @@ describe('Loading scratch gui', () => {
         test('Creating new project resets active tab to Code tab', async () => {
             await loadUri(uri);
             await clickText('View 2.0 Project');
-            const el = await findByXpath("//input[@placeholder='scratch.mit.edu/projects/123456789']");
+            const inputElement = await findByXpath("//input[@placeholder='scratch.mit.edu/projects/123456789']");
             const projectId = '96708228';
-            await el.sendKeys(`scratch.mit.edu/projects/${projectId}`);
+            await inputElement.sendKeys(`scratch.mit.edu/projects/${projectId}`);
             await clickXpath('//button[@title="View Project"]');
             await new Promise(resolve => setTimeout(resolve, 2000));
             await findByXpath('//*[span[text()="Costumes"]]');
             await clickText('Costumes');
+            await clickXpath(
+                '//div[contains(@class, "menu-bar_menu-bar-item") and ' +
+                'contains(@class, "menu-bar_hoverable")][span[text()="File"]]'
+            );
+            await clickXpath('//li[span[text()="New"]]');
+            await findByXpath('//*[div[@class="scratchCategoryMenu"]]');
+            await clickText('Operators', scope.blocksTab);
+        });
+
+        test('Not logged in->made no changes to project->create new project should not show alert', async () => {
+            await loadUri(uri);
+            await clickText('View 2.0 Project');
+            const inputElement = await findByXpath("//input[@placeholder='scratch.mit.edu/projects/123456789']");
+            const projectId = '96708228';
+            await inputElement.sendKeys(`scratch.mit.edu/projects/${projectId}`);
+            await clickXpath('//button[@title="View Project"]');
+            await new Promise(resolve => setTimeout(resolve, 2000));
+            await clickXpath(
+                '//div[contains(@class, "menu-bar_menu-bar-item") and ' +
+                'contains(@class, "menu-bar_hoverable")][span[text()="File"]]'
+            );
+            await clickXpath('//li[span[text()="New"]]');
+            await findByXpath('//*[div[@class="scratchCategoryMenu"]]');
+            await clickText('Operators', scope.blocksTab);
+        });
+
+        test('Not logged in->made a change to project->create new project should show alert', async () => {
+            await loadUri(uri);
+            await clickText('View 2.0 Project');
+            const inputElement = await findByXpath("//input[@placeholder='scratch.mit.edu/projects/123456789']");
+            const projectId = '96708228';
+            await inputElement.sendKeys(`scratch.mit.edu/projects/${projectId}`);
+            await clickXpath('//button[@title="View Project"]');
+            await new Promise(resolve => setTimeout(resolve, 2000));
+            await clickText('move');
             await clickXpath(
                 '//div[contains(@class, "menu-bar_menu-bar-item") and ' +
                 'contains(@class, "menu-bar_hoverable")][span[text()="File"]]'


### PR DESCRIPTION
### Resolves

- Resolves https://github.com/LLK/scratch-gui/issues/3744

### Proposed Changes

don't warn user with a confirm about leaving project, if user could choose to save the project, or project will autosave, or project is already saved.

### Reason for Changes

Prompt was sometimes unnecessary and confusing.

### Test Coverage

none.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
