### PR TITLE
Remove Vivaldi block

### DIFF
--- a/src/components/browser-modal/browser-modal.jsx
+++ b/src/components/browser-modal/browser-modal.jsx
@@ -32,7 +32,7 @@ const BrowserModal = ({intl, ...props}) => (
                 <p>
                     { /* eslint-disable max-len */ }
                     <FormattedMessage
-                        defaultMessage="We're very sorry, but Scratch 3.0 does not support Internet Explorer, Vivaldi, Opera or Silk. We recommend trying a newer browser such as Google Chrome, Mozilla Firefox, or Microsoft Edge."
+                        defaultMessage="We're very sorry, but Scratch 3.0 does not support Internet Explorer, Opera or Silk. We recommend trying a newer browser such as Google Chrome, Mozilla Firefox, or Microsoft Edge."
                         description="Unsupported browser description"
                         id="gui.unsupportedBrowser.description"
                     />

--- a/src/components/browser-modal/browser-modal.jsx
+++ b/src/components/browser-modal/browser-modal.jsx
@@ -32,7 +32,7 @@ const BrowserModal = ({intl, ...props}) => (
                 <p>
                     { /* eslint-disable max-len */ }
                     <FormattedMessage
-                        defaultMessage="We're very sorry, but Scratch 3.0 does not support Internet Explorer, Opera or Silk. We recommend trying a newer browser such as Google Chrome, Mozilla Firefox, or Microsoft Edge."
+                        defaultMessage="We are very sorry, but Scratch does not support this browser. We recommend trying a supported browser such as Google Chrome, Mozilla Firefox, Microsoft Edge, or Apple Safari."
                         description="Unsupported browser description"
                         id="gui.unsupportedBrowser.description"
                     />

--- a/src/lib/supported-browser.js
+++ b/src/lib/supported-browser.js
@@ -6,7 +6,6 @@ import bowser from 'bowser';
  */
 export default function () {
     if (bowser.msie ||
-        bowser.vivaldi ||
         bowser.opera ||
         bowser.silk) {
         return false;


### PR DESCRIPTION
### Resolves

- Resolves #2370 

### Proposed Changes

Remove the case of Vivaldi in the blocking browsers logic

### Reason for Changes

Because there is no reason to block Vivaldi, as it's always based on a recent version of Chromium, and Scratch supports Chromium.

### Test Coverage

No test coverage but the change is trivial.