### PR TITLE
Do not remove the window beforeunload handler in componentWillUnmount.

### DIFF
--- a/src/lib/project-saver-hoc.jsx
+++ b/src/lib/project-saver-hoc.jsx
@@ -100,7 +100,10 @@ const ProjectSaverHOC = function (WrappedComponent) {
         }
         componentWillUnmount () {
             this.clearAutoSaveTimeout();
-            window.onbeforeunload = undefined; // eslint-disable-line no-undefined
+            // Cant unset the beforeunload because it might no longer belong to this component
+            // i.e. if another of this component has been mounted before this one gets unmounted
+            // which happens when going from project to editor view.
+            // window.onbeforeunload = undefined; // eslint-disable-line no-undefined
         }
         leavePageConfirm (e) {
             if (this.props.projectChanged) {


### PR DESCRIPTION
This is because when switching from project to editor view, this component gets unmounted and then remounted, but the componentDidMount seems to happen before the componentWillUnmount. Because it is dealing with a global variable, it is unsafe to always unset the beforeunload when unmounting.

### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/LLK/scratch-gui/issues/4155


The repro was:
1. Be logged in, load up a project from mystuff
2. Add a backdrop or something to change it
3. Click mystuff, see that there is no prompt about unsaved changes.