### PR TITLE
Add container with overflow hidden to prevent scrollbars from playhead

### DIFF
--- a/src/components/audio-trimmer/audio-trimmer.css
+++ b/src/components/audio-trimmer/audio-trimmer.css
@@ -53,6 +53,15 @@ $hover-scale: 2;
     border: 1px solid $red-tertiary;
 }
 
+.playhead-container {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 100%;
+    overflow: hidden;
+}
+
 .playhead {
     /*
         Even though playhead is just a line, it is 100% width (the width of the waveform)

--- a/src/components/audio-trimmer/audio-trimmer.jsx
+++ b/src/components/audio-trimmer/audio-trimmer.jsx
@@ -32,12 +32,14 @@ const AudioTrimmer = props => (
         )}
 
         {props.playhead ? (
-            <Box
-                className={classNames(styles.trimLine, styles.playhead)}
-                style={{
-                    transform: `translateX(${100 * props.playhead}%)`
-                }}
-            />
+            <div className={styles.playheadContainer}>
+                <div
+                    className={classNames(styles.trimLine, styles.playhead)}
+                    style={{
+                        transform: `translateX(${100 * props.playhead}%)`
+                    }}
+                />
+            </div>
         ) : null}
 
         {props.trimEnd === null ? null : (


### PR DESCRIPTION
Fixes an issue where the playhead caused scrollbars to appear while playing a sound in the sound editor.

/cc @picklesrus 