### PR TITLE
warn user if they leave project that's not saved

### DIFF
--- a/src/lib/project-saver-hoc.jsx
+++ b/src/lib/project-saver-hoc.jsx
@@ -50,7 +50,9 @@ const ProjectSaverHOC = function (WrappedComponent) {
         }
         componentWillMount () {
             if (typeof window === 'object') {
-                window.addEventListener('beforeunload', this.leavePageConfirm);
+                // Note: it might be better to use a listener instead of assigning onbeforeunload;
+                // but then it'd be hard to turn this listening off in our tests
+                window.onbeforeunload = () => this.leavePageConfirm;
             }
         }
         componentDidUpdate (prevProps) {
@@ -92,7 +94,7 @@ const ProjectSaverHOC = function (WrappedComponent) {
         }
         componentWillUnmount () {
             this.clearAutoSaveTimeout();
-            window.removeEventListener('beforeunload', this.leavePageConfirm);
+            window.onbeforeunload = undefined; // eslint-disable-line no-undefined
         }
         leavePageConfirm (e) {
             if (this.props.projectChanged) {

--- a/src/lib/project-saver-hoc.jsx
+++ b/src/lib/project-saver-hoc.jsx
@@ -52,7 +52,7 @@ const ProjectSaverHOC = function (WrappedComponent) {
             if (typeof window === 'object') {
                 // Note: it might be better to use a listener instead of assigning onbeforeunload;
                 // but then it'd be hard to turn this listening off in our tests
-                window.onbeforeunload = () => this.leavePageConfirm;
+                window.onbeforeunload = (e) => this.leavePageConfirm(e);
             }
         }
         componentDidUpdate (prevProps) {
@@ -102,7 +102,7 @@ const ProjectSaverHOC = function (WrappedComponent) {
                 (e || window.event).returnValue = true;
                 return true;
             }
-            return false; // do not prompt
+            return; // Returning undefined prevents the prompt from coming up
         }
         clearAutoSaveTimeout () {
             if (this.props.autoSaveTimeoutId !== null) {

--- a/src/lib/project-saver-hoc.jsx
+++ b/src/lib/project-saver-hoc.jsx
@@ -44,8 +44,14 @@ const ProjectSaverHOC = function (WrappedComponent) {
         constructor (props) {
             super(props);
             bindAll(this, [
+                'leavePageConfirm',
                 'tryToAutoSave'
             ]);
+        }
+        componentWillMount () {
+            if (typeof window === 'object') {
+                window.addEventListener('beforeunload', this.leavePageConfirm);
+            }
         }
         componentDidUpdate (prevProps) {
             if (this.props.projectChanged && !prevProps.projectChanged) {
@@ -86,6 +92,15 @@ const ProjectSaverHOC = function (WrappedComponent) {
         }
         componentWillUnmount () {
             this.clearAutoSaveTimeout();
+            window.removeEventListener('beforeunload', this.leavePageConfirm);
+        }
+        leavePageConfirm (e) {
+            if (this.props.projectChanged) {
+                // both methods of returning a value may be necessary for browser compatibility
+                (e || window.event).returnValue = true;
+                return true;
+            }
+            return false; // do not prompt
         }
         clearAutoSaveTimeout () {
             if (this.props.autoSaveTimeoutId !== null) {

--- a/test/integration/sounds.test.js
+++ b/test/integration/sounds.test.js
@@ -32,6 +32,7 @@ describe('Working with sounds', () => {
 
         // Delete the sound
         await rightClickText('Meow', scope.soundsTab);
+        await driver.sleep(500); // Wait a moment for context menu; only needed for local testing
         await clickText('delete', scope.soundsTab);
 
         // Add it back


### PR DESCRIPTION
### Resolves

- Resolves https://github.com/LLK/scratch-gui/issues/3684

### Proposed Changes

project-saver-hoc now listens for window unload events, and before proceeding with browsing away from the page, checks if the project is dirty and prompts the user if it is.

Issue: since `projectChanged` is sometimes set to true when the vm is loaded -- a know issue, I believe -- this PR so far behaves wrong if you are looking at a project which you do not own; in that case, `projectChanged` seems to be always true, making it prompt you every time you navigate away from such a page, which is annoying.

Also, it's unclear to me whether I should delete the other window unload code in `playground/render-gui.jsx`. It seems to work fine with or without that code, possibly because it's being overridden by the listening in project-saver.

### Test Coverage

Unsure how to test this.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
