### PR TITLE
Prevent thumbnails from containing the video layer

### DIFF
--- a/src/lib/project-saver-hoc.jsx
+++ b/src/lib/project-saver-hoc.jsx
@@ -224,7 +224,9 @@ const ProjectSaverHOC = function (WrappedComponent) {
          */
         storeProjectThumbnail (projectId) {
             try {
+                this.props.vm.postIOData('video', {forceTransparentPreview: true});
                 this.props.vm.renderer.requestSnapshot(dataURI => {
+                    this.props.vm.postIOData('video', {forceTransparentPreview: false});
                     this.props.onUpdateProjectThumbnail(
                         projectId, dataURItoBlob(dataURI));
                 });


### PR DESCRIPTION
Fixes an issue where project thumbnails could contain the video preview.

Requires https://github.com/LLK/scratch-vm/pull/1812.

As discussed with @rschamp, because the way the forceTransparentPreview flag is implemented in the VM, there is no way that any blocks can show the preview layer when the forceTransparentPreview is true. This makes it a safe way to prevent the video layer from being included in project thumbnails.

