### PR TITLE
Reduce analytics events

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -7,7 +7,6 @@ import React from 'react';
 import VMScratchBlocks from '../lib/blocks';
 import VM from 'scratch-vm';
 
-import analytics from '../lib/analytics';
 import log from '../lib/log.js';
 import Prompt from './prompt.jsx';
 import BlocksComponent from '../components/blocks/blocks.jsx';
@@ -113,8 +112,6 @@ class Blocks extends React.Component {
         if (this.props.isVisible) {
             this.setLocale();
         }
-
-        analytics.pageview('/editors/blocks');
     }
     shouldComponentUpdate (nextProps, nextState) {
         return (

--- a/src/containers/error-boundary.jsx
+++ b/src/containers/error-boundary.jsx
@@ -42,6 +42,7 @@ class ErrorBoundary extends React.Component {
                     Object.keys(info).forEach(key => {
                         scope.setExtra(key, info[key]);
                     });
+                    scope.setExtra('action', this.props.action);
                     window.Sentry.captureException(error);
                 });
             }

--- a/src/containers/paint-editor-wrapper.jsx
+++ b/src/containers/paint-editor-wrapper.jsx
@@ -4,8 +4,6 @@ import bindAll from 'lodash.bindall';
 import VM from 'scratch-vm';
 import PaintEditor from 'scratch-paint';
 
-import analytics from '../lib/analytics';
-
 import {connect} from 'react-redux';
 
 class PaintEditorWrapper extends React.Component {
@@ -15,9 +13,6 @@ class PaintEditorWrapper extends React.Component {
             'handleUpdateImage',
             'handleUpdateName'
         ]);
-    }
-    componentDidMount () {
-        analytics.pageview('/editors/paint');
     }
     shouldComponentUpdate (nextProps) {
         return this.props.imageId !== nextProps.imageId ||

--- a/src/containers/sound-editor.jsx
+++ b/src/containers/sound-editor.jsx
@@ -44,7 +44,6 @@ class SoundEditor extends React.Component {
     }
     componentDidMount () {
         this.audioBufferPlayer = new AudioBufferPlayer(this.props.samples, this.props.sampleRate);
-        analytics.pageview('/editors/sound');
     }
     componentWillReceiveProps (newProps) {
         if (newProps.soundId !== this.props.soundId) { // A different sound has been selected

--- a/src/lib/project-fetcher-hoc.jsx
+++ b/src/lib/project-fetcher-hoc.jsx
@@ -7,7 +7,6 @@ import {connect} from 'react-redux';
 import {setProjectUnchanged} from '../reducers/project-changed';
 import {
     LoadingStates,
-    defaultProjectId,
     getIsCreatingNew,
     getIsFetchingWithId,
     getIsLoading,
@@ -21,7 +20,6 @@ import {
     BLOCKS_TAB_INDEX
 } from '../reducers/editor-tab';
 
-import analytics from './analytics';
 import log from './log';
 import storage from './storage';
 
@@ -79,17 +77,6 @@ const ProjectFetcherHOC = function (WrappedComponent) {
                         // Treat failure to load as an error
                         // Throw to be caught by catch later on
                         throw new Error('Could not find project');
-                    }
-                })
-                .then(() => {
-                    if (projectId !== defaultProjectId) {
-                        // if not default project, register a project load event
-                        analytics.event({
-                            category: 'project',
-                            action: 'Load Project',
-                            label: projectId,
-                            nonInteraction: true
-                        });
                     }
                 })
                 .catch(err => {

--- a/src/reducers/modals.js
+++ b/src/reducers/modals.js
@@ -1,5 +1,3 @@
-import analytics from '../lib/analytics';
-
 const OPEN_MODAL = 'scratch-gui/modals/OPEN_MODAL';
 const CLOSE_MODAL = 'scratch-gui/modals/CLOSE_MODAL';
 
@@ -59,51 +57,39 @@ const closeModal = function (modal) {
     };
 };
 const openBackdropLibrary = function () {
-    analytics.pageview('/libraries/backdrops');
     return openModal(MODAL_BACKDROP_LIBRARY);
 };
 const openCameraCapture = function () {
-    analytics.pageview('/modals/camera');
     return openModal(MODAL_CAMERA_CAPTURE);
 };
 const openCostumeLibrary = function () {
-    analytics.pageview('/libraries/costumes');
     return openModal(MODAL_COSTUME_LIBRARY);
 };
 const openExtensionLibrary = function () {
-    analytics.pageview('/libraries/extensions');
     return openModal(MODAL_EXTENSION_LIBRARY);
 };
 const openImportInfo = function () {
-    analytics.pageview('modals/import');
     return openModal(MODAL_IMPORT_INFO);
 };
 const openLoadingProject = function () {
-    analytics.pageview('modals/loading');
     return openModal(MODAL_LOADING_PROJECT);
 };
 const openPreviewInfo = function () {
-    analytics.pageview('/modals/preview');
     return openModal(MODAL_PREVIEW_INFO);
 };
 const openSoundLibrary = function () {
-    analytics.pageview('/libraries/sounds');
     return openModal(MODAL_SOUND_LIBRARY);
 };
 const openSpriteLibrary = function () {
-    analytics.pageview('/libraries/sprites');
     return openModal(MODAL_SPRITE_LIBRARY);
 };
 const openSoundRecorder = function () {
-    analytics.pageview('/modals/microphone');
     return openModal(MODAL_SOUND_RECORDER);
 };
 const openConnectionModal = function () {
-    analytics.pageview('/modals/connection');
     return openModal(MODAL_CONNECTION);
 };
 const openTipsLibrary = function () {
-    analytics.pageview('/modals/tips');
     return openModal(MODAL_TIPS_LIBRARY);
 };
 const closeBackdropLibrary = function () {


### PR DESCRIPTION
/cc @thisandagain @rschamp 

Removes all the `pageview` analytics calls except the search query one for the libraries, and removes the error logging to GA. 

There are still a fair number of individual events I we need to look at to decide whether they should be kept or not