### PR TITLE
Use 3.0 routes for GETs

### DIFF
--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -36,7 +36,7 @@ class Storage extends ScratchStorage {
         this.projectHost = projectHost;
     }
     getProjectGetConfig (projectAsset) {
-        return `${this.projectHost}/internalapi/project/${projectAsset.assetId}/get/`;
+        return `${this.projectHost}/${projectAsset.assetId}`;
     }
     getProjectCreateConfig () {
         return {

--- a/test/integration/examples.test.js
+++ b/test/integration/examples.test.js
@@ -40,9 +40,9 @@ describe('player example', () => {
             .then(pLogs => pLogs.map(log => JSON.parse(log.message).message)
                 .filter(m => m.method === 'Network.requestWillBeSent')
                 .map(m => m.params.request.url)
-                .filter(url => url === 'https://projects.scratch.mit.edu/internalapi/project/96708228/get/')
+                .filter(url => url === 'https://projects.scratch.mit.edu/96708228')
             );
-        await expect(projectRequests).toEqual(['https://projects.scratch.mit.edu/internalapi/project/96708228/get/']);
+        await expect(projectRequests).toEqual(['https://projects.scratch.mit.edu/96708228']);
     });
 });
 
@@ -71,9 +71,9 @@ describe('blocks example', () => {
             .then(pLogs => pLogs.map(log => JSON.parse(log.message).message)
                 .filter(m => m.method === 'Network.requestWillBeSent')
                 .map(m => m.params.request.url)
-                .filter(url => url === 'https://projects.scratch.mit.edu/internalapi/project/96708228/get/')
+                .filter(url => url === 'https://projects.scratch.mit.edu/96708228')
             );
-        await expect(projectRequests).toEqual(['https://projects.scratch.mit.edu/internalapi/project/96708228/get/']);
+        await expect(projectRequests).toEqual(['https://projects.scratch.mit.edu/96708228']);
     });
 
     test('Change categories', async () => {


### PR DESCRIPTION
This should have happened a while ago, but the Fastly config needed to be updated. It's updated now.

### Resolves

_What Github issue does this resolve (please include link)?_

- Needed for https://github.com/LLK/scratch-projects/issues/102

### Proposed Changes

_Describe what this Pull Request does_
Update storage to use the 3.0 GET route, rather than legacy

### Reason for Changes

_Explain why these changes should be made_
This route is simpler, and we can discern whether someone is requesting for 3.0 or 2.0 with this change.

### Test Coverage

_Please show how you have added tests to cover your changes_
They have been amended to support this change

### Browser Coverage
Check the OS/browser combinations tested (At least 2)
N/A