### PR TITLE
Use new sentry API provided by www, and use analytics ID from www

### DIFF
--- a/src/containers/error-boundary.jsx
+++ b/src/containers/error-boundary.jsx
@@ -27,7 +27,7 @@ class ErrorBoundary extends React.Component {
         // Display fallback UI
         this.setState({
             hasError: true,
-            errorId: window.Raven ? window.Raven.lastEventId() : null
+            errorId: window.Sentry ? window.Sentry.lastEventId() : null
         });
 
         // Log errors to analytics, separating supported browsers from unsupported.
@@ -37,8 +37,13 @@ class ErrorBoundary extends React.Component {
                 action: this.props.action,
                 label: error.message
             });
-            if (window.Raven) {
-                window.Raven.captureException(error, {extra: info});
+            if (window.Sentry) {
+                window.Sentry.withScope(scope => {
+                    Object.keys(info).forEach(key => {
+                        scope.setExtra(key, info[key]);
+                    });
+                    window.Sentry.captureException(error);
+                });
             }
         } else {
             analytics.event({

--- a/src/lib/analytics.js
+++ b/src/lib/analytics.js
@@ -1,6 +1,6 @@
 import GoogleAnalytics from 'react-ga';
 
-GoogleAnalytics.initialize(process.env.GA_ID, {
+GoogleAnalytics.initialize(process.env.GA_ID || window.GA_ID, {
     debug: (process.env.NODE_ENV !== 'production'),
     titleCase: true,
     sampleRate: (process.env.NODE_ENV === 'production') ? 100 : 0,


### PR DESCRIPTION
/cc @colbygk @rschamp 

Use the new Sentry API using the `window.Sentry` object provided by www. This is a bit of a hack until www builds gui and they can share the same Sentry object.

Also consume the GA_ID provided to the window by www