### PR TITLE
Clear trim handles if trim cannot be completed.

### DIFF
--- a/src/containers/sound-editor.jsx
+++ b/src/containers/sound-editor.jsx
@@ -136,6 +136,12 @@ class SoundEditor extends React.Component {
             if (endIndex > startIndex) { // Strictly greater to prevent 0 sample sounds
                 const clippedSamples = samples.slice(startIndex, endIndex);
                 this.submitNewSamples(clippedSamples, sampleRate);
+            } else {
+                // Just clear the trim state, it cannot be completed
+                this.setState({
+                    trimStart: null,
+                    trimEnd: null
+                });
             }
         }
     }


### PR DESCRIPTION
There was a useability issue discovered in testing where trying to trim a sound to be of zero length would fail, but just leave the trimmers active. Clear them out, since the trim is invalid.

Repro by trying to trim a sound down to a single sample then keep trimming. The "save" button now always clears the trim handles.

/cc @ericrosenbaum 