### PR TITLE
Allow putting mp3 sounds in the backpack.

### DIFF
--- a/src/lib/backpack/sound-payload.js
+++ b/src/lib/backpack/sound-payload.js
@@ -18,6 +18,13 @@ const soundPayload = sound => {
         payload.mime = 'audio/x-wav';
         payload.body = assetDataUrl.replace('data:audio/x-wav;base64,', '');
         break;
+    case 'mp3':
+        payload.mime = 'audio/mp3';
+        // TODO scratch-storage should be fixed so that encodeDataURI does not
+        // always prepend the wave format header; Once that is fixed, the following
+        // line will have to change.
+        payload.body = assetDataUrl.replace('data:audio/x-wav;base64,', '');
+        break;
     default:
         alert(`Cannot serialize for format: ${assetDataFormat}`); // eslint-disable-line
     }


### PR DESCRIPTION
### Proposed Changes

Allow putting mp3 sounds in the backpack. We were previously ignoring them completely.

### Reason for Changes

MP3 Sounds exist.

### Test Coverage

Tested manually.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [x] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
