### PR TITLE
Include polyfill for promise.finally so Edge can load projects

### DIFF
--- a/src/playground/index.jsx
+++ b/src/playground/index.jsx
@@ -1,6 +1,7 @@
 // Polyfills
 import 'es6-object-assign/auto';
 import 'core-js/fn/array/includes';
+import 'core-js/fn/promise/finally';
 import 'intl'; // For Safari 9
 
 import React from 'react';


### PR DESCRIPTION
Resolves https://github.com/LLK/scratch-gui/issues/3919 by including a Promise.finally polyfill. I will also add that polyfill in www to fix it there as well.

Tested using Sauce to load Edge 15/16. 