### PR TITLE
Try to always keep the tutorial in view despite screen height

### DIFF
--- a/src/components/cards/cards.jsx
+++ b/src/components/cards/cards.jsx
@@ -234,7 +234,11 @@ const Cards = props => {
     if (x === 0 && y === 0) {
         // initialize positions
         x = isRtl ? -292 : 292;
-        y = 365;
+        // The tallest cards are about 385px high, and the default position is pinned
+        // to near the bottom of the blocks palette to allow room to work above.
+        const tallCardHeight = 385;
+        const bottomMargin = 60; // To avoid overlapping the backpack region
+        y = window.innerHeight - tallCardHeight - bottomMargin;
     }
 
     const steps = content[activeDeckId].steps;


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/LLK/scratch-gui/issues/2154

### Proposed Changes

_Describe what this Pull Request does_

Make the card dynamically lay out so that it doesn't ever lay out off the bottom of the screen.

### Reason for Changes

_Explain why these changes should be made_

We previously used a fixed height, but now that we are using the tutorials more, it seems to fall off the bottom of the screen for many, many people.

Tested on various screen sizes.

/cc @ericrosenbaum @thisandagain 