### PR TITLE
Disable target updates while sound recording

### DIFF
--- a/src/lib/vm-listener-hoc.jsx
+++ b/src/lib/vm-listener-hoc.jsx
@@ -164,7 +164,9 @@ const vmListenerHOC = function (WrappedComponent) {
     };
     const mapStateToProps = state => ({
         // Do not emit target or project updates in fullscreen or player only mode
-        shouldEmitUpdates: !state.scratchGui.mode.isFullScreen && !state.scratchGui.mode.isPlayerOnly,
+        // or when recording sounds (it leads to garbled recordings on low-power machines)
+        shouldEmitUpdates: !state.scratchGui.mode.isFullScreen && !state.scratchGui.mode.isPlayerOnly &&
+            !state.scratchGui.modals.soundRecorder,
         vm: state.scratchGui.vm,
         username: state.session && state.session.session && state.session.session.user ?
             state.session.session.user.username : ''

--- a/test/unit/util/vm-listener-hoc.test.jsx
+++ b/test/unit/util/vm-listener-hoc.test.jsx
@@ -15,6 +15,7 @@ describe('VMListenerHOC', () => {
         store = mockStore({
             scratchGui: {
                 mode: {},
+                modals: {},
                 vm: vm
             }
         });
@@ -48,5 +49,46 @@ describe('VMListenerHOC', () => {
         );
         const child = wrapper.find(Component);
         expect(child.props().onGreenFlag).toBeUndefined();
+    });
+
+    test('targetsUpdate event from vm triggers targets update action', () => {
+        const Component = () => (<div />);
+        const WrappedComponent = vmListenerHOC(Component);
+        mount(
+            <WrappedComponent
+                store={store}
+                vm={vm}
+            />
+        );
+        const targetList = [];
+        const editingTarget = 'id';
+        vm.emit('targetsUpdate', {targetList, editingTarget});
+        const actions = store.getActions();
+        expect(actions[0].type).toEqual('scratch-gui/targets/UPDATE_TARGET_LIST');
+        expect(actions[0].targets).toEqual(targetList);
+        expect(actions[0].editingTarget).toEqual(editingTarget);
+    });
+
+    test('targetsUpdate does not dispatch if the sound recorder is visible', () => {
+        const Component = () => (<div />);
+        const WrappedComponent = vmListenerHOC(Component);
+        store = mockStore({
+            scratchGui: {
+                mode: {},
+                modals: {soundRecorder: true},
+                vm: vm
+            }
+        });
+        mount(
+            <WrappedComponent
+                store={store}
+                vm={vm}
+            />
+        );
+        const targetList = [];
+        const editingTarget = 'id';
+        vm.emit('targetsUpdate', {targetList, editingTarget});
+        const actions = store.getActions();
+        expect(actions.length).toEqual(0);
     });
 });


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Partially resolves issue where trying to record a sound while a project was running would result in choppy recordings.

it is still possible to get the VM to absorb so much CPU time that the recording is choppy, but this removes a common cause of choppy recordings.

### Proposed Changes

_Describe what this Pull Request does_

Do not dispatch the targetsUpdate event when the sound recorder is up.

### Reason for Changes

_Explain why these changes should be made_

Anything that consumes CPU time while making a recording can lead to choppy recordings, this is a simple way to prevent one such thing.

### Test Coverage

_Please show how you have added tests to cover your changes_

Added a unit test for the vm-listener to cover the targetsUpdate dispatch functionality, and add another test for the new functionality.


For testing manually, just try recording a sound while you have a stack of blocks changing the editing targets properties (like forever -> turn 15 degrees), or while running a project like "Birds" #198711193 