### PR TITLE
check for non-null flyout

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -259,7 +259,7 @@ class Blocks extends React.Component {
     }
 
     onTargetsUpdate () {
-        if (this.props.vm.editingTarget) {
+        if (this.props.vm.editingTarget && this.workspace.getFlyout()) {
             ['glide', 'move', 'set'].forEach(prefix => {
                 this.updateToolboxBlockValue(`${prefix}x`, Math.round(this.props.vm.editingTarget.x).toString());
                 this.updateToolboxBlockValue(`${prefix}y`, Math.round(this.props.vm.editingTarget.y).toString());


### PR DESCRIPTION
### Resolves
Fixes the `Cannot read property 'getWorkspace' of null` errors in the console. I was starting to write up an issue documenting why it was happening, and instead convinced myself that it would be better to fix it in blocks than elsewhere.

### Proposed Changes
_Describe what this Pull Request does_
Check for a non-null flyout in addition to an editing target before trying to update toolbox values.

### Reason for Changes
The `onTargetsUpdate` is actually a 'debounced' method that runs every 100 milliseconds to ensure that blocks in the toolbox get updated values when necessary (e.g. goto). If a project with two sprites is running (e.g. forever, turn 15 degrees on one sprite), and you switch sprites, and immediately click `see project page`, the debounced method runs after the project page has removed the toolbox. 
https://github.com/LLK/scratch-gui/blob/123b0a68816f182282bc374dfb37abaa35cc2de2/src/containers/blocks.jsx#L83

Alternatively we could try to have the `See project page` change a state that will cause the blocks to cancel the debounced onTargetsUpdate. However, `See project page` has a bunch of internal logic to figure out if this is your project, whether to save it, etc. With everything happening asynchronously, it seems less prone to race conditions to just check for a non-null flyout in the method.

### Test Coverage

manual testing

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
