### PR TITLE
Fix "TouchEvent is not defined" error

### DIFF
--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -236,7 +236,7 @@ class Stage extends React.Component {
         this.updateRect();
         const {x, y} = getEventXY(e);
         const mousePosition = [x - this.rect.left, y - this.rect.top];
-        if (e.button === 0 || e instanceof TouchEvent) {
+        if (e.button === 0 || (window.TouchEvent && e instanceof TouchEvent)) {
             this.setState({
                 mouseDown: true,
                 mouseDownPosition: mousePosition,


### PR DESCRIPTION
### Resolves

Resolves #1317.

### Proposed Changes

Avoids an error that gets thrown on some specific cases of Firefox (mainly non-Windows, as far as I can tell).

### Reason for Changes

Helps keep the console clean. Also means the code past this `if` block can always run on any click (not just left).

### Test Coverage

Tested manually.

### Browser Coverage

Linux Firefox and Chromium.