### PR TITLE
update the scratch-vm we use in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "scratch-render": "0.1.0-prerelease.20181127194508",
     "scratch-storage": "1.2.0",
     "scratch-svg-renderer": "0.2.0-prerelease.20181126212715",
-    "scratch-vm": "0.2.0-prerelease.20181205175228",
+    "scratch-vm": "0.2.0-prerelease.20181206210221",
     "selenium-webdriver": "3.6.0",
     "startaudiocontext": "1.2.1",
     "style-loader": "^0.23.0",


### PR DESCRIPTION
### Resolves

Part of resolving https://github.com/LLK/scratch-www/issues/1858

### Proposed Changes

Use latest scratch-vm

### Reason for Changes

scratch-vm has support for a callback `PROJECT_START`, which we need to count project views
