### PR TITLE
Do not show cloud variable option in list modal.

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -384,6 +384,7 @@ class Blocks extends React.Component {
             optVarType !== this.ScratchBlocks.BROADCAST_MESSAGE_VARIABLE_TYPE &&
             p.prompt.title !== this.ScratchBlocks.Msg.RENAME_VARIABLE_MODAL_TITLE &&
             p.prompt.title !== this.ScratchBlocks.Msg.RENAME_LIST_MODAL_TITLE;
+        p.prompt.showCloudOption = (optVarType === this.ScratchBlocks.SCALAR_VARIABLE_TYPE) && this.props.canUseCloud;
         this.setState(p);
     }
     handleConnectionModalStart (extensionId) {
@@ -460,7 +461,7 @@ class Blocks extends React.Component {
                         isStage={vm.runtime.getEditingTarget().isStage}
                         label={this.state.prompt.message}
                         placeholder={this.state.prompt.defaultValue}
-                        showCloudOption={canUseCloud}
+                        showCloudOption={this.state.prompt.showCloudOption}
                         showVariableOptions={this.state.prompt.showVariableOptions}
                         title={this.state.prompt.title}
                         vm={vm}


### PR DESCRIPTION
### Proposed Changes

Only show cloud variable option in variable modal, not list modal as well.

Variable and list modals after change:

![image](https://user-images.githubusercontent.com/1786240/49560678-6a53b180-f8e1-11e8-8f2a-10760a748ca2.png)

![image](https://user-images.githubusercontent.com/1786240/49560685-72135600-f8e1-11e8-91f1-7eb10ffdc53a.png)


### Test Coverage

Tested manually with local environment (need to have a Scratcher user).

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [x] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
