### PR TITLE
Cloud Variable Rate Limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "lodash.isequal": "4.5.0",
     "lodash.omit": "4.5.0",
     "lodash.pick": "4.4.0",
+    "lodash.throttle": "4.0.1",
     "minilog": "3.1.0",
     "mkdirp": "^0.5.1",
     "postcss-import": "^12.0.0",

--- a/src/lib/cloud-provider.js
+++ b/src/lib/cloud-provider.js
@@ -1,4 +1,5 @@
 import log from './log.js';
+import throttle from 'lodash.throttle';
 
 
 class CloudProvider {
@@ -25,6 +26,10 @@ class CloudProvider {
         this.queuedData = [];
 
         this.openConnection();
+
+        // Send a message to the cloud server at a rate of no more
+        // than 10 messages/sec.
+        this.sendCloudData = throttle(this._sendCloudData, 100);
     }
 
     /**
@@ -149,7 +154,7 @@ class CloudProvider {
      * Send a formatted message to the cloud data server.
      * @param {string} data The formatted message to send.
      */
-    sendCloudData (data) {
+    _sendCloudData (data) {
         this.connection.send(`${data}\n`);
         log.info(`Sent message to clouddata server: ${data}`);
     }


### PR DESCRIPTION
### Proposed Changes

Limit sending cloud variable messages to the rate of 10 msgs/sec.

### Reason for Changes

Limit getting bumped off by the cloud data server for sending messages too fast.

### Test Coverage

Manually tested and compared against scratch.ly

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [x] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
