### PR TITLE
Make mousedown on the stage blur inputs, with @picklesrus

### DIFF
--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -255,7 +255,12 @@ class Stage extends React.Component {
         };
         this.props.vm.postIOData('mouse', data);
         if (e.preventDefault) {
+            // Prevent default to prevent touch from dragging page
             e.preventDefault();
+            // But we do want any active input to be blurred
+            if (document.activeElement && document.activeElement.blur) {
+                document.activeElement.blur();
+            }
         }
         if (this.props.isColorPicking) {
             const {r, g, b} = this.state.colorInfo.color;


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/LLK/scratch-gui/issues/3207

### Proposed Changes

_Describe what this Pull Request does_

Micromanage the browser default, so that we can still prevent preventDefault action for touch devices (stop scrolling the body), but we also want to get blurring the active element.

### Reason for Changes

_Explain why these changes should be made_

https://github.com/LLK/scratch-gui/issues/3207

### Test Coverage

_Please show how you have added tests to cover your changes_

Tested on desktop, safari, chrome, android and ios tablets.
