### PR TITLE
Randomize Sprite Positions

### DIFF
--- a/src/containers/sprite-library.jsx
+++ b/src/containers/sprite-library.jsx
@@ -6,6 +6,7 @@ import VM from 'scratch-vm';
 
 import analytics from '../lib/analytics';
 import spriteLibraryContent from '../lib/libraries/sprites.json';
+import randomizeSpritePosition from '../lib/randomize-sprite-position';
 import spriteTags from '../lib/libraries/sprite-tags';
 
 import LibraryComponent from '../components/library/library.jsx';
@@ -39,6 +40,8 @@ class SpriteLibrary extends React.PureComponent {
         clearInterval(this.intervalId);
     }
     handleItemSelect (item) {
+        // Randomize position of library sprite
+        randomizeSpritePosition(item);
         this.props.vm.addSprite(JSON.stringify(item.json)).then(() => {
             this.props.onActivateBlocksTab();
         });

--- a/src/containers/target-pane.jsx
+++ b/src/containers/target-pane.jsx
@@ -20,6 +20,7 @@ import sharedMessages from '../lib/shared-messages';
 import {emptySprite} from '../lib/empty-assets';
 import {highlightTarget} from '../reducers/targets';
 import {fetchSprite, fetchCode} from '../lib/backpack-api';
+import randomizeSpritePosition from '../lib/randomize-sprite-position';
 
 class TargetPane extends React.Component {
     constructor (props) {
@@ -117,6 +118,7 @@ class TargetPane extends React.Component {
     }
     handleSurpriseSpriteClick () {
         const item = spriteLibraryContent[Math.floor(Math.random() * spriteLibraryContent.length)];
+        randomizeSpritePosition(item);
         this.props.vm.addSprite(JSON.stringify(item.json))
             .then(this.handleActivateBlocksTab);
     }

--- a/src/lib/file-uploader.js
+++ b/src/lib/file-uploader.js
@@ -1,5 +1,6 @@
 import {BitmapAdapter} from 'scratch-svg-renderer';
 import log from './log.js';
+import randomizeSpritePosition from './randomize-sprite-position.js';
 
 /**
  * Extract the file name given a string of the form fileName + ext
@@ -199,7 +200,7 @@ const spriteUpload = function (fileData, fileType, spriteName, storage, handleSp
             const newSprite = {
                 name: spriteName,
                 isStage: false,
-                x: 0,
+                x: 0, // x/y will be randomized below
                 y: 0,
                 visible: true,
                 size: 100,
@@ -212,6 +213,7 @@ const spriteUpload = function (fileData, fileType, spriteName, storage, handleSp
                 costumes: [vmCostume],
                 sounds: [] // TODO are all of these necessary?
             };
+            randomizeSpritePosition(newSprite);
             // TODO probably just want sprite upload to handle this object directly
             handleSprite(JSON.stringify(newSprite));
         }));

--- a/src/lib/randomize-sprite-position.js
+++ b/src/lib/randomize-sprite-position.js
@@ -1,0 +1,16 @@
+const randomizeSpritePosition = spriteObject => {
+    // https://github.com/LLK/scratch-flash/blob/689f3c79a7e8b2e98f5be80056d877f303a8d8ba/src/Scratch.as#L1385
+    const randomX = Math.floor((200 * Math.random()) - 100);
+    const randomY = Math.floor((100 * Math.random()) - 50);
+    if (spriteObject.hasOwnProperty('json')) {
+        // Library sprite object
+        spriteObject.json.scratchX = randomX;
+        spriteObject.json.scratchY = randomY;
+    } else if (spriteObject.hasOwnProperty('x') && spriteObject.hasOwnProperty('y')) {
+        // Scratch 3 sprite object
+        spriteObject.x = randomX;
+        spriteObject.y = randomY;
+    }
+};
+
+export default randomizeSpritePosition;


### PR DESCRIPTION
### Resolves

Resolves #2072

### Proposed Changes

Randomize sprite positions when added from image file or from library (through 'choose from library' and 'surprise'). 

Should not randomize positions of sprites that are added from an actual .sprite2 or .sprite3 file. 


### Test Coverage

Manually tested. Also wrote integration tests that I did not end up checking in because they can fail sometimes...

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [x] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
