### PR TITLE
Fix delete button on sprite tiles

### DIFF
--- a/src/components/sprite-selector-item/sprite-selector-item.jsx
+++ b/src/components/sprite-selector-item/sprite-selector-item.jsx
@@ -26,13 +26,6 @@ const SpriteSelectorItem = props => (
         disable={props.dragging}
         id={`${props.name}-${contextMenuId}`}
     >
-        {(props.selected && props.onDeleteButtonClick) ? (
-            <CloseButton
-                className={styles.deleteButton}
-                size={CloseButton.SIZE_SMALL}
-                onClick={props.onDeleteButtonClick}
-            />
-        ) : null }
         {typeof props.number === 'undefined' ? null : (
             <div className={styles.number}>{props.number}</div>
         )}
@@ -53,6 +46,13 @@ const SpriteSelectorItem = props => (
                 <div className={styles.spriteDetails}>{props.details}</div>
             ) : null}
         </div>
+        {(props.selected && props.onDeleteButtonClick) ? (
+            <CloseButton
+                className={styles.deleteButton}
+                size={CloseButton.SIZE_SMALL}
+                onClick={props.onDeleteButtonClick}
+            />
+        ) : null }
         {props.onDuplicateButtonClick || props.onDeleteButtonClick || props.onExportButtonClick ? (
             <ContextMenu id={`${props.name}-${contextMenuId++}`}>
                 {props.onDuplicateButtonClick ? (

--- a/test/integration/sprites.test.js
+++ b/test/integration/sprites.test.js
@@ -76,6 +76,17 @@ describe('Working with sprites', () => {
         await expect(logs).toEqual([]);
     });
 
+    test('Deleting by x button on sprite tile', async () => {
+        await loadUri(uri);
+        await clickXpath('//button[@title="Try It"]');
+        await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for scroll animation
+        await clickXpath('//*[@aria-label="Close"]'); // Only visible close button is on the sprite
+        // Confirm that the stage has been switched to
+        await findByText('Stage selected: no motion blocks');
+        const logs = await getLogs();
+        await expect(logs).toEqual([]);
+    });
+
     test('Adding a sprite by uploading a png', async () => {
         await loadUri(uri);
         await clickXpath('//button[@title="Try It"]');

--- a/test/unit/components/__snapshots__/sprite-selector-item.test.jsx.snap
+++ b/test/unit/components/__snapshots__/sprite-selector-item.test.jsx.snap
@@ -14,18 +14,6 @@ exports[`SpriteSelectorItemComponent matches snapshot when given a number and de
   onTouchStart={[Function]}
 >
   <div
-    aria-label="Close"
-    className=""
-    onClick={[Function]}
-    role="button"
-    tabIndex="0"
-  >
-    <img
-      className=""
-      src="test-file-stub"
-    />
-  </div>
-  <div
     className={undefined}
   >
     5
@@ -56,6 +44,18 @@ exports[`SpriteSelectorItemComponent matches snapshot when given a number and de
     >
       480 x 360
     </div>
+  </div>
+  <div
+    aria-label="Close"
+    className=""
+    onClick={[Function]}
+    role="button"
+    tabIndex="0"
+  >
+    <img
+      className=""
+      src="test-file-stub"
+    />
   </div>
   <nav
     className="react-contextmenu"
@@ -104,18 +104,6 @@ exports[`SpriteSelectorItemComponent matches snapshot when selected 1`] = `
   onTouchStart={[Function]}
 >
   <div
-    aria-label="Close"
-    className=""
-    onClick={[Function]}
-    role="button"
-    tabIndex="0"
-  >
-    <img
-      className=""
-      src="test-file-stub"
-    />
-  </div>
-  <div
     className={undefined}
   >
     <div
@@ -136,6 +124,18 @@ exports[`SpriteSelectorItemComponent matches snapshot when selected 1`] = `
     >
       Pony sprite
     </div>
+  </div>
+  <div
+    aria-label="Close"
+    className=""
+    onClick={[Function]}
+    role="button"
+    tabIndex="0"
+  >
+    <img
+      className=""
+      src="test-file-stub"
+    />
   </div>
   <nav
     className="react-contextmenu"


### PR DESCRIPTION
This fixes a bug I introduced in https://github.com/LLK/scratch-gui/pull/4362, by putting an absolutely positioned image above the "close" button that deletes sprites. 

I fixed the issue and added an integration test. Previous integration tests only tested the right-click -> delete sprite for some reason.