### PR TITLE
Fix sound recorder issues

### DIFF
--- a/src/containers/record-modal.jsx
+++ b/src/containers/record-modal.jsx
@@ -43,7 +43,9 @@ class RecordModal extends React.Component {
         this.setState({recording: true});
     }
     handleStopRecording (samples, sampleRate, levels, trimStart, trimEnd) {
-        this.setState({samples, sampleRate, levels, trimStart, trimEnd, recording: false});
+        if (samples.length > 0) {
+            this.setState({samples, sampleRate, levels, trimStart, trimEnd, recording: false});
+        }
     }
     handlePlay () {
         this.setState({playing: true});

--- a/src/containers/recording-step.jsx
+++ b/src/containers/recording-step.jsx
@@ -41,7 +41,7 @@ class RecordingStep extends React.Component {
         this.setState({listening: true});
     }
     handleRecordingError () {
-        alert(this.props.intl.formatMessage(messages.extensionUrl)); // eslint-disable-line no-alert
+        alert(this.props.intl.formatMessage(messages.alertMsg)); // eslint-disable-line no-alert
     }
     handleLevelUpdate (level) {
         this.setState({level});

--- a/src/containers/sound-editor.jsx
+++ b/src/containers/sound-editor.jsx
@@ -120,8 +120,10 @@ class SoundEditor extends React.Component {
             const sampleCount = samples.length;
             const startIndex = Math.floor(this.state.trimStart * sampleCount);
             const endIndex = Math.floor(this.state.trimEnd * sampleCount);
-            const clippedSamples = samples.slice(startIndex, endIndex);
-            this.submitNewSamples(clippedSamples, sampleRate);
+            if (endIndex > startIndex) { // Strictly greater to prevent 0 sample sounds
+                const clippedSamples = samples.slice(startIndex, endIndex);
+                this.submitNewSamples(clippedSamples, sampleRate);
+            }
         }
     }
     handleUpdateTrimEnd (trimEnd) {

--- a/src/lib/audio/audio-recorder.js
+++ b/src/lib/audio/audio-recorder.js
@@ -96,8 +96,14 @@ class AudioRecorder {
             }
         }
 
-        const trimStart = Math.max(2, firstChunkAboveThreshold - 2) / this.buffers.length;
-        const trimEnd = Math.min(this.buffers.length - 2, lastChunkAboveThreshold + 2) / this.buffers.length;
+        let trimStart = Math.max(2, firstChunkAboveThreshold - 2) / this.buffers.length;
+        let trimEnd = Math.min(this.buffers.length - 2, lastChunkAboveThreshold + 2) / this.buffers.length;
+
+        // With very few samples, the automatic trimming can produce invalid values
+        if (trimStart >= trimEnd) {
+            trimStart = 0;
+            trimEnd = 1;
+        }
 
         const buffer = new Float32Array(this.buffers.length * this.bufferLength);
 


### PR DESCRIPTION
Fixes a few crashing errors that you could get related to zero sample audio buffers. In order of the commits:

- Fixes an issue where the auto trim could give invalid trim start/end values for short sounds
- Fixes an issue where clicking quickly on the record button could crash the recorder
- Fixes an issue where the alert message for sounds was incorrect
- Fixes https://github.com/LLK/scratch-gui/issues/715, where you could use the trimmers in the editor to get a zero length sound

