### PR TITLE
Do not change to backdrops tab after adding a backdrop.

### DIFF
--- a/src/containers/backdrop-library.jsx
+++ b/src/containers/backdrop-library.jsx
@@ -5,11 +5,6 @@ import {defineMessages, injectIntl, intlShape} from 'react-intl';
 import {connect} from 'react-redux';
 import VM from 'scratch-vm';
 
-import {
-    activateTab,
-    COSTUMES_TAB_INDEX
-} from '../reducers/editor-tab';
-
 import analytics from '../lib/analytics';
 import backdropLibraryContent from '../lib/libraries/backdrops.json';
 import backdropTags from '../lib/libraries/backdrop-tags';
@@ -40,7 +35,6 @@ class BackdropLibrary extends React.Component {
             skinId: null
         };
         this.props.vm.setEditingTarget(this.props.stageID);
-        this.props.onActivateTab(COSTUMES_TAB_INDEX);
         this.props.vm.addBackdrop(item.md5, vmBackdrop);
         analytics.event({
             category: 'library',
@@ -64,7 +58,6 @@ class BackdropLibrary extends React.Component {
 
 BackdropLibrary.propTypes = {
     intl: intlShape.isRequired,
-    onActivateTab: PropTypes.func.isRequired,
     onRequestClose: PropTypes.func,
     stageID: PropTypes.string.isRequired,
     vm: PropTypes.instanceOf(VM).isRequired
@@ -74,9 +67,7 @@ const mapStateToProps = state => ({
     stageID: state.scratchGui.targets.stage.id
 });
 
-const mapDispatchToProps = dispatch => ({
-    onActivateTab: tab => dispatch(activateTab(tab))
-});
+const mapDispatchToProps = () => ({});
 
 export default injectIntl(connect(
     mapStateToProps,

--- a/test/integration/backdrops.test.js
+++ b/test/integration/backdrops.test.js
@@ -1,0 +1,52 @@
+import path from 'path';
+import SeleniumHelper from '../helpers/selenium-helper';
+
+const {
+    clickText,
+    clickXpath,
+    findByXpath,
+    getDriver,
+    getLogs,
+    loadUri,
+    scope
+} = new SeleniumHelper();
+
+const uri = path.resolve(__dirname, '../../build/index.html');
+
+let driver;
+
+describe('Working with backdrops', () => {
+    beforeAll(() => {
+        driver = getDriver();
+    });
+
+    afterAll(async () => {
+        await driver.quit();
+    });
+
+    test('Adding a backdrop from the library', async () => {
+        await loadUri(uri);
+        await clickXpath('//button[@title="Try It"]');
+
+        // Start on the sounds tab of sprite1 to test switching behavior
+        await clickText('Sounds');
+
+        // Add a backdrop without selecting the stage first to test switching
+        await clickXpath('//button[@aria-label="Choose a Backdrop"]');
+        const el = await findByXpath("//input[@placeholder='Search']");
+        await el.sendKeys('blue');
+        await clickText('Blue Sky'); // Adds the backdrop
+
+        // Make sure the stage is selected and the sound tab remains selected.
+        // This is different from Scratch2 which selected backdrop tab automatically
+        // See issue #3500
+        await clickText('pop', scope.soundsTab);
+
+        // Make sure the backdrop was actually added by going to the backdrops tab
+        await clickText('Backdrops');
+        await clickText('Blue Sky', scope.costumesTab);
+
+        const logs = await getLogs();
+        await expect(logs).toEqual([]);
+    });
+});

--- a/test/integration/costumes.test.js
+++ b/test/integration/costumes.test.js
@@ -80,17 +80,6 @@ describe('Working with costumes', () => {
         await expect(logs).toEqual([]);
     });
 
-    test('Adding a backdrop', async () => {
-        await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
-        await clickXpath('//button[@aria-label="Choose a Backdrop"]');
-        const el = await findByXpath("//input[@placeholder='Search']");
-        await el.sendKeys('blue');
-        await clickText('Blue Sky'); // Should close the modal
-        const logs = await getLogs();
-        await expect(logs).toEqual([]);
-    });
-
     test('Converting bitmap/vector in paint editor', async () => {
         await loadUri(uri);
         await clickXpath('//button[@title="Try It"]');


### PR DESCRIPTION
Expand on the backdrop integration test to make sure this is documented/tested behavior

### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/LLK/scratch-gui/issues/3500

### Proposed Changes

_Describe what this Pull Request does_

Do not activate the backdrop (costumes) tab after selecting a backdrop from the library


### Test Coverage

_Please show how you have added tests to cover your changes_

I've expanded on the existing backdrop integration test by pulling it out into its own file and adding a few new assertions. 
1. If the stage wasn't the editing target, it becomes the editing target ("selected"). That is, the code on the workspace is the code that belongs to the stage, ditto for sounds/costumes. This is existing behavior that I assume we want to maintain, but wasn't mentioned specifically. Can you confirm @thisandagain. 
2. The tab that was visible (code/costumes/sounds) remains visible. The integration test covers this by making sure the sound tab remains visible after using the backdrop library. 