### PR TITLE
Avoid double toolbox update on mount and when setting language

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -170,13 +170,16 @@ class Blocks extends React.Component {
     }
 
     setLocale () {
-        this.workspace.getFlyout().setRecyclingEnabled(false);
         this.ScratchBlocks.ScratchMsgs.setLocale(this.props.locale);
         this.props.vm.setLocale(this.props.locale, this.props.messages)
             .then(() => {
+                this.workspace.getFlyout().setRecyclingEnabled(false);
                 this.props.vm.refreshWorkspace();
-                this.updateToolbox();
-                this.workspace.getFlyout().setRecyclingEnabled(true);
+                // refreshWorkspace will cause a toolbox update
+                // wait for update to go through before reenabling recycling
+                this.withToolboxUpdates(() => {
+                    this.workspace.getFlyout().setRecyclingEnabled(true);
+                });
             });
     }
 


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Resolves an issue where the toolbox was being repopulated twice when switching languages, as well as on initial mount (since setLocale is called in componentDidMount)

### Proposed Changes

_Describe what this Pull Request does_

This change removes the explicit `updateToolbox` call from `setLocale`, since it is called in the `componentDidUpdate` that happens as a result of calling `vm.refreshWorkspace`. Use the utility for waiting until the toolbox update has gone through in order to make sure to turn back on block recycling _after_ the toolbox update.

### Reason for Changes

_Explain why these changes should be made_

It gets rid of a 100+ms of load time when loading the editor/"see inside"/switching languages. 

@chrisgarrity I remember you saw an issue before where the toolbox updates were "1 language behind" when initially implementing the language switching. I think this was because of the async nature of the toolbox update, i.e. you have to put the recycle enable after the toolbox update using the queue managing utility function `withToolboxUpdates`. 

/cc @picklesrus who paired with me on this, and found the double update issue in the first place.

### Test Coverage

_Please show how you have added tests to cover your changes_

I confirmed that the "one language behind" issue is covered by the existing localization test (i.e. it fails without the `withToolboxUpdates` function). 

@chrisgarrity tagging you because i think you did some of the original work in this part of the code, so you might know more about things that might go wrong.

The performance improvement is also not just a time improvement, it also moves that redundant toolbox update out of `componentDidMount`, meaning the whole editor will show up faster.