### PR TITLE
refactored font loading state to be in redux

### DIFF
--- a/src/lib/vm-manager-hoc.jsx
+++ b/src/lib/vm-manager-hoc.jsx
@@ -117,6 +117,7 @@ const vmManagerHOC = function (WrappedComponent) {
     const mapStateToProps = state => {
         const loadingState = state.scratchGui.projectState.loadingState;
         return {
+            fontsLoaded: state.scratchGui.fontsLoaded,
             isLoadingWithId: getIsLoadingWithId(loadingState),
             projectData: state.scratchGui.projectState.projectData,
             projectId: state.scratchGui.projectState.projectId,

--- a/src/reducers/fonts-loaded.js
+++ b/src/reducers/fonts-loaded.js
@@ -1,0 +1,23 @@
+const SET_FONTS_LOADED = 'fontsLoaded/SET_FONTS_LOADED';
+
+const initialState = false;
+
+const reducer = function (state, action) {
+    if (typeof state === 'undefined') state = initialState;
+    switch (action.type) {
+    case SET_FONTS_LOADED:
+        return action.loaded;
+    default:
+        return state;
+    }
+};
+const setFontsLoaded = () => ({
+    type: SET_FONTS_LOADED,
+    loaded: true
+});
+
+export {
+    reducer as default,
+    initialState as fontsLoadedInitialState,
+    setFontsLoaded
+};

--- a/src/reducers/gui.js
+++ b/src/reducers/gui.js
@@ -17,6 +17,7 @@ import monitorLayoutReducer, {monitorLayoutInitialState} from './monitor-layout'
 import projectChangedReducer, {projectChangedInitialState} from './project-changed';
 import projectStateReducer, {projectStateInitialState} from './project-state';
 import projectTitleReducer, {projectTitleInitialState} from './project-title';
+import fontsLoadedReducer, {fontsLoadedInitialState} from './fonts-loaded';
 import restoreDeletionReducer, {restoreDeletionInitialState} from './restore-deletion';
 import stageSizeReducer, {stageSizeInitialState} from './stage-size';
 import targetReducer, {targetsInitialState} from './targets';
@@ -50,6 +51,7 @@ const guiInitialState = {
     projectChanged: projectChangedInitialState,
     projectState: projectStateInitialState,
     projectTitle: projectTitleInitialState,
+    fontsLoaded: fontsLoadedInitialState,
     restoreDeletion: restoreDeletionInitialState,
     targets: targetsInitialState,
     timeout: timeoutInitialState,
@@ -146,6 +148,7 @@ const guiReducer = combineReducers({
     projectChanged: projectChangedReducer,
     projectState: projectStateReducer,
     projectTitle: projectTitleReducer,
+    fontsLoaded: fontsLoadedReducer,
     restoreDeletion: restoreDeletionReducer,
     targets: targetReducer,
     timeout: timeoutReducer,

--- a/src/reducers/project-state.js
+++ b/src/reducers/project-state.js
@@ -452,7 +452,7 @@ const onLoadedProject = (loadingState, canSave, success) => {
                 type: DONE_LOADING_VM_WITHOUT_ID
             };
         default:
-            break;
+            return;
         }
     }
     return {


### PR DESCRIPTION
### Resolves

- Resolves https://github.com/LLK/scratch-gui/issues/4159

### Proposed Changes

instead of maintaining the state of font loading in the `font-loader-hoc`, put it into redux.

### Reason for Changes

We need font loading state to be shared across project page and editor, so that fonts are not loaded a second time.

The second font load was triggering a second vm load of the project data.

### Test Coverage

none... not obvious what we would test

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
