### PR TITLE
resolve name conflict by renaming onProjectLoaded in project-fetcher-hoc

### DIFF
--- a/src/containers/gui.jsx
+++ b/src/containers/gui.jsx
@@ -9,7 +9,6 @@ import {defineMessages, injectIntl, intlShape} from 'react-intl';
 import ErrorBoundaryHOC from '../lib/error-boundary-hoc.jsx';
 import {
     getIsError,
-    getIsLoaded,
     getIsShowingProject
 } from '../reducers/project-state';
 import {setProjectTitle} from '../reducers/project-title';
@@ -61,7 +60,7 @@ class GUI extends React.Component {
         if (this.props.projectTitle !== prevProps.projectTitle) {
             this.setReduxTitle(this.props.projectTitle);
         }
-        if (this.props.isProjectLoaded && !prevProps.isProjectLoaded) {
+        if (this.props.isShowingProject && !prevProps.isShowingProject) {
             // this only notifies container when a project changes from not yet loaded to loaded
             // At this time the project view in www doesn't need to know when a project is unloaded
             this.props.onProjectLoaded();
@@ -87,7 +86,6 @@ class GUI extends React.Component {
             cloudHost,
             error,
             isError,
-            isProjectLoaded,
             isScratchDesktop,
             isShowingProject,
             onProjectLoaded,
@@ -125,7 +123,6 @@ GUI.propTypes = {
     intl: intlShape,
     isError: PropTypes.bool,
     isLoading: PropTypes.bool,
-    isProjectLoaded: PropTypes.bool,
     isScratchDesktop: PropTypes.bool,
     isShowingProject: PropTypes.bool,
     loadingStateVisible: PropTypes.bool,
@@ -165,7 +162,6 @@ const mapStateToProps = state => {
         importInfoVisible: state.scratchGui.modals.importInfo,
         isError: getIsError(loadingState),
         isPlayerOnly: state.scratchGui.mode.isPlayerOnly,
-        isProjectLoaded: getIsLoaded(loadingState),
         isRtl: state.locales.isRtl,
         isShowingProject: getIsShowingProject(loadingState),
         loadingStateVisible: state.scratchGui.modals.loadingProject,

--- a/src/lib/project-fetcher-hoc.jsx
+++ b/src/lib/project-fetcher-hoc.jsx
@@ -61,7 +61,7 @@ const ProjectFetcherHOC = function (WrappedComponent) {
                 this.fetchProject(this.props.reduxProjectId, this.props.loadingState);
             }
             if (this.props.isShowingProject && !prevProps.isShowingProject) {
-                this.props.onProjectLoaded();
+                this.props.onProjectUnchanged();
             }
             if (this.props.isShowingProject && (prevProps.isLoadingProject || prevProps.isCreatingNew)) {
                 this.props.onActivateTab(BLOCKS_TAB_INDEX);
@@ -94,7 +94,7 @@ const ProjectFetcherHOC = function (WrappedComponent) {
                 onActivateTab,
                 onError: onErrorProp,
                 onFetchedProjectData: onFetchedProjectDataProp,
-                onProjectLoaded,
+                onProjectUnchanged,
                 projectHost,
                 projectId,
                 reduxProjectId,
@@ -121,6 +121,7 @@ const ProjectFetcherHOC = function (WrappedComponent) {
         onActivateTab: PropTypes.func,
         onError: PropTypes.func,
         onFetchedProjectData: PropTypes.func,
+        onProjectUnchanged: PropTypes.func,
         projectHost: PropTypes.string,
         projectId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
         reduxProjectId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
@@ -145,7 +146,7 @@ const ProjectFetcherHOC = function (WrappedComponent) {
         onFetchedProjectData: (projectData, loadingState) =>
             dispatch(onFetchedProjectData(projectData, loadingState)),
         setProjectId: projectId => dispatch(setProjectId(projectId)),
-        onProjectLoaded: () => dispatch(setProjectUnchanged())
+        onProjectUnchanged: () => dispatch(setProjectUnchanged())
     });
     // Allow incoming props to override redux-provided props. Used to mock in tests.
     const mergeProps = (stateProps, dispatchProps, ownProps) => Object.assign(

--- a/src/reducers/project-state.js
+++ b/src/reducers/project-state.js
@@ -70,10 +70,6 @@ const getIsLoading = loadingState => (
 const getIsLoadingUpload = loadingState => (
     loadingState === LoadingState.LOADING_VM_FILE_UPLOAD
 );
-const getIsLoaded = loadingState => (
-    loadingState === LoadingState.SHOWING_WITH_ID ||
-    loadingState === LoadingState.SHOWING_WITHOUT_ID
-);
 const getIsCreatingNew = loadingState => (
     loadingState === LoadingState.CREATING_NEW
 );
@@ -551,7 +547,6 @@ export {
     getIsError,
     getIsFetchingWithId,
     getIsFetchingWithoutId,
-    getIsLoaded,
     getIsLoading,
     getIsLoadingWithId,
     getIsLoadingUpload,


### PR DESCRIPTION

### Resolves

Follow up to resolving https://github.com/LLK/scratch-www/issues/2628

### Proposed Changes

https://github.com/LLK/scratch-gui/pull/4312 had a function name conflict with the existing code. This change fixes that by renaming the conflicting function, and removes redundant code.
