### PR TITLE
Use the loading screen in player mode

### DIFF
--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -141,6 +141,7 @@ const GUIComponent = props => {
             <StageWrapper
                 isRendererSupported={isRendererSupported}
                 isRtl={isRtl}
+                loading={loading}
                 stageSize={STAGE_SIZE_MODES.large}
                 vm={vm}
             >

--- a/src/components/loader/loader.css
+++ b/src/components/loader/loader.css
@@ -2,7 +2,7 @@
 @import "../../css/z-index.css";
 
 .background {
-    position: fixed;
+    position: absolute;
     top: 0;
     left: 0;
     width: 100%;

--- a/src/components/stage-wrapper/stage-wrapper.jsx
+++ b/src/components/stage-wrapper/stage-wrapper.jsx
@@ -6,6 +6,7 @@ import Box from '../box/box.jsx';
 import {STAGE_DISPLAY_SIZES} from '../../lib/layout-constants.js';
 import StageHeader from '../../containers/stage-header.jsx';
 import Stage from '../../containers/stage.jsx';
+import Loader from '../loader/loader.jsx';
 
 import styles from './stage-wrapper.css';
 
@@ -13,6 +14,7 @@ const StageWrapperComponent = function (props) {
     const {
         isRtl,
         isRendererSupported,
+        loading,
         stageSize,
         vm
     } = props;
@@ -38,6 +40,9 @@ const StageWrapperComponent = function (props) {
                         null
                 }
             </Box>
+            {loading ? (
+                <Loader />
+            ) : null}
         </Box>
     );
 };
@@ -45,6 +50,7 @@ const StageWrapperComponent = function (props) {
 StageWrapperComponent.propTypes = {
     isRendererSupported: PropTypes.bool.isRequired,
     isRtl: PropTypes.bool,
+    loading: PropTypes.bool,
     stageSize: PropTypes.oneOf(Object.keys(STAGE_DISPLAY_SIZES)).isRequired,
     vm: PropTypes.instanceOf(VM).isRequired
 };


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/LLK/scratch-gui/issues/2134

### Proposed Changes

_Describe what this Pull Request does_

Use the loading animation in player mode as well as editor mode.

### Reason for Changes

_Explain why these changes should be made_

The lack of loading animation makes the project page view feel like it isn't working.

Here is what it currently looks like
![loading-animation-without](https://user-images.githubusercontent.com/654102/50485389-19584a00-09c3-11e9-8af0-31b92116a345.gif)

With this change it looks like this
![loading-animation](https://user-images.githubusercontent.com/654102/50485397-207f5800-09c3-11e9-8ef2-71b1229c6292.gif)

I simply passed in the loading prop to the stage wrapper so that it can be shown in player only mode.

I also changed the CSS for the loading animation so that it is position absolute instead of fixed, so that it can be contained within the stage size in player mode (but is still full screen in editor mode, which I made sure to test)

/cc @thisandagain @rschamp  I made this because i was concerned about the way the project page felt using larger projects. We can talk offline about whether you think this should go in before release or not.