### PR TITLE
Update scratch-storage package

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "scratch-l10n": "3.1.20181213173343",
     "scratch-paint": "0.2.0-prerelease.20181218161344",
     "scratch-render": "0.1.0-prerelease.20181218160410",
-    "scratch-storage": "1.2.0",
+    "scratch-storage": "1.2.1",
     "scratch-svg-renderer": "0.2.0-prerelease.20181218153528",
     "scratch-vm": "0.2.0-prerelease.20181218172555",
     "selenium-webdriver": "3.6.0",


### PR DESCRIPTION
### Resolves

Helps in the fix for https://github.com/LLK/scratch-vm/pull/1840

### Proposed Changes

Update the scratch-storage version number to pull in the latest fixes for loading default assets.

### Reason for Changes

Previously the loading settings for default assets were incorrect (https://github.com/LLK/scratch-storage/pull/62). This update to scratch storage fixes them. 
