### PR TITLE
Remove transition on sprite tiles to make placeholder not flash black.

### DIFF
--- a/src/components/asset-panel/selector.css
+++ b/src/components/asset-panel/selector.css
@@ -72,6 +72,6 @@ $fade-out-distance: 100px;
 
 
 .list-item.placeholder {
-    background: black;
+    background: white;
     filter: opacity(15%) brightness(0%);
 }

--- a/src/components/sprite-selector-item/sprite-selector-item.css
+++ b/src/components/sprite-selector-item/sprite-selector-item.css
@@ -18,7 +18,6 @@
 
     text-align: center;
     cursor: pointer;
-    transition: 0.25s ease-out;
 
     user-select: none;
     touch-action: none;


### PR DESCRIPTION
Also use white as the background since it gives the same impact and will not look bad if the filter isn't applied or takes a while to be applied

![reorder-black](https://user-images.githubusercontent.com/654102/51427657-77460f00-1bc8-11e9-8b43-95877085bb52.gif)
![reorder-fixed](https://user-images.githubusercontent.com/654102/51427658-77460f00-1bc8-11e9-9830-bfc740d74403.gif)

This is one of the things that appears much more on slower machines, since the background color is not transitioned but the filter is.

Resolves https://github.com/LLK/scratch-gui/issues/2512