### PR TITLE
handle the onRemixing prop from www

### DIFF
--- a/src/lib/project-saver-hoc.jsx
+++ b/src/lib/project-saver-hoc.jsx
@@ -61,7 +61,10 @@ const ProjectSaverHOC = function (WrappedComponent) {
                 this.createCopyToStorage();
             }
             if (this.props.isRemixing && !prevProps.isRemixing) {
+                this.props.onRemixing(true);
                 this.createRemixToStorage();
+            } else if (!this.props.isRemixing && prevProps.isRemixing) {
+                this.props.onRemixing(false);
             }
 
             // see if we should "create" the current project on the server
@@ -294,6 +297,7 @@ const ProjectSaverHOC = function (WrappedComponent) {
         onCreateProject: PropTypes.func,
         onCreatedProject: PropTypes.func,
         onProjectError: PropTypes.func,
+        onRemixing: PropTypes.func,
         onShowAlert: PropTypes.func,
         onShowCreateSuccessAlert: PropTypes.func,
         onShowCreatingAlert: PropTypes.func,
@@ -307,7 +311,8 @@ const ProjectSaverHOC = function (WrappedComponent) {
         vm: PropTypes.instanceOf(VM).isRequired
     };
     ProjectSaverComponent.defaultProps = {
-        autosaveIntervalSecs: 120
+        autosaveIntervalSecs: 120,
+        onRemixing: () => {}
     };
     const mapStateToProps = (state, ownProps) => {
         const loadingState = state.scratchGui.projectState.loadingState;

--- a/src/lib/project-saver-hoc.jsx
+++ b/src/lib/project-saver-hoc.jsx
@@ -258,6 +258,7 @@ const ProjectSaverHOC = function (WrappedComponent) {
                 onCreatedProject,
                 onCreateProject,
                 onProjectError,
+                onRemixing,
                 onShowAlert,
                 onShowCreateSuccessAlert,
                 onShowCreatingAlert,

--- a/test/unit/util/project-saver-hoc.test.jsx
+++ b/test/unit/util/project-saver-hoc.test.jsx
@@ -399,4 +399,44 @@ describe('projectSaverHOC', () => {
         jest.runAllTimers();
         expect(mockedAutoUpdate).not.toHaveBeenCalled();
     });
+
+    test('when starting to remix, onRemixing should be called with param true', () => {
+        const mockedOnRemixing = jest.fn();
+        const mockedStoreProject = jest.fn(() => Promise.resolve());
+        const Component = () => <div />;
+        const WrappedComponent = projectSaverHOC(Component);
+        WrappedComponent.WrappedComponent.prototype.storeProject = mockedStoreProject;
+        const mounted = mount(
+            <WrappedComponent
+                isRemixing={false}
+                store={store}
+                vm={vm}
+                onRemixing={mockedOnRemixing}
+            />
+        );
+        mounted.setProps({
+            isRemixing: true
+        });
+        expect(mockedOnRemixing).toHaveBeenCalledWith(true);
+    });
+
+    test('when starting to remix, onRemixing should be called with param true', () => {
+        const mockedOnRemixing = jest.fn();
+        const mockedStoreProject = jest.fn(() => Promise.resolve());
+        const Component = () => <div />;
+        const WrappedComponent = projectSaverHOC(Component);
+        WrappedComponent.WrappedComponent.prototype.storeProject = mockedStoreProject;
+        const mounted = mount(
+            <WrappedComponent
+                isRemixing
+                store={store}
+                vm={vm}
+                onRemixing={mockedOnRemixing}
+            />
+        );
+        mounted.setProps({
+            isRemixing: false
+        });
+        expect(mockedOnRemixing).toHaveBeenCalledWith(false);
+    });
 });


### PR DESCRIPTION
### Resolves

With https://github.com/LLK/scratch-www/pull/2408 , resolves https://github.com/LLK/scratch-www/issues/2328

### Proposed Changes

calls `onRemixing()` prop function when starting to remix and stopping remixing

### Reason for Changes

allows www project page to show remixing state

### Test Coverage

Added 2 tests for calling `onRemixing(true)` and `onRemixing(false)`

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
