### PR TITLE
Pin eslint-plugin-react because v7.12 has a bug causing erroneous fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "eslint": "^5.0.1",
     "eslint-config-scratch": "^5.0.0",
     "eslint-plugin-import": "^2.8.0",
-    "eslint-plugin-react": "^7.5.1",
+    "eslint-plugin-react": "7.11.1",
     "file-loader": "2.0.0",
     "get-float-time-domain-data": "0.1.0",
     "get-user-media-promise": "1.1.4",


### PR DESCRIPTION
/cc @rschamp, pinned to the most recent working version (this version has been published for several months)