### PR TITLE
Actually use the showPreviewInfo prop to show the preview modal

### DIFF
--- a/src/lib/app-state-hoc.jsx
+++ b/src/lib/app-state-hoc.jsx
@@ -63,7 +63,7 @@ const AppStateHOC = function (WrappedComponent, localesOnly) {
                     if (props.isPlayerOnly) {
                         initializedGui = initPlayer(initializedGui);
                     }
-                } else {
+                } else if (props.showPreviewInfo) {
                     initializedGui = initPreviewInfo(initializedGui);
                 }
                 reducers = {


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves an issue @cwillisf found that you could not pass showPreviewInfo={false} to the app state hoc to prevent the preview info from being shown. 

This does not effect www, which does not use the app-state-hoc. 

@cwillisf no tutorial ID changes were required, because the default redux state is false for preview info, and the new stuff in query-parser-hoc just makes sure that if there is a tutorial in the url that the preview gets closed, which we always want.

Will eventually rip out all preview-info related code.