### PR TITLE
Control/Command+S to save

### DIFF
--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -227,7 +227,8 @@ class MenuBar extends React.Component {
         };
     }
     handleKeyPress (event) {
-        if (event.key === 's' && event.ctrlKey) {
+        const modifier = (window.navigator.platform === 'MacIntel') ? event.metaKey : event.ctrlKey;
+        if (modifier && event.key === 's') {
             this.props.onClickSave();
             event.preventDefault();
         }

--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -151,10 +151,17 @@ class MenuBar extends React.Component {
             'handleClickSeeCommunity',
             'handleClickShare',
             'handleCloseFileMenuAndThen',
+            'handleKeyPress',
             'handleLanguageMouseUp',
             'handleRestoreOption',
             'restoreOptionMessage'
         ]);
+    }
+    componentDidMount () {
+        document.addEventListener('keydown', this.handleKeyPress);
+    }
+    componentWillUnmount () {
+        document.removeEventListener('keydown', this.handleKeyPress);
     }
     handleClickNew () {
         let readyToReplaceProject = true;
@@ -218,6 +225,12 @@ class MenuBar extends React.Component {
             this.props.onRequestCloseFile();
             fn();
         };
+    }
+    handleKeyPress (event) {
+        if (event.key === 's' && event.ctrlKey) {
+            this.props.onClickSave();
+            event.preventDefault();
+        }
     }
     handleLanguageMouseUp (e) {
         if (!this.props.languageMenuOpen) {

--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -3,6 +3,7 @@ import {connect} from 'react-redux';
 import {defineMessages, FormattedMessage, injectIntl, intlShape} from 'react-intl';
 import PropTypes from 'prop-types';
 import bindAll from 'lodash.bindall';
+import bowser from 'bowser';
 import React from 'react';
 
 import Box from '../box/box.jsx';
@@ -227,7 +228,7 @@ class MenuBar extends React.Component {
         };
     }
     handleKeyPress (event) {
-        const modifier = (window.navigator.platform === 'MacIntel') ? event.metaKey : event.ctrlKey;
+        const modifier = bowser.mac ? event.metaKey : event.ctrlKey;
         if (modifier && event.key === 's') {
             this.props.onClickSave();
             event.preventDefault();


### PR DESCRIPTION
### Resolves

Resolves #4262.

### Proposed Changes

Makes it so that when Control+S (Command+S, if on macOS) is pressed, the "save now" button is effectively pressed, and the browser's save-as dialog is not displayed.

### Reason for Changes

It's a useful and familiar keybinding to introduce to Scratch.

### Test Coverage

No new tests (there didn't seem to be any for the menu bar component yet).

I tested this manually by confirming that the browser "Save page as..." dialog is prevented from appearing. Because "save now" is not a feature in non-www scratch-gui, this PR has no effect on the standalone editor (Scratch Desktop or llk.github.io, etc). If wanted, I could probably make it so that pressing Ctrl+S opens up the "save to your computer" dialog if "save now" is unavailable. This isn't as smooth as simply overwriting an existing file, what Ctrl+S does on any native app, but it may be better than nothing. (Of course file overwriting is outside the scope of this PR - once it's done, the relevant code added by this PR could be modified.) Thoughts?

### Browser Coverage

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Linux
* [x] Firefox