### PR TITLE
Make uploaded sprites not draggable

### DIFF
--- a/src/lib/file-uploader.js
+++ b/src/lib/file-uploader.js
@@ -206,7 +206,7 @@ const spriteUpload = function (fileData, fileType, spriteName, storage, handleSp
                 size: 100,
                 rotationStyle: 'all around',
                 direction: 90,
-                draggable: true,
+                draggable: false,
                 currentCostume: 0,
                 blocks: {},
                 variables: {},


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves an issue where sprites uploaded from 

### Proposed Changes

_Describe what this Pull Request does_

Don't do that!

### Reason for Changes

_Explain why these changes should be made_

The default for sprites is NOT draggable. They can still be dragged in the editor, but cannot be dragged in the player.
