### PR TITLE
Fix stage wrapper not setting dir="ltr/rtl" property, buttons look wrong

### DIFF
--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -132,6 +132,7 @@ const GUIComponent = props => {
         return isPlayerOnly ? (
             <StageWrapper
                 isRendererSupported={isRendererSupported}
+                isRtl={isRtl}
                 stageSize={stageSize}
                 vm={vm}
             >

--- a/src/components/stage-wrapper/stage-wrapper.jsx
+++ b/src/components/stage-wrapper/stage-wrapper.jsx
@@ -11,13 +11,17 @@ import styles from './stage-wrapper.css';
 
 const StageWrapperComponent = function (props) {
     const {
+        isRtl,
         isRendererSupported,
         stageSize,
         vm
     } = props;
 
     return (
-        <Box className={styles.stageWrapper}>
+        <Box
+            className={styles.stageWrapper}
+            dir={isRtl ? 'rtl' : 'ltr'}
+        >
             <Box className={styles.stageMenuWrapper}>
                 <StageHeader
                     stageSize={stageSize}
@@ -40,6 +44,7 @@ const StageWrapperComponent = function (props) {
 
 StageWrapperComponent.propTypes = {
     isRendererSupported: PropTypes.bool.isRequired,
+    isRtl: PropTypes.bool,
     stageSize: PropTypes.oneOf(Object.keys(STAGE_DISPLAY_SIZES)).isRequired,
     vm: PropTypes.instanceOf(VM).isRequired
 };


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves an issue where the ask/answer button was in the wrong place, because there was not a parent with dir="..." set. 

### Proposed Changes

_Describe what this Pull Request does_

Add dir="..." to the stage wrapper.

### Testing

Tested by embedding in www and using the ask block
Before
![image](https://user-images.githubusercontent.com/654102/49382057-665a4080-f6e3-11e8-8f2d-2b008a7bbb29.png)

After
![image](https://user-images.githubusercontent.com/654102/49382029-50e51680-f6e3-11e8-9694-123e8826238f.png)

