### PR TITLE
Save project state before storing assets instead of after.

### DIFF
--- a/src/lib/project-saver-hoc.jsx
+++ b/src/lib/project-saver-hoc.jsx
@@ -201,6 +201,13 @@ const ProjectSaverHOC = function (WrappedComponent) {
         storeProject (projectId, requestParams) {
             requestParams = requestParams || {};
             this.clearAutoSaveTimeout();
+            // Serialize VM state now before embarking on
+            // the asynchronous journey of storing assets to
+            // the server. This ensures that assets don't update
+            // while in the process of saving a project (e.g. the
+            // serialized project refers to a newer asset than what
+            // we just finished saving).
+            const savedVMState = this.props.vm.toJSON();
             return Promise.all(this.props.vm.assets
                 .filter(asset => !asset.clean)
                 .map(
@@ -215,7 +222,7 @@ const ProjectSaverHOC = function (WrappedComponent) {
                 )
             ).then(() => {
                 const opts = {
-                    body: this.props.vm.toJSON(),
+                    body: savedVMState,
                     // If we set json:true then the body is double-stringified, so don't
                     headers: {
                         'Content-Type': 'application/json'


### PR DESCRIPTION
### Resolves

Resolves an issue where projects are getting saved in a state where they reference an asset that hasn't been stored on the asset server.

### Proposed Changes

Serialize the project state before attempting to store assets. The project isn't stored until all assets were successfully stored, but this ensures that updates being made to the assets during the auto-save project don't result in a project getting saved that references an asset that isn't on the server yet.

### Test Coverage

Tested manually.
On production, updating a costume (constantly) in the middle of an auto save can result in a BSOD after reloading the project (the project got stored on the project server in a broken state).

This should no longer happen.

Thanks to @paulkaplan, @picklesrus and @thisandagain.