### PR TITLE
Show loading screen in fullscreen mode

### DIFF
--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -335,6 +335,7 @@ const GUIComponent = props => {
                         <Box className={classNames(styles.stageAndTargetWrapper, styles[stageSize])}>
                             <StageWrapper
                                 isRendererSupported={isRendererSupported}
+                                isRtl={isRtl}
                                 stageSize={stageSize}
                                 vm={vm}
                             />

--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -83,6 +83,7 @@ const GUIComponent = props => {
         importInfoVisible,
         intl,
         isCreating,
+        isFullScreen,
         isPlayerOnly,
         isRtl,
         isShared,
@@ -139,6 +140,7 @@ const GUIComponent = props => {
 
         return isPlayerOnly ? (
             <StageWrapper
+                isFullScreen={isFullScreen}
                 isRendererSupported={isRendererSupported}
                 isRtl={isRtl}
                 loading={loading}
@@ -380,6 +382,7 @@ GUIComponent.propTypes = {
     importInfoVisible: PropTypes.bool,
     intl: intlShape.isRequired,
     isCreating: PropTypes.bool,
+    isFullScreen: PropTypes.bool,
     isPlayerOnly: PropTypes.bool,
     isRtl: PropTypes.bool,
     isShared: PropTypes.bool,

--- a/src/components/loader/loader.css
+++ b/src/components/loader/loader.css
@@ -17,6 +17,13 @@
     color: white;
 }
 
+.fullscreen {
+    /* Break out of the layout using position: fixed to cover the whole screen */
+    position: fixed;
+    /* Use the fullscreen stage z-index to allow covering full-screen mode */
+    z-index: $z-index-stage-wrapper-overlay;
+}
+
 .block-animation {
     width: 125px;
     height: 150px;

--- a/src/components/loader/loader.jsx
+++ b/src/components/loader/loader.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
+import classNames from 'classnames';
 import styles from './loader.css';
 import PropTypes from 'prop-types';
 
@@ -148,7 +149,11 @@ class LoaderComponent extends React.Component {
     }
     render () {
         return (
-            <div className={styles.background}>
+            <div
+                className={classNames(styles.background, {
+                    [styles.fullscreen]: this.props.isFullScreen
+                })}
+            >
                 <div className={styles.container}>
                     <div className={styles.blockAnimation}>
                         <img
@@ -189,9 +194,11 @@ class LoaderComponent extends React.Component {
 }
 
 LoaderComponent.propTypes = {
+    isFullScreen: PropTypes.bool,
     messageId: PropTypes.string
 };
 LoaderComponent.defaultProps = {
+    isFullScreen: false,
     messageId: 'gui.loader.headline'
 };
 

--- a/src/components/stage-wrapper/stage-wrapper.jsx
+++ b/src/components/stage-wrapper/stage-wrapper.jsx
@@ -12,6 +12,7 @@ import styles from './stage-wrapper.css';
 
 const StageWrapperComponent = function (props) {
     const {
+        isFullScreen,
         isRtl,
         isRendererSupported,
         loading,
@@ -41,13 +42,14 @@ const StageWrapperComponent = function (props) {
                 }
             </Box>
             {loading ? (
-                <Loader />
+                <Loader isFullScreen={isFullScreen} />
             ) : null}
         </Box>
     );
 };
 
 StageWrapperComponent.propTypes = {
+    isFullScreen: PropTypes.bool,
     isRendererSupported: PropTypes.bool.isRequired,
     isRtl: PropTypes.bool.isRequired,
     loading: PropTypes.bool,

--- a/src/components/stage-wrapper/stage-wrapper.jsx
+++ b/src/components/stage-wrapper/stage-wrapper.jsx
@@ -49,7 +49,7 @@ const StageWrapperComponent = function (props) {
 
 StageWrapperComponent.propTypes = {
     isRendererSupported: PropTypes.bool.isRequired,
-    isRtl: PropTypes.bool,
+    isRtl: PropTypes.bool.isRequired,
     loading: PropTypes.bool,
     stageSize: PropTypes.oneOf(Object.keys(STAGE_DISPLAY_SIZES)).isRequired,
     vm: PropTypes.instanceOf(VM).isRequired

--- a/src/containers/gui.jsx
+++ b/src/containers/gui.jsx
@@ -153,6 +153,7 @@ const mapStateToProps = state => {
         error: state.scratchGui.projectState.error,
         importInfoVisible: state.scratchGui.modals.importInfo,
         isError: getIsError(loadingState),
+        isFullScreen: state.scratchGui.mode.isFullScreen,
         isPlayerOnly: state.scratchGui.mode.isPlayerOnly,
         isRtl: state.locales.isRtl,
         isShowingProject: getIsShowingProject(loadingState),


### PR DESCRIPTION
Allow the loader component to display over the whole screen when in fullscreen mode. 

![fullscreen-loading](https://user-images.githubusercontent.com/654102/51045203-02078800-1591-11e9-97af-94490442b2e3.gif)

Also /cc @chrisgarrity this incidentally fixes an issue where the "ask" bubble went the wrong direction in RTL, which was caused by a mismatch between props passed in editor vs. player mode to the same StageWrapper component we were working on.


![image](https://user-images.githubusercontent.com/654102/51045328-5579d600-1591-11e9-8e0d-0279e122a0b2.png)

![image](https://user-images.githubusercontent.com/654102/51045387-7510fe80-1591-11e9-802e-325d9c0e7e72.png)
