### PR TITLE
Fix error logging when workspace fails to update 

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -325,7 +325,9 @@ class Blocks extends React.Component {
             // incomplete. Throwing the error would keep things like setting the
             // correct editing target from happening which can interfere with
             // some blocks and processes in the vm.
-            error.message = `Workspace Update Error: ${error.message}`;
+            if (error.message) {
+                error.message = `Workspace Update Error: ${error.message}`;
+            }
             log.error(error);
         }
         this.workspace.addChangeListener(this.props.vm.blockListener);


### PR DESCRIPTION
### Resolves

- Resolves #3251

### Proposed Changes

Fix catching/logging of workspace update errors being caught from scratch-blocks.

### Reason for Changes

Some existing projects were failing to load with a BSOD because of any error thrown from scratch-blocks which uses the `throw 'Some error string'` construct instead of `throw Error('some error string)'`.

An example project that was failing to load before but succeeds now is:
55574144

### Test Coverage

Tested with project mentioned above. It fails to load on develop but succeeds with these changes.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [x] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
