### PR TITLE
Use refreshToolboxSelection package method

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -417,7 +417,7 @@ class Blocks extends React.Component {
     handleCustomProceduresClose (data) {
         this.props.onRequestCloseCustomProcedures(data);
         const ws = this.workspace;
-        ws.refreshToolboxSelection_();
+        ws.refreshToolboxSelection();
         ws.toolbox_.scrollToCategoryById('myBlocks');
     }
     handleDrop (dragInfo) {


### PR DESCRIPTION
### Resolves

https://github.com/LLK/scratch-blocks/issues/1354 - Update refreshToolboxSelection

### Proposed Changes

Use refreshToolboxSelection, a package method, instead of refreshToolboxSelection_ which is a private method.

This should only be merged after https://github.com/LLK/scratch-blocks/pull/1833 is merged and the latest version of scratch-blocks with those changes is incorporated into this project.