### PR TITLE
do not attempt to autosave on gui unmounting

### DIFF
--- a/src/lib/project-saver-hoc.jsx
+++ b/src/lib/project-saver-hoc.jsx
@@ -71,12 +71,6 @@ const ProjectSaverHOC = function (WrappedComponent) {
                 this.props.onAutoUpdateProject();
             }
         }
-        componentWillUnmount () {
-            const showingSaveable = this.props.canSave && this.props.isShowingWithId;
-            if (showingSaveable) {
-                this.updateProjectToStorage();
-            }
-        }
         isShowingCreatable (props) {
             return props.canCreateNew && props.isShowingWithoutId;
         }


### PR DESCRIPTION
### Resolves

- Resolves https://github.com/LLK/scratch-www/issues/2348

### Proposed Changes

We were trying to autosave when GUI unmounts. But it unmounts every time the language is switched. So let's not autosave when GUI unmounts.

### Reason for Changes

Was causing "Saving" alert forever...

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
