### PR TITLE
Fix backpack squishing

### DIFF
--- a/src/components/backpack/backpack.css
+++ b/src/components/backpack/backpack.css
@@ -72,6 +72,7 @@
     width: 4rem;
     height: 4.5rem;
     margin: 0 0.25rem;
+    flex-shrink: 0;
 
     /* Need to hide overflow because of background setting below */
     overflow: hidden;


### PR DESCRIPTION
The layout perf fixed introduced an issue where the backpack items could squash instead of scrolling, because we removed the min-width, and width is just a suggestion in flex :) 

Added flex-shrink to really, really demand that the width be the width. 

![image](https://user-images.githubusercontent.com/654102/51347040-28d02d80-1a6d-11e9-807a-e08ed22bf9d2.png)


![image](https://user-images.githubusercontent.com/654102/51347044-2a99f100-1a6d-11e9-9fa9-74bb0c8d4aae.png)

/cc @BryceLTaylor 
