### PR TITLE
Sprite and costume library fixes

### DIFF
--- a/src/lib/libraries/costumes.json
+++ b/src/lib/libraries/costumes.json
@@ -10337,12 +10337,13 @@
         ]
     },
     {
-        "name": "Zebra-b",
+        "name": "Zebra-a",
         "md5": "f58632e6b34fa8f9b35219e52ed2c864.svg",
         "type": "costume",
         "tags": [
             "animals",
             "savanna",
+            "zebra",
             "robert hunter"
         ],
         "info": [
@@ -10352,12 +10353,13 @@
         ]
     },
     {
-        "name": "Zebra-c",
+        "name": "Zebra-b",
         "md5": "ea23797598a55938a2d46f2b0a389fd6.svg",
         "type": "costume",
         "tags": [
             "animals",
             "savanna",
+            "zebra",
             "robert hunter"
         ],
         "info": [

--- a/src/lib/libraries/costumes.json
+++ b/src/lib/libraries/costumes.json
@@ -10300,6 +10300,7 @@
         "tags": [
             "fantasy",
             "people",
+            "animals",
             "ipzy",
             "castle",
             "animals",
@@ -10319,6 +10320,7 @@
         "tags": [
             "fantasy",
             "people",
+            "animals",
             "ipzy",
             "castle",
             "amphibians",

--- a/src/lib/libraries/costumes.json
+++ b/src/lib/libraries/costumes.json
@@ -4051,6 +4051,7 @@
         "type": "costume",
         "tags": [
             "fantasy",
+            "people",
             "spooky",
             "halloween",
             "frankenstein",
@@ -4070,6 +4071,7 @@
         "tags": [
             "fantasy",
             "spooky",
+            "people",
             "halloween",
             "frankenstein",
             "monster",
@@ -4088,6 +4090,7 @@
         "tags": [
             "fantasy",
             "spooky",
+            "people",
             "halloween",
             "frankenstein",
             "monster",
@@ -4106,6 +4109,7 @@
         "tags": [
             "fantasy",
             "spooky",
+            "people",
             "halloween",
             "frankenstein",
             "monster",

--- a/src/lib/libraries/costumes.json
+++ b/src/lib/libraries/costumes.json
@@ -687,7 +687,7 @@
     },
     {
         "name": "Bananas",
-        "md5": "40bb8a1afe88cec78254f6fcfee98242.svg",
+        "md5": "1d56c40cd7486cb5ab7c9b116da8b539.svg",
         "type": "costume",
         "tags": [
             "food",
@@ -697,8 +697,8 @@
             "fruit"
         ],
         "info": [
-            36,
-            37,
+            39,
+            38,
             1
         ]
     },
@@ -2449,54 +2449,54 @@
     },
     {
         "name": "Devin-a",
-        "md5": "b59226656f090124fb4dcbfd8946275b.png",
+        "md5": "b1897e56265470b55fa65fabe2423c55.svg",
         "type": "costume",
         "tags": [
             "people"
         ],
         "info": [
-            156,
-            380,
-            2
+            39,
+            95,
+            1
         ]
     },
     {
         "name": "Devin-b",
-        "md5": "0116dd2fa16bbce2b4701a2c9b15119e.png",
+        "md5": "873fbd641768c8f753a6568da97633e7.svg",
         "type": "costume",
         "tags": [
             "people"
         ],
         "info": [
-            160,
-            382,
-            2
+            40,
+            96,
+            1
         ]
     },
     {
         "name": "Devin-c",
-        "md5": "075cf6f2967e71cd09574f961958258a.png",
+        "md5": "eac3c03d86cebb42c8f30e373cb7f623.svg",
         "type": "costume",
         "tags": [
             "people"
         ],
         "info": [
-            128,
-            380,
-            2
+            32,
+            95,
+            1
         ]
     },
     {
         "name": "Devin-d",
-        "md5": "3892cc13b6abd08f166976c15c4da242.png",
+        "md5": "fa6a75afb0e4b822b91d8bb20d40c68f.svg",
         "type": "costume",
         "tags": [
             "people"
         ],
         "info": [
-            162,
-            378,
-            2
+            41,
+            95,
+            1
         ]
     },
     {
@@ -3167,6 +3167,7 @@
         "md5": "3b9e6830365aeadb63c21b681777b783.svg",
         "type": "costume",
         "tags": [
+            "animals",
             "space",
             "dog",
             "wren mcdonald"
@@ -3182,6 +3183,7 @@
         "md5": "a80a07906ffbb9671dba3633223859af.svg",
         "type": "costume",
         "tags": [
+            "animals",
             "space",
             "dog",
             "wren mcdonald"
@@ -3197,6 +3199,7 @@
         "md5": "1e1bdccbab5b566beb7f91b5ec01352f.svg",
         "type": "costume",
         "tags": [
+            "animals",
             "space",
             "dog",
             "wren mcdonald"
@@ -3212,6 +3215,7 @@
         "md5": "06d70d5de0e25f97c1c606e513ab019c.svg",
         "type": "costume",
         "tags": [
+            "animals",
             "space",
             "dog",
             "wren mcdonald"
@@ -3337,6 +3341,7 @@
         "md5": "87aaecd2fb73580e6f1f38c5a2e579a9.svg",
         "type": "costume",
         "tags": [
+            "animals",
             "insect",
             "dragonfly",
             "wetland",
@@ -3353,6 +3358,7 @@
         "md5": "4e775a49bd5a7a6d38392731924f72e0.svg",
         "type": "costume",
         "tags": [
+            "animals",
             "insect",
             "dragonfly",
             "wetland",
@@ -4134,7 +4140,7 @@
         "md5": "07160d455202e95f5b4b5c842eff6788.svg",
         "type": "costume",
         "tags": [
-            "animal",
+            "animals",
             "frog",
             "wetland",
             "owen davey"
@@ -4150,7 +4156,7 @@
         "md5": "9663ddb4d100eb4e18702ee13eca835e.svg",
         "type": "costume",
         "tags": [
-            "animal",
+            "animals",
             "frog",
             "wetland",
             "owen davey"
@@ -4166,7 +4172,7 @@
         "md5": "5c2ec9de8d1695cd4b59beea45046560.svg",
         "type": "costume",
         "tags": [
-            "animal",
+            "animals",
             "frog",
             "wetland",
             "owen davey"
@@ -5078,7 +5084,7 @@
     },
     {
         "name": "Hare-c",
-        "md5": "4bc5c29283dfff4b9c876cc23540a4b5.svg",
+        "md5": "cd21514d0531fdffb22204e0ec5ed84a.svg",
         "type": "costume",
         "tags": [
             "animals",
@@ -5092,8 +5098,8 @@
             "robert hunter"
         ],
         "info": [
-            40,
-            40,
+            240,
+            180,
             1
         ]
     },
@@ -7537,6 +7543,7 @@
         "md5": "0e78708b8988802d2209a34b50292bd3.svg",
         "type": "costume",
         "tags": [
+            "penguin",
             "animals",
             "bird",
             "cold",
@@ -7559,6 +7566,7 @@
         "type": "costume",
         "tags": [
             "animals",
+            "penguin",
             "bird",
             "cold",
             "north pole",
@@ -7580,6 +7588,7 @@
         "type": "costume",
         "tags": [
             "animals",
+            "penguin",
             "bird",
             "cold",
             "north pole",
@@ -7856,6 +7865,7 @@
         "md5": "b1d892d9f8a897bc6a446e2ff766ba74.svg",
         "type": "costume",
         "tags": [
+            "bear",
             "animals",
             "cold",
             "north pole",
@@ -7876,6 +7886,7 @@
         "md5": "54728e795213e67ac7cecca1c32fe293.svg",
         "type": "costume",
         "tags": [
+            "bear",
             "animals",
             "cold",
             "north pole",
@@ -7896,6 +7907,7 @@
         "md5": "7d5812e0aa1cde33771f9270ff521cfe.svg",
         "type": "costume",
         "tags": [
+            "bear",
             "animals",
             "cold",
             "north pole",

--- a/src/lib/libraries/costumes.json
+++ b/src/lib/libraries/costumes.json
@@ -5084,7 +5084,7 @@
     },
     {
         "name": "Hare-c",
-        "md5": "cd21514d0531fdffb22204e0ec5ed84a.svg",
+        "md5": "4bc5c29283dfff4b9c876cc23540a4b5.svg",
         "type": "costume",
         "tags": [
             "animals",
@@ -5098,8 +5098,8 @@
             "robert hunter"
         ],
         "info": [
-            240,
-            180,
+            40,
+            40,
             1
         ]
     },
@@ -9932,6 +9932,7 @@
         "type": "costume",
         "tags": [
             "fantasy",
+            "animals",
             "horse",
             "horn",
             "rainbow"

--- a/src/lib/libraries/costumes.json
+++ b/src/lib/libraries/costumes.json
@@ -6276,7 +6276,7 @@
         "md5": "c018a3eed966d5f92c69f2188dfd2aae.svg",
         "type": "costume",
         "tags": [
-            "animal",
+            "animals",
             "insect",
             "arthropod",
             "antennae",
@@ -6292,7 +6292,13 @@
         "name": "Ladybug2-b",
         "md5": "a2bb15ace808e070a2b815502952b292.svg",
         "type": "costume",
-        "tags": [],
+        "tags": [
+            "animals",
+            "insect",
+            "arthropod",
+            "antennae",
+            "aphids"
+        ],
         "info": [
             49,
             28,
@@ -10295,6 +10301,7 @@
             "people",
             "ipzy",
             "castle",
+            "animals",
             "amphibians",
             "magic"
         ],

--- a/src/lib/libraries/sounds.json
+++ b/src/lib/libraries/sounds.json
@@ -819,7 +819,10 @@
         "sampleCount": 2912,
         "rate": 11025,
         "format": "",
-        "tags": []
+        "tags": [
+            "effects",
+            "human"
+        ]
     },
     {
         "name": "Chord",

--- a/src/lib/libraries/sprites.json
+++ b/src/lib/libraries/sprites.json
@@ -2544,7 +2544,7 @@
             "cat",
             "kitty",
             "kitten",
-            "animal",
+            "animals",
             "mammal"
         ],
         "info": [
@@ -6787,7 +6787,7 @@
             "sounds": [
                 {
                     "soundName": "fairydust",
-                    "soundID": 0,
+                    "soundID": -1,
                     "md5": "b92de59d992a655c1b542223a784cda6.wav",
                     "sampleCount": 11247,
                     "rate": 22050,
@@ -9327,7 +9327,7 @@
         "md5": "c018a3eed966d5f92c69f2188dfd2aae.svg",
         "type": "sprite",
         "tags": [
-            "animal",
+            "animals",
             "insect",
             "arthropod",
             "antennae",

--- a/src/lib/libraries/sprites.json
+++ b/src/lib/libraries/sprites.json
@@ -5966,6 +5966,7 @@
         "tags": [
             "fantasy",
             "spooky",
+            "people",
             "halloween",
             "frankenstein",
             "monster",

--- a/src/lib/libraries/sprites.json
+++ b/src/lib/libraries/sprites.json
@@ -15264,6 +15264,7 @@
         "type": "sprite",
         "tags": [
             "fantasy",
+            "animals",
             "people",
             "ipzy",
             "castle",

--- a/src/lib/libraries/sprites.json
+++ b/src/lib/libraries/sprites.json
@@ -15332,6 +15332,7 @@
         "type": "sprite",
         "tags": [
             "animals",
+            "zebra",
             "savanna",
             "robert hunter"
         ],
@@ -15354,7 +15355,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "zebra-b",
+                    "costumeName": "zebra-a",
                     "baseLayerID": -1,
                     "baseLayerMD5": "f58632e6b34fa8f9b35219e52ed2c864.svg",
                     "bitmapResolution": 1,
@@ -15362,7 +15363,7 @@
                     "rotationCenterY": 56
                 },
                 {
-                    "costumeName": "zebra-c",
+                    "costumeName": "zebra-b",
                     "baseLayerID": -1,
                     "baseLayerMD5": "ea23797598a55938a2d46f2b0a389fd6.svg",
                     "bitmapResolution": 1,

--- a/src/lib/libraries/sprites.json
+++ b/src/lib/libraries/sprites.json
@@ -818,7 +818,7 @@
     },
     {
         "name": "Bananas",
-        "md5": "40bb8a1afe88cec78254f6fcfee98242.svg",
+        "md5": "1d56c40cd7486cb5ab7c9b116da8b539.svg",
         "type": "sprite",
         "tags": [
             "food",
@@ -856,10 +856,10 @@
                 {
                     "costumeName": "bananas",
                     "baseLayerID": -1,
-                    "baseLayerMD5": "40bb8a1afe88cec78254f6fcfee98242.svg",
+                    "baseLayerMD5": "1d56c40cd7486cb5ab7c9b116da8b539.svg",
                     "bitmapResolution": 1,
-                    "rotationCenterX": 36,
-                    "rotationCenterY": 37
+                    "rotationCenterX": 39,
+                    "rotationCenterY": 38
                 }
             ],
             "currentCostumeIndex": 0,
@@ -3667,7 +3667,7 @@
     },
     {
         "name": "Devin",
-        "md5": "b59226656f090124fb4dcbfd8946275b.png",
+        "md5": "b1897e56265470b55fa65fabe2423c55.svg",
         "type": "sprite",
         "tags": [
             "people"
@@ -3693,39 +3693,39 @@
                 {
                     "costumeName": "devin-a",
                     "baseLayerID": -1,
-                    "baseLayerMD5": "b59226656f090124fb4dcbfd8946275b.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 78,
-                    "rotationCenterY": 190
+                    "baseLayerMD5": "b1897e56265470b55fa65fabe2423c55.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 39,
+                    "rotationCenterY": 95
                 },
                 {
                     "costumeName": "devin-b",
                     "baseLayerID": -1,
-                    "baseLayerMD5": "0116dd2fa16bbce2b4701a2c9b15119e.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 80,
-                    "rotationCenterY": 191
+                    "baseLayerMD5": "873fbd641768c8f753a6568da97633e7.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 40,
+                    "rotationCenterY": 96
                 },
                 {
                     "costumeName": "devin-c",
                     "baseLayerID": -1,
-                    "baseLayerMD5": "075cf6f2967e71cd09574f961958258a.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 64,
-                    "rotationCenterY": 190
+                    "baseLayerMD5": "eac3c03d86cebb42c8f30e373cb7f623.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 32,
+                    "rotationCenterY": 95
                 },
                 {
                     "costumeName": "devin-d",
                     "baseLayerID": -1,
-                    "baseLayerMD5": "3892cc13b6abd08f166976c15c4da242.png",
-                    "bitmapResolution": 2,
-                    "rotationCenterX": 81,
-                    "rotationCenterY": 189
+                    "baseLayerMD5": "fa6a75afb0e4b822b91d8bb20d40c68f.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 41,
+                    "rotationCenterY": 95
                 }
             ],
             "currentCostumeIndex": 0,
-            "scratchX": 30,
-            "scratchY": 12,
+            "scratchX": 82,
+            "scratchY": -18,
             "scale": 1,
             "direction": 90,
             "rotationStyle": "normal",
@@ -4502,6 +4502,7 @@
         "tags": [
             "space",
             "dog",
+            "animals",
             "wren mcdonald"
         ],
         "info": [
@@ -4690,6 +4691,7 @@
         "md5": "87aaecd2fb73580e6f1f38c5a2e579a9.svg",
         "type": "sprite",
         "tags": [
+            "animals",
             "insect",
             "dragonfly",
             "wetland",
@@ -4723,7 +4725,7 @@
                 },
                 {
                     "costumeName": "Dragonfly-b",
-                    "baseLayerID": 0,
+                    "baseLayerID": -1,
                     "baseLayerMD5": "4e775a49bd5a7a6d38392731924f72e0.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 108,
@@ -6082,17 +6084,23 @@
         }
     },
     {
-        "name": "Frog 2",
+        "name": "Frog 2 ",
         "md5": "07160d455202e95f5b4b5c842eff6788.svg",
         "type": "sprite",
-        "tags": [],
+        "tags": [
+            "animals",
+            "insect",
+            "bug",
+            "wetland",
+            "owen davey"
+        ],
         "info": [
             0,
             3,
             1
         ],
         "json": {
-            "objName": "Frog 2",
+            "objName": "Frog 2 ",
             "sounds": [
                 {
                     "soundName": "pop",
@@ -7545,10 +7553,10 @@
                 {
                     "costumeName": "hare-c",
                     "baseLayerID": -1,
-                    "baseLayerMD5": "4bc5c29283dfff4b9c876cc23540a4b5.svg",
+                    "baseLayerMD5": "cd21514d0531fdffb22204e0ec5ed84a.svg",
                     "bitmapResolution": 1,
-                    "rotationCenterX": 40,
-                    "rotationCenterY": 40
+                    "rotationCenterX": 240,
+                    "rotationCenterY": 180
                 }
             ],
             "currentCostumeIndex": 0,
@@ -11072,7 +11080,17 @@
         "name": "Penguin",
         "md5": "0e78708b8988802d2209a34b50292bd3.svg",
         "type": "sprite",
-        "tags": [],
+        "tags": [
+            "animals",
+            "penguin",
+            "cold",
+            "north pole",
+            "south pole",
+            "ice",
+            "antarctica",
+            "arctic",
+            "robert hunter"
+        ],
         "info": [
             0,
             3,
@@ -11460,7 +11478,18 @@
         "name": "Polar Bear",
         "md5": "b1d892d9f8a897bc6a446e2ff766ba74.svg",
         "type": "sprite",
-        "tags": [],
+        "tags": [
+            "animals",
+            "bear",
+            "polar bear",
+            "cold",
+            "north pole",
+            "south pole",
+            "ice",
+            "antarctica",
+            "arctic",
+            "robert hunter"
+        ],
         "info": [
             0,
             3,
@@ -12358,8 +12387,8 @@
                 }
             ],
             "currentCostumeIndex": 0,
-            "scratchX": 116,
-            "scratchY": 82,
+            "scratchX": 123,
+            "scratchY": 50,
             "scale": 1,
             "direction": 90,
             "rotationStyle": "normal",
@@ -13778,7 +13807,7 @@
             "sounds": [
                 {
                     "soundName": "chomp",
-                    "soundID": 0,
+                    "soundID": -1,
                     "md5": "0b1e3033140d094563248e61de4039e5.wav",
                     "sampleCount": 2912,
                     "rate": 11025,
@@ -15286,6 +15315,61 @@
             "currentCostumeIndex": 0,
             "scratchX": -128,
             "scratchY": -85,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Zebra",
+        "md5": "f58632e6b34fa8f9b35219e52ed2c864.svg",
+        "type": "sprite",
+        "tags": [
+            "animals",
+            "savanna",
+            "robert hunter"
+        ],
+        "info": [
+            0,
+            2,
+            1
+        ],
+        "json": {
+            "objName": "Zebra",
+            "sounds": [
+                {
+                    "soundName": "horse gallop",
+                    "soundID": -1,
+                    "md5": "058a34b5fb8b57178b5322d994b6b8c8.wav",
+                    "sampleCount": 38336,
+                    "rate": 11025,
+                    "format": ""
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "zebra-b",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "f58632e6b34fa8f9b35219e52ed2c864.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 97,
+                    "rotationCenterY": 56
+                },
+                {
+                    "costumeName": "zebra-c",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "ea23797598a55938a2d46f2b0a389fd6.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 96,
+                    "rotationCenterY": 56
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": 122,
+            "scratchY": 11,
             "scale": 1,
             "direction": 90,
             "rotationStyle": "normal",

--- a/src/lib/libraries/sprites.json
+++ b/src/lib/libraries/sprites.json
@@ -7553,10 +7553,10 @@
                 {
                     "costumeName": "hare-c",
                     "baseLayerID": -1,
-                    "baseLayerMD5": "cd21514d0531fdffb22204e0ec5ed84a.svg",
+                    "baseLayerMD5": "4bc5c29283dfff4b9c876cc23540a4b5.svg",
                     "bitmapResolution": 1,
-                    "rotationCenterX": 240,
-                    "rotationCenterY": 180
+                    "rotationCenterX": 40,
+                    "rotationCenterY": 40
                 }
             ],
             "currentCostumeIndex": 0,
@@ -14734,6 +14734,7 @@
         "type": "sprite",
         "tags": [
             "fantasy",
+            "animals",
             "horse",
             "horn",
             "rainbow"


### PR DESCRIPTION
Various regression fixes to the sprite and costume libraries:

- Banana: update costume
- Devin: use vector version 
- Dot: fix tags
- Dragonfly: fix tags
- Frog: fix tags
- Hare: update costume
- Penguin: fix tags
- Polar bear: fix tags
- Zebra: re-added