### PR TITLE
Unskip integration test for #3608.

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "scratch-render": "0.1.0-prerelease.20181127194508",
     "scratch-storage": "1.2.0",
     "scratch-svg-renderer": "0.2.0-prerelease.20181126212715",
-    "scratch-vm": "0.2.0-prerelease.20181210152453",
+    "scratch-vm": "0.2.0-prerelease.20181210154926",
     "selenium-webdriver": "3.6.0",
     "startaudiocontext": "1.2.1",
     "style-loader": "^0.23.0",

--- a/test/integration/sprites.test.js
+++ b/test/integration/sprites.test.js
@@ -91,7 +91,7 @@ describe('Working with sprites', () => {
 
     // This test fails because uploading an SVG as a sprite changes the scaling
     // Enable when this is fixed issues/3608
-    test.skip('Adding a sprite by uploading an svg (gh-3608)', async () => {
+    test('Adding a sprite by uploading an svg (gh-3608)', async () => {
         await loadUri(uri);
         await clickXpath('//button[@title="Try It"]');
         const el = await findByXpath('//button[@aria-label="Choose a Sprite"]');


### PR DESCRIPTION
Pull in latest changes from scratch-vm including bugfix for #3608 and unskip integration test for that bug which was previously failing.