### PR TITLE
Fix cursors

### DIFF
--- a/src/components/blocks/blocks.css
+++ b/src/components/blocks/blocks.css
@@ -74,7 +74,7 @@
 }
 
 
-.blocks :global(.blocklyBlockDragSurface) {
+.blocks :global(.blocklyDraggingMouseThrough) {
     /*
         Fix an issue where the drag surface was preventing hover events for sharing blocks.
         This does not prevent user interaction on the blocks themselves.


### PR DESCRIPTION
### Resolves

Resolves #2755 - Drag cursor (and delete cursor) disappears from block after starting drag.

### Proposed Changes

Essentially, this PR makes a small difference to the changes done to fix issue #2584.

Rather than disabling pointer events for elements with class `blocklyBlockDragSurface` (which ends up disabling the delete and other cursors as well), this solution disables pointer events for class `blocklyDraggingMouseThrough`. See https://github.com/LLK/scratch-blocks/blob/develop/core/block_svg.js#L1029

### Reason for Changes

Fixes cursor issues.

### Test Coverage

None

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
