### PR TITLE
Make whole stage clickable for green flag overlay

### DIFF
--- a/src/components/stage/stage.css
+++ b/src/components/stage/stage.css
@@ -147,6 +147,8 @@ to adjust for the border using a different method */
     align-items: center;
     background: rgba(0,0,0,0.25);
     border-radius: 0.5rem;
+    pointer-events: all;
+    cursor: pointer;
 }
 
 .green-flag-overlay {
@@ -154,8 +156,6 @@ to adjust for the border using a different method */
     border-radius: 100%;
     background: rgba(255,255,255,0.75);
     border: 3px solid $ui-white;
-    pointer-events: all;
-    cursor: pointer;
     display: flex;
     justify-content: center;
     align-items: center;

--- a/src/components/stage/stage.jsx
+++ b/src/components/stage/stage.jsx
@@ -81,11 +81,10 @@ const StageComponent = props => {
                     />
                 </Box>
                 {isStarted ? null : (
-                    <Box className={styles.greenFlagOverlayWrapper}>
-                        <GreenFlagOverlay
-                            className={styles.greenFlagOverlay}
-                        />
-                    </Box>
+                    <GreenFlagOverlay
+                        className={styles.greenFlagOverlay}
+                        wrapperClass={styles.greenFlagOverlayWrapper}
+                    />
                 )}
                 {isColorPicking && colorInfo ? (
                     <Box className={styles.colorPickerWrapper}>

--- a/src/containers/green-flag-overlay.jsx
+++ b/src/containers/green-flag-overlay.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 
 import {connect} from 'react-redux';
 import VM from 'scratch-vm';
+import Box from '../components/box/box.jsx';
 import greenFlag from '../components/green-flag/icon--green-flag.svg';
 
 class GreenFlagOverlay extends React.Component {
@@ -23,15 +24,18 @@ class GreenFlagOverlay extends React.Component {
         if (this.props.isStarted) return null;
 
         return (
-            <div
-                className={this.props.className}
+            <Box
+                className={this.props.wrapperClass}
                 onClick={this.handleClick}
             >
-                <img
-                    draggable={false}
-                    src={greenFlag}
-                />
-            </div>
+                <div className={this.props.className}>
+                    <img
+                        draggable={false}
+                        src={greenFlag}
+                    />
+                </div>
+            </Box>
+
         );
     }
 }
@@ -39,7 +43,8 @@ class GreenFlagOverlay extends React.Component {
 GreenFlagOverlay.propTypes = {
     className: PropTypes.string,
     isStarted: PropTypes.bool,
-    vm: PropTypes.instanceOf(VM)
+    vm: PropTypes.instanceOf(VM),
+    wrapperClass: PropTypes.string
 };
 
 const mapStateToProps = state => ({


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Resolves #4229 (can't click anywhere on the stage to start the project after it loads).

### Proposed Changes

_Describe what this Pull Request does_
Move the onClick handler to the overlay wrapper so that the whole stage is clickable to start the project instead of just the green flag button

### Reason for Changes

_Explain why these changes should be made_
User requests

### Test Coverage

manual testing

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [x] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
