### PR TITLE
Force margin on inputs which is reset by normalizer in www

### DIFF
--- a/src/components/custom-procedures/custom-procedures.css
+++ b/src/components/custom-procedures/custom-procedures.css
@@ -11,6 +11,11 @@
     padding: 1.5rem 2.25rem;
 }
 
+.body input[type="checkbox"],
+.body input[type="radio"] {
+    margin: 3px;
+}
+
 /* Blocks workspace for custom procedure declaration editor */
 .workspace {
     min-height: 200px;

--- a/src/components/prompt/prompt.css
+++ b/src/components/prompt/prompt.css
@@ -10,6 +10,11 @@
     padding: 1.5rem 2.25rem;
 }
 
+.body input[type="checkbox"],
+.body input[type="radio"] {
+    margin: 3px;
+}
+
 .label {
     font-weight: 500;
     margin: 0 0 0.75rem;


### PR DESCRIPTION
/cc @kchadha 

Fixes https://github.com/LLK/scratch-gui/issues/3736, the issue where the variable modal checkboxes/radios have the wrong padding.