### PR TITLE
Fix issue #4428 by update .alerts-container css

### DIFF
--- a/src/components/gui/gui.css
+++ b/src/components/gui/gui.css
@@ -305,10 +305,11 @@ $fade-out-distance: 15px;
 .alerts-container {
     display: flex;
     justify-content: center;
-    width: 100%;
     z-index: $z-index-alerts;
     position: absolute;
     margin-top: 53px;
+    left: 50%;
+    transform: translateX(-50%);
 }
 
 /*


### PR DESCRIPTION
### Resolves

- Resolves # 4428 https://github.com/LLK/scratch-gui/issues/4428

### Proposed Changes

fix alert message div blocked some menu bar dropdown buttons

### Reason for Changes

This PR improved users get a consistent user experience

### Test Coverage

I tested my code by building Scratch-GUI locally with several browsers

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [x] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
