### PR TITLE
Revert "Make remixing/saving faster by marking all assets as clean to start."

### DIFF
--- a/src/lib/vm-manager-hoc.jsx
+++ b/src/lib/vm-manager-hoc.jsx
@@ -53,9 +53,6 @@ const vmManagerHOC = function (WrappedComponent) {
         loadProject () {
             return this.props.vm.loadProject(this.props.projectData)
                 .then(() => {
-                    // Mark all the assets as clean since they just got loaded
-                    this.props.vm.assets.forEach(asset => (asset.clean = true));
-
                     this.props.onLoadedProject(this.props.loadingState, this.props.canSave);
                     // Wrap in a setTimeout because skin loading in
                     // the renderer can be async.


### PR DESCRIPTION
Reverts LLK/scratch-gui#4153

This was marking assets as clean after the whole vm load process is done, which is _after_ the vm has the chance to modify scratch2 vector assets and stuff them back into storage. That means there are assets in the vm that are actually NEW after loadProject has run. We should move the marking as clean to right after the asset is loaded from storage

/cc @kchadha @rschamp 