### PR TITLE
Add divider above "hide" context menu option

### DIFF
--- a/src/components/context-menu/context-menu.css
+++ b/src/components/context-menu/context-menu.css
@@ -24,7 +24,14 @@
     transition: 0.1s ease;
 }
 
-.menu-item:hover {
+.menu-item:not(.divider):hover {
     background: $motion-primary;
     color: white;
+}
+
+.divider {
+    border-bottom: 1px solid $ui-black-transparent;
+    cursor: inherit;
+    margin-bottom: 3px;
+    padding: 2px 0;
 }

--- a/src/components/context-menu/context-menu.jsx
+++ b/src/components/context-menu/context-menu.jsx
@@ -13,7 +13,7 @@ const StyledContextMenu = props => (
 const StyledMenuItem = props => (
     <MenuItem
         {...props}
-        attributes={{className: styles.menuItem}}
+        attributes={{className: styles.menuItem, dividerClassName: styles.divider}}
     />
 );
 

--- a/src/components/monitor/monitor.jsx
+++ b/src/components/monitor/monitor.jsx
@@ -83,6 +83,7 @@ const MonitorComponent = props => (
                         />
                     </MenuItem>
                 ) : null}
+                {props.onHide && <MenuItem divider />}
                 {props.onHide &&
                     <MenuItem onClick={props.onHide}>
                         <FormattedMessage

--- a/src/components/monitor/monitor.jsx
+++ b/src/components/monitor/monitor.jsx
@@ -83,6 +83,14 @@ const MonitorComponent = props => (
                         />
                     </MenuItem>
                 ) : null}
+                {props.onHide &&
+                    <MenuItem onClick={props.onHide}>
+                        <FormattedMessage
+                            defaultMessage="hide"
+                            description="Menu item to hide the monitor"
+                            id="gui.monitor.contextMenu.hide"
+                        />
+                    </MenuItem>}
             </ContextMenu>
         ), document.body)}
     </ContextMenuTrigger>
@@ -100,6 +108,7 @@ MonitorComponent.propTypes = {
     label: PropTypes.string.isRequired,
     mode: PropTypes.oneOf(monitorModes),
     onDragEnd: PropTypes.func.isRequired,
+    onHide: PropTypes.func,
     onNextMode: PropTypes.func.isRequired,
     onSetModeToDefault: PropTypes.func.isRequired,
     onSetModeToLarge: PropTypes.func.isRequired,

--- a/src/containers/monitor.jsx
+++ b/src/containers/monitor.jsx
@@ -26,6 +26,7 @@ class Monitor extends React.Component {
         super(props);
         bindAll(this, [
             'handleDragEnd',
+            'handleHide',
             'handleNextMode',
             'handleSetModeToDefault',
             'handleSetModeToLarge',
@@ -94,6 +95,12 @@ class Monitor extends React.Component {
             y: newY
         }));
     }
+    handleHide () {
+        this.props.vm.runtime.requestUpdateMonitor(Map({
+            id: this.props.id,
+            visible: false
+        }));
+    }
     handleNextMode () {
         const modes = availableModes(this.props.opcode);
         const modeIndex = modes.indexOf(this.props.mode);
@@ -139,6 +146,7 @@ class Monitor extends React.Component {
                 targetId={this.props.targetId}
                 width={this.props.width}
                 onDragEnd={this.handleDragEnd}
+                onHide={this.handleHide}
                 onNextMode={this.handleNextMode}
                 onSetModeToDefault={this.handleSetModeToDefault}
                 onSetModeToLarge={this.handleSetModeToLarge}

--- a/test/unit/components/__snapshots__/sprite-selector-item.test.jsx.snap
+++ b/test/unit/components/__snapshots__/sprite-selector-item.test.jsx.snap
@@ -67,6 +67,7 @@ exports[`SpriteSelectorItemComponent matches snapshot when given a number and de
       aria-disabled="false"
       aria-orientation={null}
       className="react-contextmenu-item"
+      dividerClassName={undefined}
       onClick={[Function]}
       onMouseLeave={[Function]}
       onMouseMove={[Function]}
@@ -139,6 +140,7 @@ exports[`SpriteSelectorItemComponent matches snapshot when selected 1`] = `
       aria-disabled="false"
       aria-orientation={null}
       className="react-contextmenu-item"
+      dividerClassName={undefined}
       onClick={[Function]}
       onMouseLeave={[Function]}
       onMouseMove={[Function]}


### PR DESCRIPTION
Mostly cherry-picked from #4125.

### Resolves

Doesn't resolve any particular issue, but is a follow-up to (and branches off of) #4148. Should be merged after that one.

### Proposed Changes

Adds a divider above the "hide" context menu option:

![The context menu of a monitor, showing "slider", then the divider line, then "hide"](https://user-images.githubusercontent.com/9948030/50246152-cff87100-03aa-11e9-99b9-9188d71df686.png)

### Reason for Changes

To match the 2.0 appearance, and to make this option distinct from the above options, which are unrelated to the visibility of the context menu (they either change what the type of monitor is, or export/import a list as CSV text).

### Test Coverage

Tested manually to see if it shows up. Updated snapshot tests.. although I don't totally understand why `dividerClassName` is undefined in them. See discussion here: https://github.com/LLK/scratch-gui/pull/4125#discussion_r242600502

### Browser Coverage

Tested on Linux Firefox and Chromium.