### PR TITLE
admins will see author credits, not title editing field, in editor

### DIFF
--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -459,7 +459,7 @@ class MenuBar extends React.Component {
                         <FormattedMessage {...ariaMessages.tutorials} />
                     </div>
                     <Divider className={classNames(styles.divider)} />
-                    {this.props.canEditTitle ? (
+                    {this.props.canSave && this.props.canEditTitle ? (
                         <div className={classNames(styles.menuBarItem, styles.growable)}>
                             <MenuBarItemTooltip
                                 enable


### PR DESCRIPTION
### Resolves

- Resolves https://github.com/LLK/scratch-gui/issues/3995

### Proposed Changes

Show the title editing field only if you can save the project in general.

### Reason for Changes

Admins were seeing title editing field, which they really don't want to see for miscellaneous projects.
Better to see info on the author.

### Test Coverage

None -- I started to make a `unit/components/menu-bar.test.jsx`, but gave up. I guess there's a reason there's no menu bar unit tests...
 
To test manually, view a project you don't own in editor as an admin. You should see the author info. View a project as its owner. You should see the editable title. View a project by someone else, as a regular user. You should see the author field.