### PR TITLE
Revert "admins will see author credits, not title editing field, in editor"

### DIFF
--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -461,7 +461,7 @@ class MenuBar extends React.Component {
                         <FormattedMessage {...ariaMessages.tutorials} />
                     </div>
                     <Divider className={classNames(styles.divider)} />
-                    {this.props.canSave && this.props.canEditTitle ? (
+                    {this.props.canEditTitle ? (
                         <div className={classNames(styles.menuBarItem, styles.growable)}>
                             <MenuBarItemTooltip
                                 enable


### PR DESCRIPTION
Reverts LLK/scratch-gui#4035

Fixes https://github.com/LLK/scratch-gui/issues/4064

It was a "mini bug" fix caused a critical problem, so I'm going to revert it.

/cc @benjiwheeler 