### PR TITLE
chore(package): update scratch-l10n to version 3.1.20181220222259

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "rimraf": "^2.6.1",
     "scratch-audio": "0.1.0-prerelease.20181023202904",
     "scratch-blocks": "0.1.0-prerelease.1545162154",
-    "scratch-l10n": "3.1.20181213173343",
+    "scratch-l10n": "3.1.20181220222259",
     "scratch-paint": "0.2.0-prerelease.20181220194927",
     "scratch-render": "0.1.0-prerelease.20181220195236",
     "scratch-storage": "1.2.1",


### PR DESCRIPTION
Closes #4173

updates to the newer version of scratch-l10n