### PR TITLE
Prevent arrow/space from scrolling the page

### DIFF
--- a/src/lib/vm-listener-hoc.jsx
+++ b/src/lib/vm-listener-hoc.jsx
@@ -82,6 +82,12 @@ const vmListenerHOC = function (WrappedComponent) {
                 key: e.key,
                 isDown: true
             });
+
+            // Prevent space/arrow key from scrolling the page.
+            if (e.keyCode === 32 || // 32=space
+                (e.keyCode >= 37 && e.keyCode <= 40)) { // 37, 38, 39, 40 are arrows
+                e.preventDefault();
+            }
         }
         handleKeyUp (e) {
             // Always capture up events,


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/LLK/scratch-www/issues/2210

### Proposed Changes

_Describe what this Pull Request does_

Prevent default behavior of arrows/spacebar when those keys are used against the document body (i.e. without an input or element focused. If an element is focused, all those keys will still do the thing they are meant to do).

### Reason for Changes

_Explain why these changes should be made_

This is needed to make the project page work as expected. In the future, investing in ways of making those accessibility features work would be good (as mentioned by @towerofnix in https://github.com/LLK/scratch-www/issues/2210) But for now, it is broken for everyone because it both sends events to the VM _and_ scrolls the page.

### Test Coverage

_Please show how you have added tests to cover your changes_

We do not currently have any way of doing an integration test for this, but I tested it manually by building it into www and trying to use the spacebar directly when loading the project page.