### PR TITLE
Menus should be over most things

### DIFF
--- a/src/css/z-index.css
+++ b/src/css/z-index.css
@@ -5,7 +5,6 @@
 */
 
 /* Toolbox z-index: 40; set in scratch-blocks */
-$z-index-menu-bar: 41;
 $z-index-extension-button: 42;
 $z-index-stage-indicator: 45;
 $z-index-add-button: 46;
@@ -15,6 +14,7 @@ $z-index-monitor: 48; /* monitors go over add buttons */
 
 $z-index-card: 480;
 $z-index-alerts: 490;
+$z-index-menu-bar: 491; /* menu-bar should go over monitors, alerts and tutorials */
 $z-index-loader: 500;
 $z-index-modal: 510;
 


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/LLK/scratch-www/issues/2587 and https://github.com/LLK/scratch-gui/issues/4428

### Proposed Changes

_Describe what this Pull Request does_
Changed menu-bar z-index so that the menu, and the drop down menus that are nested in the menu bar are above almost everything. The only things that cover the menu are the loading animation (in editor mode) or modals.

This does mean that dragging blocks are under the menus, as shown in the animated gif below.
### Reason for Changes

_Explain why these changes should be made_
* monitors should not be above the user profile menu
* alerts should not block menus from being used

### Test Coverage
![z-index-menu](https://user-images.githubusercontent.com/399209/51988778-cf70f100-24a5-11e9-95dc-c5c062e6ade7.gif)

![alert](https://user-images.githubusercontent.com/399209/51989068-82d9e580-24a6-11e9-8348-ff527060637b.gif)

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [x] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
