### PR TITLE
Call add costume from library to fix bounding box issues with some library sprites

### DIFF
--- a/src/containers/costume-library.jsx
+++ b/src/containers/costume-library.jsx
@@ -37,7 +37,7 @@ class CostumeLibrary extends React.PureComponent {
             bitmapResolution: item.info.length > 2 ? item.info[2] : 1,
             skinId: null
         };
-        this.props.vm.addCostume(item.md5, vmCostume);
+        this.props.vm.addCostumeFromLibrary(item.md5, vmCostume);
         analytics.event({
             category: 'library',
             action: 'Select Costume',

--- a/src/containers/costume-tab.jsx
+++ b/src/containers/costume-tab.jsx
@@ -150,8 +150,12 @@ class CostumeTab extends React.Component {
     handleDuplicateCostume (costumeIndex) {
         this.props.vm.duplicateCostume(costumeIndex);
     }
-    handleNewCostume (costume) {
-        this.props.vm.addCostume(costume.md5, costume);
+    handleNewCostume (costume, fromCostumeLibrary) {
+        if (fromCostumeLibrary) {
+            this.props.vm.addCostumeFromLibrary(costume.md5, costume);
+        } else {
+            this.props.vm.addCostume(costume.md5, costume);
+        }
     }
     handleNewBlankCostume () {
         const name = this.props.vm.editingTarget.isStage ?
@@ -173,7 +177,7 @@ class CostumeTab extends React.Component {
             bitmapResolution: item.info.length > 2 ? item.info[2] : 1,
             skinId: null
         };
-        this.handleNewCostume(vmCostume);
+        this.handleNewCostume(vmCostume, true /* fromCostumeLibrary */);
     }
     handleSurpriseBackdrop () {
         const item = backdropLibraryContent[Math.floor(Math.random() * backdropLibraryContent.length)];


### PR DESCRIPTION
### Resolves
With https://github.com/LLK/scratch-vm/pull/1849, fixes https://github.com/LLK/scratch-vm/issues/1773
https://github.com/LLK/scratch-vm/pull/1849 should go in first.

### Proposed Changes
Load costumes from library as if they are from scratch 2

### Reason for Changes
Some library sprites need the fixes that are only applied to scratch 2 svgs

### Test Coverage
To test, load abby sprite and abby-d costume, and make sure that abby-d looks the same on the stage whether you upload as sprite or as costume.
![image](https://user-images.githubusercontent.com/2855464/50033007-ce9f0100-ffc4-11e8-81e6-86c1a08f3153.png)
How it should NOT look

All costumes that appear cut-off in the costume library should appear whole when shown on stage. For instance, shark 2 c.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [x] Chrome 
 * [ ] Firefox 
 * [x] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
