### PR TITLE
Make remixing/saving faster by marking all assets as clean to start.

### DIFF
--- a/src/lib/vm-manager-hoc.jsx
+++ b/src/lib/vm-manager-hoc.jsx
@@ -53,6 +53,9 @@ const vmManagerHOC = function (WrappedComponent) {
         loadProject () {
             return this.props.vm.loadProject(this.props.projectData)
                 .then(() => {
+                    // Mark all the assets as clean since they just got loaded
+                    this.props.vm.assets.forEach(asset => (asset.clean = true));
+
                     this.props.onLoadedProject(this.props.loadingState, this.props.canSave);
                     // Wrap in a setTimeout because skin loading in
                     // the renderer can be async.


### PR DESCRIPTION
They were not being marked as clean when loaded from the server, causing remixes that included only minimal (or no) changes to take a very long time as it waited for hundreds of network requests to resolve. Mark them as clean when loaded from the server so we know they do not need to be resaved.

Discussed this with @rschamp , but @benjiwheeler it would be great to get some eyes on testing this locally with some larger projects. I tested remixing and saving, modifying costumes and resaving and seeing only a single asset trying to get saved. 

/cc @rschamp 