### PR TITLE
set stage size when passed into gui

### DIFF
--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -141,7 +141,7 @@ const GUIComponent = props => {
                 isRendererSupported={isRendererSupported}
                 isRtl={isRtl}
                 loading={loading}
-                stageSize={STAGE_SIZE_MODES.large}
+                stageSize={stageSize}
                 vm={vm}
             >
                 {alertsVisible ? (

--- a/src/containers/gui.jsx
+++ b/src/containers/gui.jsx
@@ -18,6 +18,7 @@ import {
     COSTUMES_TAB_INDEX,
     SOUNDS_TAB_INDEX
 } from '../reducers/editor-tab';
+import {setStageSize} from '../reducers/stage-size';
 
 import {
     closeCostumeLibrary,
@@ -52,6 +53,9 @@ class GUI extends React.Component {
         setIsScratchDesktop(this.props.isScratchDesktop);
         this.setReduxTitle(this.props.projectTitle);
         this.props.onStorageInit(storage);
+        if (this.props.stageSizeMode) {
+            this.props.onSetStageSize(this.props.stageSizeMode);
+        }
     }
     componentDidUpdate (prevProps) {
         if (this.props.projectId !== prevProps.projectId && this.props.projectId !== null) {
@@ -89,12 +93,14 @@ class GUI extends React.Component {
             isScratchDesktop,
             isShowingProject,
             onProjectLoaded,
+            onSetStageSize,
             onStorageInit,
             onUpdateProjectId,
             onUpdateReduxProjectTitle,
             projectHost,
             projectId,
             projectTitle,
+            stageSizeMode,
             /* eslint-enable no-unused-vars */
             children,
             fetchingProject,
@@ -127,6 +133,7 @@ GUI.propTypes = {
     loadingStateVisible: PropTypes.bool,
     onProjectLoaded: PropTypes.func,
     onSeeCommunity: PropTypes.func,
+    onSetStageSize: PropTypes.func,
     onStorageInit: PropTypes.func,
     onUpdateProjectId: PropTypes.func,
     onUpdateProjectTitle: PropTypes.func,
@@ -134,6 +141,7 @@ GUI.propTypes = {
     projectHost: PropTypes.string,
     projectId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     projectTitle: PropTypes.string,
+    stageSizeMode: PropTypes.string,
     telemetryModalVisible: PropTypes.bool,
     vm: PropTypes.instanceOf(VM).isRequired
 };
@@ -183,6 +191,7 @@ const mapDispatchToProps = dispatch => ({
     onRequestCloseBackdropLibrary: () => dispatch(closeBackdropLibrary()),
     onRequestCloseCostumeLibrary: () => dispatch(closeCostumeLibrary()),
     onRequestCloseTelemetryModal: () => dispatch(closeTelemetryModal()),
+    onSetStageSize: mode => dispatch(setStageSize(mode)),
     onUpdateReduxProjectTitle: title => dispatch(setProjectTitle(title))
 });
 


### PR DESCRIPTION
### Resolves

Partially addresses https://github.com/LLK/scratch-www/issues/2513, together with https://github.com/LLK/scratch-www/pull/2518

### Proposed Changes

Take `stageSizeMode` prop; if provided to gui, use it to set reducer value. Use stage size state variable to set player stage size, not just stage in editor.

Needs work to make this work correctly.

### Reason for Changes

Make mobile portrait mode look good!

### Test Coverage

none

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome (and a bunch of simulated phones)
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
