### PR TITLE
Hidden tutorial library items for LEGO WeDo 2.0 and EV3

### DIFF
--- a/src/components/library-item/library-item.css
+++ b/src/components/library-item/library-item.css
@@ -30,6 +30,10 @@
     border-color: $motion-primary;
 }
 
+.hidden {
+    display: none;
+}
+
 .disabled {
     opacity: .5;
     cursor: auto;

--- a/src/components/library-item/library-item.jsx
+++ b/src/components/library-item/library-item.jsx
@@ -55,7 +55,8 @@ class LibraryItem extends React.PureComponent {
                     {
                         [styles.disabled]: this.props.disabled
                     },
-                    this.props.extensionId ? styles.libraryItemExtension : null
+                    this.props.extensionId ? styles.libraryItemExtension : null,
+                    this.props.hidden ? styles.hidden : null
                 )}
                 onClick={this.handleClick}
             >
@@ -139,7 +140,10 @@ class LibraryItem extends React.PureComponent {
             </div>
         ) : (
             <Box
-                className={styles.libraryItem}
+                className={classNames(
+                    styles.libraryItem,
+                    this.props.hidden ? styles.hidden : null
+                )}
                 role="button"
                 tabIndex="0"
                 onBlur={this.handleBlur}
@@ -174,6 +178,7 @@ LibraryItem.propTypes = {
     disabled: PropTypes.bool,
     extensionId: PropTypes.string,
     featured: PropTypes.bool,
+    hidden: PropTypes.bool,
     iconURL: PropTypes.string.isRequired,
     id: PropTypes.number.isRequired,
     insetIconURL: PropTypes.string,
@@ -181,7 +186,7 @@ LibraryItem.propTypes = {
     name: PropTypes.oneOfType([
         PropTypes.string,
         PropTypes.node
-    ]).isRequired,
+    ]),
     onBlur: PropTypes.func,
     onFocus: PropTypes.func,
     onMouseEnter: PropTypes.func.isRequired,

--- a/src/components/library-item/library-item.jsx
+++ b/src/components/library-item/library-item.jsx
@@ -179,7 +179,7 @@ LibraryItem.propTypes = {
     extensionId: PropTypes.string,
     featured: PropTypes.bool,
     hidden: PropTypes.bool,
-    iconURL: PropTypes.string.isRequired,
+    iconURL: PropTypes.string,
     id: PropTypes.number.isRequired,
     insetIconURL: PropTypes.string,
     internetConnectionRequired: PropTypes.bool,

--- a/src/components/library/library.jsx
+++ b/src/components/library/library.jsx
@@ -182,6 +182,7 @@ class LibraryComponent extends React.Component {
                                 disabled={dataItem.disabled}
                                 extensionId={dataItem.extensionId}
                                 featured={dataItem.featured}
+                                hidden={dataItem.hidden}
                                 iconURL={scratchURL}
                                 id={index}
                                 insetIconURL={dataItem.insetIconURL}
@@ -212,7 +213,7 @@ LibraryComponent.propTypes = {
             name: PropTypes.oneOfType([
                 PropTypes.string,
                 PropTypes.node
-            ]).isRequired,
+            ]),
             rawURL: PropTypes.string
         })
         /* eslint-enable react/no-unused-prop-types, lines-around-comment */

--- a/src/components/library/library.jsx
+++ b/src/components/library/library.jsx
@@ -98,10 +98,12 @@ class LibraryComponent extends React.Component {
                 (dataItem.tags || [])
                     // Second argument to map sets `this`
                     .map(String.prototype.toLowerCase.call, String.prototype.toLowerCase)
-                    .concat((typeof dataItem.name === 'string' ?
+                    .concat(dataItem.name ?
+                        (typeof dataItem.name === 'string' ?
                         // Use the name if it is a string, else use formatMessage to get the translated name
-                        dataItem.name : this.props.intl.formatMessage(dataItem.name.props)
-                    ).toLowerCase())
+                            dataItem.name : this.props.intl.formatMessage(dataItem.name.props)
+                        ).toLowerCase() :
+                        null)
                     .join('\n') // unlikely to partially match newlines
                     .indexOf(this.state.filterQuery.toLowerCase()) !== -1
             ));

--- a/src/containers/tips-library.jsx
+++ b/src/containers/tips-library.jsx
@@ -63,7 +63,8 @@ class TipsLibrary extends React.PureComponent {
             featured: true,
             tags: decksLibraryContent[id].tags,
             urlId: decksLibraryContent[id].urlId,
-            requiredProjectId: decksLibraryContent[id].requiredProjectId
+            requiredProjectId: decksLibraryContent[id].requiredProjectId,
+            hidden: decksLibraryContent[id].hidden || false
         }));
 
         if (!this.props.visible) return null;

--- a/src/lib/libraries/decks/index.jsx
+++ b/src/lib/libraries/decks/index.jsx
@@ -1181,5 +1181,21 @@ export default {
             ]
         }],
         urlId: 'add-effects'
+    },
+    'wedo2': {
+        img: addEffectsThumb, // placeholder
+        steps: [{
+            video: 'add-effects'
+        }],
+        urlId: 'wedo2',
+        hidden: true
+    },
+    'ev3': {
+        img: addEffectsThumb, // placeholder
+        steps: [{
+            video: 'add-effects'
+        }],
+        urlId: 'ev3',
+        hidden: true
     }
 };

--- a/src/lib/libraries/decks/index.jsx
+++ b/src/lib/libraries/decks/index.jsx
@@ -1182,18 +1182,16 @@ export default {
         }],
         urlId: 'add-effects'
     },
-    'wedo2': {
-        img: addEffectsThumb, // placeholder
+    'wedo2-getting-started': {
         steps: [{
-            video: 'add-effects'
+            video: 'dsiz0qumyl'
         }],
-        urlId: 'wedo2',
+        urlId: 'wedo',
         hidden: true
     },
-    'ev3': {
-        img: addEffectsThumb, // placeholder
+    'ev3-getting-started': {
         steps: [{
-            video: 'add-effects'
+            video: 'qgu78c5y7d'
         }],
         urlId: 'ev3',
         hidden: true


### PR DESCRIPTION
### Resolves

- Resolves #3957: Add EV3 and WeDo video tutorials that can load by URL only

### URLs

http://localhost:8601/?tutorial=wedo
<img width="1080" alt="screen shot 2018-12-06 at 11 55 22 am" src="https://user-images.githubusercontent.com/699840/49599077-103d0580-f94e-11e8-853e-8590ce10491b.png">

http://localhost:8601/?tutorial=ev3
<img width="1075" alt="screen shot 2018-12-06 at 11 55 07 am" src="https://user-images.githubusercontent.com/699840/49599092-1632e680-f94e-11e8-8f34-6b12153ad67b.png">
