### PR TITLE
Throttle target updates to 500ms

### DIFF
--- a/src/containers/direction-picker.jsx
+++ b/src/containers/direction-picker.jsx
@@ -12,11 +12,16 @@ class DirectionPicker extends React.Component {
             'handleClosePopover',
             'handleClickLeftRight',
             'handleClickDontRotate',
-            'handleClickAllAround'
+            'handleClickAllAround',
+            'handleChangeDirection'
         ]);
         this.state = {
-            popoverOpen: false
+            popoverOpen: false,
+            direction: props.direction
         };
+    }
+    componentWillReceiveProps (nextProps) {
+        this.setState({direction: nextProps.direction});
     }
     handleOpenPopover () {
         this.setState({popoverOpen: true});
@@ -33,15 +38,23 @@ class DirectionPicker extends React.Component {
     handleClickDontRotate () {
         this.props.onChangeRotationStyle(RotationStyles.DONT_ROTATE);
     }
+    handleChangeDirection (direction) {
+        // Wrap clamp the dial output to [-180, 180]
+        const clamped = Math.round(direction - (Math.floor((direction + 179) / 360) * 360));
+        this.setState({direction: Math.round(clamped)}); // Display as rounded
+
+        // Send the raw direction to the VM, it will wrap it but not round it
+        this.props.onChangeDirection(direction);
+    }
     render () {
         return (
             <DirectionComponent
-                direction={this.props.direction}
+                direction={this.state.direction}
                 disabled={this.props.disabled}
                 labelAbove={this.props.labelAbove}
                 popoverOpen={this.state.popoverOpen && !this.props.disabled}
                 rotationStyle={this.props.rotationStyle}
-                onChangeDirection={this.props.onChangeDirection}
+                onChangeDirection={this.handleChangeDirection}
                 onClickAllAround={this.handleClickAllAround}
                 onClickDontRotate={this.handleClickDontRotate}
                 onClickLeftRight={this.handleClickLeftRight}

--- a/src/lib/vm-listener-hoc.jsx
+++ b/src/lib/vm-listener-hoc.jsx
@@ -2,6 +2,7 @@ import bindAll from 'lodash.bindall';
 import PropTypes from 'prop-types';
 import React from 'react';
 import VM from 'scratch-vm';
+import throttle from 'lodash.throttle';
 
 import {connect} from 'react-redux';
 
@@ -34,7 +35,7 @@ const vmListenerHOC = function (WrappedComponent) {
             // mounts.
             // If the wrapped component uses the vm in componentDidMount, then
             // we need to start listening before mounting the wrapped component.
-            this.props.vm.on('targetsUpdate', this.handleTargetsUpdate);
+            this.props.vm.on('targetsUpdate', throttle(this.handleTargetsUpdate, 500));
             this.props.vm.on('MONITORS_UPDATE', this.props.onMonitorsUpdate);
             this.props.vm.on('BLOCK_DRAG_UPDATE', this.props.onBlockDragUpdate);
             this.props.vm.on('TURBO_MODE_ON', this.props.onTurboModeOn);


### PR DESCRIPTION
Mostly this helps with longer sprite lists with rotating costumes, but generally removes the react bottleneck while running the project.

Had to update the direction picker to act like a "buffered input", i.e. store a temporary state to make dragging the dial smooth, and take updates from the VM when they come.

This brings the costume updates in the sprite list more in line with the scratch2 behavior, where it didn't change the tile image every frame.

/cc @picklesrus 

Before merging, I'd like to talk to @carljbowman about the design implications of this. I'll add it to the agenda for next team meeting too.