### PR TITLE
Improve layout/paint performance in editor while running a project

### DIFF
--- a/src/components/asset-panel/selector.css
+++ b/src/components/asset-panel/selector.css
@@ -56,7 +56,7 @@ $fade-out-distance: 100px;
 
 .list-item {
     width: 5rem;
-    min-height: 5rem;
+    height: 5rem;
     margin: 0.5rem auto;
 }
 

--- a/src/components/backpack/backpack.css
+++ b/src/components/backpack/backpack.css
@@ -69,9 +69,17 @@
 }
 
 .backpack-item {
-    min-width: 4rem;
-    max-width: 6rem;
+    width: 4rem;
+    height: 4.5rem;
     margin: 0 0.25rem;
+
+    /* Need to hide overflow because of background setting below */
+    overflow: hidden;
+}
+
+.backpack-item > div {
+    /* Need to set the background to get blend-mode below to work */
+    background: $ui-primary;
 }
 
 .backpack-item img {

--- a/src/components/sprite-selector-item/sprite-selector-item.css
+++ b/src/components/sprite-selector-item/sprite-selector-item.css
@@ -39,8 +39,24 @@
     filter: drop-shadow(0px 0px 2px  $ui-black-transparent);
 }
 
+/* Outer/Inner chicanery is to prevent layouts when sprite image changes */
+.sprite-image-outer {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    transform: translateZ(0);
+}
+
+.sprite-image-inner {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
 .sprite-image {
-    margin: auto;
     user-select: none;
     pointer-events: none;
     max-width: 32px;

--- a/src/components/sprite-selector-item/sprite-selector-item.jsx
+++ b/src/components/sprite-selector-item/sprite-selector-item.jsx
@@ -37,11 +37,15 @@ const SpriteSelectorItem = props => (
             <div className={styles.number}>{props.number}</div>
         )}
         {props.costumeURL ? (
-            <img
-                className={styles.spriteImage}
-                draggable={false}
-                src={props.costumeURL}
-            />
+            <div className={styles.spriteImageOuter}>
+                <div className={styles.spriteImageInner}>
+                    <img
+                        className={styles.spriteImage}
+                        draggable={false}
+                        src={props.costumeURL}
+                    />
+                </div>
+            </div>
         ) : null}
         <div className={styles.spriteInfo}>
             <div className={styles.spriteName}>{props.name}</div>

--- a/test/unit/components/__snapshots__/sprite-selector-item.test.jsx.snap
+++ b/test/unit/components/__snapshots__/sprite-selector-item.test.jsx.snap
@@ -30,11 +30,19 @@ exports[`SpriteSelectorItemComponent matches snapshot when given a number and de
   >
     5
   </div>
-  <img
+  <div
     className={undefined}
-    draggable={false}
-    src="https://scratch.mit.edu/foo/bar/pony"
-  />
+  >
+    <div
+      className={undefined}
+    >
+      <img
+        className={undefined}
+        draggable={false}
+        src="https://scratch.mit.edu/foo/bar/pony"
+      />
+    </div>
+  </div>
   <div
     className={undefined}
   >
@@ -107,11 +115,19 @@ exports[`SpriteSelectorItemComponent matches snapshot when selected 1`] = `
       src="test-file-stub"
     />
   </div>
-  <img
+  <div
     className={undefined}
-    draggable={false}
-    src="https://scratch.mit.edu/foo/bar/pony"
-  />
+  >
+    <div
+      className={undefined}
+    >
+      <img
+        className={undefined}
+        draggable={false}
+        src="https://scratch.mit.edu/foo/bar/pony"
+      />
+    </div>
+  </div>
   <div
     className={undefined}
   >


### PR DESCRIPTION
This PR introduces a couple of layout/css tricks in order to vastly improve the layout+paint+composition performance of the editor while a typical projects is running. The main improvement is to apply the same layout trick that is used in the sprite library to allow the sprite selector images to change frequently without causing a layout of the target pane as a whole. That makes it so much less layout/painting has to happen:

![birds-develop](https://user-images.githubusercontent.com/654102/51263957-5345bc00-1983-11e9-8735-2be239ab69c8.gif)
![birds-fixed](https://user-images.githubusercontent.com/654102/51263959-5345bc00-1983-11e9-80d7-ab0988145651.gif)

This improves the composition time by almost a half on both low-power machines (chromebook composition time goes from 20ms to 10ms) and high-power machines (my laptop goes from 5ms to 2.5ms).

I see an almost 50% improvement in frame times on the low-power chromebook using the "Birds" project (id=198711193) which was chosen from the front page.

Prior to this change, the react updates were a smaller part of frame time than the layout+paint+comp part, but this change makes the react portion the dominant blocker for frame time (on this project). 

FYI the changes to the selector/backpack is to make those work with the style changes on the sprite-selector-item, since that component is used in those places as well.
