### PR TITLE
Give max-width to sprite tiles to prevent long names issue

### DIFF
--- a/src/components/backpack/backpack.css
+++ b/src/components/backpack/backpack.css
@@ -70,6 +70,7 @@
 
 .backpack-item {
     min-width: 4rem;
+    max-width: 6rem;
     margin: 0 0.25rem;
 }
 

--- a/src/components/sprite-selector/sprite-selector.css
+++ b/src/components/sprite-selector/sprite-selector.css
@@ -31,6 +31,7 @@
     */
     box-sizing: border-box;
     width: calc((100% / $sprites-per-row ) - $space);
+    max-width: 6rem;
     min-width: 4rem;
     min-height: 4rem; /* @todo: calc height same as width */
     margin: calc($space / 2);


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/LLK/scratch-gui/issues/3073

### Proposed Changes

_Describe what this Pull Request does_

Give a max-width to sprite/backpack tiles to prevent long name issues like the one in #3073 
