### PR TITLE
Make the git links in the README consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install https://github.com/LLK/scratch-gui.git
 ```
 If you want to edit/play yourself:
 ```bash
-git clone git@github.com:LLK/scratch-gui.git
+git clone https://github.com/LLK/scratch-gui.git
 cd scratch-gui
 npm install
 ```


### PR DESCRIPTION
### Resolves

Resolves #4006

### Proposed Changes

Makes the git url in the README consistent. Now they are both the https one.

### Reason for Changes

To be consistent.