### PR TITLE
Asset name fixes

### DIFF
--- a/src/lib/libraries/backdrops.json
+++ b/src/lib/libraries/backdrops.json
@@ -866,7 +866,7 @@
         ]
     },
     {
-        "name": "Soccer",
+        "name": "Soccer 1",
         "md5": "04a63154f04b09494354090f7cc2f1b9.png",
         "type": "backdrop",
         "tags": [
@@ -1007,7 +1007,7 @@
         ]
     },
     {
-        "name": "Theater",
+        "name": "Theater 1",
         "md5": "c2b097bc5cdb6a14ef5485202bc5ee76.png",
         "type": "backdrop",
         "tags": [

--- a/src/lib/libraries/costumes.json
+++ b/src/lib/libraries/costumes.json
@@ -348,7 +348,7 @@
         ]
     },
     {
-        "name": "Arrow 1-a",
+        "name": "Arrow-a",
         "md5": "62f8794dd120e9b4ead4d098d50fc64b.svg",
         "type": "costume",
         "tags": [
@@ -363,7 +363,7 @@
         ]
     },
     {
-        "name": "Arrow 1-b",
+        "name": "Arrow-b",
         "md5": "a157dc7e33d7c7a048af933de999e397.svg",
         "type": "costume",
         "tags": [
@@ -378,7 +378,7 @@
         ]
     },
     {
-        "name": "Arrow 1-c",
+        "name": "Arrow-c",
         "md5": "d3b389e91f7beb22b2b1a80af09990ee.svg",
         "type": "costume",
         "tags": [
@@ -393,7 +393,7 @@
         ]
     },
     {
-        "name": "Arrow 1-d",
+        "name": "Arrow-d",
         "md5": "412717ff731e9f19003a5840054057eb.svg",
         "type": "costume",
         "tags": [
@@ -632,7 +632,7 @@
         ]
     },
     {
-        "name": "Balloon 1-a",
+        "name": "Balloon-a",
         "md5": "bc96a1fb5fe794377acd44807e421ce2.svg",
         "type": "costume",
         "tags": [
@@ -650,7 +650,7 @@
         ]
     },
     {
-        "name": "Balloon 1-b",
+        "name": "Balloon-b",
         "md5": "d7bb51d9c38af6314bd2b4058d2a592d.svg",
         "type": "costume",
         "tags": [
@@ -668,7 +668,7 @@
         ]
     },
     {
-        "name": "Balloon 1-c",
+        "name": "Balloon-c",
         "md5": "247cef27b665d77d9efaca69327cae77.svg",
         "type": "costume",
         "tags": [
@@ -1136,7 +1136,7 @@
         ]
     },
     {
-        "name": "Bowl-a",
+        "name": "Bowl",
         "md5": "86f616639846f06fef29931e6b9b59de.svg",
         "type": "costume",
         "tags": [
@@ -2181,7 +2181,7 @@
         ]
     },
     {
-        "name": "Cloud-a",
+        "name": "Clouds-a",
         "md5": "c7d7de8e29179407f03b054fa640f4d0.svg",
         "type": "costume",
         "tags": [
@@ -2197,7 +2197,7 @@
         ]
     },
     {
-        "name": "Cloud-b",
+        "name": "Clouds-b",
         "md5": "d8595350ebb460494c9189dabb968336.svg",
         "type": "costume",
         "tags": [
@@ -2213,7 +2213,7 @@
         ]
     },
     {
-        "name": "Cloud-c",
+        "name": "Clouds-c",
         "md5": "395fc991e64ac0a4aa46758ab4bc65cb.svg",
         "type": "costume",
         "tags": [
@@ -2229,7 +2229,7 @@
         ]
     },
     {
-        "name": "Cloud-d",
+        "name": "Clouds-d",
         "md5": "1767e704acb11ffa409f77cc79ba7e86.svg",
         "type": "costume",
         "tags": [
@@ -6747,7 +6747,7 @@
         ]
     },
     {
-        "name": "Llama",
+        "name": "Llama-a",
         "md5": "f5841f36b41c4df26f9c724d913c279b.svg",
         "type": "costume",
         "tags": [
@@ -7744,7 +7744,7 @@
         ]
     },
     {
-        "name": "Party Hat-e",
+        "name": "Party Hat-c",
         "md5": "e69516f2a9bb6d632fdaba4fadd8f8f1.svg",
         "type": "costume",
         "tags": [
@@ -10150,7 +10150,7 @@
         ]
     },
     {
-        "name": "Tree 1",
+        "name": "Tree",
         "md5": "8c40e2662c55d17bc384f47165ac43c1.svg",
         "type": "costume",
         "tags": [
@@ -10494,7 +10494,7 @@
         ]
     },
     {
-        "name": "Witch",
+        "name": "Witch 1",
         "md5": "c991196a708294535a1dbdce7189c23c.svg",
         "type": "costume",
         "tags": [
@@ -10512,7 +10512,7 @@
         ]
     },
     {
-        "name": "Witch-a",
+        "name": "Witch 2-a",
         "md5": "cbc54e15cd62f0c16369587377636099.svg",
         "type": "costume",
         "tags": [
@@ -10530,7 +10530,7 @@
         ]
     },
     {
-        "name": "Witch-b",
+        "name": "Witch 2-b",
         "md5": "64d2c4c51e6cb6008cd5e93f77e6f591.svg",
         "type": "costume",
         "tags": [
@@ -10548,7 +10548,7 @@
         ]
     },
     {
-        "name": "Witch-c",
+        "name": "Witch 2-c",
         "md5": "00b768c3da5b4ee3efddf05d1eb88de2.svg",
         "type": "costume",
         "tags": [
@@ -10566,7 +10566,7 @@
         ]
     },
     {
-        "name": "Witch-d",
+        "name": "Witch 2-d",
         "md5": "4fe4c0ee34a9028f2c6988b7294a61c1.svg",
         "type": "costume",
         "tags": [

--- a/src/lib/libraries/costumes.json
+++ b/src/lib/libraries/costumes.json
@@ -348,7 +348,7 @@
         ]
     },
     {
-        "name": "Arrow1-a",
+        "name": "Arrow 1-a",
         "md5": "62f8794dd120e9b4ead4d098d50fc64b.svg",
         "type": "costume",
         "tags": [
@@ -363,7 +363,7 @@
         ]
     },
     {
-        "name": "Arrow1-b",
+        "name": "Arrow 1-b",
         "md5": "a157dc7e33d7c7a048af933de999e397.svg",
         "type": "costume",
         "tags": [
@@ -378,7 +378,7 @@
         ]
     },
     {
-        "name": "Arrow1-c",
+        "name": "Arrow 1-c",
         "md5": "d3b389e91f7beb22b2b1a80af09990ee.svg",
         "type": "costume",
         "tags": [
@@ -393,7 +393,7 @@
         ]
     },
     {
-        "name": "Arrow1-d",
+        "name": "Arrow 1-d",
         "md5": "412717ff731e9f19003a5840054057eb.svg",
         "type": "costume",
         "tags": [
@@ -632,7 +632,7 @@
         ]
     },
     {
-        "name": "Balloon1-a",
+        "name": "Balloon 1-a",
         "md5": "bc96a1fb5fe794377acd44807e421ce2.svg",
         "type": "costume",
         "tags": [
@@ -650,7 +650,7 @@
         ]
     },
     {
-        "name": "Balloon1-b",
+        "name": "Balloon 1-b",
         "md5": "d7bb51d9c38af6314bd2b4058d2a592d.svg",
         "type": "costume",
         "tags": [
@@ -668,7 +668,7 @@
         ]
     },
     {
-        "name": "Balloon1-c",
+        "name": "Balloon 1-c",
         "md5": "247cef27b665d77d9efaca69327cae77.svg",
         "type": "costume",
         "tags": [
@@ -1052,7 +1052,7 @@
         ]
     },
     {
-        "name": "Bell1",
+        "name": "Bell",
         "md5": "f35056c772395455d703773657e1da6e.svg",
         "type": "costume",
         "tags": [
@@ -1353,7 +1353,7 @@
         ]
     },
     {
-        "name": "Butterfly1-a",
+        "name": "Butterfly 1-a",
         "md5": "8419d4851defd1e862e4f7c1699d2190.svg",
         "type": "costume",
         "tags": [
@@ -1370,7 +1370,7 @@
         ]
     },
     {
-        "name": "Butterfly1-b",
+        "name": "Butterfly 1-b",
         "md5": "0873714e8d55d9eeb0bc8e8ab64441cc.svg",
         "type": "costume",
         "tags": [
@@ -1387,7 +1387,7 @@
         ]
     },
     {
-        "name": "Butterfly1-c",
+        "name": "Butterfly 1-c",
         "md5": "9c422631ca8d46413487f5dd627b65c6.svg",
         "type": "costume",
         "tags": [
@@ -1404,7 +1404,7 @@
         ]
     },
     {
-        "name": "Butterfly2-a",
+        "name": "Butterfly 2-a",
         "md5": "836d4cc7889f4a1cbcb0303934f31f79.svg",
         "type": "costume",
         "tags": [
@@ -1422,7 +1422,7 @@
         ]
     },
     {
-        "name": "Butterfly2-b",
+        "name": "Butterfly 2-b",
         "md5": "55dd0671a359d7c35f7b78f4176660e8.svg",
         "type": "costume",
         "tags": [
@@ -1440,7 +1440,7 @@
         ]
     },
     {
-        "name": "Button1",
+        "name": "Button 1",
         "md5": "7ef67c5bc8cf7df64fdb3b1d6b250f71.svg",
         "type": "costume",
         "tags": [
@@ -1456,7 +1456,7 @@
         ]
     },
     {
-        "name": "Button2-a",
+        "name": "Button 2-a",
         "md5": "c0051ff23e9aae78295964206793c1e3.svg",
         "type": "costume",
         "tags": [
@@ -1471,7 +1471,7 @@
         ]
     },
     {
-        "name": "Button2-b",
+        "name": "Button 2-b",
         "md5": "712a561dc0ad66e348b8247e566b50ef.svg",
         "type": "costume",
         "tags": [
@@ -1486,7 +1486,7 @@
         ]
     },
     {
-        "name": "Button3-a",
+        "name": "Button 3-a",
         "md5": "ffb2a9c21084c58fdb677c8d12a97519.svg",
         "type": "costume",
         "tags": [
@@ -1501,7 +1501,7 @@
         ]
     },
     {
-        "name": "Button3-b",
+        "name": "Button 3-b",
         "md5": "7a9ccb55e4da36f48811ab125d2492e0.svg",
         "type": "costume",
         "tags": [
@@ -1516,7 +1516,7 @@
         ]
     },
     {
-        "name": "Button4-a",
+        "name": "Button 4-a",
         "md5": "ecfe263bc256349777e571eaf39761d4.svg",
         "type": "costume",
         "tags": [
@@ -1530,7 +1530,7 @@
         ]
     },
     {
-        "name": "Button4-b",
+        "name": "Button 4-b",
         "md5": "9c49edde00b80cd22d636a0577a9b1c9.svg",
         "type": "costume",
         "tags": [
@@ -1544,7 +1544,7 @@
         ]
     },
     {
-        "name": "Button5-a",
+        "name": "Button 5-a",
         "md5": "71e97245b7be4fd6fe3ba8cdeecadaf1.svg",
         "type": "costume",
         "tags": [
@@ -2245,7 +2245,7 @@
         ]
     },
     {
-        "name": "Convertible",
+        "name": "Convertible 1",
         "md5": "5b883f396844ff5cfecd7c95553fa4fb.png",
         "type": "costume",
         "tags": [
@@ -2259,7 +2259,7 @@
         ]
     },
     {
-        "name": "Convertible 3",
+        "name": "Convertible 2",
         "md5": "b6ac3c9e1789cba2302d2ef82d62d019.svg",
         "type": "costume",
         "tags": [
@@ -2530,7 +2530,7 @@
         ]
     },
     {
-        "name": "Dinosaur1-a",
+        "name": "Dinosaur 1-a",
         "md5": "e70ab4de006f3df64e776abf912a62be.svg",
         "type": "costume",
         "tags": [
@@ -2546,7 +2546,7 @@
         ]
     },
     {
-        "name": "Dinosaur1-b",
+        "name": "Dinosaur 1-b",
         "md5": "af2d8211a65dce9871d49fa70671ce0c.svg",
         "type": "costume",
         "tags": [
@@ -2562,7 +2562,7 @@
         ]
     },
     {
-        "name": "Dinosaur1-c",
+        "name": "Dinosaur 1-c",
         "md5": "a2bb28d5ba55ba997bec63772437cecf.svg",
         "type": "costume",
         "tags": [
@@ -2578,7 +2578,7 @@
         ]
     },
     {
-        "name": "Dinosaur1-d",
+        "name": "Dinosaur 1-d",
         "md5": "91f3dba45e8cec7bdff31ed5acde2c85.svg",
         "type": "costume",
         "tags": [
@@ -2594,7 +2594,7 @@
         ]
     },
     {
-        "name": "Dinosaur2-a",
+        "name": "Dinosaur 2-a",
         "md5": "f49719e8f2440f5d328f2604e97eb71d.svg",
         "type": "costume",
         "tags": [
@@ -2610,7 +2610,7 @@
         ]
     },
     {
-        "name": "Dinosaur2-b",
+        "name": "Dinosaur 2-b",
         "md5": "1af6b3af3bf2cda862bbe01034a336bb.svg",
         "type": "costume",
         "tags": [
@@ -2626,7 +2626,7 @@
         ]
     },
     {
-        "name": "Dinosaur2-c",
+        "name": "Dinosaur 2-c",
         "md5": "e83b30a4517bbe155e2b4a6367c8f70b.svg",
         "type": "costume",
         "tags": [
@@ -2642,7 +2642,7 @@
         ]
     },
     {
-        "name": "Dinosaur2-d",
+        "name": "Dinosaur 2-d",
         "md5": "8244f1fb159237179d1caaa69c070060.svg",
         "type": "costume",
         "tags": [
@@ -2658,7 +2658,7 @@
         ]
     },
     {
-        "name": "Dinosaur3-a",
+        "name": "Dinosaur 3-a",
         "md5": "c4867c44f38df5bde472844878d5beea.svg",
         "type": "costume",
         "tags": [
@@ -2675,7 +2675,7 @@
         ]
     },
     {
-        "name": "Dinosaur3-b",
+        "name": "Dinosaur 3-b",
         "md5": "b682c1e58ea1c6bea737670f57517b6f.svg",
         "type": "costume",
         "tags": [
@@ -2692,7 +2692,7 @@
         ]
     },
     {
-        "name": "Dinosaur3-c",
+        "name": "Dinosaur 3-c",
         "md5": "47a617ca48f4782efeeb60199cff801e.svg",
         "type": "costume",
         "tags": [
@@ -2709,7 +2709,7 @@
         ]
     },
     {
-        "name": "Dinosaur3-d",
+        "name": "Dinosaur 3-d",
         "md5": "710ff3380d6872b04785db97dc0565c6.svg",
         "type": "costume",
         "tags": [
@@ -2726,7 +2726,7 @@
         ]
     },
     {
-        "name": "Dinosaur3-e",
+        "name": "Dinosaur 3-e",
         "md5": "6f40025c1157f37858adf7fa85090e64.svg",
         "type": "costume",
         "tags": [
@@ -2742,7 +2742,7 @@
         ]
     },
     {
-        "name": "Dinosaur4-a",
+        "name": "Dinosaur 4-a",
         "md5": "d87b5e3c45f5d234c7aa47107c788f18.svg",
         "type": "costume",
         "tags": [
@@ -2760,7 +2760,7 @@
         ]
     },
     {
-        "name": "Dinosaur4-b",
+        "name": "Dinosaur 4-b",
         "md5": "cfe906702bbd30bc3bb8acb53079b6b0.svg",
         "type": "costume",
         "tags": [
@@ -2778,7 +2778,7 @@
         ]
     },
     {
-        "name": "Dinosaur4-c",
+        "name": "Dinosaur 4-c",
         "md5": "1879b07cfe788b0258afada17aa46973.svg",
         "type": "costume",
         "tags": [
@@ -2796,7 +2796,7 @@
         ]
     },
     {
-        "name": "Dinosaur4-d",
+        "name": "Dinosaur 4-d",
         "md5": "52c17657698ab82881ed3ccf83080684.svg",
         "type": "costume",
         "tags": [
@@ -2814,7 +2814,7 @@
         ]
     },
     {
-        "name": "Diver1",
+        "name": "Diver 1",
         "md5": "853803d5600b66538474909c5438c8ee.svg",
         "type": "costume",
         "tags": [
@@ -2832,7 +2832,7 @@
         ]
     },
     {
-        "name": "Diver2",
+        "name": "Diver 2",
         "md5": "248d3e69ada69a64b1077149ef6a931a.svg",
         "type": "costume",
         "tags": [
@@ -2990,7 +2990,7 @@
         ]
     },
     {
-        "name": "Dm Top R Leg",
+        "name": "Dm Top R Leg 1",
         "md5": "12db59633a1709a2c39534d35263791f.png",
         "type": "costume",
         "tags": [
@@ -3004,7 +3004,7 @@
         ]
     },
     {
-        "name": "Dm Top R Leg2",
+        "name": "Dm Top R Leg 2",
         "md5": "fcb8c2b6cf9b7e6ce9df521b2486deb3.png",
         "type": "costume",
         "tags": [],
@@ -3029,7 +3029,7 @@
         ]
     },
     {
-        "name": "Dog1-a",
+        "name": "Dog 1-a",
         "md5": "39ddefa0cc58f3b1b06474d63d81ef56.svg",
         "type": "costume",
         "tags": [
@@ -3045,7 +3045,7 @@
         ]
     },
     {
-        "name": "Dog1-b",
+        "name": "Dog 1-b",
         "md5": "598f4aa3d8f671375d1d2b3acf753416.svg",
         "type": "costume",
         "tags": [
@@ -3061,7 +3061,7 @@
         ]
     },
     {
-        "name": "Dog2-a",
+        "name": "Dog 2-a",
         "md5": "e921f865b19b27cd99e16a341dbf09c2.svg",
         "type": "costume",
         "tags": [
@@ -3077,7 +3077,7 @@
         ]
     },
     {
-        "name": "Dog2-b",
+        "name": "Dog 2-b",
         "md5": "891f2fb7daf79ba8b224a9173eeb0a63.svg",
         "type": "costume",
         "tags": [
@@ -3093,7 +3093,7 @@
         ]
     },
     {
-        "name": "Dog2-c",
+        "name": "Dog 2-c",
         "md5": "cd236d5eef4431dea82983ac9eec406b.svg",
         "type": "costume",
         "tags": [
@@ -3335,7 +3335,7 @@
         ]
     },
     {
-        "name": "Dragon1-a",
+        "name": "Dragon 1-a",
         "md5": "ee0082b436d6d5dc3de33047166e7bf2.svg",
         "type": "costume",
         "tags": [
@@ -3351,7 +3351,7 @@
         ]
     },
     {
-        "name": "Dragon1-b",
+        "name": "Dragon 1-b",
         "md5": "bb58ce36997fa205a86a085f202837fd.svg",
         "type": "costume",
         "tags": [
@@ -4473,7 +4473,7 @@
         ]
     },
     {
-        "name": "Giga Walk1",
+        "name": "Giga Walk 1",
         "md5": "f76bc420011db2cdb2de378c1536f6da.svg",
         "type": "costume",
         "tags": [
@@ -4487,7 +4487,7 @@
         ]
     },
     {
-        "name": "Giga Walk2",
+        "name": "Giga Walk 2",
         "md5": "43b5874e8a54f93bd02727f0abf6905b.svg",
         "type": "costume",
         "tags": [
@@ -4501,7 +4501,7 @@
         ]
     },
     {
-        "name": "Giga Walk3",
+        "name": "Giga Walk 3",
         "md5": "9aab3bbb375765391978be4f6d478ab3.svg",
         "type": "costume",
         "tags": [
@@ -5102,7 +5102,7 @@
         ]
     },
     {
-        "name": "Guitar-electric1-a",
+        "name": "Guitar-electric 1-a",
         "md5": "b2b469b9d11fd23bdd671eab94dc58ff.svg",
         "type": "costume",
         "tags": [
@@ -5116,7 +5116,7 @@
         ]
     },
     {
-        "name": "Guitar-electric1-b",
+        "name": "Guitar-electric 1-b",
         "md5": "3632184c19c66a088a99568570d61b13.svg",
         "type": "costume",
         "tags": [
@@ -5130,7 +5130,7 @@
         ]
     },
     {
-        "name": "Guitar-electric2-a",
+        "name": "Guitar-electric 2-a",
         "md5": "1fc433b89038f9e16092c9f4d7514cca.svg",
         "type": "costume",
         "tags": [
@@ -5144,7 +5144,7 @@
         ]
     },
     {
-        "name": "Guitar-electric2-b",
+        "name": "Guitar-electric 2-b",
         "md5": "7b843dbc93d4b2ea31fa67cca3d5077c.svg",
         "type": "costume",
         "tags": [
@@ -5659,7 +5659,7 @@
         ]
     },
     {
-        "name": "Hippo1-a",
+        "name": "Hippo 1-a",
         "md5": "c1353c4a5eec5e6f32ed053e6f6e8f99.svg",
         "type": "costume",
         "tags": [
@@ -5677,7 +5677,7 @@
         ]
     },
     {
-        "name": "Hippo1-b",
+        "name": "Hippo 1-b",
         "md5": "e65ed93bbb9cccf698fc7e774ab609a6.svg",
         "type": "costume",
         "tags": [
@@ -6418,7 +6418,7 @@
         ]
     },
     {
-        "name": "Ladybug2",
+        "name": "Ladybug 1",
         "md5": "f16a1ccc69a4a8190a927f1595aa7bfa.svg",
         "type": "costume",
         "tags": [
@@ -6434,7 +6434,7 @@
         ]
     },
     {
-        "name": "Ladybug2-a",
+        "name": "Ladybug 2-a",
         "md5": "c018a3eed966d5f92c69f2188dfd2aae.svg",
         "type": "costume",
         "tags": [
@@ -6451,7 +6451,7 @@
         ]
     },
     {
-        "name": "Ladybug2-b",
+        "name": "Ladybug 2-b",
         "md5": "a2bb15ace808e070a2b815502952b292.svg",
         "type": "costume",
         "tags": [
@@ -7225,7 +7225,7 @@
         ]
     },
     {
-        "name": "Mouse1-a",
+        "name": "Mouse-a",
         "md5": "e1f0c26afecbe9d4b9923d8e6bf489a8.svg",
         "type": "costume",
         "tags": [
@@ -7240,7 +7240,7 @@
         ]
     },
     {
-        "name": "Mouse1-b",
+        "name": "Mouse-b",
         "md5": "f5e477a3f94fc98ba3cd927228405646.svg",
         "type": "costume",
         "tags": [
@@ -7438,7 +7438,7 @@
         ]
     },
     {
-        "name": "Orange",
+        "name": "Orange 1",
         "md5": "27d5dfbadceea215e983d2641ce3e51f.svg",
         "type": "costume",
         "tags": [
@@ -7452,7 +7452,7 @@
         ]
     },
     {
-        "name": "Orange2-a",
+        "name": "Orange 2-a",
         "md5": "8a7d8515df41f83c1326ec3233a3a42a.svg",
         "type": "costume",
         "tags": [
@@ -7467,7 +7467,7 @@
         ]
     },
     {
-        "name": "Orange2-b",
+        "name": "Orange 2-b",
         "md5": "70c7f1822ffdb37157c304273dae9102.svg",
         "type": "costume",
         "tags": [
@@ -7786,7 +7786,7 @@
         ]
     },
     {
-        "name": "Penguin-a",
+        "name": "Penguin 1-a",
         "md5": "0e78708b8988802d2209a34b50292bd3.svg",
         "type": "costume",
         "tags": [
@@ -7808,7 +7808,7 @@
         ]
     },
     {
-        "name": "Penguin-b",
+        "name": "Penguin 1-b",
         "md5": "43af2a0b7f922ec5dc94217b2f3e08e4.svg",
         "type": "costume",
         "tags": [
@@ -7830,7 +7830,7 @@
         ]
     },
     {
-        "name": "Penguin-c",
+        "name": "Penguin 1-c",
         "md5": "4f35c3940957e3ffc2e83a2565942171.svg",
         "type": "costume",
         "tags": [
@@ -7852,7 +7852,7 @@
         ]
     },
     {
-        "name": "Penguin2-a",
+        "name": "Penguin 2-a",
         "md5": "c17d9e4bdb59c574e0c34aa70af516da.svg",
         "type": "costume",
         "tags": [
@@ -7868,7 +7868,7 @@
         ]
     },
     {
-        "name": "Penguin2-b",
+        "name": "Penguin 2-b",
         "md5": "b224a582395e0847c2ef4eefcfbc4546.svg",
         "type": "costume",
         "tags": [
@@ -7884,7 +7884,7 @@
         ]
     },
     {
-        "name": "Penguin2-c",
+        "name": "Penguin 2-c",
         "md5": "35fec7aa5f60cca945fe0615413f1f08.svg",
         "type": "costume",
         "tags": [
@@ -7900,7 +7900,7 @@
         ]
     },
     {
-        "name": "Penguin2-d",
+        "name": "Penguin 2-d",
         "md5": "18fa51a64ebd5518f0c5c465525346e5.svg",
         "type": "costume",
         "tags": [
@@ -7916,7 +7916,7 @@
         ]
     },
     {
-        "name": "Pico Walk1",
+        "name": "Pico Walk 1",
         "md5": "8eab5fe20dd249bf22964298b1d377eb.svg",
         "type": "costume",
         "tags": [
@@ -7930,7 +7930,7 @@
         ]
     },
     {
-        "name": "Pico Walk2",
+        "name": "Pico Walk 2",
         "md5": "39ecd3c38d3f2cd81e3a17ee6c25699f.svg",
         "type": "costume",
         "tags": [
@@ -7944,7 +7944,7 @@
         ]
     },
     {
-        "name": "Pico Walk3",
+        "name": "Pico Walk 3",
         "md5": "43f7d92dcf9eadf77c07a6fc1eb4104f.svg",
         "type": "costume",
         "tags": [
@@ -7958,7 +7958,7 @@
         ]
     },
     {
-        "name": "Pico Walk4",
+        "name": "Pico Walk 4",
         "md5": "2582d012d57bca59bc0315c5c5954958.svg",
         "type": "costume",
         "tags": [
@@ -8095,7 +8095,7 @@
         ]
     },
     {
-        "name": "Planet2",
+        "name": "Planet",
         "md5": "978784738c1d9dd4b1d397fd18bdf406.svg",
         "type": "costume",
         "tags": [
@@ -8655,7 +8655,7 @@
         ]
     },
     {
-        "name": "Retro Robot A",
+        "name": "Retro Robot-a",
         "md5": "a17c1ce38c261395ae268f3b8a9037db.svg",
         "type": "costume",
         "tags": [
@@ -8668,7 +8668,7 @@
         ]
     },
     {
-        "name": "Retro Robot B",
+        "name": "Retro Robot-b",
         "md5": "bfb5afe62358ef542f118299bb53d4b7.svg",
         "type": "costume",
         "tags": [
@@ -8681,7 +8681,7 @@
         ]
     },
     {
-        "name": "Retro Robot C",
+        "name": "Retro Robot-c",
         "md5": "f925e3bde178001133a11fa97847a9ae.svg",
         "type": "costume",
         "tags": [
@@ -9109,7 +9109,7 @@
         ]
     },
     {
-        "name": "Shark-a",
+        "name": "Shark 1-a",
         "md5": "4ca6776e9c021e8b21c3346793c9361d.svg",
         "type": "costume",
         "tags": [
@@ -9125,7 +9125,7 @@
         ]
     },
     {
-        "name": "Shark-b",
+        "name": "Shark 1-b",
         "md5": "0bb623f0bbec53ee9667cee0b7ad6d47.svg",
         "type": "costume",
         "tags": [
@@ -9141,7 +9141,7 @@
         ]
     },
     {
-        "name": "Shark2-a",
+        "name": "Shark 2-a",
         "md5": "7c0a907eae79462f69f8e2af8e7df828.svg",
         "type": "costume",
         "tags": [
@@ -9160,7 +9160,7 @@
         ]
     },
     {
-        "name": "Shark2-b",
+        "name": "Shark 2-b",
         "md5": "cff9ae87a93294693a0650b38a7a33d2.svg",
         "type": "costume",
         "tags": [
@@ -9179,7 +9179,7 @@
         ]
     },
     {
-        "name": "Shark2-c",
+        "name": "Shark 2-c",
         "md5": "afeae3f998598424f7c50918507f6ce6.svg",
         "type": "costume",
         "tags": [
@@ -9198,7 +9198,7 @@
         ]
     },
     {
-        "name": "Shirt-a",
+        "name": "Shirt",
         "md5": "659465944053fe6fb6aa1ed0e11be9aa.svg",
         "type": "costume",
         "tags": [
@@ -9316,7 +9316,7 @@
         ]
     },
     {
-        "name": "Singer1",
+        "name": "Singer",
         "md5": "e47ef1af3b925e5ac9e3b3f809d440b3.svg",
         "type": "costume",
         "tags": [
@@ -9366,7 +9366,7 @@
         ]
     },
     {
-        "name": "Skeleton-d",
+        "name": "Skeleton-c",
         "md5": "155efd0dfdc59a0e2a546a4a7d068ece.svg",
         "type": "costume",
         "tags": [
@@ -9384,7 +9384,7 @@
         ]
     },
     {
-        "name": "Skeleton-e",
+        "name": "Skeleton-d",
         "md5": "c41a11468602522cdc6dec7043215f65.svg",
         "type": "costume",
         "tags": [
@@ -9735,7 +9735,7 @@
         ]
     },
     {
-        "name": "Taco",
+        "name": "Taco-a",
         "md5": "bc78fb90ed373d56c11d5fafa4203ccd.svg",
         "type": "costume",
         "tags": [
@@ -9749,7 +9749,7 @@
         ]
     },
     {
-        "name": "Taco-wizard",
+        "name": "Taco-b",
         "md5": "5e9e65db20d403b590578ed44b1a3792.svg",
         "type": "costume",
         "tags": [
@@ -9757,7 +9757,8 @@
             "fantasy",
             "abrakadabra",
             "alakazam",
-            "designerd"
+            "designerd",
+            "wizard"
         ],
         "info": [
             125,
@@ -10149,7 +10150,7 @@
         ]
     },
     {
-        "name": "Tree1",
+        "name": "Tree 1",
         "md5": "8c40e2662c55d17bc384f47165ac43c1.svg",
         "type": "costume",
         "tags": [
@@ -10270,7 +10271,7 @@
         ]
     },
     {
-        "name": "Unicorn",
+        "name": "Unicorn 1",
         "md5": "c491fd1867375aa0160b013788d188e5.svg",
         "type": "costume",
         "tags": [

--- a/src/lib/libraries/sounds.json
+++ b/src/lib/libraries/sounds.json
@@ -3856,17 +3856,6 @@
         ]
     },
     {
-        "name": "Whinny",
-        "md5": "f9513bacf2fc665de05a8dd9bcb88117.wav",
-        "sampleCount": 46108,
-        "rate": 22050,
-        "format": "adpcm",
-        "tags": [
-            "animals",
-            "horse"
-        ]
-    },
-    {
         "name": "Whistle Thump",
         "md5": "a3fab5681aedaa678982173ed9ca3d36.wav",
         "sampleCount": 14441,

--- a/src/lib/libraries/sounds.json
+++ b/src/lib/libraries/sounds.json
@@ -143,7 +143,7 @@
         ]
     },
     {
-        "name": "Alien Creak1",
+        "name": "Alien Creak 1",
         "md5": "0377a7476136e5e8c780c64a4828922d.wav",
         "sampleCount": 8045,
         "rate": 11025,
@@ -154,7 +154,7 @@
         ]
     },
     {
-        "name": "Alien Creak2",
+        "name": "Alien Creak 2",
         "md5": "21f82b7f1a83c501539c5031aea4fa8c.wav",
         "sampleCount": 8300,
         "rate": 11025,
@@ -312,7 +312,7 @@
         "tags": []
     },
     {
-        "name": "Beat Box1",
+        "name": "Beat Box 1",
         "md5": "663270af0235bf14c890ba184631675f.wav",
         "sampleCount": 5729,
         "rate": 11025,
@@ -325,7 +325,7 @@
         ]
     },
     {
-        "name": "Beat Box2",
+        "name": "Beat Box 2",
         "md5": "b9b8073f6aa9a60085ad11b0341a4af2.wav",
         "sampleCount": 5729,
         "rate": 11025,
@@ -924,15 +924,18 @@
         ]
     },
     {
-        "name": "Computer Beep",
+        "name": "Computer Beep 1",
         "md5": "28c76b6bebd04be1383fe9ba4933d263.wav",
         "sampleCount": 9536,
         "rate": 11025,
         "format": "",
-        "tags": []
+        "tags": [
+            "effects",
+            "electronic"
+        ]
     },
     {
-        "name": "Computer Beep2",
+        "name": "Computer Beep 2",
         "md5": "1da43f6d52d0615da8a250e28100a80d.wav",
         "sampleCount": 19200,
         "rate": 11025,
@@ -955,7 +958,7 @@
         ]
     },
     {
-        "name": "Cough1",
+        "name": "Cough 1",
         "md5": "98ec3e1eeb7893fca519aa52cc1ef3c1.wav",
         "sampleCount": 7516,
         "rate": 11025,
@@ -965,7 +968,7 @@
         ]
     },
     {
-        "name": "Cough2",
+        "name": "Cough 2",
         "md5": "467fe8ef3cab475af4b3088fd1261510.wav",
         "sampleCount": 16612,
         "rate": 22050,
@@ -1241,7 +1244,7 @@
         ]
     },
     {
-        "name": "Dance Celebrate",
+        "name": "Dance Celebrate 1",
         "md5": "0edb8fb88af19e6e17d0f8cf64c1d136.wav",
         "sampleCount": 176401,
         "rate": 22050,
@@ -1253,7 +1256,7 @@
         ]
     },
     {
-        "name": "Dance Celebrate2",
+        "name": "Dance Celebrate 2",
         "md5": "0edb8fb88af19e6e17d0f8cf64c1d136.wav",
         "sampleCount": 176401,
         "rate": 22050,
@@ -1383,7 +1386,7 @@
         ]
     },
     {
-        "name": "Dog1",
+        "name": "Dog 1",
         "md5": "b15adefc3c12f758b6dc6a045362532f.wav",
         "sampleCount": 3672,
         "rate": 22050,
@@ -1393,7 +1396,7 @@
         ]
     },
     {
-        "name": "Dog2",
+        "name": "Dog 2",
         "md5": "cd8fa8390b0efdd281882533fbfcfcfb.wav",
         "sampleCount": 3168,
         "rate": 22050,
@@ -1474,7 +1477,7 @@
         ]
     },
     {
-        "name": "Drum Bass1",
+        "name": "Drum Bass 1",
         "md5": "48328c874353617451e4c7902cc82817.wav",
         "sampleCount": 6528,
         "rate": 22050,
@@ -1482,7 +1485,7 @@
         "tags": []
     },
     {
-        "name": "Drum Bass2",
+        "name": "Drum Bass 2",
         "md5": "711a1270d1cf2e5de9b145ee539213e4.wav",
         "sampleCount": 3791,
         "rate": 22050,
@@ -1490,7 +1493,7 @@
         "tags": []
     },
     {
-        "name": "Drum Bass3",
+        "name": "Drum Bass 3",
         "md5": "c21704337b16359ea631b5f8eb48f765.wav",
         "sampleCount": 8576,
         "rate": 22050,
@@ -1582,7 +1585,7 @@
         ]
     },
     {
-        "name": "Drum Set1",
+        "name": "Drum Set 1",
         "md5": "38a2bb8129bddb4e8eaa06781cfa3040.wav",
         "sampleCount": 46080,
         "rate": 22050,
@@ -1595,7 +1598,7 @@
         ]
     },
     {
-        "name": "Drum Set2",
+        "name": "Drum Set 2",
         "md5": "738e871fda577295e8beb9021f670e28.wav",
         "sampleCount": 37440,
         "rate": 22050,
@@ -2233,7 +2236,7 @@
         ]
     },
     {
-        "name": "Guitar Chords1",
+        "name": "Guitar Chords 1",
         "md5": "2b1a5bc63580d8625cf24ff3d7622c0b.wav",
         "sampleCount": 123264,
         "rate": 22050,
@@ -2245,7 +2248,7 @@
         ]
     },
     {
-        "name": "Guitar Chords2",
+        "name": "Guitar Chords 2",
         "md5": "e956f15da397a13fae0c90d9fe4571fb.wav",
         "sampleCount": 158976,
         "rate": 22050,
@@ -2430,7 +2433,7 @@
         "tags": []
     },
     {
-        "name": "Human Beatbox1",
+        "name": "Human Beatbox 1",
         "md5": "37f37455c35fea71449926eb0bff05dd.wav",
         "sampleCount": 103680,
         "rate": 22050,
@@ -2444,7 +2447,7 @@
         ]
     },
     {
-        "name": "Human Beatbox2",
+        "name": "Human Beatbox 2",
         "md5": "f62e9f7deeb0e06268df6edffa14f5de.wav",
         "sampleCount": 62392,
         "rate": 22050,
@@ -2531,7 +2534,7 @@
         ]
     },
     {
-        "name": "Laser1",
+        "name": "Laser 1",
         "md5": "46571f8ec0f2cc91666c80e312579082.wav",
         "sampleCount": 516,
         "rate": 11025,
@@ -2539,7 +2542,7 @@
         "tags": []
     },
     {
-        "name": "Laser2",
+        "name": "Laser 2",
         "md5": "27654ed2e3224f0a3f77c244e4fae9aa.wav",
         "sampleCount": 755,
         "rate": 11025,
@@ -2547,7 +2550,7 @@
         "tags": []
     },
     {
-        "name": "Laugh1",
+        "name": "Laugh 1",
         "md5": "1e8e7fb94103282d02a4bb597248c788.wav",
         "sampleCount": 13547,
         "rate": 11025,
@@ -2558,7 +2561,7 @@
         ]
     },
     {
-        "name": "Laugh2",
+        "name": "Laugh 2",
         "md5": "8b1e025f38b0635f7e34e9afcace1b5e.wav",
         "sampleCount": 14662,
         "rate": 11025,
@@ -2569,7 +2572,7 @@
         ]
     },
     {
-        "name": "Laugh3",
+        "name": "Laugh 3",
         "md5": "86dee6fa7cd73095ba17e4d666a27804.wav",
         "sampleCount": 32065,
         "rate": 11025,
@@ -2688,7 +2691,7 @@
         ]
     },
     {
-        "name": "Medieval1",
+        "name": "Medieval 1",
         "md5": "9329fef6a59c5406d70cbe5837976d6b.wav",
         "sampleCount": 213120,
         "rate": 22050,
@@ -2700,7 +2703,7 @@
         ]
     },
     {
-        "name": "Medieval2",
+        "name": "Medieval 2",
         "md5": "7bc8c4a9d0525f04451356c6cc483dd7.wav",
         "sampleCount": 324288,
         "rate": 22050,
@@ -2712,7 +2715,7 @@
         ]
     },
     {
-        "name": "Meow",
+        "name": "Meow 1",
         "md5": "83c36d806dc92327b9e7049a565c6bff.wav",
         "sampleCount": 18688,
         "rate": 22050,
@@ -2723,7 +2726,7 @@
         ]
     },
     {
-        "name": "Meow2",
+        "name": "Meow 2",
         "md5": "cf51a0c4088942d95bcc20af13202710.wav",
         "sampleCount": 6512,
         "rate": 11025,
@@ -3085,7 +3088,7 @@
         ]
     },
     {
-        "name": "Scream1",
+        "name": "Scream 1",
         "md5": "10420bb2f5a3ab440f3b10fc8ea2b08b.wav",
         "sampleCount": 6628,
         "rate": 11025,
@@ -3096,7 +3099,7 @@
         ]
     },
     {
-        "name": "Scream2",
+        "name": "Scream 2",
         "md5": "e06e29398d770dae3cd57447439752ef.wav",
         "sampleCount": 17010,
         "rate": 22050,
@@ -3170,7 +3173,7 @@
         "tags": []
     },
     {
-        "name": "Singer1",
+        "name": "Singer 1",
         "md5": "92ee32e9be5ed7b69370fc38bb550597.wav",
         "sampleCount": 23653,
         "rate": 11025,
@@ -3183,7 +3186,7 @@
         ]
     },
     {
-        "name": "Singer2",
+        "name": "Singer 2",
         "md5": "5d3d2865906889e866b3edf154e6cf5d.wav",
         "sampleCount": 28636,
         "rate": 11025,
@@ -3256,7 +3259,7 @@
         ]
     },
     {
-        "name": "Snare Beatbox",
+        "name": "Snare Beatbox 1",
         "md5": "c642c4c00135d890998f351faec55498.wav",
         "sampleCount": 5630,
         "rate": 22050,
@@ -3264,7 +3267,7 @@
         "tags": []
     },
     {
-        "name": "Snare Beatbox2",
+        "name": "Snare Beatbox 2",
         "md5": "7ede1382b578d8fc32850b48d082d914.wav",
         "sampleCount": 4960,
         "rate": 22050,
@@ -3295,7 +3298,7 @@
         ]
     },
     {
-        "name": "Sneeze1",
+        "name": "Sneeze 1",
         "md5": "31600c613823710b66a74f4dd54c4cdd.wav",
         "sampleCount": 11818,
         "rate": 11025,
@@ -3306,7 +3309,7 @@
         ]
     },
     {
-        "name": "Sneeze2",
+        "name": "Sneeze 2",
         "md5": "42b5a31628083f3089f494f2ba644660.wav",
         "sampleCount": 15218,
         "rate": 22050,
@@ -3567,7 +3570,7 @@
         "tags": []
     },
     {
-        "name": "Techno",
+        "name": "Techno 1",
         "md5": "8700dac70c8e08f4a5d21411980304bb.wav",
         "sampleCount": 175680,
         "rate": 22050,
@@ -3579,7 +3582,7 @@
         ]
     },
     {
-        "name": "Techno2",
+        "name": "Techno 2",
         "md5": "693b428f3797561a11ad0ddbd897b5df.wav",
         "sampleCount": 327168,
         "rate": 22050,
@@ -3591,7 +3594,7 @@
         ]
     },
     {
-        "name": "Telephone Ring",
+        "name": "Telephone Ring 1",
         "md5": "276f97d3a9d0f9938b37db8225af97f5.wav",
         "sampleCount": 74666,
         "rate": 22050,
@@ -3602,7 +3605,7 @@
         ]
     },
     {
-        "name": "Telephone Ring2",
+        "name": "Telephone Ring 2",
         "md5": "d0096aa9ecc28c0729a99b0349399371.wav",
         "sampleCount": 25373,
         "rate": 22050,
@@ -3613,7 +3616,7 @@
         ]
     },
     {
-        "name": "Teleport",
+        "name": "Teleport 1",
         "md5": "2d625187556c4323169fc1a8f29a7a7d.wav",
         "sampleCount": 110250,
         "rate": 22050,
@@ -3626,7 +3629,7 @@
         ]
     },
     {
-        "name": "Teleport2",
+        "name": "Teleport 2",
         "md5": "7e5019890a930f3535604cf9cad63ba4.wav",
         "sampleCount": 15898,
         "rate": 22050,
@@ -3639,7 +3642,7 @@
         ]
     },
     {
-        "name": "Teleport3",
+        "name": "Teleport 3",
         "md5": "58f76f299a1df2373d4fca3614221186.wav",
         "sampleCount": 95440,
         "rate": 22050,
@@ -3773,7 +3776,7 @@
         ]
     },
     {
-        "name": "Trumpet1",
+        "name": "Trumpet 1",
         "md5": "851c9e2c38e5e71922231a8f64c37e70.wav",
         "sampleCount": 25800,
         "rate": 11025,
@@ -3785,7 +3788,7 @@
         ]
     },
     {
-        "name": "Trumpet2",
+        "name": "Trumpet 2",
         "md5": "dd73f891deca0241b800ed203408b6f3.wav",
         "sampleCount": 23424,
         "rate": 11025,
@@ -3950,7 +3953,7 @@
         "tags": []
     },
     {
-        "name": "Xylo1",
+        "name": "Xylo 1",
         "md5": "6ac484e97c1c1fe1384642e26a125e70.wav",
         "sampleCount": 238232,
         "rate": 22050,
@@ -3961,7 +3964,7 @@
         ]
     },
     {
-        "name": "Xylo2",
+        "name": "Xylo 2",
         "md5": "d38fc904a0acfc27854baf7335ed46f9.wav",
         "sampleCount": 246552,
         "rate": 22050,
@@ -3972,7 +3975,7 @@
         ]
     },
     {
-        "name": "Xylo3",
+        "name": "Xylo 3",
         "md5": "786a7a66e96c801ca2efed59b20bf025.wav",
         "sampleCount": 208832,
         "rate": 22050,
@@ -3983,7 +3986,7 @@
         ]
     },
     {
-        "name": "Xylo4",
+        "name": "Xylo 4",
         "md5": "b3ee7b6515eaf85aebab3c624c1423e9.wav",
         "sampleCount": 77184,
         "rate": 22050,

--- a/src/lib/libraries/sprites.json
+++ b/src/lib/libraries/sprites.json
@@ -390,7 +390,7 @@
         }
     },
     {
-        "name": "Arrow1",
+        "name": "Arrow",
         "md5": "62f8794dd120e9b4ead4d098d50fc64b.svg",
         "type": "sprite",
         "tags": [
@@ -405,7 +405,7 @@
             1
         ],
         "json": {
-            "objName": "Arrow1",
+            "objName": "Arrow",
             "sounds": [
                 {
                     "soundName": "pop",
@@ -418,7 +418,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "arrow1-a",
+                    "costumeName": "arrow-a",
                     "baseLayerID": -1,
                     "baseLayerMD5": "62f8794dd120e9b4ead4d098d50fc64b.svg",
                     "bitmapResolution": 1,
@@ -426,7 +426,7 @@
                     "rotationCenterY": 23
                 },
                 {
-                    "costumeName": "arrow1-b",
+                    "costumeName": "arrow-b",
                     "baseLayerID": -1,
                     "baseLayerMD5": "a157dc7e33d7c7a048af933de999e397.svg",
                     "bitmapResolution": 1,
@@ -434,7 +434,7 @@
                     "rotationCenterY": 23
                 },
                 {
-                    "costumeName": "arrow1-c",
+                    "costumeName": "arrow-c",
                     "baseLayerID": -1,
                     "baseLayerMD5": "d3b389e91f7beb22b2b1a80af09990ee.svg",
                     "bitmapResolution": 1,
@@ -442,7 +442,7 @@
                     "rotationCenterY": 28
                 },
                 {
-                    "costumeName": "arrow1-d",
+                    "costumeName": "arrow-d",
                     "baseLayerID": -1,
                     "baseLayerMD5": "412717ff731e9f19003a5840054057eb.svg",
                     "bitmapResolution": 1,
@@ -749,7 +749,7 @@
         }
     },
     {
-        "name": "Balloon1",
+        "name": "Balloon",
         "md5": "bc96a1fb5fe794377acd44807e421ce2.svg",
         "type": "sprite",
         "tags": [
@@ -768,7 +768,7 @@
             1
         ],
         "json": {
-            "objName": "Balloon1",
+            "objName": "Balloon",
             "sounds": [
                 {
                     "soundName": "Pop",
@@ -781,7 +781,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "balloon1-a",
+                    "costumeName": "balloon-a",
                     "baseLayerID": -1,
                     "baseLayerMD5": "bc96a1fb5fe794377acd44807e421ce2.svg",
                     "bitmapResolution": 1,
@@ -789,7 +789,7 @@
                     "rotationCenterY": 94
                 },
                 {
-                    "costumeName": "balloon1-b",
+                    "costumeName": "balloon-b",
                     "baseLayerID": -1,
                     "baseLayerMD5": "d7bb51d9c38af6314bd2b4058d2a592d.svg",
                     "bitmapResolution": 1,
@@ -797,7 +797,7 @@
                     "rotationCenterY": 94
                 },
                 {
-                    "costumeName": "balloon1-c",
+                    "costumeName": "balloon-c",
                     "baseLayerID": -1,
                     "baseLayerMD5": "247cef27b665d77d9efaca69327cae77.svg",
                     "bitmapResolution": 1,
@@ -1403,7 +1403,7 @@
             "objName": "Bell",
             "sounds": [
                 {
-                    "soundName": "xylo1",
+                    "soundName": "xylo 1",
                     "soundID": -1,
                     "md5": "6ac484e97c1c1fe1384642e26a125e70.wav",
                     "sampleCount": 238232,
@@ -1421,7 +1421,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "bell1",
+                    "costumeName": "bell",
                     "baseLayerID": -1,
                     "baseLayerMD5": "f35056c772395455d703773657e1da6e.svg",
                     "bitmapResolution": 1,
@@ -1548,7 +1548,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "bowl-a",
+                    "costumeName": "bowl",
                     "baseLayerID": -1,
                     "baseLayerMD5": "86f616639846f06fef29931e6b9b59de.svg",
                     "bitmapResolution": 1,
@@ -1858,7 +1858,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "butterfly1-a",
+                    "costumeName": "butterfly 1-a",
                     "baseLayerID": -1,
                     "baseLayerMD5": "8419d4851defd1e862e4f7c1699d2190.svg",
                     "bitmapResolution": 1,
@@ -1866,7 +1866,7 @@
                     "rotationCenterY": 49
                 },
                 {
-                    "costumeName": "butterfly1-b",
+                    "costumeName": "butterfly 1-b",
                     "baseLayerID": -1,
                     "baseLayerMD5": "0873714e8d55d9eeb0bc8e8ab64441cc.svg",
                     "bitmapResolution": 1,
@@ -1874,7 +1874,7 @@
                     "rotationCenterY": 49
                 },
                 {
-                    "costumeName": "butterfly1-c",
+                    "costumeName": "butterfly 1-c",
                     "baseLayerID": -1,
                     "baseLayerMD5": "9c422631ca8d46413487f5dd627b65c6.svg",
                     "bitmapResolution": 1,
@@ -1925,7 +1925,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "butterfly2-a",
+                    "costumeName": "butterfly 2-a",
                     "baseLayerID": -1,
                     "baseLayerMD5": "836d4cc7889f4a1cbcb0303934f31f79.svg",
                     "bitmapResolution": 1,
@@ -1933,7 +1933,7 @@
                     "rotationCenterY": 75
                 },
                 {
-                    "costumeName": "butterfly2-b",
+                    "costumeName": "butterfly 2-b",
                     "baseLayerID": -1,
                     "baseLayerMD5": "55dd0671a359d7c35f7b78f4176660e8.svg",
                     "bitmapResolution": 1,
@@ -1953,7 +1953,7 @@
         }
     },
     {
-        "name": "Button1",
+        "name": "Button 1",
         "md5": "7ef67c5bc8cf7df64fdb3b1d6b250f71.svg",
         "type": "sprite",
         "tags": [
@@ -1968,7 +1968,7 @@
             1
         ],
         "json": {
-            "objName": "Button1",
+            "objName": "Button 1",
             "sounds": [
                 {
                     "soundName": "pop",
@@ -1981,7 +1981,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "button1",
+                    "costumeName": "button 1",
                     "baseLayerID": -1,
                     "baseLayerMD5": "7ef67c5bc8cf7df64fdb3b1d6b250f71.svg",
                     "bitmapResolution": 1,
@@ -2001,7 +2001,7 @@
         }
     },
     {
-        "name": "Button2",
+        "name": "Button 2",
         "md5": "c0051ff23e9aae78295964206793c1e3.svg",
         "type": "sprite",
         "tags": [
@@ -2015,7 +2015,7 @@
             1
         ],
         "json": {
-            "objName": "Button2",
+            "objName": "Button 2",
             "sounds": [
                 {
                     "soundName": "pop",
@@ -2028,7 +2028,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "button2-a",
+                    "costumeName": "button 2-a",
                     "baseLayerID": -1,
                     "baseLayerMD5": "c0051ff23e9aae78295964206793c1e3.svg",
                     "bitmapResolution": 1,
@@ -2036,7 +2036,7 @@
                     "rotationCenterY": 72
                 },
                 {
-                    "costumeName": "button2-b",
+                    "costumeName": "button 2-b",
                     "baseLayerID": -1,
                     "baseLayerMD5": "712a561dc0ad66e348b8247e566b50ef.svg",
                     "bitmapResolution": 1,
@@ -2056,7 +2056,7 @@
         }
     },
     {
-        "name": "Button3",
+        "name": "Button 3",
         "md5": "ffb2a9c21084c58fdb677c8d12a97519.svg",
         "type": "sprite",
         "tags": [
@@ -2071,7 +2071,7 @@
             1
         ],
         "json": {
-            "objName": "Button3",
+            "objName": "Button 3",
             "sounds": [
                 {
                     "soundName": "pop",
@@ -2084,7 +2084,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "button3-a",
+                    "costumeName": "button 3-a",
                     "baseLayerID": -1,
                     "baseLayerMD5": "ffb2a9c21084c58fdb677c8d12a97519.svg",
                     "bitmapResolution": 1,
@@ -2092,7 +2092,7 @@
                     "rotationCenterY": 72
                 },
                 {
-                    "costumeName": "button3-b",
+                    "costumeName": "button 3-b",
                     "baseLayerID": -1,
                     "baseLayerMD5": "7a9ccb55e4da36f48811ab125d2492e0.svg",
                     "bitmapResolution": 1,
@@ -2112,7 +2112,7 @@
         }
     },
     {
-        "name": "Button4",
+        "name": "Button 4",
         "md5": "ecfe263bc256349777e571eaf39761d4.svg",
         "type": "sprite",
         "tags": [
@@ -2125,7 +2125,7 @@
             1
         ],
         "json": {
-            "objName": "Button4",
+            "objName": "Button 4",
             "sounds": [
                 {
                     "soundName": "pop",
@@ -2138,7 +2138,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "button4-a",
+                    "costumeName": "button 4-a",
                     "baseLayerID": -1,
                     "baseLayerMD5": "ecfe263bc256349777e571eaf39761d4.svg",
                     "bitmapResolution": 1,
@@ -2146,7 +2146,7 @@
                     "rotationCenterY": 34
                 },
                 {
-                    "costumeName": "button4-b",
+                    "costumeName": "button 4-b",
                     "baseLayerID": -1,
                     "baseLayerMD5": "9c49edde00b80cd22d636a0577a9b1c9.svg",
                     "bitmapResolution": 1,
@@ -2166,7 +2166,7 @@
         }
     },
     {
-        "name": "Button5",
+        "name": "Button 5",
         "md5": "71e97245b7be4fd6fe3ba8cdeecadaf1.svg",
         "type": "sprite",
         "tags": [
@@ -2182,7 +2182,7 @@
             1
         ],
         "json": {
-            "objName": "Button5",
+            "objName": "Button 5",
             "sounds": [
                 {
                     "soundName": "pop",
@@ -2195,7 +2195,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "button5-a",
+                    "costumeName": "button 5-a",
                     "baseLayerID": -1,
                     "baseLayerMD5": "71e97245b7be4fd6fe3ba8cdeecadaf1.svg",
                     "bitmapResolution": 1,
@@ -2203,7 +2203,7 @@
                     "rotationCenterY": 72
                 },
                 {
-                    "costumeName": "button5-b",
+                    "costumeName": "button 5-b",
                     "baseLayerID": -1,
                     "baseLayerMD5": "54cd55512f7571060e6e64168e541222.svg",
                     "bitmapResolution": 1,
@@ -2556,7 +2556,7 @@
             "objName": "Cat 2",
             "sounds": [
                 {
-                    "soundName": "meow2",
+                    "soundName": "meow 2",
                     "soundID": -1,
                     "md5": "cf51a0c4088942d95bcc20af13202710.wav",
                     "sampleCount": 6512,
@@ -3136,7 +3136,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "cloud-a",
+                    "costumeName": "clouds-a",
                     "baseLayerID": -1,
                     "baseLayerMD5": "c7d7de8e29179407f03b054fa640f4d0.svg",
                     "bitmapResolution": 1,
@@ -3144,7 +3144,7 @@
                     "rotationCenterY": 19
                 },
                 {
-                    "costumeName": "cloud-b",
+                    "costumeName": "clouds-b",
                     "baseLayerID": -1,
                     "baseLayerMD5": "d8595350ebb460494c9189dabb968336.svg",
                     "bitmapResolution": 1,
@@ -3152,7 +3152,7 @@
                     "rotationCenterY": 20
                 },
                 {
-                    "costumeName": "cloud-c",
+                    "costumeName": "clouds-c",
                     "baseLayerID": -1,
                     "baseLayerMD5": "395fc991e64ac0a4aa46758ab4bc65cb.svg",
                     "bitmapResolution": 1,
@@ -3160,7 +3160,7 @@
                     "rotationCenterY": 9
                 },
                 {
-                    "costumeName": "cloud-d",
+                    "costumeName": "clouds-d",
                     "baseLayerID": -1,
                     "baseLayerMD5": "1767e704acb11ffa409f77cc79ba7e86.svg",
                     "bitmapResolution": 1,
@@ -3180,7 +3180,7 @@
         }
     },
     {
-        "name": "Convertible",
+        "name": "Convertible 1",
         "md5": "5b883f396844ff5cfecd7c95553fa4fb.png",
         "type": "sprite",
         "tags": [
@@ -3193,7 +3193,7 @@
             1
         ],
         "json": {
-            "objName": "Convertible",
+            "objName": "Convertible 1",
             "sounds": [
                 {
                     "soundName": "pop",
@@ -3206,7 +3206,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "convertible",
+                    "costumeName": "convertible 1",
                     "baseLayerID": -1,
                     "baseLayerMD5": "5b883f396844ff5cfecd7c95553fa4fb.png",
                     "bitmapResolution": 2,
@@ -3253,7 +3253,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "convertible 3",
+                    "costumeName": "convertible 2",
                     "baseLayerID": -1,
                     "baseLayerMD5": "b6ac3c9e1789cba2302d2ef82d62d019.svg",
                     "bitmapResolution": 1,
@@ -3520,7 +3520,7 @@
                     "rotationCenterY": 240
                 },
                 {
-                    "costumeName": "dm top R leg2",
+                    "costumeName": "dm top R leg 2",
                     "baseLayerID": -1,
                     "baseLayerMD5": "fcb8c2b6cf9b7e6ce9df521b2486deb3.png",
                     "bitmapResolution": 2,
@@ -3800,7 +3800,7 @@
         }
     },
     {
-        "name": "Dinosaur1",
+        "name": "Dinosaur 1",
         "md5": "e70ab4de006f3df64e776abf912a62be.svg",
         "type": "sprite",
         "tags": [
@@ -3814,7 +3814,7 @@
             1
         ],
         "json": {
-            "objName": "Dinosaur1",
+            "objName": "Dinosaur 1",
             "sounds": [
                 {
                     "soundName": "pop",
@@ -3827,7 +3827,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "dinosaur1-a",
+                    "costumeName": "dinosaur 1-a",
                     "baseLayerID": -1,
                     "baseLayerMD5": "e70ab4de006f3df64e776abf912a62be.svg",
                     "bitmapResolution": 1,
@@ -3835,7 +3835,7 @@
                     "rotationCenterY": 92
                 },
                 {
-                    "costumeName": "dinosaur1-b",
+                    "costumeName": "dinosaur 1-b",
                     "baseLayerID": -1,
                     "baseLayerMD5": "af2d8211a65dce9871d49fa70671ce0c.svg",
                     "bitmapResolution": 1,
@@ -3843,7 +3843,7 @@
                     "rotationCenterY": 47
                 },
                 {
-                    "costumeName": "dinosaur1-c",
+                    "costumeName": "dinosaur 1-c",
                     "baseLayerID": -1,
                     "baseLayerMD5": "a2bb28d5ba55ba997bec63772437cecf.svg",
                     "bitmapResolution": 1,
@@ -3851,7 +3851,7 @@
                     "rotationCenterY": 91
                 },
                 {
-                    "costumeName": "dinosaur1-d",
+                    "costumeName": "dinosaur 1-d",
                     "baseLayerID": -1,
                     "baseLayerMD5": "91f3dba45e8cec7bdff31ed5acde2c85.svg",
                     "bitmapResolution": 1,
@@ -3871,7 +3871,7 @@
         }
     },
     {
-        "name": "Dinosaur2",
+        "name": "Dinosaur 2",
         "md5": "f49719e8f2440f5d328f2604e97eb71d.svg",
         "type": "sprite",
         "tags": [
@@ -3886,7 +3886,7 @@
             1
         ],
         "json": {
-            "objName": "Dinosaur2",
+            "objName": "Dinosaur 2",
             "sounds": [
                 {
                     "soundName": "pop",
@@ -3899,7 +3899,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "dinosaur2-a",
+                    "costumeName": "dinosaur 2-a",
                     "baseLayerID": -1,
                     "baseLayerMD5": "f49719e8f2440f5d328f2604e97eb71d.svg",
                     "bitmapResolution": 1,
@@ -3907,7 +3907,7 @@
                     "rotationCenterY": 67
                 },
                 {
-                    "costumeName": "dinosaur2-b",
+                    "costumeName": "dinosaur 2-b",
                     "baseLayerID": -1,
                     "baseLayerMD5": "1af6b3af3bf2cda862bbe01034a336bb.svg",
                     "bitmapResolution": 1,
@@ -3915,7 +3915,7 @@
                     "rotationCenterY": 67
                 },
                 {
-                    "costumeName": "dinosaur2-c",
+                    "costumeName": "dinosaur 2-c",
                     "baseLayerID": -1,
                     "baseLayerMD5": "e83b30a4517bbe155e2b4a6367c8f70b.svg",
                     "bitmapResolution": 1,
@@ -3923,7 +3923,7 @@
                     "rotationCenterY": 67
                 },
                 {
-                    "costumeName": "dinosaur2-d",
+                    "costumeName": "dinosaur 2-d",
                     "baseLayerID": -1,
                     "baseLayerMD5": "8244f1fb159237179d1caaa69c070060.svg",
                     "bitmapResolution": 1,
@@ -3943,7 +3943,7 @@
         }
     },
     {
-        "name": "Dinosaur3",
+        "name": "Dinosaur 3",
         "md5": "c4867c44f38df5bde472844878d5beea.svg",
         "type": "sprite",
         "tags": [
@@ -3959,7 +3959,7 @@
             1
         ],
         "json": {
-            "objName": "Dinosaur3",
+            "objName": "Dinosaur 3",
             "sounds": [
                 {
                     "soundName": "pop",
@@ -3972,7 +3972,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "dinosaur3-a",
+                    "costumeName": "dinosaur 3-a",
                     "baseLayerID": -1,
                     "baseLayerMD5": "c4867c44f38df5bde472844878d5beea.svg",
                     "bitmapResolution": 1,
@@ -3980,7 +3980,7 @@
                     "rotationCenterY": 42
                 },
                 {
-                    "costumeName": "dinosaur3-b",
+                    "costumeName": "dinosaur 3-b",
                     "baseLayerID": -1,
                     "baseLayerMD5": "b682c1e58ea1c6bea737670f57517b6f.svg",
                     "bitmapResolution": 1,
@@ -3988,7 +3988,7 @@
                     "rotationCenterY": 59
                 },
                 {
-                    "costumeName": "dinosaur3-c",
+                    "costumeName": "dinosaur 3-c",
                     "baseLayerID": -1,
                     "baseLayerMD5": "47a617ca48f4782efeeb60199cff801e.svg",
                     "bitmapResolution": 1,
@@ -3996,7 +3996,7 @@
                     "rotationCenterY": 59
                 },
                 {
-                    "costumeName": "dinosaur3-d",
+                    "costumeName": "dinosaur 3-d",
                     "baseLayerID": -1,
                     "baseLayerMD5": "710ff3380d6872b04785db97dc0565c6.svg",
                     "bitmapResolution": 1,
@@ -4004,7 +4004,7 @@
                     "rotationCenterY": 65
                 },
                 {
-                    "costumeName": "dinosaur3-e",
+                    "costumeName": "dinosaur 3-e",
                     "baseLayerID": -1,
                     "baseLayerMD5": "6f40025c1157f37858adf7fa85090e64.svg",
                     "bitmapResolution": 1,
@@ -4024,7 +4024,7 @@
         }
     },
     {
-        "name": "Dinosaur4",
+        "name": "Dinosaur 4",
         "md5": "d87b5e3c45f5d234c7aa47107c788f18.svg",
         "type": "sprite",
         "tags": [
@@ -4041,7 +4041,7 @@
             1
         ],
         "json": {
-            "objName": "Dinosaur4",
+            "objName": "Dinosaur 4",
             "sounds": [
                 {
                     "soundName": "pop",
@@ -4054,7 +4054,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "dinosaur4-a",
+                    "costumeName": "dinosaur 4-a",
                     "baseLayerID": 0,
                     "baseLayerMD5": "d87b5e3c45f5d234c7aa47107c788f18.svg",
                     "bitmapResolution": 1,
@@ -4062,7 +4062,7 @@
                     "rotationCenterY": 52
                 },
                 {
-                    "costumeName": "dinosaur4-b",
+                    "costumeName": "dinosaur 4-b",
                     "baseLayerID": -1,
                     "baseLayerMD5": "cfe906702bbd30bc3bb8acb53079b6b0.svg",
                     "bitmapResolution": 1,
@@ -4070,7 +4070,7 @@
                     "rotationCenterY": 52
                 },
                 {
-                    "costumeName": "dinosaur4-c",
+                    "costumeName": "dinosaur 4-c",
                     "baseLayerID": -1,
                     "baseLayerMD5": "1879b07cfe788b0258afada17aa46973.svg",
                     "bitmapResolution": 1,
@@ -4078,7 +4078,7 @@
                     "rotationCenterY": 52
                 },
                 {
-                    "costumeName": "dinosaur4-d",
+                    "costumeName": "dinosaur 4-d",
                     "baseLayerID": -1,
                     "baseLayerMD5": "52c17657698ab82881ed3ccf83080684.svg",
                     "bitmapResolution": 1,
@@ -4098,7 +4098,7 @@
         }
     },
     {
-        "name": "Dinosaur5",
+        "name": "Dinosaur 5",
         "md5": "42e3bf118c775ba54239af4276800a0a.png",
         "type": "sprite",
         "tags": [
@@ -4112,7 +4112,7 @@
             2
         ],
         "json": {
-            "objName": "Dinosaur5",
+            "objName": "Dinosaur 5",
             "sounds": [
                 {
                     "soundName": "dance funky",
@@ -4209,7 +4209,7 @@
         }
     },
     {
-        "name": "Diver1",
+        "name": "Diver 1",
         "md5": "853803d5600b66538474909c5438c8ee.svg",
         "type": "sprite",
         "tags": [
@@ -4226,7 +4226,7 @@
             1
         ],
         "json": {
-            "objName": "Diver1",
+            "objName": "Diver 1",
             "sounds": [
                 {
                     "soundName": "pop",
@@ -4239,7 +4239,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "diver1",
+                    "costumeName": "diver 1",
                     "baseLayerID": -1,
                     "baseLayerMD5": "853803d5600b66538474909c5438c8ee.svg",
                     "bitmapResolution": 1,
@@ -4259,7 +4259,7 @@
         }
     },
     {
-        "name": "Diver2",
+        "name": "Diver 2",
         "md5": "248d3e69ada69a64b1077149ef6a931a.svg",
         "type": "sprite",
         "tags": [
@@ -4276,7 +4276,7 @@
             1
         ],
         "json": {
-            "objName": "Diver2",
+            "objName": "Diver 2",
             "sounds": [
                 {
                     "soundName": "pop",
@@ -4289,7 +4289,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "diver2",
+                    "costumeName": "diver 2",
                     "baseLayerID": -1,
                     "baseLayerMD5": "248d3e69ada69a64b1077149ef6a931a.svg",
                     "bitmapResolution": 1,
@@ -4309,7 +4309,7 @@
         }
     },
     {
-        "name": "Dog1",
+        "name": "Dog 1",
         "md5": "39ddefa0cc58f3b1b06474d63d81ef56.svg",
         "type": "sprite",
         "tags": [
@@ -4324,10 +4324,10 @@
             1
         ],
         "json": {
-            "objName": "Dog1",
+            "objName": "Dog 1",
             "sounds": [
                 {
-                    "soundName": "dog1",
+                    "soundName": "dog 1",
                     "soundID": -1,
                     "md5": "b15adefc3c12f758b6dc6a045362532f.wav",
                     "sampleCount": 3672,
@@ -4337,7 +4337,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "dog1-a",
+                    "costumeName": "dog 1-a",
                     "baseLayerID": -1,
                     "baseLayerMD5": "39ddefa0cc58f3b1b06474d63d81ef56.svg",
                     "bitmapResolution": 1,
@@ -4345,7 +4345,7 @@
                     "rotationCenterY": 80
                 },
                 {
-                    "costumeName": "dog1-b",
+                    "costumeName": "dog 1-b",
                     "baseLayerID": -1,
                     "baseLayerMD5": "598f4aa3d8f671375d1d2b3acf753416.svg",
                     "bitmapResolution": 1,
@@ -4365,7 +4365,7 @@
         }
     },
     {
-        "name": "Dog2",
+        "name": "Dog 2",
         "md5": "e921f865b19b27cd99e16a341dbf09c2.svg",
         "type": "sprite",
         "tags": [
@@ -4380,10 +4380,10 @@
             1
         ],
         "json": {
-            "objName": "Dog2",
+            "objName": "Dog 2",
             "sounds": [
                 {
-                    "soundName": "dog1",
+                    "soundName": "dog 1",
                     "soundID": -1,
                     "md5": "b15adefc3c12f758b6dc6a045362532f.wav",
                     "sampleCount": 3672,
@@ -4393,7 +4393,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "dog2-a",
+                    "costumeName": "dog 2-a",
                     "baseLayerID": -1,
                     "baseLayerMD5": "e921f865b19b27cd99e16a341dbf09c2.svg",
                     "bitmapResolution": 1,
@@ -4401,7 +4401,7 @@
                     "rotationCenterY": 75
                 },
                 {
-                    "costumeName": "dog2-b",
+                    "costumeName": "dog 2-b",
                     "baseLayerID": -1,
                     "baseLayerMD5": "891f2fb7daf79ba8b224a9173eeb0a63.svg",
                     "bitmapResolution": 1,
@@ -4409,7 +4409,7 @@
                     "rotationCenterY": 75
                 },
                 {
-                    "costumeName": "dog2-c",
+                    "costumeName": "dog 2-c",
                     "baseLayerID": -1,
                     "baseLayerMD5": "cd236d5eef4431dea82983ac9eec406b.svg",
                     "bitmapResolution": 1,
@@ -4950,7 +4950,7 @@
             "objName": "Drum Kit",
             "sounds": [
                 {
-                    "soundName": "Drum Bass1",
+                    "soundName": "Drum Bass 1",
                     "soundID": -1,
                     "md5": "48328c874353617451e4c7902cc82817.wav",
                     "sampleCount": 6528,
@@ -4958,7 +4958,7 @@
                     "format": ""
                 },
                 {
-                    "soundName": "Drum Bass2",
+                    "soundName": "Drum Bass 2",
                     "soundID": -1,
                     "md5": "711a1270d1cf2e5de9b145ee539213e4.wav",
                     "sampleCount": 3791,
@@ -4966,7 +4966,7 @@
                     "format": "adpcm"
                 },
                 {
-                    "soundName": "Drum Bass3",
+                    "soundName": "Drum Bass 3",
                     "soundID": -1,
                     "md5": "c21704337b16359ea631b5f8eb48f765.wav",
                     "sampleCount": 8576,
@@ -6300,7 +6300,7 @@
         }
     },
     {
-        "name": "Frog",
+        "name": "Frog 1",
         "md5": "285483a688eed2ff8010c65112f99c41.svg",
         "type": "sprite",
         "tags": [
@@ -6317,7 +6317,7 @@
             1
         ],
         "json": {
-            "objName": "Frog",
+            "objName": "Frog 1",
             "sounds": [
                 {
                     "soundName": "pop",
@@ -6330,7 +6330,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "frog",
+                    "costumeName": "frog 1",
                     "baseLayerID": -1,
                     "baseLayerMD5": "285483a688eed2ff8010c65112f99c41.svg",
                     "bitmapResolution": 1,
@@ -6350,7 +6350,7 @@
         }
     },
     {
-        "name": "Frog 2 ",
+        "name": "Frog 2",
         "md5": "07160d455202e95f5b4b5c842eff6788.svg",
         "type": "sprite",
         "tags": [
@@ -6366,7 +6366,7 @@
             1
         ],
         "json": {
-            "objName": "Frog 2 ",
+            "objName": "Frog 2",
             "sounds": [
                 {
                     "soundName": "pop",
@@ -6730,7 +6730,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "Giga walk1",
+                    "costumeName": "Giga walk 1",
                     "baseLayerID": -1,
                     "baseLayerMD5": "f76bc420011db2cdb2de378c1536f6da.svg",
                     "bitmapResolution": 1,
@@ -6738,7 +6738,7 @@
                     "rotationCenterY": 107
                 },
                 {
-                    "costumeName": "Giga walk2",
+                    "costumeName": "Giga walk 2",
                     "baseLayerID": -1,
                     "baseLayerMD5": "43b5874e8a54f93bd02727f0abf6905b.svg",
                     "bitmapResolution": 1,
@@ -6746,7 +6746,7 @@
                     "rotationCenterY": 107
                 },
                 {
-                    "costumeName": "Giga walk3",
+                    "costumeName": "Giga walk 3",
                     "baseLayerID": -1,
                     "baseLayerMD5": "9aab3bbb375765391978be4f6d478ab3.svg",
                     "bitmapResolution": 1,
@@ -7486,7 +7486,7 @@
         }
     },
     {
-        "name": "Guitar-electric1",
+        "name": "Guitar-electric 1",
         "md5": "b2b469b9d11fd23bdd671eab94dc58ff.svg",
         "type": "sprite",
         "tags": [
@@ -7499,7 +7499,7 @@
             8
         ],
         "json": {
-            "objName": "Guitar-electric1",
+            "objName": "Guitar-electric 1",
             "sounds": [
                 {
                     "soundName": "C Elec Guitar",
@@ -7568,7 +7568,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "guitar-electric1-a",
+                    "costumeName": "guitar-electric 1-a",
                     "baseLayerID": -1,
                     "baseLayerMD5": "b2b469b9d11fd23bdd671eab94dc58ff.svg",
                     "bitmapResolution": 1,
@@ -7576,7 +7576,7 @@
                     "rotationCenterY": 85
                 },
                 {
-                    "costumeName": "guitar-electric1-b",
+                    "costumeName": "guitar-electric 1-b",
                     "baseLayerID": -1,
                     "baseLayerMD5": "3632184c19c66a088a99568570d61b13.svg",
                     "bitmapResolution": 1,
@@ -7596,7 +7596,7 @@
         }
     },
     {
-        "name": "Guitar-electric2",
+        "name": "Guitar-electric 2",
         "md5": "1fc433b89038f9e16092c9f4d7514cca.svg",
         "type": "sprite",
         "tags": [
@@ -7609,7 +7609,7 @@
             8
         ],
         "json": {
-            "objName": "Guitar-electric2",
+            "objName": "Guitar-electric 2",
             "sounds": [
                 {
                     "soundName": "C Elec Guitar",
@@ -7678,7 +7678,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "guitar-electric2-a",
+                    "costumeName": "guitar-electric 2-a",
                     "baseLayerID": -1,
                     "baseLayerMD5": "1fc433b89038f9e16092c9f4d7514cca.svg",
                     "bitmapResolution": 1,
@@ -7686,7 +7686,7 @@
                     "rotationCenterY": 94
                 },
                 {
-                    "costumeName": "guitar-electric2-b",
+                    "costumeName": "guitar-electric 2-b",
                     "baseLayerID": -1,
                     "baseLayerMD5": "7b843dbc93d4b2ea31fa67cca3d5077c.svg",
                     "bitmapResolution": 1,
@@ -7900,7 +7900,7 @@
         }
     },
     {
-        "name": "Hat1 ",
+        "name": "Hat",
         "md5": "52540f9dba4537f79f1ad3067d44e3f6.svg",
         "type": "sprite",
         "tags": [
@@ -7914,7 +7914,7 @@
             1
         ],
         "json": {
-            "objName": "Hat1 ",
+            "objName": "Hat",
             "sounds": [
                 {
                     "soundName": "pop",
@@ -8359,7 +8359,7 @@
         }
     },
     {
-        "name": "Hippo1",
+        "name": "Hippo",
         "md5": "c1353c4a5eec5e6f32ed053e6f6e8f99.svg",
         "type": "sprite",
         "tags": [
@@ -8378,7 +8378,7 @@
             1
         ],
         "json": {
-            "objName": "Hippo1",
+            "objName": "Hippo",
             "sounds": [
                 {
                     "soundName": "meow",
@@ -8391,7 +8391,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "hippo1-a",
+                    "costumeName": "hippo-a",
                     "baseLayerID": -1,
                     "baseLayerMD5": "c1353c4a5eec5e6f32ed053e6f6e8f99.svg",
                     "bitmapResolution": 1,
@@ -8399,7 +8399,7 @@
                     "rotationCenterY": 65
                 },
                 {
-                    "costumeName": "hippo1-b",
+                    "costumeName": "hippo-b",
                     "baseLayerID": -1,
                     "baseLayerMD5": "e65ed93bbb9cccf698fc7e774ab609a6.svg",
                     "bitmapResolution": 1,
@@ -8930,7 +8930,7 @@
             "objName": "Jouvi Dance",
             "sounds": [
                 {
-                    "soundName": "dance celebrate2",
+                    "soundName": "dance celebrate 2",
                     "soundID": -1,
                     "md5": "0edb8fb88af19e6e17d0f8cf64c1d136.wav",
                     "sampleCount": 176401,
@@ -9541,7 +9541,7 @@
         }
     },
     {
-        "name": "Ladybug1",
+        "name": "Ladybug 1",
         "md5": "f16a1ccc69a4a8190a927f1595aa7bfa.svg",
         "type": "sprite",
         "tags": [
@@ -9556,7 +9556,7 @@
             1
         ],
         "json": {
-            "objName": "Ladybug1",
+            "objName": "Ladybug 1",
             "sounds": [
                 {
                     "soundName": "pop",
@@ -9569,7 +9569,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "ladybug2",
+                    "costumeName": "ladybug 1",
                     "baseLayerID": -1,
                     "baseLayerMD5": "f16a1ccc69a4a8190a927f1595aa7bfa.svg",
                     "bitmapResolution": 1,
@@ -9589,7 +9589,7 @@
         }
     },
     {
-        "name": "Ladybug2",
+        "name": "Ladybug 2",
         "md5": "c018a3eed966d5f92c69f2188dfd2aae.svg",
         "type": "sprite",
         "tags": [
@@ -9605,7 +9605,7 @@
             1
         ],
         "json": {
-            "objName": "Ladybug2",
+            "objName": "Ladybug 2",
             "sounds": [
                 {
                     "soundName": "pop",
@@ -9618,7 +9618,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "ladybug2-a",
+                    "costumeName": "ladybug 2-a",
                     "baseLayerID": -1,
                     "baseLayerMD5": "c018a3eed966d5f92c69f2188dfd2aae.svg",
                     "bitmapResolution": 1,
@@ -9626,7 +9626,7 @@
                     "rotationCenterY": 28
                 },
                 {
-                    "costumeName": "ladybug2-b",
+                    "costumeName": "ladybug 2-b",
                     "baseLayerID": -1,
                     "baseLayerMD5": "a2bb15ace808e070a2b815502952b292.svg",
                     "bitmapResolution": 1,
@@ -9888,7 +9888,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "llama",
+                    "costumeName": "llama-a",
                     "baseLayerID": -1,
                     "baseLayerMD5": "f5841f36b41c4df26f9c724d913c279b.svg",
                     "bitmapResolution": 1,
@@ -10163,7 +10163,7 @@
                     "format": ""
                 },
                 {
-                    "soundName": "Snare Beatbox",
+                    "soundName": "Snare Beatbox 1",
                     "soundID": -1,
                     "md5": "c642c4c00135d890998f351faec55498.wav",
                     "sampleCount": 5630,
@@ -10171,7 +10171,7 @@
                     "format": "adpcm"
                 },
                 {
-                    "soundName": "Snare Beatbox2",
+                    "soundName": "Snare Beatbox 2",
                     "soundID": -1,
                     "md5": "7ede1382b578d8fc32850b48d082d914.wav",
                     "sampleCount": 4960,
@@ -10543,7 +10543,7 @@
         }
     },
     {
-        "name": "Mouse1",
+        "name": "Mouse",
         "md5": "e1f0c26afecbe9d4b9923d8e6bf489a8.svg",
         "type": "sprite",
         "tags": [
@@ -10557,7 +10557,7 @@
             1
         ],
         "json": {
-            "objName": "Mouse1",
+            "objName": "Mouse",
             "sounds": [
                 {
                     "soundName": "pop",
@@ -10570,7 +10570,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "mouse1-a",
+                    "costumeName": "mouse-a",
                     "baseLayerID": -1,
                     "baseLayerMD5": "e1f0c26afecbe9d4b9923d8e6bf489a8.svg",
                     "bitmapResolution": 1,
@@ -10578,7 +10578,7 @@
                     "rotationCenterY": 27
                 },
                 {
-                    "costumeName": "mouse1-b",
+                    "costumeName": "mouse-b",
                     "baseLayerID": -1,
                     "baseLayerMD5": "f5e477a3f94fc98ba3cd927228405646.svg",
                     "bitmapResolution": 1,
@@ -10856,7 +10856,7 @@
         }
     },
     {
-        "name": "Orange",
+        "name": "Orange 1",
         "md5": "27d5dfbadceea215e983d2641ce3e51f.svg",
         "type": "sprite",
         "tags": [
@@ -10869,7 +10869,7 @@
             1
         ],
         "json": {
-            "objName": "Orange",
+            "objName": "Orange 1",
             "sounds": [
                 {
                     "soundName": "pop",
@@ -10882,7 +10882,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "orange",
+                    "costumeName": "orange 1",
                     "baseLayerID": -1,
                     "baseLayerMD5": "27d5dfbadceea215e983d2641ce3e51f.svg",
                     "bitmapResolution": 1,
@@ -10902,7 +10902,7 @@
         }
     },
     {
-        "name": "Orange2",
+        "name": "Orange 2",
         "md5": "8a7d8515df41f83c1326ec3233a3a42a.svg",
         "type": "sprite",
         "tags": [
@@ -10916,7 +10916,7 @@
             1
         ],
         "json": {
-            "objName": "Orange2",
+            "objName": "Orange 2",
             "sounds": [
                 {
                     "soundName": "pop",
@@ -10929,7 +10929,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "orange2-a",
+                    "costumeName": "orange 2-a",
                     "baseLayerID": -1,
                     "baseLayerMD5": "8a7d8515df41f83c1326ec3233a3a42a.svg",
                     "bitmapResolution": 1,
@@ -10937,7 +10937,7 @@
                     "rotationCenterY": 24
                 },
                 {
-                    "costumeName": "orange2-b",
+                    "costumeName": "orange 2-b",
                     "baseLayerID": -1,
                     "baseLayerMD5": "70c7f1822ffdb37157c304273dae9102.svg",
                     "bitmapResolution": 1,
@@ -11357,7 +11357,7 @@
                     "rotationCenterY": 61
                 },
                 {
-                    "costumeName": "Party Hat-e",
+                    "costumeName": "Party Hat-c",
                     "baseLayerID": -1,
                     "baseLayerMD5": "e69516f2a9bb6d632fdaba4fadd8f8f1.svg",
                     "bitmapResolution": 1,
@@ -11431,7 +11431,7 @@
         }
     },
     {
-        "name": "Penguin",
+        "name": "Penguin 1",
         "md5": "0e78708b8988802d2209a34b50292bd3.svg",
         "type": "sprite",
         "tags": [
@@ -11451,7 +11451,7 @@
             1
         ],
         "json": {
-            "objName": "Penguin",
+            "objName": "Penguin 1",
             "sounds": [
                 {
                     "soundName": "pop",
@@ -11464,7 +11464,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "penguin-a",
+                    "costumeName": "penguin 1-a",
                     "baseLayerID": -1,
                     "baseLayerMD5": "0e78708b8988802d2209a34b50292bd3.svg",
                     "bitmapResolution": 1,
@@ -11472,7 +11472,7 @@
                     "rotationCenterY": 46
                 },
                 {
-                    "costumeName": "penguin-b",
+                    "costumeName": "penguin 1-b",
                     "baseLayerID": -1,
                     "baseLayerMD5": "43af2a0b7f922ec5dc94217b2f3e08e4.svg",
                     "bitmapResolution": 1,
@@ -11480,7 +11480,7 @@
                     "rotationCenterY": 46
                 },
                 {
-                    "costumeName": "penguin-c",
+                    "costumeName": "penguin 1-c",
                     "baseLayerID": -1,
                     "baseLayerMD5": "4f35c3940957e3ffc2e83a2565942171.svg",
                     "bitmapResolution": 1,
@@ -11528,7 +11528,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "penguin2-a",
+                    "costumeName": "penguin 2-a",
                     "baseLayerID": -1,
                     "baseLayerMD5": "c17d9e4bdb59c574e0c34aa70af516da.svg",
                     "bitmapResolution": 1,
@@ -11536,7 +11536,7 @@
                     "rotationCenterY": 61
                 },
                 {
-                    "costumeName": "penguin2-b",
+                    "costumeName": "penguin 2-b",
                     "baseLayerID": -1,
                     "baseLayerMD5": "b224a582395e0847c2ef4eefcfbc4546.svg",
                     "bitmapResolution": 1,
@@ -11544,7 +11544,7 @@
                     "rotationCenterY": 61
                 },
                 {
-                    "costumeName": "penguin2-c",
+                    "costumeName": "penguin 2-c",
                     "baseLayerID": -1,
                     "baseLayerMD5": "35fec7aa5f60cca945fe0615413f1f08.svg",
                     "bitmapResolution": 1,
@@ -11552,7 +11552,7 @@
                     "rotationCenterY": 62
                 },
                 {
-                    "costumeName": "penguin2-d",
+                    "costumeName": "penguin 2-d",
                     "baseLayerID": -1,
                     "baseLayerMD5": "18fa51a64ebd5518f0c5c465525346e5.svg",
                     "bitmapResolution": 1,
@@ -11668,7 +11668,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "Pico walk1",
+                    "costumeName": "Pico walk 1",
                     "baseLayerID": -1,
                     "baseLayerMD5": "8eab5fe20dd249bf22964298b1d377eb.svg",
                     "bitmapResolution": 1,
@@ -11676,7 +11676,7 @@
                     "rotationCenterY": 71
                 },
                 {
-                    "costumeName": "Pico walk2",
+                    "costumeName": "Pico walk 2",
                     "baseLayerID": -1,
                     "baseLayerMD5": "39ecd3c38d3f2cd81e3a17ee6c25699f.svg",
                     "bitmapResolution": 1,
@@ -11684,7 +11684,7 @@
                     "rotationCenterY": 71
                 },
                 {
-                    "costumeName": "Pico walk3",
+                    "costumeName": "Pico walk 3",
                     "baseLayerID": -1,
                     "baseLayerMD5": "43f7d92dcf9eadf77c07a6fc1eb4104f.svg",
                     "bitmapResolution": 1,
@@ -11692,7 +11692,7 @@
                     "rotationCenterY": 70
                 },
                 {
-                    "costumeName": "Pico walk4",
+                    "costumeName": "Pico walk 4",
                     "baseLayerID": -1,
                     "baseLayerMD5": "2582d012d57bca59bc0315c5c5954958.svg",
                     "bitmapResolution": 1,
@@ -11784,7 +11784,7 @@
         }
     },
     {
-        "name": "Planet2",
+        "name": "Planet",
         "md5": "978784738c1d9dd4b1d397fd18bdf406.svg",
         "type": "sprite",
         "tags": [
@@ -11796,7 +11796,7 @@
             1
         ],
         "json": {
-            "objName": "Planet2",
+            "objName": "Planet",
             "sounds": [
                 {
                     "soundName": "pop",
@@ -11809,7 +11809,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "planet2",
+                    "costumeName": "planet",
                     "baseLayerID": -1,
                     "baseLayerMD5": "978784738c1d9dd4b1d397fd18bdf406.svg",
                     "bitmapResolution": 1,
@@ -12180,7 +12180,7 @@
             "objName": "Puppy",
             "sounds": [
                 {
-                    "soundName": "dog2",
+                    "soundName": "dog 2",
                     "soundID": -1,
                     "md5": "cd8fa8390b0efdd281882533fbfcfcfb.wav",
                     "sampleCount": 3168,
@@ -12342,7 +12342,7 @@
                     "format": ""
                 },
                 {
-                    "soundName": "snare beatbox2",
+                    "soundName": "snare beatbox 2",
                     "soundID": -1,
                     "md5": "7ede1382b578d8fc32850b48d082d914.wav",
                     "sampleCount": 4960,
@@ -12578,7 +12578,7 @@
             "objName": "Retro Robot",
             "sounds": [
                 {
-                    "soundName": "computer beeps1",
+                    "soundName": "computer beep 1",
                     "soundID": -1,
                     "md5": "1da43f6d52d0615da8a250e28100a80d.wav",
                     "sampleCount": 19200,
@@ -12586,7 +12586,7 @@
                     "format": ""
                 },
                 {
-                    "soundName": "computer beeps2",
+                    "soundName": "computer beep 2",
                     "soundID": -1,
                     "md5": "28c76b6bebd04be1383fe9ba4933d263.wav",
                     "sampleCount": 9536,
@@ -12596,7 +12596,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "Retro Robot a",
+                    "costumeName": "Retro Robot-a",
                     "baseLayerID": -1,
                     "baseLayerMD5": "a17c1ce38c261395ae268f3b8a9037db.svg",
                     "bitmapResolution": 1,
@@ -12604,7 +12604,7 @@
                     "rotationCenterY": 86
                 },
                 {
-                    "costumeName": "Retro Robot b",
+                    "costumeName": "Retro Robot-b",
                     "baseLayerID": -1,
                     "baseLayerMD5": "bfb5afe62358ef542f118299bb53d4b7.svg",
                     "bitmapResolution": 1,
@@ -12612,7 +12612,7 @@
                     "rotationCenterY": 88
                 },
                 {
-                    "costumeName": "Retro Robot c",
+                    "costumeName": "Retro Robot-c",
                     "baseLayerID": -1,
                     "baseLayerMD5": "f925e3bde178001133a11fa97847a9ae.svg",
                     "bitmapResolution": 1,
@@ -12736,7 +12736,7 @@
             "objName": "Robot",
             "sounds": [
                 {
-                    "soundName": "computer beep",
+                    "soundName": "computer beep 1",
                     "soundID": -1,
                     "md5": "28c76b6bebd04be1383fe9ba4933d263.wav",
                     "sampleCount": 9536,
@@ -12831,7 +12831,7 @@
                     "format": ""
                 },
                 {
-                    "soundName": "laser1",
+                    "soundName": "laser 1",
                     "soundID": -1,
                     "md5": "46571f8ec0f2cc91666c80e312579082.wav",
                     "sampleCount": 516,
@@ -12839,7 +12839,7 @@
                     "format": ""
                 },
                 {
-                    "soundName": "laser2",
+                    "soundName": "laser 2",
                     "soundID": -1,
                     "md5": "27654ed2e3224f0a3f77c244e4fae9aa.wav",
                     "sampleCount": 755,
@@ -13335,7 +13335,7 @@
         }
     },
     {
-        "name": "Shark",
+        "name": "Shark 1",
         "md5": "4ca6776e9c021e8b21c3346793c9361d.svg",
         "type": "sprite",
         "tags": [
@@ -13350,7 +13350,7 @@
             1
         ],
         "json": {
-            "objName": "Shark",
+            "objName": "Shark 1",
             "sounds": [
                 {
                     "soundName": "chomp",
@@ -13363,7 +13363,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "shark-a",
+                    "costumeName": "shark 1-a",
                     "baseLayerID": -1,
                     "baseLayerMD5": "4ca6776e9c021e8b21c3346793c9361d.svg",
                     "bitmapResolution": 1,
@@ -13371,7 +13371,7 @@
                     "rotationCenterY": 60
                 },
                 {
-                    "costumeName": "shark-b",
+                    "costumeName": "shark 1-b",
                     "baseLayerID": -1,
                     "baseLayerMD5": "0bb623f0bbec53ee9667cee0b7ad6d47.svg",
                     "bitmapResolution": 1,
@@ -13438,7 +13438,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "shark2-a",
+                    "costumeName": "shark 2-a",
                     "baseLayerID": -1,
                     "baseLayerMD5": "7c0a907eae79462f69f8e2af8e7df828.svg",
                     "bitmapResolution": 1,
@@ -13446,7 +13446,7 @@
                     "rotationCenterY": 75
                 },
                 {
-                    "costumeName": "shark2-b",
+                    "costumeName": "shark 2-b",
                     "baseLayerID": -1,
                     "baseLayerMD5": "cff9ae87a93294693a0650b38a7a33d2.svg",
                     "bitmapResolution": 1,
@@ -13454,7 +13454,7 @@
                     "rotationCenterY": 75
                 },
                 {
-                    "costumeName": "shark2-c",
+                    "costumeName": "shark 2-c",
                     "baseLayerID": -1,
                     "baseLayerMD5": "afeae3f998598424f7c50918507f6ce6.svg",
                     "bitmapResolution": 1,
@@ -13500,7 +13500,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "shirt-a",
+                    "costumeName": "shirt",
                     "baseLayerID": -1,
                     "baseLayerMD5": "659465944053fe6fb6aa1ed0e11be9aa.svg",
                     "bitmapResolution": 1,
@@ -13656,7 +13656,7 @@
         }
     },
     {
-        "name": "Singer1",
+        "name": "Singer",
         "md5": "e47ef1af3b925e5ac9e3b3f809d440b3.svg",
         "type": "sprite",
         "tags": [
@@ -13669,7 +13669,7 @@
             1
         ],
         "json": {
-            "objName": "Singer1",
+            "objName": "Singer",
             "sounds": [
                 {
                     "soundName": "pop",
@@ -13682,7 +13682,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "Singer1",
+                    "costumeName": "Singer",
                     "baseLayerID": -1,
                     "baseLayerMD5": "e47ef1af3b925e5ac9e3b3f809d440b3.svg",
                     "bitmapResolution": 1,
@@ -13996,28 +13996,7 @@
         ],
         "json": {
             "objName": "Speaker",
-            "variables": [
-                {
-                    "name": "scale degree",
-                    "value": 1,
-                    "isPersistent": false
-                },
-                {
-                    "name": "octave",
-                    "value": 0,
-                    "isPersistent": false
-                },
-                {
-                    "name": "note number",
-                    "value": 62,
-                    "isPersistent": false
-                },
-                {
-                    "name": "loop number",
-                    "value": 1,
-                    "isPersistent": false
-                }
-            ],
+            "variables": [],
             "sounds": [
                 {
                     "soundName": "Drive Around",
@@ -14226,7 +14205,7 @@
                     "rotationCenterY": 75
                 },
                 {
-                    "costumeName": "starfish-b ",
+                    "costumeName": "starfish-b",
                     "baseLayerID": -1,
                     "baseLayerMD5": "ad8007f4e63693984d4adc466ffa3ad2.svg",
                     "bitmapResolution": 1,
@@ -14421,7 +14400,7 @@
         }
     },
     {
-        "name": "Sunglasses1",
+        "name": "Sunglasses",
         "md5": "424393e8705aeadcfecb8559ce4dcea2.svg",
         "type": "sprite",
         "tags": [
@@ -14434,7 +14413,7 @@
             1
         ],
         "json": {
-            "objName": "Sunglasses1",
+            "objName": "Sunglasses",
             "sounds": [
                 {
                     "soundName": "pop",
@@ -14501,7 +14480,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "Taco",
+                    "costumeName": "Taco-a",
                     "baseLayerID": -1,
                     "baseLayerMD5": "bc78fb90ed373d56c11d5fafa4203ccd.svg",
                     "bitmapResolution": 1,
@@ -14509,7 +14488,7 @@
                     "rotationCenterY": 48
                 },
                 {
-                    "costumeName": "Taco-wizard",
+                    "costumeName": "Taco-b",
                     "baseLayerID": -1,
                     "baseLayerMD5": "5e9e65db20d403b590578ed44b1a3792.svg",
                     "bitmapResolution": 1,
@@ -14973,7 +14952,7 @@
         }
     },
     {
-        "name": "Tree1",
+        "name": "Tree",
         "md5": "8c40e2662c55d17bc384f47165ac43c1.svg",
         "type": "sprite",
         "tags": [
@@ -14987,7 +14966,7 @@
             1
         ],
         "json": {
-            "objName": "Tree1",
+            "objName": "Tree",
             "sounds": [
                 {
                     "soundName": "pop",
@@ -15000,7 +14979,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "tree1",
+                    "costumeName": "tree",
                     "baseLayerID": -1,
                     "baseLayerMD5": "8c40e2662c55d17bc384f47165ac43c1.svg",
                     "bitmapResolution": 1,
@@ -15249,7 +15228,7 @@
         }
     },
     {
-        "name": "Unicorn",
+        "name": "Unicorn 1",
         "md5": "c491fd1867375aa0160b013788d188e5.svg",
         "type": "sprite",
         "tags": [
@@ -15263,7 +15242,7 @@
             1
         ],
         "json": {
-            "objName": "Unicorn",
+            "objName": "Unicorn 1",
             "sounds": [
                 {
                     "soundName": "Magic Spell",
@@ -15276,7 +15255,7 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "unicorn",
+                    "costumeName": "unicorn 1",
                     "baseLayerID": -1,
                     "baseLayerMD5": "c491fd1867375aa0160b013788d188e5.svg",
                     "bitmapResolution": 1,


### PR DESCRIPTION
### Resolves
Mainly resolves #4218 

### Proposed Changes
Fixes asset names

### Reason for Changes
It was inconsitent.

I followed these rules:
* Space between sprite name and numbers/alphabets, like `FooBar 2` or `Baz-b`
* If `XX 2` exists, rename `XX` to `XX 1`
* If `XX 1` exists but `XX 2` does not exist, remove 1

### Other library issues I fixed
Also fixes #4266 
Resolves #4186 