### PR TITLE
revised alerts and spinner styling

### DIFF
--- a/src/components/alerts/alert.css
+++ b/src/components/alerts/alert.css
@@ -72,6 +72,7 @@
 
 .alert-connection-button {
     min-height: 2rem;
+    width: 6.5rem;
     padding: 0.55rem 0.9rem;
     border-radius: 0.35rem;
     background: #FF8C1A;
@@ -81,8 +82,9 @@
     border: none;
     cursor: pointer;
     display: flex;
+    justify-content: center;
     align-items: center;
-    align-self: center;
+    align-self: stretch;
     outline-style:none;
 }
 
@@ -92,4 +94,10 @@
 
 [dir="rtl"] .alert-connection-button {
     margin-left: 13px;
+}
+
+/* prevent last button in list from too much margin to edge of alert */
+.alert-buttons > :last-child {
+    margin-left: 0;
+    margin-right: 0;
 }

--- a/src/components/alerts/alert.css
+++ b/src/components/alerts/alert.css
@@ -7,9 +7,12 @@
     display: flex;
     flex-direction: row;
     overflow: hidden;
-    justify-content: space-between;
+    justify-content: flex-start;
     border-radius: $space;
-    padding: $space;
+    padding-top: .875rem;
+    padding-bottom: .875rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
     margin-bottom: 7px;
     min-height: 1.5rem;
 }
@@ -26,20 +29,28 @@
     box-shadow: 0px 0px 0px 2px $extensions-light;
 }
 
+.alert-spinner {
+    self-align: center;
+}
+
+.icon-section {
+    min-width: 1.25rem;
+    min-height: 1.25rem;
+    display: flex;
+    padding-right: 1rem;
+}
+
 .alert-icon {
-    margin-left: .25rem;
-    margin-right: .25rem;
     vertical-align: middle;
 }
 
 .alert-message {
     color: #555;
     font-weight: bold;
-    font-size: .75rem;
-    line-height: 14px;
+    font-size: .8125rem;
+    line-height: .875rem;
     display: flex;
     align-items: center;
-    padding-left: .5rem;
     padding-right: .5rem;
 }
 

--- a/src/components/alerts/alert.jsx
+++ b/src/components/alerts/alert.jsx
@@ -9,7 +9,6 @@ import Spinner from '../spinner/spinner.jsx';
 import {AlertLevels} from '../../lib/alerts/index.jsx';
 
 import styles from './alert.css';
