### PR TITLE
Update WeDo 2.0 extension name

### DIFF
--- a/src/lib/libraries/extensions/index.jsx
+++ b/src/lib/libraries/extensions/index.jsx
@@ -204,7 +204,7 @@ export default [
         helpLink: 'https://scratch.mit.edu/ev3'
     },
     {
-        name: 'LEGO WeDo 2.0',
+        name: 'LEGO Education WeDo 2.0',
         extensionId: 'wedo2',
         collaborator: 'LEGO',
         iconURL: wedoImage,


### PR DESCRIPTION
Note that the extension name appears in the extension library and in the connection modal. 