### PR TITLE
Only show the `SaveStatus` component for people who can save

### DIFF
--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -542,7 +542,9 @@ class MenuBar extends React.Component {
                 logged in, and whether a session is available to log in with */}
                 <div className={styles.accountInfoGroup}>
                     <div className={styles.menuBarItem}>
-                        <SaveStatus />
+                        {this.props.canSave && (
+                            <SaveStatus />
+                        )}
                     </div>
                     {this.props.sessionExists ? (
                         this.props.username ? (


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/LLK/scratch-gui/issues/3986

### Proposed Changes

_Describe what this Pull Request does_

For some reason I didn't commit the part that wrapped this in `this.props.canSave`. Sorry @benjiwheeler 
