### PR TITLE
render vm when requesting project thumbnail, so it is set immediately

### DIFF
--- a/src/lib/project-saver-hoc.jsx
+++ b/src/lib/project-saver-hoc.jsx
@@ -278,6 +278,7 @@ const ProjectSaverHOC = function (WrappedComponent) {
                     this.props.onUpdateProjectThumbnail(
                         projectId, dataURItoBlob(dataURI));
                 });
+                this.props.vm.renderer.draw();
             } catch (e) {
                 log.error('Project thumbnail save error', e);
                 // This is intentionally fire/forget because a failure


### PR DESCRIPTION
### Resolves

Helps to address https://github.com/LLK/scratch-www/issues/2484 by getting project thumbnail immediately upon project creation

Also see https://github.com/LLK/scratch-www/issues/2484 


### Proposed Changes

Asks the vm renderer to `draw()` when requesting project thumbnail, so it is done immediately

### Reason for Changes

This will make it not wait until the user has hit the green flag to produce a thumbnail image and send it to the server

### Test Coverage

none

**NOTE:** since we cannot produce thumbnails locally, we will have to carefully check after deploy to staging to ensure that this works and doesn't break anything

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
