### PR TITLE
Automatically update flyout checkboxes; add "hide" context menu option

### DIFF
--- a/src/components/context-menu/context-menu.css
+++ b/src/components/context-menu/context-menu.css
@@ -24,7 +24,14 @@
     transition: 0.1s ease;
 }
 
-.menu-item:hover {
+.menu-item:not(.divider):hover {
     background: $motion-primary;
     color: white;
+}
+
+.divider {
+    border-bottom: 1px solid $ui-black-transparent;
+    cursor: inherit;
+    margin-bottom: 3px;
+    padding: 2px 0;
 }

--- a/src/components/context-menu/context-menu.jsx
+++ b/src/components/context-menu/context-menu.jsx
@@ -13,7 +13,7 @@ const StyledContextMenu = props => (
 const StyledMenuItem = props => (
     <MenuItem
         {...props}
-        attributes={{className: styles.menuItem}}
+        attributes={{className: styles.menuItem, dividerClassName: styles.divider}}
     />
 );
 

--- a/src/components/monitor/monitor.jsx
+++ b/src/components/monitor/monitor.jsx
@@ -54,36 +54,56 @@ const MonitorComponent = props => (
                 })}
             </Box>
         </Draggable>
-        {props.mode === 'list' ? null : ReactDOM.createPortal((
+        {ReactDOM.createPortal((
             // Use a portal to render the context menu outside the flow to avoid
             // positioning conflicts between the monitors `transform: scale` and
             // the context menus `position: fixed`. For more details, see
             // http://meyerweb.com/eric/thoughts/2011/09/12/un-fixing-fixed-elements-with-css-transforms/
-            <ContextMenu id={`monitor-${props.label}`}>
-                <MenuItem onClick={props.onSetModeToDefault}>
-                    <FormattedMessage
-                        defaultMessage="normal readout"
-                        description="Menu item to switch to the default monitor"
-                        id="gui.monitor.contextMenu.default"
-                    />
-                </MenuItem>
-                <MenuItem onClick={props.onSetModeToLarge}>
-                    <FormattedMessage
-                        defaultMessage="large readout"
-                        description="Menu item to switch to the large monitor"
-                        id="gui.monitor.contextMenu.large"
-                    />
-                </MenuItem>
-                {props.onSetModeToSlider ? (
-                    <MenuItem onClick={props.onSetModeToSlider}>
+            props.mode === 'list' ? (
+                <ContextMenu id={`monitor-${props.label}`}>
+                    <MenuItem onClick={props.onHide}>
                         <FormattedMessage
-                            defaultMessage="slider"
-                            description="Menu item to switch to the slider monitor"
-                            id="gui.monitor.contextMenu.slider"
+                            defaultMessage="hide"
+                            description="Menu item to hide the monitor"
+                            id="gui.monitor.contextMenu.hide"
                         />
                     </MenuItem>
-                ) : null}
-            </ContextMenu>
+                </ContextMenu>
+            ) : (
+                <ContextMenu id={`monitor-${props.label}`}>
+                    <MenuItem onClick={props.onSetModeToDefault}>
+                        <FormattedMessage
+                            defaultMessage="normal readout"
+                            description="Menu item to switch to the default monitor"
+                            id="gui.monitor.contextMenu.default"
+                        />
+                    </MenuItem>
+                    <MenuItem onClick={props.onSetModeToLarge}>
+                        <FormattedMessage
+                            defaultMessage="large readout"
+                            description="Menu item to switch to the large monitor"
+                            id="gui.monitor.contextMenu.large"
+                        />
+                    </MenuItem>
+                    {props.onSetModeToSlider ? (
+                        <MenuItem onClick={props.onSetModeToSlider}>
+                            <FormattedMessage
+                                defaultMessage="slider"
+                                description="Menu item to switch to the slider monitor"
+                                id="gui.monitor.contextMenu.slider"
+                            />
+                        </MenuItem>
+                    ) : null}
+                    <MenuItem divider />
+                    <MenuItem onClick={props.onHide}>
+                        <FormattedMessage
+                            defaultMessage="hide"
+                            description="Menu item to hide the monitor"
+                            id="gui.monitor.contextMenu.hide"
+                        />
+                    </MenuItem>
+                </ContextMenu>
+            )
         ), document.body)}
     </ContextMenuTrigger>
 
@@ -100,6 +120,7 @@ MonitorComponent.propTypes = {
     label: PropTypes.string.isRequired,
     mode: PropTypes.oneOf(monitorModes),
     onDragEnd: PropTypes.func.isRequired,
+    onHide: PropTypes.func.isRequired,
     onNextMode: PropTypes.func.isRequired,
     onSetModeToDefault: PropTypes.func.isRequired,
     onSetModeToLarge: PropTypes.func.isRequired,

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -64,6 +64,7 @@ class Blocks extends React.Component {
             'onScriptGlowOff',
             'onBlockGlowOn',
             'onBlockGlowOff',
+            'handleMonitorsUpdate',
             'handleExtensionAdded',
             'handleBlocksInfoUpdate',
             'onTargetsUpdate',
@@ -230,6 +231,7 @@ class Blocks extends React.Component {
         this.props.vm.addListener('VISUAL_REPORT', this.onVisualReport);
         this.props.vm.addListener('workspaceUpdate', this.onWorkspaceUpdate);
         this.props.vm.addListener('targetsUpdate', this.onTargetsUpdate);
+        this.props.vm.addListener('MONITORS_UPDATE', this.handleMonitorsUpdate);
         this.props.vm.addListener('EXTENSION_ADDED', this.handleExtensionAdded);
         this.props.vm.addListener('BLOCKSINFO_UPDATE', this.handleBlocksInfoUpdate);
         this.props.vm.addListener('PERIPHERAL_CONNECTED', this.handleStatusButtonUpdate);
@@ -344,6 +346,23 @@ class Blocks extends React.Component {
         // fresh workspace and we don't want any changes made to another sprites
         // workspace to be 'undone' here.
         this.workspace.clearUndo();
+    }
+    handleMonitorsUpdate (monitors) {
+        // Update the checkboxes of the relevant monitors.
+        // TODO: What about monitors that have fields? (See todo in scratch-vm blocks.js changeBlock.)
+        const flyout = this.workspace.getFlyout();
+        for (const monitor of monitors.values()) {
+            const blockId = monitor.get('id');
+            const isVisible = monitor.get('visible');
+            flyout.setCheckboxState(blockId, isVisible);
+            // We also need to update the isMonitored flag for this block on the VM, since it's used to determine
+            // whether the checkbox is activated or not when the checkbox is re-displayed (e.g. local variables/blocks
+            // when switching between sprites).
+            const block = this.props.vm.runtime.monitorBlocks._blocks[blockId];
+            if (block) {
+                block.isMonitored = isVisible;
+            }
+        }
     }
     handleExtensionAdded (blocksInfo) {
         // select JSON from each block info object then reject the pseudo-blocks which don't have JSON, like separators

--- a/src/containers/monitor.jsx
+++ b/src/containers/monitor.jsx
@@ -26,6 +26,7 @@ class Monitor extends React.Component {
         super(props);
         bindAll(this, [
             'handleDragEnd',
+            'handleHide',
             'handleNextMode',
             'handleSetModeToDefault',
             'handleSetModeToLarge',
@@ -94,6 +95,9 @@ class Monitor extends React.Component {
             y: newY
         }));
     }
+    handleHide () {
+        console.log('Hide!');
+    }
     handleNextMode () {
         const modes = availableModes(this.props.opcode);
         const modeIndex = modes.indexOf(this.props.mode);
@@ -139,6 +143,7 @@ class Monitor extends React.Component {
                 targetId={this.props.targetId}
                 width={this.props.width}
                 onDragEnd={this.handleDragEnd}
+                onHide={this.handleHide}
                 onNextMode={this.handleNextMode}
                 onSetModeToDefault={this.handleSetModeToDefault}
                 onSetModeToLarge={this.handleSetModeToLarge}

--- a/src/containers/monitor.jsx
+++ b/src/containers/monitor.jsx
@@ -96,7 +96,10 @@ class Monitor extends React.Component {
         }));
     }
     handleHide () {
-        console.log('Hide!');
+        this.props.vm.runtime.requestUpdateMonitor(Map({
+            id: this.props.id,
+            visible: false
+        }));
     }
     handleNextMode () {
         const modes = availableModes(this.props.opcode);

--- a/test/unit/components/__snapshots__/sprite-selector-item.test.jsx.snap
+++ b/test/unit/components/__snapshots__/sprite-selector-item.test.jsx.snap
@@ -67,6 +67,7 @@ exports[`SpriteSelectorItemComponent matches snapshot when given a number and de
       aria-disabled="false"
       aria-orientation={null}
       className="react-contextmenu-item"
+      dividerClassName={undefined}
       onClick={[Function]}
       onMouseLeave={[Function]}
       onMouseMove={[Function]}
@@ -139,6 +140,7 @@ exports[`SpriteSelectorItemComponent matches snapshot when selected 1`] = `
       aria-disabled="false"
       aria-orientation={null}
       className="react-contextmenu-item"
+      dividerClassName={undefined}
       onClick={[Function]}
       onMouseLeave={[Function]}
       onMouseMove={[Function]}


### PR DESCRIPTION
### Resolves

Resolves #2032; resolves #4116.

### Proposed Changes

This PR does two things:

* It makes the monitor visibility checkboxes in the scratch-blocks flyout automatically update when variables are shown or hidden (#2032). (1d939b2)

* It adds a "hide" option to the context menus of monitors (#4116). To do this..
  * It adds CSS for "divider" options in `<ContextMenu>`, pulled from react-contextmenu. (f349d9a)
  * It adds a new context menu for list monitors (which previously didn't have one). (b13efcf)
  * It sends an "update monitor" request to the VM when the option is pressed. (e17b675)

### Reason for Changes

First I set out to fix #4116, which is a useful feature brought over from Scratch 2.0. Then I realized that the flyout checkboxes weren't automatically updating, which would be a very surprising and confusing non-effect, so I fixed that, already filed earlier in #2032.

The fix to #2032 is a handy change on its own since it's already a bug you'll notice when toggling variables with the show/hide blocks, but I included it in this PR because it's dramatically more noticeable when there's another manual option to hide the monitor.

### Test Coverage

Tested manually...maybe unit tests are appropriate for the auto-updating checkbox fix? (I don't have much experience with gui tests, though, iirc.)

Since the changes involve calling a function on scratch-blocks (`flyout.setCheckboxState`) for every monitor whenever any monitor is shown or hidden, I was worried there might be a hit on performance when variables are shown or hidden, [so I created a test project to check if there is](https://scratch.mit.edu/projects/271901648/). The result: there isn't! I think that [the "throttle" option in the `updateMonitors` dispatch](https://github.com/LLK/scratch-gui/blob/3a774f8c4cd7dfeca43b06aa7b121b3dfcc3a284/src/reducers/monitors.js#L20-L22) might be helping here.

### Browser Coverage

Tested on Linux Firefox and Chromium.