### PR TITLE
Change WebGL link

### DIFF
--- a/src/components/webgl-modal/webgl-modal.jsx
+++ b/src/components/webgl-modal/webgl-modal.jsx
@@ -39,7 +39,7 @@ const WebGlModal = ({intl, ...props}) => (
                             webGlLink: (
                                 <a
                                     className={styles.faqLink}
-                                    href="https://en.wikipedia.org/wiki/WebGL#Support"
+                                    href="https://get.webgl.org/"
                                 >
                                     <FormattedMessage
                                         defaultMessage="does not support WebGL"


### PR DESCRIPTION
### Resolves
Resolves #4201 

### Proposed Changes
Changes the link from wikipedia to WebGL official website
### Reason for Changes
It's not user-friendly

