### PR TITLE
Stop action menu focus stealing keyboard events from the VM

### DIFF
--- a/src/components/action-menu/action-menu.jsx
+++ b/src/components/action-menu/action-menu.jsx
@@ -78,6 +78,9 @@ class ActionMenu extends React.Component {
         return event => {
             ReactTooltip.hide();
             if (fn) fn(event);
+            // Blur the button so it does not keep focus after being clicked
+            // This prevents keyboard events from triggering the button
+            this.buttonRef.blur();
             this.setState({forceHide: true, isOpen: false}, () => {
                 setTimeout(() => this.setState({forceHide: false}));
             });


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/LLK/scratch-gui/issues/3269

### Proposed Changes

_Describe what this Pull Request does_

Automatically blur the action menu buttons when clicked to prevent it from blocking keyboard events from going to the VM and from reacting to future enter keys.

Tested by doing the following in develop vs. this branch
1. Load the editor
2. Add a "forever =>  if "a" key pressed => rotate"
3. Use it to make sure it is working
4. Open the sprite library
5. Add a new sprite
6. Without clicking anywhere else, try using the "a" key to rotate, it should work. It doesn't work on develop.

