### PR TITLE
Support changing slider range!

### DIFF
--- a/src/components/context-menu/context-menu.css
+++ b/src/components/context-menu/context-menu.css
@@ -29,10 +29,10 @@
     color: white;
 }
 
-.menu-item-bordered {
+.menu-item-bordered, .menu-item-danger {
     border-top: 1px solid $ui-black-transparent;
 }
 
-.menu-item-bordered:hover {
+.menu-item-danger:hover {
     background: $error-primary;
 }

--- a/src/components/context-menu/context-menu.jsx
+++ b/src/components/context-menu/context-menu.jsx
@@ -25,9 +25,21 @@ const BorderedMenuItem = props => (
     />
 );
 
+const DangerousMenuItem = props => (
+    <MenuItem
+        {...props}
+        attributes={{className: classNames(
+            styles.menuItem,
+            styles.menuItemBordered,
+            styles.menuItemDanger
+        )}}
+    />
+);
+
 
 export {
     BorderedMenuItem,
+    DangerousMenuItem,
     StyledContextMenu as ContextMenu,
     StyledMenuItem as MenuItem
 };

--- a/src/components/monitor/monitor.jsx
+++ b/src/components/monitor/monitor.jsx
@@ -84,6 +84,14 @@ const MonitorComponent = props => (
                             id="gui.monitor.contextMenu.slider"
                         />
                     </MenuItem>}
+                {props.onSliderPromptOpen && props.mode === 'slider' &&
+                    <MenuItem onClick={props.onSliderPromptOpen}>
+                        <FormattedMessage
+                            defaultMessage="change slider range"
+                            description="Menu item to change the slider range"
+                            id="gui.monitor.contextMenu.sliderRange"
+                        />
+                    </MenuItem>}
                 {props.onImport &&
                     <MenuItem onClick={props.onImport}>
                         <FormattedMessage
@@ -103,7 +111,6 @@ const MonitorComponent = props => (
             </ContextMenu>
         ), document.body)}
     </ContextMenuTrigger>
-
 );
 
 MonitorComponent.categories = categories;
