### PR TITLE
Use the correct font fallbacks for navbar save messages

### DIFF
--- a/src/components/alerts/inline-message.css
+++ b/src/components/alerts/inline-message.css
@@ -3,7 +3,7 @@
 
 .inline-message {
     color: $ui-white;
-    font-family: "Helvetica Neue";
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
     display: flex;
     justify-content: end;
     align-items: center;


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/LLK/scratch-gui/issues/3987

### Proposed Changes

_Describe what this Pull Request does_

Use the correct font family declaration in the CSS, for platforms missing Helvetica Neue
