### PR TITLE
Update WeDo tutorial video

### DIFF
--- a/src/lib/libraries/decks/index.jsx
+++ b/src/lib/libraries/decks/index.jsx
@@ -1184,7 +1184,7 @@ export default {
     },
     'wedo2-getting-started': {
         steps: [{
-            video: 'dsiz0qumyl'
+            video: '4im7iizv47'
         }],
         urlId: 'wedo',
         hidden: true


### PR DESCRIPTION
Update the video to show in the WeDo tutorial. The resources team consolidated two videos into one, so we can display the same video on the [landing page](https://github.com/LLK/scratch-www/blob/develop/src/views/wedo2/wedo2.jsx#L57) and here in the GUI.