### PR TITLE
Add BorderedMenuItem and use it for delete menu, with updated style

### DIFF
--- a/src/components/context-menu/context-menu.css
+++ b/src/components/context-menu/context-menu.css
@@ -28,3 +28,11 @@
     background: $motion-primary;
     color: white;
 }
+
+.menu-item-bordered {
+    border-top: 2px solid $text-primary-transparent;
+}
+
+.menu-item-bordered:hover {
+    background: $red-primary;
+}

--- a/src/components/context-menu/context-menu.css
+++ b/src/components/context-menu/context-menu.css
@@ -34,5 +34,5 @@
 }
 
 .menu-item-bordered:hover {
-    background: $error-light;
+    background: $error-primary;
 }

--- a/src/components/context-menu/context-menu.css
+++ b/src/components/context-menu/context-menu.css
@@ -30,9 +30,9 @@
 }
 
 .menu-item-bordered {
-    border-top: 2px solid $text-primary-transparent;
+    border-top: 1px solid $ui-black-transparent;
 }
 
 .menu-item-bordered:hover {
-    background: $red-primary;
+    background: $error-light;
 }

--- a/src/components/context-menu/context-menu.jsx
+++ b/src/components/context-menu/context-menu.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {ContextMenu, MenuItem} from 'react-contextmenu';
+import classNames from 'classnames';
 
 import styles from './context-menu.css';
 
@@ -17,7 +18,16 @@ const StyledMenuItem = props => (
     />
 );
 
+const BorderedMenuItem = props => (
+    <MenuItem
+        {...props}
+        attributes={{className: classNames(styles.menuItem, styles.menuItemBordered)}}
+    />
+);
+
+
 export {
+    BorderedMenuItem,
     StyledContextMenu as ContextMenu,
     StyledMenuItem as MenuItem
 };

--- a/src/components/sprite-selector-item/sprite-selector-item.jsx
+++ b/src/components/sprite-selector-item/sprite-selector-item.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import CloseButton from '../close-button/close-button.jsx';
 import styles from './sprite-selector-item.css';
 import {ContextMenuTrigger} from 'react-contextmenu';
-import {ContextMenu, MenuItem} from '../context-menu/context-menu.jsx';
+import {BorderedMenuItem, ContextMenu, MenuItem} from '../context-menu/context-menu.jsx';
 import {FormattedMessage} from 'react-intl';
 
 // react-contextmenu requires unique id to match trigger and context menu
@@ -64,15 +64,6 @@ const SpriteSelectorItem = props => (
                         />
                     </MenuItem>
                 ) : null}
-                {props.onDeleteButtonClick ? (
-                    <MenuItem onClick={props.onDeleteButtonClick}>
-                        <FormattedMessage
-                            defaultMessage="delete"
-                            description="Menu item to delete in the right click menu"
-                            id="gui.spriteSelectorItem.contextMenuDelete"
-                        />
-                    </MenuItem>
-                ) : null }
                 {props.onExportButtonClick ? (
                     <MenuItem onClick={props.onExportButtonClick}>
                         <FormattedMessage
@@ -81,6 +72,15 @@ const SpriteSelectorItem = props => (
                             id="gui.spriteSelectorItem.contextMenuExport"
                         />
                     </MenuItem>
+                ) : null }
+                {props.onDeleteButtonClick ? (
+                    <BorderedMenuItem onClick={props.onDeleteButtonClick}>
+                        <FormattedMessage
+                            defaultMessage="delete"
+                            description="Menu item to delete in the right click menu"
+                            id="gui.spriteSelectorItem.contextMenuDelete"
+                        />
+                    </BorderedMenuItem>
                 ) : null }
             </ContextMenu>
         ) : null}


### PR DESCRIPTION
Reverts the reversion LLK/scratch-gui#4374 , and adds updated styling

Resolves https://github.com/LLK/scratch-gui/issues/4345

## Proposed Changes

Adds BorderedMenuItem, which has a border at the top and becomes red when hovered
Use it for Delete menu (also reorder it)

## Reason for Changes

Some people accidentally delete sprites because there was no difference between this and the others