### PR TITLE
Feature/3942 embed project

### DIFF
--- a/src/components/stage-header/stage-header.css
+++ b/src/components/stage-header/stage-header.css
@@ -26,6 +26,12 @@
     padding-bottom: $space;
 }
 
+.embed-scratch-logo img {
+    height:  1.6rem;
+    vertical-align: middle;
+    opacity: .6;
+}
+
 .stage-size-row {
     display: flex;
 }

--- a/src/components/stage-header/stage-header.jsx
+++ b/src/components/stage-header/stage-header.jsx
@@ -16,6 +16,7 @@ import largeStageIcon from './icon--large-stage.svg';
 import smallStageIcon from './icon--small-stage.svg';
 import unFullScreenIcon from './icon--unfullscreen.svg';
 
+import scratchLogo from '../menu-bar/scratch-logo.svg';
 import styles from './stage-header.css';
 
 const messages = defineMessages({
@@ -48,6 +49,7 @@ const messages = defineMessages({
 
 const StageHeaderComponent = function (props) {
     const {
+        isEmbedded,
         isFullScreen,
         isPlayerOnly,
         onKeyPress,
@@ -63,6 +65,34 @@ const StageHeaderComponent = function (props) {
 
     if (isFullScreen) {
         const stageDimensions = getStageDimensions(null, true);
+        const stageButton = isEmbedded ? (
+            <div className={styles.embedScratchLogo}>
+                <a
+                    href="https://scratch.mit.edu"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                >
+                    <img
+                        alt="Scratch"
+                        src={scratchLogo}
+                    />
+                </a>
+            </div>
+        ) : (
+            <Button
+                className={styles.stageButton}
+                onClick={onSetStageUnFull}
+                onKeyPress={onKeyPress}
+            >
+                <img
+                    alt={props.intl.formatMessage(messages.unFullStageSizeMessage)}
+                    className={styles.stageButtonIcon}
+                    draggable={false}
+                    src={unFullScreenIcon}
+                    title={props.intl.formatMessage(messages.fullscreenControl)}
+                />
+            </Button>
+        );
         header = (
             <Box className={styles.stageHeaderWrapperOverlay}>
                 <Box
@@ -70,19 +100,7 @@ const StageHeaderComponent = function (props) {
                     style={{width: stageDimensions.width}}
                 >
                     <Controls vm={vm} />
-                    <Button
-                        className={styles.stageButton}
-                        onClick={onSetStageUnFull}
-                        onKeyPress={onKeyPress}
-                    >
-                        <img
-                            alt={props.intl.formatMessage(messages.unFullStageSizeMessage)}
-                            className={styles.stageButtonIcon}
-                            draggable={false}
-                            src={unFullScreenIcon}
-                            title={props.intl.formatMessage(messages.fullscreenControl)}
-                        />
-                    </Button>
+                    {stageButton}
                 </Box>
             </Box>
         );
@@ -164,6 +182,7 @@ const mapStateToProps = state => ({
 
 StageHeaderComponent.propTypes = {
     intl: intlShape,
+    isEmbedded: PropTypes.bool.isRequired,
     isFullScreen: PropTypes.bool.isRequired,
     isPlayerOnly: PropTypes.bool.isRequired,
     onKeyPress: PropTypes.func.isRequired,

--- a/src/components/stage-header/stage-header.jsx
+++ b/src/components/stage-header/stage-header.jsx
@@ -49,7 +49,6 @@ const messages = defineMessages({
 
 const StageHeaderComponent = function (props) {
     const {
-        isEmbedded,
         isFullScreen,
         isPlayerOnly,
         onKeyPress,
@@ -57,6 +56,7 @@ const StageHeaderComponent = function (props) {
         onSetStageSmall,
         onSetStageFull,
         onSetStageUnFull,
+        showBranding,
         stageSizeMode,
         vm
     } = props;
@@ -65,7 +65,7 @@ const StageHeaderComponent = function (props) {
 
     if (isFullScreen) {
         const stageDimensions = getStageDimensions(null, true);
-        const stageButton = isEmbedded ? (
+        const stageButton = showBranding ? (
             <div className={styles.embedScratchLogo}>
                 <a
                     href="https://scratch.mit.edu"
@@ -182,7 +182,6 @@ const mapStateToProps = state => ({
 
 StageHeaderComponent.propTypes = {
     intl: intlShape,
-    isEmbedded: PropTypes.bool.isRequired,
     isFullScreen: PropTypes.bool.isRequired,
     isPlayerOnly: PropTypes.bool.isRequired,
     onKeyPress: PropTypes.func.isRequired,
@@ -190,6 +189,7 @@ StageHeaderComponent.propTypes = {
     onSetStageLarge: PropTypes.func.isRequired,
     onSetStageSmall: PropTypes.func.isRequired,
     onSetStageUnFull: PropTypes.func.isRequired,
+    showBranding: PropTypes.bool.isRequired,
     stageSizeMode: PropTypes.oneOf(Object.keys(STAGE_SIZE_MODES)),
     vm: PropTypes.instanceOf(VM).isRequired
 };

--- a/src/containers/stage-header.jsx
+++ b/src/containers/stage-header.jsx
@@ -43,6 +43,7 @@ class StageHeader extends React.Component {
 }
 
 StageHeader.propTypes = {
+    isEmbedded: PropTypes.bool,
     isFullScreen: PropTypes.bool,
     isPlayerOnly: PropTypes.bool,
     onSetStageUnFull: PropTypes.func.isRequired,
@@ -52,6 +53,7 @@ StageHeader.propTypes = {
 
 const mapStateToProps = state => ({
     stageSizeMode: state.scratchGui.stageSize.stageSize,
+    isEmbedded: state.scratchGui.mode.isEmbedded,
     isFullScreen: state.scratchGui.mode.isFullScreen,
     isPlayerOnly: state.scratchGui.mode.isPlayerOnly
 });

--- a/src/containers/stage-header.jsx
+++ b/src/containers/stage-header.jsx
@@ -43,17 +43,17 @@ class StageHeader extends React.Component {
 }
 
 StageHeader.propTypes = {
-    isEmbedded: PropTypes.bool,
     isFullScreen: PropTypes.bool,
     isPlayerOnly: PropTypes.bool,
     onSetStageUnFull: PropTypes.func.isRequired,
+    showBranding: PropTypes.bool,
     stageSizeMode: PropTypes.oneOf(Object.keys(STAGE_SIZE_MODES)),
     vm: PropTypes.instanceOf(VM).isRequired
 };
 
 const mapStateToProps = state => ({
     stageSizeMode: state.scratchGui.stageSize.stageSize,
-    isEmbedded: state.scratchGui.mode.isEmbedded,
+    showBranding: state.scratchGui.mode.showBranding,
     isFullScreen: state.scratchGui.mode.isFullScreen,
     isPlayerOnly: state.scratchGui.mode.isPlayerOnly
 });

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import GUI from './containers/gui.jsx';
 import AppStateHOC from './lib/app-state-hoc.jsx';
-import GuiReducer, {guiInitialState, guiMiddleware, initFullScreen, initPlayer} from './reducers/gui';
+import GuiReducer, {guiInitialState, guiMiddleware, initEmbedded, initFullScreen, initPlayer} from './reducers/gui';
 import LocalesReducer, {localesInitialState, initLocale} from './reducers/locales';
 import {ScratchPaintReducer} from 'scratch-paint';
 import {setFullScreen, setPlayer} from './reducers/mode';
@@ -20,6 +20,7 @@ export {
     guiReducers,
     guiInitialState,
     guiMiddleware,
+    initEmbedded,
     initPlayer,
     initFullScreen,
     initLocale,

--- a/src/reducers/gui.js
+++ b/src/reducers/gui.js
@@ -88,7 +88,7 @@ const initEmbedded = function (currentState) {
         {},
         currentState,
         {mode: {
-            isEmbedded: true,
+            showBranding: true,
             isFullScreen: true,
             isPlayerOnly: true,
             hasEverEnteredEditor: false

--- a/src/reducers/gui.js
+++ b/src/reducers/gui.js
@@ -83,6 +83,19 @@ const initFullScreen = function (currentState) {
     );
 };
 
+const initEmbedded = function (currentState) {
+    return Object.assign(
+        {},
+        currentState,
+        {mode: {
+            isEmbedded: true,
+            isFullScreen: true,
+            isPlayerOnly: true,
+            hasEverEnteredEditor: false
+        }}
+    );
+};
+
 const initTutorialCard = function (currentState, deckId) {
     return Object.assign(
         {},
@@ -145,6 +158,7 @@ export {
     guiReducer as default,
     guiInitialState,
     guiMiddleware,
+    initEmbedded,
     initFullScreen,
     initPlayer,
     initPreviewInfo,

--- a/src/reducers/mode.js
+++ b/src/reducers/mode.js
@@ -2,6 +2,7 @@ const SET_FULL_SCREEN = 'scratch-gui/mode/SET_FULL_SCREEN';
 const SET_PLAYER = 'scratch-gui/mode/SET_PLAYER';
 
 const initialState = {
+    isEmbedded: false,
     isFullScreen: false,
     isPlayerOnly: false,
     hasEverEnteredEditor: true

--- a/src/reducers/mode.js
+++ b/src/reducers/mode.js
@@ -2,7 +2,7 @@ const SET_FULL_SCREEN = 'scratch-gui/mode/SET_FULL_SCREEN';
 const SET_PLAYER = 'scratch-gui/mode/SET_PLAYER';
 
 const initialState = {
-    isEmbedded: false,
+    showBranding: false,
     isFullScreen: false,
     isPlayerOnly: false,
     hasEverEnteredEditor: true


### PR DESCRIPTION
### Resolves

- Resolves #3942

### Proposed Changes

* Adds new embed mode
* Does not support autoplay as browser requires user action for audio to work properly in all cases
* replaces fullscreen toggle with the Scratch Logo (linked to scratch.mit.edu)
* Full screen toggle did nothing in the 2.0 embed. If we do want to support a full screen mode, we can revisit it later.

Will be going over styles with Kathy to see if there are any adjustments (logo size etc)

### Reason for Changes

To be compatible with 2.0

### Test Coverage
Manual Testing:
* There should be no effect for anyone using Gui standalone as there's no UI to switch to embed view. (perhaps it would be a good idea to add an embed view to the playground)
* Testing in the context of www embed URL

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [x] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
