### PR TITLE
Bind vm project_start event to passed in onGreenFlag prop

### DIFF
--- a/src/lib/vm-listener-hoc.jsx
+++ b/src/lib/vm-listener-hoc.jsx
@@ -43,6 +43,7 @@ const vmListenerHOC = function (WrappedComponent) {
             this.props.vm.on('PROJECT_RUN_STOP', this.props.onProjectRunStop);
             this.props.vm.on('PROJECT_CHANGED', this.handleProjectChanged);
             this.props.vm.on('RUNTIME_STARTED', this.props.onRuntimeStarted);
+            this.props.vm.on('PROJECT_START', this.props.onGreenFlag);
             this.props.vm.on('PERIPHERAL_DISCONNECT_ERROR', this.props.onShowExtensionAlert);
             this.props.vm.on('MIC_LISTENING', this.props.onMicListeningUpdate);
 
@@ -116,6 +117,7 @@ const vmListenerHOC = function (WrappedComponent) {
                 attachKeyboardEvents,
                 shouldEmitTargetsUpdate,
                 onBlockDragUpdate,
+                onGreenFlag,
                 onKeyDown,
                 onKeyUp,
                 onMicListeningUpdate,
@@ -136,6 +138,7 @@ const vmListenerHOC = function (WrappedComponent) {
     VMListener.propTypes = {
         attachKeyboardEvents: PropTypes.bool,
         onBlockDragUpdate: PropTypes.func.isRequired,
+        onGreenFlag: PropTypes.func,
         onKeyDown: PropTypes.func,
         onKeyUp: PropTypes.func,
         onMicListeningUpdate: PropTypes.func.isRequired,
@@ -152,7 +155,8 @@ const vmListenerHOC = function (WrappedComponent) {
         vm: PropTypes.instanceOf(VM).isRequired
     };
     VMListener.defaultProps = {
-        attachKeyboardEvents: true
+        attachKeyboardEvents: true,
+        onGreenFlag: () => ({})
     };
     const mapStateToProps = state => ({
         // Do not emit target updates in fullscreen or player only mode

--- a/test/unit/util/vm-listener-hoc.test.jsx
+++ b/test/unit/util/vm-listener-hoc.test.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import configureStore from 'redux-mock-store';
+import {mount} from 'enzyme';
+import VM from 'scratch-vm';
+
+import vmListenerHOC from '../../../src/lib/vm-listener-hoc.jsx';
+
+describe('VMListenerHOC', () => {
+    const mockStore = configureStore();
+    let store;
+    let vm;
+
+    beforeEach(() => {
+        vm = new VM();
+        store = mockStore({
+            scratchGui: {
+                mode: {},
+                vm: vm
+            }
+        });
+    });
+
+    test('vm green flag event is bound to the passed in prop callback', () => {
+        const Component = () => (<div />);
+        const WrappedComponent = vmListenerHOC(Component);
+        const onGreenFlag = jest.fn();
+        mount(
+            <WrappedComponent
+                store={store}
+                vm={vm}
+                onGreenFlag={onGreenFlag}
+            />
+        );
+        expect(onGreenFlag).not.toHaveBeenCalled();
+        vm.emit('PROJECT_START');
+        expect(onGreenFlag).toHaveBeenCalled();
+    });
+
+    test('onGreenFlag is not passed to the children', () => {
+        const Component = () => (<div />);
+        const WrappedComponent = vmListenerHOC(Component);
+        const wrapper = mount(
+            <WrappedComponent
+                store={store}
+                vm={vm}
+                onGreenFlag={jest.fn()}
+            />
+        );
+        const child = wrapper.find(Component);
+        expect(child.props().onGreenFlag).toBeUndefined();
+    });
+});


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/LLK/scratch-gui/issues/3968

### Proposed Changes

_Describe what this Pull Request does_

Uses the publicly emitted PROJECT_START event from the VM to call a passed in onGreenFlag prop

### Reason for Changes

_Explain why these changes should be made_

Consumer of GUI wants to know when the green flag has been clicked, see https://github.com/LLK/scratch-www/issues/1858

### Test Coverage

_Please show how you have added tests to cover your changes_

Added a new unit test for the vm-listener-hoc just to test this!

Won't work until https://github.com/LLK/scratch-vm/pull/1825 is merged, but won't break without it.
