### PR TITLE
Revert "Update scratch-render to the latest version 🚀"

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "scratch-blocks": "0.1.0-prerelease.1545364693",
     "scratch-l10n": "3.1.20181220222259",
     "scratch-paint": "0.2.0-prerelease.20181220194927",
-    "scratch-render": "0.1.0-prerelease.20190108175224",
+    "scratch-render": "0.1.0-prerelease.20190107163047",
     "scratch-storage": "1.2.2",
     "scratch-svg-renderer": "0.2.0-prerelease.20181220183040",
     "scratch-vm": "0.2.0-prerelease.20190107184530",


### PR DESCRIPTION
Reverts LLK/scratch-gui#4289

On the older chromebooks this caused the sonic project level to be completely blank.