### PR TITLE
Stop waiting for non scratch fonts to load.

### DIFF
--- a/src/lib/font-loader-hoc.jsx
+++ b/src/lib/font-loader-hoc.jsx
@@ -4,6 +4,17 @@ import omit from 'lodash.omit';
 import {connect} from 'react-redux';
 import {setFontsLoaded} from '../reducers/fonts-loaded';
 
+// This list is from scratch-render-fonts:
+// https://github.com/LLK/scratch-render-fonts/blob/master/src/index.js#L4
+const FONTS = [
+    'Sans Serif',
+    'Serif',
+    'Handwriting',
+    'Marker',
+    'Curly',
+    'Pixel',
+    'Scratch'
+];
 /* Higher Order Component to provide behavior for loading fonts.
  * @param {React.Component} WrappedComponent component to receive fontsLoaded prop
  * @returns {React.Component} component with font loading behavior
@@ -22,8 +33,12 @@ const FontLoaderHOC = function (WrappedComponent) {
                     typeof document.fonts.values === 'function' &&
                     typeof document.fonts.values()[Symbol.iterator] === 'function') {
                     for (const fontFace of document.fonts.values()) {
-                        fontPromises.push(fontFace.loaded);
-                        fontFace.load();
+                        // Only load fonts from this list. If we load all fonts on the document, we may block on
+                        // loading fonts from things like chrome extensions.
+                        if (FONTS.indexOf(fontFace.family) !== -1) {
+                            fontPromises.push(fontFace.loaded);
+                            fontFace.load();
+                        }
                     }
                 }
                 return fontPromises;


### PR DESCRIPTION
### Resolves

A problem where the Avast SafePrice chrome extension caused all projects not to load.  We were iterating over all fonts in the document and waiting for them to load, which meant we were waiting for the extension fonts to load. They were not loading properly (there was a network error), so the project never loaded either.

### Proposed Changes

Only load fonts from the list in the scratch-render-fonts repo.