@@ -122,7 +129,8 @@ MonitorComponent.propTypes = {
     onNextMode: PropTypes.func.isRequired,
     onSetModeToDefault: PropTypes.func,
     onSetModeToLarge: PropTypes.func,
-    onSetModeToSlider: PropTypes.func
+    onSetModeToSlider: PropTypes.func,
+    onSliderPromptOpen: PropTypes.func
 };
 
 MonitorComponent.defaultProps = {

--- a/src/components/monitor/monitor.jsx
+++ b/src/components/monitor/monitor.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import Draggable from 'react-draggable';
 import {FormattedMessage} from 'react-intl';
 import {ContextMenuTrigger} from 'react-contextmenu';
-import {ContextMenu, MenuItem} from '../context-menu/context-menu.jsx';
+import {BorderedMenuItem, ContextMenu, MenuItem} from '../context-menu/context-menu.jsx';
 import Box from '../box/box.jsx';
 import DefaultMonitor from './default-monitor.jsx';
 import LargeMonitor from './large-monitor.jsx';
@@ -85,13 +85,13 @@ const MonitorComponent = props => (
                         />
                     </MenuItem>}
                 {props.onSliderPromptOpen && props.mode === 'slider' &&
-                    <MenuItem onClick={props.onSliderPromptOpen}>
+                    <BorderedMenuItem onClick={props.onSliderPromptOpen}>
                         <FormattedMessage
                             defaultMessage="change slider range"
                             description="Menu item to change the slider range"
                             id="gui.monitor.contextMenu.sliderRange"
                         />
-                    </MenuItem>}
+                    </BorderedMenuItem>}
                 {props.onImport &&
                     <MenuItem onClick={props.onImport}>
                         <FormattedMessage

--- a/src/components/slider-prompt/slider-prompt.css
+++ b/src/components/slider-prompt/slider-prompt.css
@@ -1,0 +1,62 @@
+@import "../../css/colors.css";
+@import "../../css/units.css";
+
+.modal-content {
+    width: 360px;
+}
+
+.body {
+    background: $ui-white;
+    padding: 1.5rem 2.25rem;
+}
+
+.label {
+    font-weight: 500;
+    margin: 0 0 0.75rem;
+}
+
+.min-input, .max-input {
+    margin-bottom: 1.5rem;
+    width: 100%;
+    border: 1px solid $ui-black-transparent;
+    border-radius: 5px;
+    padding: 0 1rem;
+    height: 3rem;
+    color: $text-primary-transparent;
+    font-size: .875rem;
+}
+
+.error-row {
+    font-weight: bolder;
+    text-align: right;
+    background: $error-primary;
+    color: white;
+}
+
+.button-row {
+    font-weight: bolder;
+    text-align: right;
+}
+
+.button-row button {
+    padding: 0.75rem 1rem;
+    border-radius: 0.25rem;
+    background: white;
+    border: 1px solid $ui-black-transparent;
+    font-weight: 600;
+    font-size: 0.85rem;
+}
+
+.button-row button.ok-button {
+    background: $motion-primary;
+    border: $motion-primary;
+    color: white;
+}
+
+[dir="ltr"] .button-row button + button {
+    margin-left: 0.5rem;
+}
+
+[dir="rtl"] .button-row button + button {
+    margin-right: 0.5rem;
+}

--- a/src/components/slider-prompt/slider-prompt.jsx
+++ b/src/components/slider-prompt/slider-prompt.jsx
@@ -1,0 +1,104 @@
+import {defineMessages, FormattedMessage, intlShape, injectIntl} from 'react-intl';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import Box from '../box/box.jsx';
+import Modal from '../../containers/modal.jsx';
+
+import styles from './slider-prompt.css';
+
+
+const messages = defineMessages({
+    minValue: {
+        defaultMessage: 'Minimum value',
+        description: 'Label of slider modal',
+        id: 'gui.sliderModal.min'
+    },
+    maxValue: {
+        defaultMessage: 'Maximum value',
+        description: 'Label of slider modal',
+        id: 'gui.sliderModal.max'
+    },
+    title: {
+        defaultMessage: 'Change slider range',
+        description: 'Title of slider modal',
+        id: 'gui.sliderModal.title'
+    }
+});
+
+const SliderPromptComponent = props => (
+    <Modal
+        className={styles.modalContent}
+        contentLabel={props.intl.formatMessage(messages.title)}
+        id="sliderPrompt"
+        onRequestClose={props.onCancel}
+    >
+        <Box className={styles.body}>
+            <Box className={styles.label}>
+                {props.intl.formatMessage(messages.minValue)}
+            </Box>
+            <Box>
+                <input
+                    autoFocus
+                    className={styles.minInput}
+                    defaultValue={props.defaultMinValue}
+                    name={props.intl.formatMessage(messages.minValue)}
+                    type="number"
+                    onChange={props.onChangeMin}
+                    onFocus={props.onFocus}
+                    onKeyPress={props.onKeyPress}
+                />
+            </Box>
+            <Box className={styles.label}>
+                {props.intl.formatMessage(messages.maxValue)}
+            </Box>
+            <Box>
+                <input
+                    className={styles.maxInput}
+                    defaultValue={props.defaultMaxValue}
+                    name={props.intl.formatMessage(messages.maxValue)}
+                    type="number"
+                    onChange={props.onChangeMax}
+                    onFocus={props.onFocus}
+                    onKeyPress={props.onKeyPress}
+                />
+            </Box>
+            <Box className={styles.buttonRow}>
+                <button
+                    className={styles.cancelButton}
+                    onClick={props.onCancel}
+                >
+                    <FormattedMessage
+                        defaultMessage="Cancel"
+                        description="Button in prompt for cancelling the dialog"
+                        id="gui.sliderPrompt.cancel"
+                    />
+                </button>
+                <button
+                    className={styles.okButton}
+                    onClick={props.onOk}
+                >
+                    <FormattedMessage
+                        defaultMessage="OK"
+                        description="Button in prompt for confirming the dialog"
+                        id="gui.sliderPrompt.ok"
+                    />
+                </button>
+            </Box>
+        </Box>
+    </Modal>
+);
+
+SliderPromptComponent.propTypes = {
+    defaultMaxValue: PropTypes.number,
+    defaultMinValue: PropTypes.number,
+    intl: intlShape,
+    onCancel: PropTypes.func.isRequired,
+    onChangeMax: PropTypes.func.isRequired,
+    onChangeMin: PropTypes.func.isRequired,
+    onFocus: PropTypes.func.isRequired,
+    onKeyPress: PropTypes.func.isRequired,
+    onOk: PropTypes.func.isRequired
+};
+
+export default injectIntl(SliderPromptComponent);

--- a/src/components/sprite-selector-item/sprite-selector-item.jsx
+++ b/src/components/sprite-selector-item/sprite-selector-item.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import CloseButton from '../close-button/close-button.jsx';
 import styles from './sprite-selector-item.css';
 import {ContextMenuTrigger} from 'react-contextmenu';
-import {BorderedMenuItem, ContextMenu, MenuItem} from '../context-menu/context-menu.jsx';
+import {DangerousMenuItem, ContextMenu, MenuItem} from '../context-menu/context-menu.jsx';
 import {FormattedMessage} from 'react-intl';
 
 // react-contextmenu requires unique id to match trigger and context menu
@@ -74,13 +74,13 @@ const SpriteSelectorItem = props => (
                     </MenuItem>
                 ) : null }
                 {props.onDeleteButtonClick ? (
-                    <BorderedMenuItem onClick={props.onDeleteButtonClick}>
+                    <DangerousMenuItem onClick={props.onDeleteButtonClick}>
                         <FormattedMessage
                             defaultMessage="delete"
                             description="Menu item to delete in the right click menu"
                             id="gui.spriteSelectorItem.contextMenuDelete"
                         />
-                    </BorderedMenuItem>
+                    </DangerousMenuItem>
                 ) : null }
             </ContextMenu>
         ) : null}

