### PR TITLE
Make the sprite drop area from the backpack highlight and large

### DIFF
--- a/src/components/backpack/backpack.css
+++ b/src/components/backpack/backpack.css
@@ -57,7 +57,7 @@
     width: 100%;
     height: 100%;
     opacity: 0.75;
-    background-color: #8cbcff;
+    background-color: $drop-highlight;
     transition: all 0.25s ease;
 }
 

--- a/src/components/blocks/blocks.css
+++ b/src/components/blocks/blocks.css
@@ -13,7 +13,7 @@
     width: 100%;
     height: 100%;
     opacity: 0.75;
-    background-color: #8cbcff;
+    background-color: $drop-highlight;
     transition: all 0.25s ease;
 }
 

--- a/src/components/sprite-selector/sprite-list.jsx
+++ b/src/components/sprite-selector/sprite-list.jsx
@@ -34,62 +34,68 @@ const SpriteList = function (props) {
 
     return (
         <Box
-            className={styles.itemsWrapper}
+            className={classNames(styles.scrollWrapper, {
+                [styles.scrollWrapperDragging]: draggingType === DragConstants.BACKPACK_SPRITE
+            })}
             componentRef={containerRef}
         >
-            {items.map((sprite, index) => {
+            <Box
+                className={styles.itemsWrapper}
+            >
+                {items.map((sprite, index) => {
 
-                // If the sprite has just received a block drop, used for green highlight
-                const receivedBlocks = (
-                    hoveredTarget.sprite === sprite.id &&
+                    // If the sprite has just received a block drop, used for green highlight
+                    const receivedBlocks = (
+                        hoveredTarget.sprite === sprite.id &&
                     sprite.id !== editingTarget &&
                     hoveredTarget.receivedBlocks
-                );
+                    );
 
-                // If the sprite is indicating it can receive block dropping, used for blue highlight
-                let isRaised = !receivedBlocks && raised && sprite.id !== editingTarget;
+                    // If the sprite is indicating it can receive block dropping, used for blue highlight
+                    let isRaised = !receivedBlocks && raised && sprite.id !== editingTarget;
 
-                // A sprite is also raised if a costume or sound is being dragged.
-                // Note the absence of the self-sharing check: a sprite can share assets with itself.
-                // This is a quirk of 2.0, but seems worth leaving possible, it
-                // allows quick (albeit unusual) duplication of assets.
-                isRaised = isRaised || [
-                    DragConstants.COSTUME,
-                    DragConstants.SOUND,
-                    DragConstants.BACKPACK_COSTUME,
-                    DragConstants.BACKPACK_SOUND,
-                    DragConstants.BACKPACK_CODE].includes(draggingType);
+                    // A sprite is also raised if a costume or sound is being dragged.
+                    // Note the absence of the self-sharing check: a sprite can share assets with itself.
+                    // This is a quirk of 2.0, but seems worth leaving possible, it
+                    // allows quick (albeit unusual) duplication of assets.
+                    isRaised = isRaised || [
+                        DragConstants.COSTUME,
+                        DragConstants.SOUND,
+                        DragConstants.BACKPACK_COSTUME,
+                        DragConstants.BACKPACK_SOUND,
+                        DragConstants.BACKPACK_CODE].includes(draggingType);
 
-                return (
-                    <SortableAsset
-                        className={classNames(styles.spriteWrapper, {
-                            [styles.placeholder]: isSpriteDrag && index === draggingIndex})}
-                        index={isSpriteDrag ? ordering.indexOf(index) : index}
-                        key={sprite.name}
-                        onAddSortable={onAddSortable}
-                        onRemoveSortable={onRemoveSortable}
-                    >
-                        <SpriteSelectorItem
-                            asset={sprite.costume && sprite.costume.asset}
-                            className={classNames(styles.sprite, {
-                                [styles.raised]: isRaised,
-                                [styles.receivedBlocks]: receivedBlocks
-                            })}
-                            dragPayload={sprite}
-                            dragType={DragConstants.SPRITE}
-                            id={sprite.id}
-                            index={index}
-                            key={sprite.id}
-                            name={sprite.name}
-                            selected={sprite.id === selectedId}
-                            onClick={onSelectSprite}
-                            onDeleteButtonClick={onDeleteSprite}
-                            onDuplicateButtonClick={onDuplicateSprite}
-                            onExportButtonClick={onExportSprite}
-                        />
-                    </SortableAsset>
-                );
-            })}
+                    return (
+                        <SortableAsset
+                            className={classNames(styles.spriteWrapper, {
+                                [styles.placeholder]: isSpriteDrag && index === draggingIndex})}
+                            index={isSpriteDrag ? ordering.indexOf(index) : index}
+                            key={sprite.name}
+                            onAddSortable={onAddSortable}
+                            onRemoveSortable={onRemoveSortable}
+                        >
+                            <SpriteSelectorItem
+                                asset={sprite.costume && sprite.costume.asset}
+                                className={classNames(styles.sprite, {
+                                    [styles.raised]: isRaised,
+                                    [styles.receivedBlocks]: receivedBlocks
+                                })}
+                                dragPayload={sprite}
+                                dragType={DragConstants.SPRITE}
+                                id={sprite.id}
+                                index={index}
+                                key={sprite.id}
+                                name={sprite.name}
+                                selected={sprite.id === selectedId}
+                                onClick={onSelectSprite}
+                                onDeleteButtonClick={onDeleteSprite}
+                                onDuplicateButtonClick={onDuplicateSprite}
+                                onExportButtonClick={onExportSprite}
+                            />
+                        </SortableAsset>
+                    );
+                })}
+            </Box>
         </Box>
     );
 };

