### PR TITLE
Adds BorderedMenuItem and use it for delete menu

### DIFF
--- a/src/components/context-menu/context-menu.css
+++ b/src/components/context-menu/context-menu.css
@@ -17,23 +17,20 @@
     z-index: $z-index-context-menu;
 }
 
-.menu-item, .menu-item-bordered {
+.menu-item {
     padding: 8px 12px;
     white-space: nowrap;
     cursor: pointer;
     transition: 0.1s ease;
 }
 
-.menu-item-bordered {
-    border-top: 3px solid $text-primary;
-}
-
-.menu-item:hover, .menu-item-bordered:hover {
+.menu-item:hover {
+    background: $motion-primary;
     color: white;
 }
 
-.menu-item:hover {
-    background: $motion-primary;
+.menu-item-bordered {
+    border-top: 2px solid $text-primary-transparent;
 }
 
 .menu-item-bordered:hover {

--- a/src/components/context-menu/context-menu.css
+++ b/src/components/context-menu/context-menu.css
@@ -17,14 +17,25 @@
     z-index: $z-index-context-menu;
 }
 
-.menu-item {
+.menu-item, .menu-item-bordered {
     padding: 8px 12px;
     white-space: nowrap;
     cursor: pointer;
     transition: 0.1s ease;
 }
 
+.menu-item-bordered {
+    border-top: 3px solid $text-primary;
+}
+
+.menu-item:hover, .menu-item-bordered:hover {
+    color: white;
+}
+
 .menu-item:hover {
     background: $motion-primary;
-    color: white;
+}
+
+.menu-item-bordered:hover {
+    background: $red-primary;
 }

--- a/src/components/context-menu/context-menu.jsx
+++ b/src/components/context-menu/context-menu.jsx
@@ -17,7 +17,16 @@ const StyledMenuItem = props => (
     />
 );
 
+const BorderedMenuItem = props => (
+    <MenuItem
+        {...props}
+        attributes={{className: styles.menuItemBordered}}
+    />
+);
+
+
 export {
+    BorderedMenuItem,
     StyledContextMenu as ContextMenu,
     StyledMenuItem as MenuItem
 };

--- a/src/components/context-menu/context-menu.jsx
+++ b/src/components/context-menu/context-menu.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {ContextMenu, MenuItem} from 'react-contextmenu';
+import classNames from 'classnames';
 
 import styles from './context-menu.css';
 
@@ -20,7 +21,7 @@ const StyledMenuItem = props => (
 const BorderedMenuItem = props => (
     <MenuItem
         {...props}
-        attributes={{className: styles.menuItemBordered}}
+        attributes={{className: classNames(styles.menuItem, styles.menuItemBordered)}}
     />
 );
 

--- a/src/components/sprite-selector-item/sprite-selector-item.jsx
+++ b/src/components/sprite-selector-item/sprite-selector-item.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import CloseButton from '../close-button/close-button.jsx';
 import styles from './sprite-selector-item.css';
 import {ContextMenuTrigger} from 'react-contextmenu';
-import {ContextMenu, MenuItem} from '../context-menu/context-menu.jsx';
+import {BorderedMenuItem, ContextMenu, MenuItem} from '../context-menu/context-menu.jsx';
 import {FormattedMessage} from 'react-intl';
 
 // react-contextmenu requires unique id to match trigger and context menu
@@ -60,15 +60,6 @@ const SpriteSelectorItem = props => (
                         />
                     </MenuItem>
                 ) : null}
-                {props.onDeleteButtonClick ? (
-                    <MenuItem onClick={props.onDeleteButtonClick}>
-                        <FormattedMessage
-                            defaultMessage="delete"
-                            description="Menu item to delete in the right click menu"
-                            id="gui.spriteSelectorItem.contextMenuDelete"
-                        />
-                    </MenuItem>
-                ) : null }
                 {props.onExportButtonClick ? (
                     <MenuItem onClick={props.onExportButtonClick}>
                         <FormattedMessage
@@ -77,6 +68,15 @@ const SpriteSelectorItem = props => (
                             id="gui.spriteSelectorItem.contextMenuExport"
                         />
                     </MenuItem>
+                ) : null }
+                {props.onDeleteButtonClick ? (
+                    <BorderedMenuItem onClick={props.onDeleteButtonClick}>
+                        <FormattedMessage
+                            defaultMessage="delete"
+                            description="Menu item to delete in the right click menu"
+                            id="gui.spriteSelectorItem.contextMenuDelete"
+                        />
+                    </BorderedMenuItem>
                 ) : null }
             </ContextMenu>
         ) : null}


### PR DESCRIPTION
### Resolves
Resolves #4345 

### Proposed Changes
* Adds BorderedMenuItem, which has a border at the top and becomes red when hovered
* Use it for Delete menu (also reorder it)

![Red for delete](https://camo.githubusercontent.com/ccc86f0c64dbdc1bb1084f65170a1a44b3b4cba0/68747470733a2f2f63646e2e646973636f72646170702e636f6d2f6174746163686d656e74732f3334333436343437393534353039383234322f3533343933353433383234373539313933362f756e6b6e6f776e2e706e67)

### Reason for Changes
Some people accidentally delete sprites because there was no difference between this and the others

### Test Coverage
* Lint passed
* Checked on browser

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