--- a/src/containers/monitor.jsx
+++ b/src/containers/monitor.jsx
@@ -9,6 +9,7 @@ import {addMonitorRect, getInitialPosition, resizeMonitorRect, removeMonitorRect
 import {getVariable, setVariableValue} from '../lib/variable-utils';
 import importCSV from '../lib/import-csv';
 import downloadText from '../lib/download-text';
+import SliderPrompt from './slider-prompt.jsx';
 
 import {connect} from 'react-redux';
 import {Map} from 'immutable';
@@ -42,10 +43,16 @@ class Monitor extends React.Component {
             'handleSetModeToDefault',
             'handleSetModeToLarge',
             'handleSetModeToSlider',
+            'handleSliderPromptClose',
+            'handleSliderPromptOk',
+            'handleSliderPromptOpen',
             'handleImport',
             'handleExport',
             'setElement'
         ]);
+        this.state = {
+            sliderPrompt: false
+        };
     }
     componentDidMount () {
         let rect;
@@ -135,6 +142,22 @@ class Monitor extends React.Component {
             mode: 'slider'
         }));
     }
+    handleSliderPromptClose () {
+        this.setState({sliderPrompt: false});
+    }
+    handleSliderPromptOpen () {
+        this.setState({sliderPrompt: true});
+    }
+    handleSliderPromptOk (min, max) {
+        if (min < max) {
+            this.props.vm.runtime.requestUpdateMonitor(Map({
+                id: this.props.id,
+                sliderMin: min,
+                sliderMax: max
+            }));
+        }
+        this.handleSliderPromptClose();
+    }
     setElement (monitorElt) {
         this.element = monitorElt;
     }
