### PR TITLE
Fix an issue where switching player to editor mode caused "Save Now".

### DIFF
--- a/src/lib/vm-listener-hoc.jsx
+++ b/src/lib/vm-listener-hoc.jsx
@@ -63,7 +63,7 @@ const vmListenerHOC = function (WrappedComponent) {
             // Re-request a targets update when the shouldEmitTargetsUpdate state changes to true
             // i.e. when the editor transitions out of fullscreen/player only modes
             if (this.props.shouldEmitTargetsUpdate && !prevProps.shouldEmitTargetsUpdate) {
-                this.props.vm.emitTargetsUpdate();
+                this.props.vm.emitTargetsUpdate(false /* Emit the event, but do not trigger project change */);
             }
         }
         componentWillUnmount () {


### PR DESCRIPTION
We are emitting targets update because the event is disabled in player mode, but gets re-enabled and re-emitted when switching back. The API on that function was changed to allow events to be marked "not project changes"

### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/LLK/scratch-gui/issues/3967

### Proposed Changes

_Describe what this Pull Request does_

Use the new flag in emitTargetsUpdate to prevent `projectChanged` state
