### PR TITLE
Sprite info number inputs accept only numbers

### DIFF
--- a/src/components/forms/buffered-input-hoc.jsx
+++ b/src/components/forms/buffered-input-hoc.jsx
@@ -35,7 +35,10 @@ export default function (Input) {
             this.setState({value: null});
         }
         handleChange (e) {
-            this.setState({value: e.target.value});
+            const isNumeric = typeof this.props.value === 'number';
+            if (!isNumeric || e.target.value.match(/^[\d|-]*$/)) {
+                this.setState({value: e.target.value});
+            }
         }
         render () {
             const bufferedValue = this.state.value === null ? this.props.value : this.state.value;


### PR DESCRIPTION
### Resolves

resolves #3721 - Sprite info number inputs accept text

### Proposed Changes

Make sure sprite info number can only accept numbers when typing

### Reason for Changes

Because these inputs should be numbers

### Test Coverage

None

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
