### PR TITLE
Remove setTimeout for reattaching workspace block listener.

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -328,10 +328,7 @@ class Blocks extends React.Component {
             error.message = `Workspace Update Error: ${error.message}`;
             log.error(error);
         }
-        // All of the changes that happened during the load above are queued with
-        // timeouts, so re-enable the listener in the next tick, so it happens after
-        // the events are already fired.
-        setTimeout(() => this.workspace.addChangeListener(this.props.vm.blockListener));
+        this.workspace.addChangeListener(this.props.vm.blockListener);
 
         if (this.props.vm.editingTarget && this.state.workspaceMetrics[this.props.vm.editingTarget.id]) {
             const {scrollX, scrollY, scale} = this.state.workspaceMetrics[this.props.vm.editingTarget.id];


### PR DESCRIPTION
It was causing a bug where switching tabs and adding a sprite would make the workspace blocks not work. Needs investigation.

/cc @rschamp 

/ht @BryceLTaylor for finding this issue. We need to figure out how to write an integration test for this.