### PR TITLE
delete existing translations before building translations, to avoid errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "clean": "rimraf ./build && mkdirp build && rimraf ./dist && mkdirp dist",
     "deploy": "touch build/.nojekyll && gh-pages -t -d build -m \"Build for $(git log --pretty=format:%H -n1)\"",
     "prune": "./prune-gh-pages.sh",
-    "i18n:src": "babel src > tmp.js && rimraf tmp.js && build-i18n-src ./translations/messages/src ./translations/",
+    "i18n:src": "rimraf ./translations/messages/src && babel src > tmp.js && rimraf tmp.js && build-i18n-src ./translations/messages/src ./translations/",
     "start": "webpack-dev-server",
     "test": "npm run test:lint && npm run test:unit && npm run build && npm run test:integration",
     "test:integration": "jest --runInBand test[\\\\/]integration",


### PR DESCRIPTION
### Resolves

We discussed doing this to avoid errors a while back. Seems worth doing now.

### Proposed Changes

Delete existing translations before building new ones, to avoid errors.

### Reason for Changes

Existing translations can sometimes cause errors. They're obsolete if we're building new translations, so let's delete them upfront.

### Test Coverage

None

### Browser Coverage
n/a