### PR TITLE
Remove the redux throttle for targets update.

### DIFF
--- a/src/reducers/targets.js
+++ b/src/reducers/targets.js
@@ -39,10 +39,7 @@ const updateTargets = function (targetList, editingTarget) {
     return {
         type: UPDATE_TARGET_LIST,
         targets: targetList,
-        editingTarget: editingTarget,
-        meta: {
-            throttle: 30
-        }
+        editingTarget: editingTarget
     };
 };
 const highlightTarget = function (targetId) {


### PR DESCRIPTION
This fixes the root cause of #2858, which is caused because we are rendering the sound editor based on the GUI editing target data, but retrieving the sound based on the vms editing target data. The throttle of the redux action was causing those to get out of sync while a project was running.

The throttle is not needed because the vm runtime already batches those updates at 30 fps. The updates that come from top-level actions like switching sprites go out immediately.

This is also a minor performance boost, because there was a few ms being spent in setting and checking timers that were not needed.

/cc @picklesrus I'm glad we had just been talking about this, because i'm much more confident that this can be safely removed. 

@ericrosenbaum tagging you to just test the functionality since you found that bug.