### PR TITLE
Check for minimum versions of recommended browsers

### DIFF
--- a/src/components/browser-modal/browser-modal.jsx
+++ b/src/components/browser-modal/browser-modal.jsx
@@ -32,7 +32,7 @@ const BrowserModal = ({intl, ...props}) => (
                 <p>
                     { /* eslint-disable max-len */ }
                     <FormattedMessage
-                        defaultMessage="We are very sorry, but Scratch does not support this browser. We recommend trying a supported browser such as Google Chrome, Mozilla Firefox, Microsoft Edge, or Apple Safari."
+                        defaultMessage="We are very sorry, but Scratch does not support this browser version. We recommend updating to the latest version of a supported browser such as Google Chrome, Mozilla Firefox, Microsoft Edge, or Apple Safari."
                         description="Unsupported browser description"
                         id="gui.unsupportedBrowser.description"
                     />

--- a/src/lib/supported-browser.js
+++ b/src/lib/supported-browser.js
@@ -10,6 +10,14 @@ export default function () {
         bowser.silk) {
         return false;
     }
-    // @todo Should also test for versions of supported browsers
-    return true;
+    // IMPORTANT: If you change versions here, also change them in www
+    // minimum versions for recommended browsers
+    const minVersions = {
+        chrome: '63',
+        msedge: '15',
+        firefox: '57',
+        safari: '11'
+    };
+    // strict mode == false so any browser not mentioned in the min Versions is ok
+    return bowser.check(minVersions, false);
 }


### PR DESCRIPTION
### Resolves
Many people who were seeing crashes on the site were using very old versions of browsers that we support

### Proposed Changes

_Describe what this Pull Request does_
In addition to excluding certain browsers, it checks the browser version to ensure that it meets the minimum specified in the FAQ.

### Testing

- [ ] any version of IE, Opera, Silk should be unsupported
- [ ] Chrome:
  - [ ] version 63+ should work
  - [ ] versions <63 should be unsupported
- [ ] Edge:
  - [ ] version 15+ should work
  - [ ] versions <15 should be unsupported
- [ ] Firefox:
  - [ ] version 57+ should work
  - [ ] versions <57 should be unsupported
- [ ] Safari:
  - [ ] version 11+ should work
  - [ ] versions <11 should be unsupported
- [ ] Vivaldi is not officially supported, but it's not excluded, so any version should load the gui not the unsupported modal. 

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [x] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [x] Edge
 * [x] IE (checked for failure)
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
