### PR TITLE
Localization scaling

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -536,10 +536,16 @@ Blocks.propTypes = {
         comments: PropTypes.bool,
         collapse: PropTypes.bool
     }),
+    setWorkspaceMetrics: PropTypes.func,
     stageSize: PropTypes.oneOf(Object.keys(STAGE_DISPLAY_SIZES)).isRequired,
     toolboxXML: PropTypes.string,
     updateToolboxState: PropTypes.func,
-    vm: PropTypes.instanceOf(VM).isRequired
+    vm: PropTypes.instanceOf(VM).isRequired,
+    workspaceMetrics: PropTypes.objectOf({
+        scrollX: PropTypes.number,
+        scrollY: PropTypes.number,
+        scale: PropTypes.number
+    })
 };
 
 Blocks.defaultOptions = {

--- a/src/reducers/gui.js
+++ b/src/reducers/gui.js
@@ -24,6 +24,7 @@ import timeoutReducer, {timeoutInitialState} from './timeout';
 import toolboxReducer, {toolboxInitialState} from './toolbox';
 import vmReducer, {vmInitialState} from './vm';
 import vmStatusReducer, {vmStatusInitialState} from './vm-status';
+import workspaceMetricsReducer, {workspaceMetricsInitialState} from './workspace-metrics';
 import throttle from 'redux-throttle';
 
 import decks from '../lib/libraries/decks/index.jsx';
@@ -55,7 +56,8 @@ const guiInitialState = {
     timeout: timeoutInitialState,
     toolbox: toolboxInitialState,
     vm: vmInitialState,
-    vmStatus: vmStatusInitialState
+    vmStatus: vmStatusInitialState,
+    workspaceMetrics: workspaceMetricsInitialState
 };
 
 const initPlayer = function (currentState) {
@@ -151,7 +153,8 @@ const guiReducer = combineReducers({
     timeout: timeoutReducer,
     toolbox: toolboxReducer,
     vm: vmReducer,
-    vmStatus: vmStatusReducer
+    vmStatus: vmStatusReducer,
+    workspaceMetrics: workspaceMetricsReducer
 });
 
 export {

--- a/src/reducers/workspace-metrics.js
+++ b/src/reducers/workspace-metrics.js
@@ -1,0 +1,34 @@
+const SET_WORKSPACE_METRICS = 'scratch-gui/workspace-metrics/SET_WORKSPACE_METRICS';
+
+const initialState = {};
+
+const reducer = function (state, action) {
+    if (typeof state === 'undefined') state = initialState;
+    switch (action.type) {
+    case SET_WORKSPACE_METRICS:
+        return Object.assign({}, state, {
+            ...state,
+            [action.targetId]: {
+                scrollX: action.metrics.scrollX,
+                scrollY: action.metrics.scrollY,
+                scale: action.metrics.scale
+            }
+        });
+    default:
+        return state;
+    }
+};
+
+const setWorkspaceMetrics = function (targetId, metrics) {
+    return {
+        type: SET_WORKSPACE_METRICS,
+        targetId: targetId,
+        metrics: metrics
+    };
+};
+
+export {
+    reducer as default,
+    initialState as workspaceMetricsInitialState,
+    setWorkspaceMetrics
+};


### PR DESCRIPTION
### Resolves

After switching languages, the working area's scaling becomes 100% #3277

### Proposed Changes

- Store workspaceMetrics (scrollX, scrollY, scale) in Redux state.
- When the component mounts, pass in the scale parameter to the startScale option for scratch-blocks so that the state

### Reason for Changes

The entire component re-mounts when the language changes, so the zoom needs to be stored in the Redux state so that the component can revert back to the original zoom setting.

### Test Coverage

None

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [x] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
