### PR TITLE
Show error screen when project cannot be loaded

### DIFF
--- a/src/lib/project-fetcher-hoc.jsx
+++ b/src/lib/project-fetcher-hoc.jsx
@@ -66,6 +66,10 @@ const ProjectFetcherHOC = function (WrappedComponent) {
                 .then(projectAsset => {
                     if (projectAsset) {
                         this.props.onFetchedProjectData(projectAsset.data, loadingState);
+                    } else {
+                        // Treat failure to load as an error
+                        // Throw to be caught by catch later on
+                        throw new Error('Could not find project');
                     }
                 })
                 .then(() => {

--- a/test/integration/project-loading.test.js
+++ b/test/integration/project-loading.test.js
@@ -47,6 +47,11 @@ describe('Loading scratch gui', () => {
             await expect(logs).toEqual([]);
         });
 
+        test('Nonexistent projects show error screen', async () => {
+            await loadUri(`${uri}#999999999999999999999`);
+            await clickText('Oops! Something went wrong.');
+        });
+
         test('Invalid url when loading project through modal lets you try again', async () => {
             await loadUri(uri);
             await clickText('View 2.0 Project');


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/LLK/scratch-gui/issues/3363

### Proposed Changes

_Describe what this Pull Request does_

Make the `null` response from storage throw so the error can be caught and the error screen shown

### Reason for Changes

_Explain why these changes should be made_

To make errors visible

### Test Coverage

_Please show how you have added tests to cover your changes_

Added an integration test for this where we try to load project id=999999999999999999 and watch it fail.
