### PR TITLE
if in LoadingState.SHOWING_WITHOUT_ID, don't transition to default project

### DIFF
--- a/src/reducers/project-state.js
+++ b/src/reducers/project-state.js
@@ -197,23 +197,36 @@ const reducer = function (state, action) {
         if (state.projectId === action.projectId) {
             return state;
         }
-        // if setting the default project id, specifically fetch that project
-        if (action.projectId === defaultProjectId || action.projectId === null) {
-            return Object.assign({}, state, {
-                loadingState: LoadingState.FETCHING_NEW_DEFAULT,
-                projectId: defaultProjectId
-            });
-        }
         // if we were already showing a project, and a different projectId is set, only fetch that project if
         // projectId has changed. This prevents re-fetching projects unnecessarily.
         if (state.loadingState === LoadingState.SHOWING_WITH_ID) {
-            if (state.projectId !== action.projectId) {
+            // if setting the default project id, specifically fetch that project
+            if (action.projectId === defaultProjectId || action.projectId === null) {
+                return Object.assign({}, state, {
+                    loadingState: LoadingState.FETCHING_NEW_DEFAULT,
+                    projectId: defaultProjectId
+                });
+            }
+            return Object.assign({}, state, {
+                loadingState: LoadingState.FETCHING_WITH_ID,
+                projectId: action.projectId
+            });
+        } else if (state.loadingState === LoadingState.SHOWING_WITHOUT_ID) {
+            // if we were showing a project already, don't transition to default project.
+            if (action.projectId !== defaultProjectId && action.projectId !== null) {
                 return Object.assign({}, state, {
                     loadingState: LoadingState.FETCHING_WITH_ID,
                     projectId: action.projectId
                 });
             }
         } else { // allow any other states to transition to fetching project
+            // if setting the default project id, specifically fetch that project
+            if (action.projectId === defaultProjectId || action.projectId === null) {
+                return Object.assign({}, state, {
+                    loadingState: LoadingState.FETCHING_NEW_DEFAULT,
+                    projectId: defaultProjectId
+                });
+            }
             return Object.assign({}, state, {
                 loadingState: LoadingState.FETCHING_WITH_ID,
                 projectId: action.projectId


### PR DESCRIPTION
### Resolves

- Resolves https://github.com/LLK/scratch-gui/issues/3892

### Proposed Changes

Changes `project-state`'s `SET_PROJECT_ID` action so that if in LoadingState.SHOWING_WITHOUT_ID, don't transition to default project

### Reason for Changes

We were transitioning from state with uploaded project, where `projectId`=== `null` and `loadingState`===`SHOWING_WITHOUT_ID`, to setting `projectId` to default project. We shouldn't do that! 

### Test Coverage

Tests forthcoming...

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
