### PR TITLE
Fix issue where you couldn't add sprites from backpack when there are no sprites 

### DIFF
--- a/src/containers/costume-tab.jsx
+++ b/src/containers/costume-tab.jsx
@@ -206,7 +206,7 @@ class CostumeTab extends React.Component {
         this.fileInput.click();
     }
     handleDrop (dropInfo) {
-        if (dropInfo.dragType === DragConstants.COSTUME) {
+        if (dropInfo.dragType === DragConstants.COSTUME && dropInfo.newIndex !== null) {
             const sprite = this.props.vm.editingTarget.sprite;
             const activeCostume = sprite.costumes[this.state.selectedCostumeIndex];
             this.props.vm.reorderCostume(this.props.vm.editingTarget.id,

--- a/src/containers/sound-tab.jsx
+++ b/src/containers/sound-tab.jsx
@@ -130,7 +130,7 @@ class SoundTab extends React.Component {
     }
 
     handleDrop (dropInfo) {
-        if (dropInfo.dragType === DragConstants.SOUND) {
+        if (dropInfo.dragType === DragConstants.SOUND && dropInfo.newIndex !== null) {
             const sprite = this.props.vm.editingTarget.sprite;
             const activeSound = sprite.sounds[this.state.selectedSoundIndex];
 

--- a/src/containers/target-pane.jsx
+++ b/src/containers/target-pane.jsx
@@ -163,7 +163,7 @@ class TargetPane extends React.Component {
     }
     handleDrop (dragInfo) {
         const {sprite: targetId} = this.props.hoveredTarget;
-        if (dragInfo.dragType === DragConstants.SPRITE) {
+        if (dragInfo.dragType === DragConstants.SPRITE && dragInfo.newIndex !== null) {
             // Add one to both new and target index because we are not counting/moving the stage
             this.props.vm.reorderTarget(dragInfo.index + 1, dragInfo.newIndex + 1);
         } else if (dragInfo.dragType === DragConstants.BACKPACK_SPRITE) {

--- a/src/lib/sortable-hoc.jsx
+++ b/src/lib/sortable-hoc.jsx
@@ -33,10 +33,9 @@ const SortableHOC = function (WrappedComponent) {
                 }
                 this.containerBox = this.ref.getBoundingClientRect();
             } else if (!newProps.dragInfo.dragging && this.props.dragInfo.dragging) {
-                const newIndex = this.getMouseOverIndex();
-                if (newIndex !== null) {
-                    this.props.onDrop(Object.assign({}, this.props.dragInfo, {newIndex}));
-                }
+                this.props.onDrop(Object.assign({}, this.props.dragInfo, {
+                    newIndex: this.getMouseOverIndex()
+                }));
             }
         }
 


### PR DESCRIPTION
Fixes an issue where you could not drop a sprite from the backpack if there were no sprites in the list. Same applied for sounds if there were no sounds.

This is used because the sortable drop is also used for general dropping as well as sorting drop, so you need to be able to drop into a sortable list that does not contain any items.

Make the corresponding reorder code be more careful to check if there is a newIndex.

### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/LLK/scratch-gui/issues/4350

