### PR TITLE
Throttle costume and watermark updates

### DIFF
--- a/src/components/sprite-selector/sprite-list.jsx
+++ b/src/components/sprite-selector/sprite-list.jsx
@@ -12,7 +12,7 @@ import ThrottledPropertyHOC from '../../lib/throttled-property-hoc.jsx';
 
 import styles from './sprite-selector.css';
 
-const ThrottledSpriteSelectorItem = ThrottledPropertyHOC('asset', 500, SpriteSelectorItem);
+const ThrottledSpriteSelectorItem = ThrottledPropertyHOC('asset', 500)(SpriteSelectorItem);
 
 const SpriteList = function (props) {
     const {

--- a/src/components/sprite-selector/sprite-list.jsx
+++ b/src/components/sprite-selector/sprite-list.jsx
@@ -8,8 +8,11 @@ import Box from '../box/box.jsx';
 import SpriteSelectorItem from '../../containers/sprite-selector-item.jsx';
 import SortableHOC from '../../lib/sortable-hoc.jsx';
 import SortableAsset from '../asset-panel/sortable-asset.jsx';
+import ThrottledPropertyHOC from '../../lib/throttled-property-hoc.jsx';
 
 import styles from './sprite-selector.css';
+
+const ThrottledSpriteSelectorItem = ThrottledPropertyHOC('asset', 500, SpriteSelectorItem);
 
 const SpriteList = function (props) {
     const {
@@ -74,7 +77,7 @@ const SpriteList = function (props) {
                             onAddSortable={onAddSortable}
                             onRemoveSortable={onRemoveSortable}
                         >
-                            <SpriteSelectorItem
+                            <ThrottledSpriteSelectorItem
                                 asset={sprite.costume && sprite.costume.asset}
                                 className={classNames(styles.sprite, {
                                     [styles.raised]: isRaised,

--- a/src/components/sprite-selector/sprite-list.jsx
+++ b/src/components/sprite-selector/sprite-list.jsx
@@ -80,7 +80,7 @@ const SpriteList = function (props) {
                                     [styles.raised]: isRaised,
                                     [styles.receivedBlocks]: receivedBlocks
                                 })}
-                                dragPayload={sprite}
+                                dragPayload={sprite.id}
                                 dragType={DragConstants.SPRITE}
                                 id={sprite.id}
                                 index={index}

--- a/src/containers/sprite-selector-item.jsx
+++ b/src/containers/sprite-selector-item.jsx
@@ -14,7 +14,7 @@ import SpriteSelectorItemComponent from '../components/sprite-selector-item/spri
 
 const dragThreshold = 3; // Same as the block drag threshold
 
-class SpriteSelectorItem extends React.Component {
+class SpriteSelectorItem extends React.PureComponent {
     constructor (props) {
         super(props);
         bindAll(this, [
@@ -32,16 +32,6 @@ class SpriteSelectorItem extends React.Component {
 
         // Asset ID of the current decoded costume
         this.decodedAssetId = null;
-    }
-    shouldComponentUpdate (nextProps) {
-        // Ignore dragPayload due to https://github.com/LLK/scratch-gui/issues/3172.
-        // This function should be removed once the issue is fixed.
-        for (const property in nextProps) {
-            if (property !== 'dragPayload' && this.props[property] !== nextProps[property]) {
-                return true;
-            }
-        }
-        return false;
     }
     getCostumeData () {
         if (this.props.costumeURL) return this.props.costumeURL;
@@ -153,10 +143,7 @@ SpriteSelectorItem.propTypes = {
     asset: PropTypes.instanceOf(storage.Asset),
     costumeURL: PropTypes.string,
     dispatchSetHoveredSprite: PropTypes.func.isRequired,
-    dragPayload: PropTypes.shape({
-        name: PropTypes.string,
-        body: PropTypes.string
-    }),
+    dragPayload: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     dragType: PropTypes.string,
     dragging: PropTypes.bool,
     id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),

--- a/src/containers/sprite-selector-item.jsx
+++ b/src/containers/sprite-selector-item.jsx
@@ -29,9 +29,6 @@ class SpriteSelectorItem extends React.PureComponent {
             'handleMouseMove',
             'handleMouseUp'
         ]);
-
-        // Asset ID of the current decoded costume
-        this.decodedAssetId = null;
     }
     getCostumeData () {
         if (this.props.costumeURL) return this.props.costumeURL;

--- a/src/containers/stage-selector.jsx
+++ b/src/containers/stage-selector.jsx
@@ -10,6 +10,7 @@ import {activateTab, COSTUMES_TAB_INDEX} from '../reducers/editor-tab';
 import {setHoveredSprite} from '../reducers/hovered-target';
 import DragConstants from '../lib/drag-constants';
 import DropAreaHOC from '../lib/drop-area-hoc.jsx';
+import ThrottledPropertyHOC from '../lib/throttled-property-hoc.jsx';
 import {emptyCostume} from '../lib/empty-assets';
 import sharedMessages from '../lib/shared-messages';
 import {fetchCode} from '../lib/backpack-api';
@@ -27,7 +28,9 @@ const dragTypes = [
     DragConstants.BACKPACK_CODE
 ];
 
-const DroppableStage = DropAreaHOC(dragTypes)(StageSelectorComponent);
+const DroppableThrottledStage = DropAreaHOC(dragTypes)(
+    ThrottledPropertyHOC('url', 500, StageSelectorComponent)
+);
 
 class StageSelector extends React.Component {
     constructor (props) {
@@ -116,7 +119,7 @@ class StageSelector extends React.Component {
         const componentProps = omit(this.props, [
             'asset', 'dispatchSetHoveredSprite', 'id', 'intl', 'onActivateTab', 'onSelect']);
         return (
-            <DroppableStage
+            <DroppableThrottledStage
                 fileInputRef={this.setFileInput}
                 onBackdropFileUpload={this.handleBackdropUpload}
                 onBackdropFileUploadClick={this.handleFileUploadClick}

--- a/src/containers/stage-selector.jsx
+++ b/src/containers/stage-selector.jsx
@@ -29,7 +29,7 @@ const dragTypes = [
 ];
 
 const DroppableThrottledStage = DropAreaHOC(dragTypes)(
-    ThrottledPropertyHOC('url', 500, StageSelectorComponent)
+    ThrottledPropertyHOC('url', 500)(StageSelectorComponent)
 );
 
 class StageSelector extends React.Component {

--- a/src/containers/watermark.jsx
+++ b/src/containers/watermark.jsx
@@ -65,7 +65,7 @@ const mapStateToProps = state => {
 const ConnectedComponent = connect(
     mapStateToProps
 )(
-    ThrottledPropertyHOC('asset', 500, Watermark)
+    ThrottledPropertyHOC('asset', 500)(Watermark)
 );
 
 export default ConnectedComponent;

--- a/src/containers/watermark.jsx
+++ b/src/containers/watermark.jsx
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
 
+import ThrottledPropertyHOC from '../lib/throttled-property-hoc.jsx';
+
 import VM from 'scratch-vm';
 import storage from '../lib/storage';
 import getCostumeUrl from '../lib/get-costume-url';
@@ -16,8 +18,6 @@ class Watermark extends React.Component {
         bindAll(this, [
             'getCostumeData'
         ]);
-        // Asset ID of the current sprite's current costume
-        this.decodedAssetId = null;
     }
 
     getCostumeData () {
@@ -64,6 +64,8 @@ const mapStateToProps = state => {
 
 const ConnectedComponent = connect(
     mapStateToProps
-)(Watermark);
+)(
+    ThrottledPropertyHOC('asset', 500, Watermark)
+);
 
 export default ConnectedComponent;

--- a/src/lib/backpack/sprite-payload.js
+++ b/src/lib/backpack/sprite-payload.js
@@ -1,23 +1,29 @@
 import jpegThumbnail from './jpeg-thumbnail';
 
-const spritePayload = (sprite, vm) => vm.exportSprite(
-    sprite.id,
-    'base64'
-).then(zippedSprite => {
-    const payload = {
-        type: 'sprite',
-        name: sprite.name,
-        mime: 'application/zip',
-        body: zippedSprite,
-        // Filled in below
-        thumbnail: ''
-    };
+const spritePayload = (id, vm) => {
+    const target = vm.runtime.getTargetById(id);
+    if (!target) return null;
 
-    const costumeDataUrl = sprite.costume.asset.encodeDataURI();
-    return jpegThumbnail(costumeDataUrl).then(thumbnail => {
-        payload.thumbnail = thumbnail.replace('data:image/jpeg;base64,', '');
-        return payload;
+    return vm.exportSprite(
+        id,
+        'base64'
+    ).then(zippedSprite => {
+        const payload = {
+            type: 'sprite',
+            name: target.sprite.name,
+            mime: 'application/zip',
+            body: zippedSprite,
+            // Filled in below
+            thumbnail: ''
+        };
+
+        const costumeDataUrl = target.sprite.costumes[target.currentCostume].asset.encodeDataURI();
+
+        return jpegThumbnail(costumeDataUrl).then(thumbnail => {
+            payload.thumbnail = thumbnail.replace('data:image/jpeg;base64,', '');
+            return payload;
+        });
     });
-});
+};
 
 export default spritePayload;

--- a/src/lib/throttled-property-hoc.jsx
+++ b/src/lib/throttled-property-hoc.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+/* Higher Order Component to throttle updates to specific props.
+ * Why? Because certain prop updates are expensive, and need to be throttled.
+ * This allows renders when other properties change, and will use the last
+ * rendered value of a prop for comparison.
+ * @param {string} propName the name of the prop to throttle updates from.
+ * @param {string} throttleTime the minimum time between updates to that specific property.
+ * @param {React.Component} WrappedComponent component who will not update for certain props.
+ * @returns {React.Component} component with throttling behavior
+ */
+const ThrottledPropertyHOC = function (propName, throttleTime, WrappedComponent) {
+    class ThrottledPropertyWrapper extends React.Component {
+        shouldComponentUpdate (nextProps) {
+            for (const property in nextProps) {
+                if (property !== propName && this.props[property] !== nextProps[property]) {
+                    return true; // Always update if another property has changed
+                }
+            }
+
+            // If only that prop has changed, allow update to go to render based
+            // on _lastRenderedTime and _lastRenderTime are updated in render
+            if (nextProps[propName] !== this._lastRenderedValue &&
+                Date.now() - this._lastRenderTime > throttleTime
+            ) {
+                return true; // Allow this update to go to render
+            }
+
+            return false;
+        }
+        render () {
+            this._lastRenderTime = Date.now();
+            this._lastRenderedValue = this.props[propName];
+            return (
+                <WrappedComponent {...this.props} />
+            );
+        }
+    }
+
+    return ThrottledPropertyWrapper;
+};
+
+export default ThrottledPropertyHOC;

--- a/test/unit/util/throttled-property-hoc.test.jsx
+++ b/test/unit/util/throttled-property-hoc.test.jsx
@@ -13,7 +13,7 @@ describe('VMListenerHOC', () => {
                 value={propToThrottle}
             />
         );
-        const WrappedComponent = ThrottledPropertyHOC('propToThrottle', throttleTime, Component);
+        const WrappedComponent = ThrottledPropertyHOC('propToThrottle', throttleTime)(Component);
 
         global.Date.now = () => 0;
 

--- a/test/unit/util/throttled-property-hoc.test.jsx
+++ b/test/unit/util/throttled-property-hoc.test.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import {mount} from 'enzyme';
+
+import ThrottledPropertyHOC from '../../../src/lib/throttled-property-hoc.jsx';
+
+describe('VMListenerHOC', () => {
+    let mounted;
+    const throttleTime = 500;
+    beforeEach(() => {
+        const Component = ({propToThrottle, doNotThrottle}) => (
+            <input
+                name={doNotThrottle}
+                value={propToThrottle}
+            />
+        );
+        const WrappedComponent = ThrottledPropertyHOC('propToThrottle', throttleTime, Component);
+
+        global.Date.now = () => 0;
+
+        mounted = mount(
+            <WrappedComponent
+                doNotThrottle="oldvalue"
+                propToThrottle={0}
+            />
+        );
+    });
+
+    test('it passes the props on initial render ', () => {
+        expect(mounted.find('[value=0]').exists()).toEqual(true);
+        expect(mounted.find('[name="oldvalue"]').exists()).toEqual(true);
+    });
+
+    test('it does not rerender if throttled prop is updated too soon', () => {
+        global.Date.now = () => throttleTime / 2;
+        mounted.setProps({propToThrottle: 1});
+        mounted.update();
+        expect(mounted.find('[value=0]').exists()).toEqual(true);
+    });
+
+    test('it does rerender if throttled prop is updated after throttle timeout', () => {
+        global.Date.now = () => throttleTime * 2;
+        mounted.setProps({propToThrottle: 1});
+        mounted.update();
+        expect(mounted.find('[value=1]').exists()).toEqual(true);
+    });
+
+    test('it does rerender if a non-throttled prop is changed', () => {
+        global.Date.now = () => throttleTime / 2;
+        mounted.setProps({doNotThrottle: 'newvalue', propToThrottle: 2});
+        mounted.update();
+        expect(mounted.find('[name="newvalue"]').exists()).toEqual(true);
+        expect(mounted.find('[value=2]').exists()).toEqual(true);
+    });
+});


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Greatly improves performance of projects, specifically on low-power machines.

This is a more specific follow up to #4387, after talking to people about ux implications

### Proposed Changes

_Describe what this Pull Request does_

Throttle updates to sprite list costumes to 500ms. Does not throttle any other sprite info/list property. Also throttle the watermark updates.

Introduces a new HOC to handle this specific behavior, where we want to throttle updates on a specific prop.

### Reason for Changes

_Explain why these changes should be made_

Costume updates come in too quickly and are not very useful.

@carljbowman this avoids the UX problems identified in our group meeting. Specifically:
- it always allows updates to all the sprite info values, so interacting with the sprite info values or reordering sprites is always real-time.
- it is throttled on a per-sprite-tile basis, so costume changes are instantaneous if you make them manually on a sprite that isn't already updating.

### Test Coverage

_Please show how you have added tests to cover your changes_

Added unit test coverage for the new HOC

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Tested performance using "Birds" [198711193] on one of the older chromebooks.

---
Paired on this with @picklesrus 