### PR TITLE
Show error ID if available from Raven and report react errors

### DIFF
--- a/src/components/crash-message/crash-message.jsx
+++ b/src/components/crash-message/crash-message.jsx
@@ -29,6 +29,18 @@ const CrashMessage = props => (
                     id="gui.crashMessage.description"
                 />
             </p>
+            {props.eventId && (
+                <p>
+                    <FormattedMessage
+                        defaultMessage="Your error was logged with id {errorId}"
+                        description="Message to inform the user that page has crashed."
+                        id="gui.crashMessage.errorNumber"
+                        values={{
+                            errorId: props.eventId
+                        }}
+                    />
+                </p>
+            )}
             <button
                 className={styles.reloadButton}
                 onClick={props.onReload}
@@ -44,6 +56,7 @@ const CrashMessage = props => (
 );
 
 CrashMessage.propTypes = {
+    eventId: PropTypes.string,
     onReload: PropTypes.func.isRequired
 };
 


### PR DESCRIPTION
/cc @rschamp @colbygk this does two things:
1. Show the relevant error ID to the user if Raven is available.
2. Report react errors to raven in the error boundary.

I will need to add this to the error boundary in www as well.