--- a/src/components/sprite-selector/sprite-selector.css
+++ b/src/components/sprite-selector/sprite-selector.css
@@ -55,6 +55,10 @@
     overflow-y: auto;
 }
 
+.scroll-wrapper-dragging {
+    background-color: $drop-highlight;
+}
+
 .items-wrapper {
     display: flex;
     flex-wrap: wrap;
@@ -80,12 +84,12 @@
 }
 
 .raised {
-    background-color: #8cbcff;
+    background-color: $drop-highlight;
     transition: all 0.25s ease;
 }
 
 .raised:hover {
-    background-color: #8cbcff;
+    background-color: $drop-highlight;
     transform: scale(1.05);
 }
 
@@ -94,7 +98,7 @@
     animation-duration: 500ms;
     animation-iteration-count: 1;
     animation-timing-function: ease-in-out;
-    background-color: #8cbcff;
+    background-color: $drop-highlight;
 }
 
 @keyframes wiggle {

--- a/src/components/sprite-selector/sprite-selector.jsx
+++ b/src/components/sprite-selector/sprite-selector.jsx
@@ -100,20 +100,18 @@ const SpriteSelectorComponent = function (props) {
                 onChangeY={onChangeSpriteY}
             />
 
-            <Box className={styles.scrollWrapper}>
-                <SpriteList
-                    editingTarget={editingTarget}
-                    hoveredTarget={hoveredTarget}
-                    items={Object.keys(sprites).map(id => sprites[id])}
-                    raised={raised}
-                    selectedId={selectedId}
-                    onDeleteSprite={onDeleteSprite}
-                    onDrop={onDrop}
-                    onDuplicateSprite={onDuplicateSprite}
-                    onExportSprite={onExportSprite}
-                    onSelectSprite={onSelectSprite}
-                />
-            </Box>
+            <SpriteList
+                editingTarget={editingTarget}
+                hoveredTarget={hoveredTarget}
+                items={Object.keys(sprites).map(id => sprites[id])}
+                raised={raised}
+                selectedId={selectedId}
+                onDeleteSprite={onDeleteSprite}
+                onDrop={onDrop}
+                onDuplicateSprite={onDuplicateSprite}
+                onExportSprite={onExportSprite}
+                onSelectSprite={onSelectSprite}
+            />
             <ActionMenu
                 className={styles.addButton}
                 img={spriteIcon}

--- a/src/components/stage-selector/stage-selector.css
+++ b/src/components/stage-selector/stage-selector.css
@@ -100,7 +100,7 @@ $header-height: calc($stage-menu-height - 2px);
 }
 
 .raised, .raised .header {
-    background-color: #8cbcff;
+    background-color: $drop-highlight;
     transition: all 0.25s ease;
 }
 

--- a/src/css/colors.css
+++ b/src/css/colors.css
@@ -40,3 +40,5 @@ $extensions-primary: hsla(163, 85%, 40%, 1); /* #0FBD8C */
 $extensions-tertiary: hsla(163, 85%, 30%, 1); /* #0B8E69 */
 $extensions-transparent: hsla(163, 85%, 40%, 0.35); /* 35% transparent version of extensions-primary */
 $extensions-light: hsla(163, 57%, 85%, 1); /* opaque version of extensions-transparent, on white bg */
+
+$drop-highlight: hsla(215, 100%, 77%); /* lighter than motion-primary */


### PR DESCRIPTION
Fixes usability issue where the drop area was too small, and you couldn't see it.

### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves #4254 

### Proposed Changes

_Describe what this Pull Request does_

Highlight the drop area, and fix its size.

Move the highlight color to a css variable.

As a follow up, we could include this highlight on the costumes/sounds list when dragging out of the backpack, but so far people have not complained about that and would be a higher risk change.

/cc @thisandagain 

![drop-area](https://user-images.githubusercontent.com/654102/50775664-be491180-1264-11e9-90d3-f6c6a587a044.gif)
