### PR TITLE
Fix sound editor button spacing

### DIFF
--- a/src/components/sound-editor/sound-editor.css
+++ b/src/components/sound-editor/sound-editor.css
@@ -79,6 +79,7 @@ $border-radius: 0.25rem;
     font-size: 0.85rem;
     transition: 0.2s;
     user-select: none;
+    margin: 0px;
 }
 
 .button > img {


### PR DESCRIPTION
### Resolves

On Mac Safari, sound editor undo/redo buttons render incorrectly, resolves #3778 

### Proposed Changes
![image](https://user-images.githubusercontent.com/1689183/49840816-ec245e80-fd69-11e8-9d5f-2431c7d0ecdf.png)

Sets margin to 0px for undo/redo buttons. For some reason, Safari gives a default margin of 2px for these buttons, so this change fixes that.

### Test Coverage

None

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [x] Safari
