### PR TITLE
Update project changes test 

### DIFF
--- a/test/integration/project-loading.test.js
+++ b/test/integration/project-loading.test.js
@@ -156,7 +156,9 @@ describe('Loading scratch gui', () => {
             await inputElement.sendKeys(`scratch.mit.edu/projects/${projectId}`);
             await clickXpath('//button[@title="View Project"]');
             await new Promise(resolve => setTimeout(resolve, 2000));
-            await clickText('move');
+            await clickText('Sounds');
+            await clickXpath('//button[@aria-label="Choose a Sound"]');
+            await clickText('A Bass', scope.modal); // Should close the modal
             await clickXpath(
                 '//div[contains(@class, "menu-bar_menu-bar-item") and ' +
                 'contains(@class, "menu-bar_hoverable")][span[text()="File"]]'


### PR DESCRIPTION
### Proposed Changes

Update the integration test that ensures that an alert shows when you try to leave a project that has changes. This test has been updated to create a different change in the project. It was previously clicking the 'move' block to introduce a project change, but this not actually a change which should introduce a project changed state (consistent with Scratch 2.0 behavior). The new functionality is a better test and makes sure that tests will work when introducing the changes from LLK/scratch-vm#1962.

cc/ @chrisgarrity, @paulkaplan 
