### PR TITLE
Do not open a new tab when clicking scratch logo

### DIFF
--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -298,11 +298,7 @@ class MenuBar extends React.Component {
                 <div className={styles.mainMenu}>
                     <div className={styles.fileGroup}>
                         <div className={classNames(styles.menuBarItem)}>
-                            <a
-                                href="https://scratch.mit.edu"
-                                rel="noopener noreferrer"
-                                target="_blank"
-                            >
+                            <a href="https://scratch.mit.edu">
                                 <img
                                     alt="Scratch"
                                     className={styles.scratchLogo}


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves an issue reported by @kathymakes that the scratch logo should not open a new tab, to try to keep from opening many instances of scratch (is that right @carljbowman?)

### Proposed Changes

_Describe what this Pull Request does_

Make it navigate in the same tab.