### PR TITLE
Always show stage in large mode when isPlayerOnly.

### DIFF
--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -133,7 +133,7 @@ const GUIComponent = props => {
             <StageWrapper
                 isRendererSupported={isRendererSupported}
                 isRtl={isRtl}
-                stageSize={stageSize}
+                stageSize={STAGE_SIZE_MODES.large}
                 vm={vm}
             >
                 {alertsVisible ? (


### PR DESCRIPTION
Fixes 2 related issues:

1. The stage shrinking to 85% based on responsive stylings, which shouldn't happen when embedded in player only
2. When you click "small stage mode" in the editor then switch back to the project page view, it shouldn't show with small stage mode.

### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/LLK/scratch-www/issues/2386
- Resolves https://github.com/LLK/scratch-www/issues/2084

### Proposed Changes

_Describe what this Pull Request does_

Always use STAGE_SIZE_MODE.large in player mode

I tested this locally by going to localhost/player.html and resizing the window, at no point does the stage get smaller. I also put it in www and tested responsive and small stage fixes.