### PR TITLE
Connect to cloud based on hasCloudData

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "scratch-render": "0.1.0-prerelease.20181127194508",
     "scratch-storage": "1.2.0",
     "scratch-svg-renderer": "0.2.0-prerelease.20181126212715",
-    "scratch-vm": "0.2.0-prerelease.20181128141527",
+    "scratch-vm": "0.2.0-prerelease.20181128224414",
     "selenium-webdriver": "3.6.0",
     "startaudiocontext": "1.2.1",
     "style-loader": "^0.23.0",

--- a/test/unit/util/cloud-manager-hoc.test.jsx
+++ b/test/unit/util/cloud-manager-hoc.test.jsx
@@ -41,6 +41,9 @@ describe('CloudManagerHOC', () => {
         });
         vm = new VM();
         vm.setCloudProvider = jest.fn();
+        vm.runtime = {
+            hasCloudData: jest.fn(() => true)
+        };
         CloudProvider.mockClear();
         mockCloudProviderInstance.requestCloseConnection.mockClear();
     });
@@ -151,7 +154,7 @@ describe('CloudManagerHOC', () => {
         expect(vm.setCloudProvider).toHaveBeenCalledWith(mockCloudProviderInstance);
     });
 
-    test('when it unmounts, the cloud provider is set on the vm', () => {
+    test('when it unmounts, the cloud provider is reset to null on the vm', () => {
         const Component = () => (<div />);
         const WrappedComponent = cloudManagerHOC(Component);
         const mounted = mount(
@@ -218,6 +221,76 @@ describe('CloudManagerHOC', () => {
         mounted.setProps({
             username: 'a different user'
         });
+
+        expect(vm.setCloudProvider.mock.calls.length).toBe(2);
+        expect(vm.setCloudProvider).toHaveBeenCalledWith(null);
+        expect(requestCloseConnection).toHaveBeenCalledTimes(1);
+
+    });
+
+    test('project without cloud data should not trigger cloud connection', () => {
+        // Mock the vm runtime function so that has cloud data is not
+        // initially true
+        vm.runtime.hasCloudData = jest.fn(() => false);
+
+        const Component = () => <div />;
+        const WrappedComponent = cloudManagerHOC(Component);
+        mount(
+            <WrappedComponent
+                cloudHost="nonEmpty"
+                store={store}
+                username="user"
+                vm={vm}
+            />
+        );
+        expect(vm.setCloudProvider.mock.calls.length).toBe(0);
+        expect(CloudProvider).not.toHaveBeenCalled();
+    });
+
+    test('projectHasCloudData becoming true should trigger a cloud connection', () => {
+        // Mock the vm runtime function so that has cloud data is not
+        // initially true
+        vm.runtime.hasCloudData = jest.fn(() => false);
+
+        const Component = () => <div />;
+        const WrappedComponent = cloudManagerHOC(Component);
+        mount(
+            <WrappedComponent
+                cloudHost="nonEmpty"
+                store={store}
+                username="user"
+                vm={vm}
+            />
+        );
+        expect(vm.setCloudProvider.mock.calls.length).toBe(0);
+        expect(CloudProvider).not.toHaveBeenCalled();
+
+        // Mock VM hasCloudData becoming true and emitting an update
+        vm.runtime.hasCloudData = jest.fn(() => true);
+        vm.emit('HAS_CLOUD_DATA_UPDATE', true);
+
+        expect(vm.setCloudProvider.mock.calls.length).toBe(1);
+        expect(CloudProvider).toHaveBeenCalledTimes(1);
+        expect(vm.setCloudProvider).toHaveBeenCalledWith(mockCloudProviderInstance);
+    });
+
+    test('projectHasCloudDataUpdate becoming false should trigger cloudProvider disconnection', () => {
+        const Component = () => <div />;
+        const WrappedComponent = cloudManagerHOC(Component);
+        mount(
+            <WrappedComponent
+                cloudHost="nonEmpty"
+                store={store}
+                username="user"
+                vm={vm}
+            />
+        );
+
+        expect(CloudProvider).toHaveBeenCalled();
+        const requestCloseConnection = mockCloudProviderInstance.requestCloseConnection;
+
+        vm.runtime.hasCloudData = jest.fn(() => false);
+        vm.emit('HAS_CLOUD_DATA_UPDATE', false);
 
         expect(vm.setCloudProvider.mock.calls.length).toBe(2);
         expect(vm.setCloudProvider).toHaveBeenCalledWith(null);

--- a/test/unit/util/cloud-provider.test.js
+++ b/test/unit/util/cloud-provider.test.js
@@ -84,14 +84,6 @@ describe('CloudProvider', () => {
         expect(typeof obj.value).toEqual('undefined');
     });
 
-    test('onMessage ack', () => {
-        const msg = JSON.stringify({
-            method: 'ack',
-            name: 'name'
-        });
-        cloudProvider.connection._receive({data: msg});
-        expect(vmIOData[0].varCreate.name).toEqual('name');
-    });
 
     test('onMessage set', () => {
         const msg = JSON.stringify({
@@ -121,12 +113,13 @@ describe('CloudProvider', () => {
             value: 'value'
         });
         const msg2 = JSON.stringify({
-            method: 'ack',
-            name: 'name2'
+            method: 'set',
+            name: 'name2',
+            value: 'value2'
         });
         cloudProvider.connection._receive({data: `${msg1}\n${msg2}`});
         expect(vmIOData[0].varUpdate.name).toEqual('name1');
-        expect(vmIOData[1].varCreate.name).toEqual('name2');
+        expect(vmIOData[1].varUpdate.name).toEqual('name2');
     });
 
     test('connnection attempts set back to 1 when socket is opened', () => {


### PR DESCRIPTION
#### New version of LLK/scratch-gui#3875

### Proposed Changes

- Connect to cloud if the project has cloud data instead of on every new project.
- Listens to a new event from scratch-vm indicating an update to the project's `hasCloudData` status.
- Remove `ack` handler in the cloud-provider since it is not used in the vm anymore.
- Queue messages to send in the cloud provider if the connection is not ready yet. This is needed since creating the first cloud variable triggers initiating the connection for the first time.

### Reason for Changes

Reducing unnecessary cloud variable connections.

### Related PRs
LLK/scratch-vm#1778

### Test Coverage

Added unit tests for projectHasCloudData prop in cloud-manager-hoc. 
Updated existing tests to account for refactors described above.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [x] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
