### PR TITLE
On modal mount, push history if current history state doesn't match this modal's id

### DIFF
--- a/src/containers/modal.jsx
+++ b/src/containers/modal.jsx
@@ -19,7 +19,7 @@ class Modal extends React.Component {
     componentDidMount () {
         // Add a history event only if it's not currently for our modal. This
         // avoids polluting the history with many entries. We only need one.
-        this.pushHistory(this.id, history.state === null);
+        this.pushHistory(this.id, (history.state === null || history.state !== this.id));
     }
     componentWillUnmount () {
         this.removeEventListeners();

--- a/test/helpers/selenium-helper.js
+++ b/test/helpers/selenium-helper.js
@@ -14,6 +14,8 @@ class SeleniumHelper {
             'clickText',
             'clickButton',
             'clickXpath',
+            'elementIsVisible',
+            'elementIsNotVisible',
             'findByText',
             'findByXpath',
             'getDriver',
@@ -22,6 +24,13 @@ class SeleniumHelper {
             'loadUri',
             'rightClickText'
         ]);
+    }
+
+    elementIsVisible (element) {
+        return this.driver.wait(until.elementIsVisible(element));
+    }
+    elementIsNotVisible (element) {
+        return this.driver.wait(until.elementIsNotVisible(element));
     }
 
     get scope () {

--- a/test/helpers/selenium-helper.js
+++ b/test/helpers/selenium-helper.js
@@ -15,7 +15,6 @@ class SeleniumHelper {
             'clickButton',
             'clickXpath',
             'elementIsVisible',
-            'elementIsNotVisible',
             'findByText',
             'findByXpath',
             'getDriver',
@@ -28,9 +27,6 @@ class SeleniumHelper {
 
     elementIsVisible (element) {
         return this.driver.wait(until.elementIsVisible(element));
-    }
-    elementIsNotVisible (element) {
-        return this.driver.wait(until.elementIsNotVisible(element));
     }
 
     get scope () {

--- a/test/integration/sprites.test.js
+++ b/test/integration/sprites.test.js
@@ -4,6 +4,7 @@ import SeleniumHelper from '../helpers/selenium-helper';
 const {
     clickText,
     clickXpath,
+    elementIsVisible,
     findByText,
     findByXpath,
     getDriver,
@@ -124,4 +125,27 @@ describe('Working with sprites', () => {
         const logs = await getLogs();
         await expect(logs).toEqual([]);
     });
+
+    test('Use browser back button to close library', async () => {
+        await driver.get('https://www.google.com');
+        await loadUri(uri);
+        await clickXpath('//button[@title="Try It"]');
+        await clickText('Costumes');
+        await clickXpath('//button[@aria-label="Choose a Sprite"]');
+        const abbyElement = await findByText('Abby'); // Should show editor for new costume
+        await elementIsVisible(abbyElement);
+        await driver.navigate().back();
+        try {
+            // should throw error because library is no longer visible
+            await elementIsVisible(abbyElement);
+            throw 'ShouldNotGetHere'; // eslint-disable-line no-throw-literal
+        } catch (e) {
+            expect(e.constructor.name).toEqual('StaleElementReferenceError');
+        }
+        const costumesElement = await findByText('Costumes'); // Should show editor for new costume
+        await elementIsVisible(costumesElement);
+        const logs = await getLogs();
+        await expect(logs).toEqual([]);
+    });
+
 });


### PR DESCRIPTION
### Resolves

- Resolves https://github.com/LLK/scratch-www/issues/2129

### Proposed Changes

Currently, on modal mount, we adjust the `window.history`. If `history.state === null`, we push a new history entry; if it's not null, we just replace history.

The problem with this is that if we've already navigated within the single page application, say from the project page to editor, then `history.state` is not null; so we just replace history when the library modal is open. Then if the user hits the back button, the browser navigates back to the previous `history` entry -- in this case, the project page.

This change instead checks `history.state === null || history.state !== this.id`, which is more permissive; if the `history.state` entry exists but is not the same as the current view, we push, instead of replacing.

### Reason for Changes

Browsing was behaving in an unexpected, frustrating way.

### Test Coverage

I added a test of the back button functionality, but note that it doesn't actually fail if this code change isn't included. Still, I think it's good to have.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