@@ -162,24 +185,33 @@ class Monitor extends React.Component {
         const showSliderOption = availableModes(this.props.opcode).indexOf('slider') !== -1;
         const isList = this.props.mode === 'list';
         return (
-            <MonitorComponent
-                componentRef={this.setElement}
-                {...monitorProps}
-                draggable={this.props.draggable}
-                height={this.props.height}
-                max={this.props.max}
-                min={this.props.min}
-                mode={this.props.mode}
-                targetId={this.props.targetId}
-                width={this.props.width}
-                onDragEnd={this.handleDragEnd}
-                onExport={isList ? this.handleExport : null}
-                onImport={isList ? this.handleImport : null}
-                onNextMode={this.handleNextMode}
-                onSetModeToDefault={isList ? null : this.handleSetModeToDefault}
-                onSetModeToLarge={isList ? null : this.handleSetModeToLarge}
-                onSetModeToSlider={showSliderOption ? this.handleSetModeToSlider : null}
-            />
+            <React.Fragment>
+                {(this.state.sliderPrompt && <SliderPrompt
+                    defaultMaxValue={this.props.max}
+                    defaultMinValue={this.props.min}
+                    onCancel={this.handleSliderPromptClose}
+                    onOk={this.handleSliderPromptOk}
+                />)}
+                <MonitorComponent
+                    componentRef={this.setElement}
+                    {...monitorProps}
+                    draggable={this.props.draggable}
+                    height={this.props.height}
+                    max={this.props.max}
+                    min={this.props.min}
+                    mode={this.props.mode}
+                    targetId={this.props.targetId}
+                    width={this.props.width}
+                    onDragEnd={this.handleDragEnd}
+                    onExport={isList ? this.handleExport : null}
+                    onImport={isList ? this.handleImport : null}
+                    onNextMode={this.handleNextMode}
+                    onSetModeToDefault={isList ? null : this.handleSetModeToDefault}
+                    onSetModeToLarge={isList ? null : this.handleSetModeToLarge}
+                    onSetModeToSlider={showSliderOption ? this.handleSetModeToSlider : null}
+                    onSliderPromptOpen={this.handleSliderPromptOpen}
+                />
+            </React.Fragment>
         );
     }
 }

--- a/src/containers/slider-prompt.jsx
+++ b/src/containers/slider-prompt.jsx
@@ -1,0 +1,62 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import bindAll from 'lodash.bindall';
+import SliderPromptComponent from '../components/slider-prompt/slider-prompt.jsx';
+
+class SliderPrompt extends React.Component {
+    constructor (props) {
+        super(props);
+        bindAll(this, [
+            'handleOk',
+            'handleCancel',
+            'handleChangeMin',
+            'handleChangeMax',
+            'handleKeyPress'
+        ]);
+        this.state = {
+            minValue: 0,
+            maxValue: 100
+        };
+    }
+    handleKeyPress (event) {
+        if (event.key === 'Enter') this.handleOk();
+    }
+    handleFocus (event) {
+        event.target.select();
+    }
+    handleOk () {
+        this.props.onOk(this.state.minValue, this.state.maxValue);
+    }
+    handleCancel () {
+        this.props.onCancel();
+    }
+    handleChangeMin (e) {
+        this.setState({minValue: e.target.value});
+    }
+    handleChangeMax (e) {
+        this.setState({maxValue: e.target.value});
+    }
+    render () {
+        return (
+            <SliderPromptComponent
+                defaultMaxValue={this.props.defaultMaxValue}
+                defaultMinValue={this.props.defaultMinValue}
+                onCancel={this.handleCancel}
+                onChangeMax={this.handleChangeMax}
+                onChangeMin={this.handleChangeMin}
+                onFocus={this.handleFocus}
+                onKeyPress={this.handleKeyPress}
+                onOk={this.handleOk}
+            />
+        );
+    }
+}
+
+SliderPrompt.propTypes = {
+    defaultMaxValue: PropTypes.number,
+    defaultMinValue: PropTypes.number,
+    onCancel: PropTypes.func.isRequired,
+    onOk: PropTypes.func.isRequired
+};
+
+export default SliderPrompt;


### PR DESCRIPTION
_Sorry for fixing help-not-wanted issues..._

### Resolves
Resolves #2053 

### Proposed Changes
Adds `SliderPrompt` which has min/max field
Adds "change slider range" to the context menu when a slider variable is right-clicked

### Reason for Changes
Everyone wanted it! (see the Suggestions forum)

### Test Coverage
No tests added. To test this,
1) Make a variable
2) Set it to slider
3) Right-click the monitor and click "change slider range"
4) Change the value to:
4.1) min=0, max=-50. OK should do nothing
4.2) min=-100, max=100. OK should change the range so that you can slide to negative numbers.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome

### Gallery
* Context menu of normal monitor
![](https://screenshotscdn.firefoxusercontent.com/images/24db6a4d-265c-46e7-9aff-c51fe2d32a4c.png)

* Context menu of slider
![](https://screenshotscdn.firefoxusercontent.com/images/0317ac1c-ebed-44ed-bfc8-0065699e095a.png)

* Slider prompt
![](https://screenshotscdn.firefoxusercontent.com/images/6413cb75-9c2e-42dd-b95a-cf0276296394.png)