### PR TITLE
Use fontInliner instead of entire SVGRenderer for showing costume tiles.

### DIFF
--- a/src/lib/get-costume-url.js
+++ b/src/lib/get-costume-url.js
@@ -1,5 +1,5 @@
 import storage from './storage';
-import {SVGRenderer} from 'scratch-svg-renderer';
+import {inlineSvgFonts} from 'scratch-svg-renderer';
 
 // Contains 'font-family', but doesn't only contain 'font-family="none"'
 const HAS_FONT_REGEXP = 'font-family(?!="none")';
@@ -21,9 +21,7 @@ const getCostumeUrl = (function () {
         if (asset.assetType === storage.AssetType.ImageVector) {
             const svgString = asset.decodeText();
             if (svgString.match(HAS_FONT_REGEXP)) {
-                const svgRenderer = new SVGRenderer();
-                svgRenderer.loadString(svgString);
-                const svgText = svgRenderer.toString(true /* shouldInjectFonts */);
+                const svgText = inlineSvgFonts(svgString);
                 cachedUrl = `data:image/svg+xml;utf8,${encodeURIComponent(svgText)}`;
             } else {
                 cachedUrl = asset.encodeDataURI();


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Part of https://github.com/LLK/scratch-gui/issues/4386, but this does not address the size-1 cache issue where the cache is invalidated any time there is more than 1 sprite. But that can be handled separately.

### Proposed Changes

_Describe what this Pull Request does_

The `fontInliner` function from the `scratch-svg-renderer` was changed recently to work entirely on strings, so we can use that instead of parsing/loading/possibly drawing/stringifying the entire SVG. And `scratch-svg-renderer` already exports that function publicly, so just use it!

### Reason for Changes

_Explain why these changes should be made_

Using the 4x CPU slowdown in chrome dev tools, on a simple costume that just has a single text element the getCostumeUrl time goes from 10ms to 1ms, very important for updating in a timely way.

### Test Coverage

_Please show how you have added tests to cover your changes_

There are already tests in the svg-renderer for the functionality of this, so no additional tests are needed in GUI.

To test the performance improvement, just try a project that has more than one sprite, and that switches costumes frequently among costumes with text in them. I created project with id=281901317 for this purpose. You can also tell in that project that the tiles still appear with the correct fonts, meaning the fontInliner is working as expected.