### PR TITLE
"Save Now" menubar option when project has changed

### DIFF
--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -12,7 +12,7 @@ import ShareButton from './share-button.jsx';
 import {ComingSoonTooltip} from '../coming-soon/coming-soon.jsx';
 import Divider from '../divider/divider.jsx';
 import LanguageSelector from '../../containers/language-selector.jsx';
-import InlineMessages from '../../containers/inline-messages.jsx';
+import SaveStatus from './save-status.jsx';
 import SBFileUploader from '../../containers/sb-file-uploader.jsx';
 import ProjectWatcher from '../../containers/project-watcher.jsx';
 import MenuBarMenu from './menu-bar-menu.jsx';
@@ -535,7 +535,7 @@ class MenuBar extends React.Component {
                 logged in, and whether a session is available to log in with */}
                 <div className={styles.accountInfoGroup}>
                     <div className={styles.menuBarItem}>
-                        <InlineMessages />
+                        <SaveStatus />
                     </div>
                     {this.props.sessionExists ? (
                         this.props.username ? (

--- a/src/components/menu-bar/save-status.css
+++ b/src/components/menu-bar/save-status.css
@@ -1,0 +1,4 @@
+.save-now {
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    cursor: pointer;
+}

--- a/src/components/menu-bar/save-status.jsx
+++ b/src/components/menu-bar/save-status.jsx
@@ -1,0 +1,61 @@
+import {connect} from 'react-redux';
+import {FormattedMessage} from 'react-intl';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import InlineMessages from '../../containers/inline-messages.jsx';
+
+import {
+    manualUpdateProject
+} from '../../reducers/project-state';
+
+import {
+    filterInlineAlerts
+} from '../../reducers/alerts';
+
+import styles from './save-status.css';
+
+// Wrapper for inline messages in the nav bar, which are all related to saving.
+// Show any inline messages if present, else show the "Save Now" button if the
+// project has changed.
+// We decided to not use an inline message for "Save Now" because it is a reflection
+// of the project state, rather than an event.
+const SaveStatus = ({
+    alertsList,
+    projectChanged,
+    onClickSave
+}) => (
+    filterInlineAlerts(alertsList).length > 0 ? (
+        <InlineMessages />
+    ) : projectChanged && (
+        <div
+            className={styles.saveNow}
+            onClick={onClickSave}
+        >
+            <FormattedMessage
+                defaultMessage="Save Now"
+                description="Title bar link for saving now"
+                id="gui.menuBar.saveNowLink"
+            />
+        </div>
+    ));
+
+SaveStatus.propTypes = {
+    alertsList: PropTypes.arrayOf(PropTypes.object),
+    onClickSave: PropTypes.func,
+    projectChanged: PropTypes.bool
+};
+
+const mapStateToProps = state => ({
+    alertsList: state.scratchGui.alerts.alertsList,
+    projectChanged: state.scratchGui.projectChanged
+});
+
+const mapDispatchToProps = dispatch => ({
+    onClickSave: () => dispatch(manualUpdateProject())
+});
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(SaveStatus);

--- a/src/lib/alerts/index.jsx
+++ b/src/lib/alerts/index.jsx
@@ -87,7 +87,7 @@ const alerts = [
         ),
         iconURL: successImage,
         level: AlertLevels.SUCCESS,
-        maxDisplaySecs: 5
+        maxDisplaySecs: 3
     },
     {
         alertId: 'saving',

--- a/test/unit/containers/save-status.test.jsx
+++ b/test/unit/containers/save-status.test.jsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import {Provider} from 'react-redux';
+import configureStore from 'redux-mock-store';
+import {mountWithIntl} from '../../helpers/intl-helpers.jsx';
+import SaveStatus from '../../../src/components/menu-bar/save-status.jsx';
+import InlineMessages from '../../../src/containers/inline-messages.jsx';
+import {AlertTypes} from '../../../src/lib/alerts/index.jsx';
+
+// Stub the manualUpdateProject action creator for later testing
+jest.mock('../../../src/reducers/project-state', () => ({
+    manualUpdateProject: jest.fn(() => ({type: 'stubbed'}))
+}));
+
+describe('SaveStatus container', () => {
+    const mockStore = configureStore();
+
+    test('if there are inline messages, they are shown instead of save now', () => {
+        const store = mockStore({
+            scratchGui: {
+                projectChanged: true,
+                alerts: {
+                    alertsList: [
+                        {alertId: 'saveSuccess', alertType: AlertTypes.INLINE}
+                    ]
+                }
+            }
+        });
+        const wrapper = mountWithIntl(
+            <Provider store={store}>
+                <SaveStatus />
+            </Provider>
+        );
+        expect(wrapper.find(InlineMessages).exists()).toBe(true);
+        expect(wrapper.contains('Save Now')).not.toBe(true);
+    });
+
+    test('save now is shown if there are project changes and no inline messages', () => {
+        const store = mockStore({
+            scratchGui: {
+                projectChanged: true,
+                alerts: {
+                    alertsList: []
+                }
+            }
+        });
+        const wrapper = mountWithIntl(
+            <Provider store={store}>
+                <SaveStatus />
+            </Provider>
+        );
+        expect(wrapper.find(InlineMessages).exists()).not.toBe(true);
+        expect(wrapper.contains('Save Now')).toBe(true);
+
+        // Clicking save now should dispatch the manualUpdateProject action (stubbed above)
+        wrapper.find('[children="Save Now"]').simulate('click');
+        expect(store.getActions()[0].type).toEqual('stubbed');
+    });
+
+    test('neither is shown if there are no project changes or inline messages', () => {
+        const store = mockStore({
+            scratchGui: {
+                projectChanged: false,
+                alerts: {
+                    alertsList: []
+                }
+            }
+        });
+        const wrapper = mountWithIntl(
+            <Provider store={store}>
+                <SaveStatus />
+            </Provider>
+        );
+        expect(wrapper.find(InlineMessages).exists()).not.toBe(true);
+        expect(wrapper.contains('Save Now')).not.toBe(true);
+    });
+});

--- a/test/unit/reducers/alerts-reducer.test.js
+++ b/test/unit/reducers/alerts-reducer.test.js
@@ -5,6 +5,8 @@ import {AlertTypes, AlertLevels} from '../../../src/lib/alerts/index.jsx';
 import alertsReducer from '../../../src/reducers/alerts';
 import {
     closeAlert,
+    filterInlineAlerts,
+    filterPopupAlerts,
     showStandardAlert
 } from '../../../src/reducers/alerts';
 
@@ -122,4 +124,55 @@ test('several related alerts can be cleared at once', () => {
     resultState = alertsReducer(resultState, createSuccessAction);
     expect(resultState.alertsList.length).toBe(1);
     expect(resultState.alertsList[0].alertId).toBe('createSuccess');
+});
+
+test('filterInlineAlerts only returns inline type alerts', () => {
+    const alerts = [
+        {
+            alertId: 'extension',
+            alertType: AlertTypes.EXTENSION
+        },
+        {
+            alertId: 'inline',
+            alertType: AlertTypes.INLINE
+        },
+        {
+            alertId: 'standard',
+            alertType: AlertTypes.STANDARD
+        },
+        {
+            alertId: 'non-existent type',
+            alertType: 'wirly-burly'
+        }
+    ];
+
+    const filtered = filterInlineAlerts(alerts);
+    expect(filtered.length).toEqual(1);
+    expect(filtered[0].alertId).toEqual('inline');
+});
+
+test('filterPopupAlerts returns standard and extension type alerts', () => {
+    const alerts = [
+        {
+            alertId: 'extension',
+            alertType: AlertTypes.EXTENSION
+        },
+        {
+            alertId: 'inline',
+            alertType: AlertTypes.INLINE
+        },
+        {
+            alertId: 'standard',
+            alertType: AlertTypes.STANDARD
+        },
+        {
+            alertId: 'non-existent type',
+            alertType: 'wirly-burly'
+        }
+    ];
+
+    const filtered = filterPopupAlerts(alerts);
+    expect(filtered.length).toEqual(2);
+    expect(filtered[0].alertId).toEqual('extension');
+    expect(filtered[1].alertId).toEqual('standard');
 });


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/LLK/scratch-gui/issues/3940

### Proposed Changes

_Describe what this Pull Request does_

![save-now-demo](https://user-images.githubusercontent.com/654102/49525291-71e06f80-f87b-11e8-9947-532c22d7c5d7.gif)

### Reason for Changes

_Explain why these changes should be made_

This features helps in 2 major ways:

1. It allows the scratcher to know what the save status of their project is (albeit indirectly), if "Save Now" is shown, the project is now saved.
2. It allows a scratcher to save the project manually. 

### Test Coverage

_Please show how you have added tests to cover your changes_

@benjiwheeler and I added a test covering the rendering of the save status and the action of clicking save now. We also built it into WWW and verified the saving actually works!
