### PR TITLE
add support for onProjectLoaded

### DIFF
--- a/src/containers/gui.jsx
+++ b/src/containers/gui.jsx
@@ -9,6 +9,7 @@ import {defineMessages, injectIntl, intlShape} from 'react-intl';
 import ErrorBoundaryHOC from '../lib/error-boundary-hoc.jsx';
 import {
     getIsError,
+    getIsLoaded,
     getIsShowingProject
 } from '../reducers/project-state';
 import {setProjectTitle} from '../reducers/project-title';
@@ -60,6 +61,11 @@ class GUI extends React.Component {
         if (this.props.projectTitle !== prevProps.projectTitle) {
             this.setReduxTitle(this.props.projectTitle);
         }
+        if (this.props.isProjectLoaded && !prevProps.isProjectLoaded) {
+            // this only notifies container when a project changes from not yet loaded to loaded
+            // At this time the project view in www doesn't need to know when a project is unloaded
+            this.props.onProjectLoaded();
+        }
     }
     setReduxTitle (newTitle) {
         if (newTitle === null || typeof newTitle === 'undefined') {
@@ -81,8 +87,10 @@ class GUI extends React.Component {
             cloudHost,
             error,
             isError,
+            isProjectLoaded,
             isScratchDesktop,
             isShowingProject,
+            onProjectLoaded,
             onStorageInit,
             onUpdateProjectId,
             onUpdateReduxProjectTitle,
@@ -117,9 +125,11 @@ GUI.propTypes = {
     intl: intlShape,
     isError: PropTypes.bool,
     isLoading: PropTypes.bool,
+    isProjectLoaded: PropTypes.bool,
     isScratchDesktop: PropTypes.bool,
     isShowingProject: PropTypes.bool,
     loadingStateVisible: PropTypes.bool,
+    onProjectLoaded: PropTypes.func,
     onSeeCommunity: PropTypes.func,
     onStorageInit: PropTypes.func,
     onUpdateProjectId: PropTypes.func,
@@ -136,6 +146,7 @@ GUI.propTypes = {
 GUI.defaultProps = {
     isScratchDesktop: false,
     onStorageInit: storageInstance => storageInstance.addOfficialScratchWebStores(),
+    onProjectLoaded: () => {},
     onUpdateProjectId: () => {}
 };
 
@@ -154,6 +165,7 @@ const mapStateToProps = state => {
         importInfoVisible: state.scratchGui.modals.importInfo,
         isError: getIsError(loadingState),
         isPlayerOnly: state.scratchGui.mode.isPlayerOnly,
+        isProjectLoaded: getIsLoaded(loadingState),
         isRtl: state.locales.isRtl,
         isShowingProject: getIsShowingProject(loadingState),
         loadingStateVisible: state.scratchGui.modals.loadingProject,

--- a/src/reducers/project-state.js
+++ b/src/reducers/project-state.js
@@ -70,6 +70,10 @@ const getIsLoading = loadingState => (
 const getIsLoadingUpload = loadingState => (
     loadingState === LoadingState.LOADING_VM_FILE_UPLOAD
 );
+const getIsLoaded = loadingState => (
+    loadingState === LoadingState.SHOWING_WITH_ID ||
+    loadingState === LoadingState.SHOWING_WITHOUT_ID
+);
 const getIsCreatingNew = loadingState => (
     loadingState === LoadingState.CREATING_NEW
 );
@@ -547,6 +551,7 @@ export {
     getIsError,
     getIsFetchingWithId,
     getIsFetchingWithoutId,
+    getIsLoaded,
     getIsLoading,
     getIsLoadingWithId,
     getIsLoadingUpload,


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/LLK/scratch-www/issues/2628

### Proposed Changes

_Describe what this Pull Request does_
Adds `getIsLoaded` to the project state reducer, and uses that method to set `isProjectLoaded` in GUI. Calls the `onProjectLoaded` callback when the state becomes true.

### Reason for Changes

_Explain why these changes should be made_
www needs to know when a project finishes loading so that remixing can be disabled while the project is in a state that cannot be remixed.

### Test Coverage

- Should have no impact on standalone gui (tests should run)

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