-import spinnerStyles from '../spinner/spinner.css';
 
 const closeButtonColors = {
     [AlertLevels.SUCCESS]: CloseButton.COLOR_GREEN,
@@ -35,20 +34,22 @@ const AlertComponent = ({
         className={classNames(styles.alert, styles[level])}
     >
         {/* TODO: implement Rtl handling */}
-        <div className={styles.iconSection}>
-            {iconSpinner && (
-                <Spinner
-                    className={styles.alertSpinner}
-                    level={level}
-                />
-            )}
-            {iconURL && (
-                <img
-                    className={styles.alertIcon}
-                    src={iconURL}
-                />
-            )}
-        </div>
+        {(iconSpinner || iconURL) && (
+            <div className={styles.iconSection}>
+                {iconSpinner && (
+                    <Spinner
+                        className={styles.alertSpinner}
+                        level={level}
+                    />
+                )}
+                {iconURL && (
+                    <img
+                        className={styles.alertIcon}
+                        src={iconURL}
+                    />
+                )}
+            </div>
+        )}
         <div className={styles.alertMessage}>
             {extensionName ? (
                 <FormattedMessage

--- a/src/components/alerts/alert.jsx
+++ b/src/components/alerts/alert.jsx
@@ -9,6 +9,7 @@ import Spinner from '../spinner/spinner.jsx';
 import {AlertLevels} from '../../lib/alerts/index.jsx';
 
 import styles from './alert.css';
+import spinnerStyles from '../spinner/spinner.css';
 
 const closeButtonColors = {
     [AlertLevels.SUCCESS]: CloseButton.COLOR_GREEN,
@@ -34,15 +35,20 @@ const AlertComponent = ({
         className={classNames(styles.alert, styles[level])}
     >
         {/* TODO: implement Rtl handling */}
-        {iconSpinner && (
-            <Spinner className={styles.alertSpinner} />
-        )}
-        {iconURL && (
-            <img
-                className={styles.alertIcon}
-                src={iconURL}
-            />
-        )}
+        <div className={styles.iconSection}>
+            {iconSpinner && (
+                <Spinner
+                    className={styles.alertSpinner}
+                    level={level}
+                />
+            )}
+            {iconURL && (
+                <img
+                    className={styles.alertIcon}
+                    src={iconURL}
+                />
+            )}
+        </div>
         <div className={styles.alertMessage}>
             {extensionName ? (
                 <FormattedMessage

--- a/src/components/alerts/alerts.css
+++ b/src/components/alerts/alerts.css
@@ -1,0 +1,4 @@
+.alerts-inner-container {
+    min-width: 200px;
+    max-width: 448px;
+}

--- a/src/components/alerts/alerts.css
+++ b/src/components/alerts/alerts.css
@@ -1,4 +1,4 @@
 .alerts-inner-container {
     min-width: 200px;
-    max-width: 448px;
+    max-width: 548px;
 }

--- a/src/components/alerts/alerts.jsx
+++ b/src/components/alerts/alerts.jsx
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 import Box from '../box/box.jsx';
 import Alert from '../../containers/alert.jsx';
 
+import styles from './alerts.css';
+
 const AlertsComponent = ({
     alertsList,
     className,
@@ -13,24 +15,26 @@ const AlertsComponent = ({
         bounds="parent"
         className={className}
     >
-        {alertsList.map((a, index) => (
-            <Alert
-                closeButton={a.closeButton}
-                content={a.content}
-                extensionId={a.extensionId}
-                extensionName={a.extensionName}
-                iconSpinner={a.iconSpinner}
-                iconURL={a.iconURL}
-                index={index}
-                key={index}
-                level={a.level}
-                message={a.message}
-                showDownload={a.showDownload}
-                showReconnect={a.showReconnect}
-                showSaveNow={a.showSaveNow}
-                onCloseAlert={onCloseAlert}
-            />
-        ))}
+        <Box className={styles.alertsInnerContainer} >
+            {alertsList.map((a, index) => (
+                <Alert
+                    closeButton={a.closeButton}
+                    content={a.content}
+                    extensionId={a.extensionId}
+                    extensionName={a.extensionName}
+                    iconSpinner={a.iconSpinner}
+                    iconURL={a.iconURL}
+                    index={index}
+                    key={index}
+                    level={a.level}
+                    message={a.message}
+                    showDownload={a.showDownload}
+                    showReconnect={a.showReconnect}
+                    showSaveNow={a.showSaveNow}
+                    onCloseAlert={onCloseAlert}
+                />
+            ))}
+        </Box>
     </Box>
 );
 

--- a/src/components/alerts/inline-message.jsx
+++ b/src/components/alerts/inline-message.jsx
@@ -20,6 +20,7 @@ const InlineMessageComponent = ({
             <Spinner
                 small
                 className={styles.spinner}
+                level={'info'}
             />
         )}
         {content}

--- a/src/components/gui/gui.css
+++ b/src/components/gui/gui.css
@@ -303,15 +303,6 @@ $fade-out-distance: 15px;
 /* Alerts */
 
 .alerts-container {
-    /* width: 448px;
-    min-width: 448px;
-    z-index: $z-index-alerts;
-    left: 0;
-    right: 0;
-    margin: auto;
-    position: absolute;
-    margin-top: 53px; */
-
     display: flex;
     justify-content: center;
     width: 100%;

--- a/src/components/gui/gui.css
+++ b/src/components/gui/gui.css
@@ -303,12 +303,19 @@ $fade-out-distance: 15px;
 /* Alerts */
 
 .alerts-container {
-    width: 448px;
+    /* width: 448px;
     min-width: 448px;
     z-index: $z-index-alerts;
     left: 0;
     right: 0;
     margin: auto;
+    position: absolute;
+    margin-top: 53px; */
+
+    display: flex;
+    justify-content: center;
+    width: 100%;
+    z-index: $z-index-alerts;
     position: absolute;
     margin-top: 53px;
 }

--- a/src/components/spinner/spinner.css
+++ b/src/components/spinner/spinner.css
@@ -9,6 +9,7 @@
     border-width: .1875rem;
     border-style: solid;
     border-color: $ui-white-transparent;
+    box-sizing: content-box;
 }
 
 .spinner::before, .spinner::after {

--- a/src/components/spinner/spinner.css
+++ b/src/components/spinner/spinner.css
@@ -1,8 +1,8 @@
 @import "../../css/colors.css";
 
 .spinner {
-    width: 1rem;
-    height: 1rem;
+    width: 1.25rem;
+    height: 1.25rem;
     display: inline-block;
     position: relative;
     border-radius: 50%;
@@ -12,8 +12,8 @@
 }
 
 .spinner::before, .spinner::after {
-    width: 1rem;
-    height: 1rem;
+    width: 1.25rem;
+    height: 1.25rem;
     content: '';
     border-radius: 50%;
     display: block;
@@ -48,17 +48,25 @@
   }
 }
 
-.spinner.orange {
+.spinner.success {
+    border-color: $extensions-transparent;
+}
+
+.spinner.success::after {
+    border-top-color: $extensions-primary;
+}
+
+.spinner.warn {
     border-color: $error-transparent;
 }
 
-.spinner.orange::after {
+.spinner.warn::after {
     border-top-color: $error-primary;
 }
 
-.spinner.white {
+.spinner.info {
     border-color: $ui-white-transparent;
 }
-.spinner.white::after {
+.spinner.info::after {
     border-top-color: $ui-white;
 }

--- a/src/components/spinner/spinner.jsx
+++ b/src/components/spinner/spinner.jsx
@@ -7,6 +7,7 @@ import styles from './spinner.css';
 const SpinnerComponent = function (props) {
     const {
         className,
+        level,
         small
     } = props;
     return (
@@ -14,6 +15,7 @@ const SpinnerComponent = function (props) {
             className={classNames(
                 className,
                 styles.spinner,
+                styles[level],
                 {[styles.small]: small}
             )}
         />
@@ -21,9 +23,11 @@ const SpinnerComponent = function (props) {
 };
 SpinnerComponent.propTypes = {
     className: PropTypes.string,
+    level: PropTypes.string,
     small: PropTypes.bool
 };
 SpinnerComponent.defaultProps = {
-    className: ''
+    className: '',
+    level: 'info'
 };
 export default SpinnerComponent;


### PR DESCRIPTION
### Resolves

- Resolves https://github.com/LLK/scratch-gui/issues/3686 and ttps://github.com/LLK/scratch-gui/issues/3941

### Proposed Changes

Various changes to alert styling:
* font size bigger
* better, bigger padding within alerts
* alert width adjusts naturally from 200px to 448px as content demands
* text aligned to left, not center; everything aligns to vertical middle
* spinner color from white to green

### Reason for Changes

_Explain why these changes should be made_
