### PR TITLE
Build vernier module using babel preset to make sure it works for www

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,7 +35,11 @@ const base = {
         rules: [{
             test: /\.jsx?$/,
             loader: 'babel-loader',
-            include: [path.resolve(__dirname, 'src'), /node_modules[\\/]scratch-[^\\/]+[\\/]src/],
+            include: [
+                path.resolve(__dirname, 'src'),
+                /node_modules[\\/]scratch-[^\\/]+[\\/]src/,
+                /node_modules[\\/]@vernier[\\/]dist // Vernier build needs to be transpiled for es5
+            ],
             options: {
                 // Explicitly disable babelrc so we don't catch various config
                 // in much lower dependencies.


### PR DESCRIPTION
Fixes an issue where the vms vernier dependency was not being built for es5 the way that www is expecting.

Use our babel presets to transpile it. 

/cc @ericrosenbaum 