### PR TITLE
Add what’s new tutorial (hidden)

### DIFF
--- a/src/lib/libraries/decks/index.jsx
+++ b/src/lib/libraries/decks/index.jsx
@@ -1195,5 +1195,12 @@ export default {
         }],
         urlId: 'ev3',
         hidden: true
+    },
+    'whats-new': {
+        steps: [{
+            video: 'mtqymxg0qq'
+        }],
+        urlId: 'whatsnew',
+        hidden: true
     }
 };

--- a/test/integration/tutorials-shortcut.test.js
+++ b/test/integration/tutorials-shortcut.test.js
@@ -9,6 +9,7 @@ const {
 } = new SeleniumHelper();
 
 const uri = path.resolve(__dirname, '../../build/index.html?tutorial=all');
+const uriPrefix = path.resolve(__dirname, '../../build/index.html?tutorial=');
 
 let driver;
 
@@ -28,5 +29,10 @@ describe('Working with shortcut to Tutorials library', () => {
         await findByXpath('//div[contains(@class, "step-video")]');
     });
 
+    test('can open hidden tutorials', async () => {
+        await loadUri(`${uriPrefix}whatsnew`);
+        // should open the tutorial video immediately
+        await findByXpath('//div[contains(@class, "step-video")]');
+    });
     // @todo navigating cards, etc.
 });


### PR DESCRIPTION
### Resolves
- Resolves #4038 

### Proposed Changes

Adds hidden what's new video tutorial

### Reason for Changes
Needed for the launch banner 'call to action' for logged in users.

### Test Coverage
- [ ] `/?tutorial=whatsnew` opens the editor with the what's new video showing
![screen shot 2018-12-12 at 3 47 30 pm](https://user-images.githubusercontent.com/399209/49897970-9ad9a500-fe25-11e8-928f-d9bf682d5561.png)

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
