### PR TITLE
Call updateToolbox after adding new blocks from the backpack.

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -454,6 +454,7 @@ class Blocks extends React.Component {
             .then(blocks => this.props.vm.shareBlocksToTarget(blocks, this.props.vm.editingTarget.id))
             .then(() => {
                 this.props.vm.refreshWorkspace();
+                this.updateToolbox(); // To show new variables/custom blocks
             });
     }
     render () {


### PR DESCRIPTION
This fixes the issue where you could not see any new variables or custom block callers, as well as fixing the issue where the toolbox did not update from then on.

### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/LLK/scratch-gui/issues/4459
- Resolves https://github.com/LLK/scratch-gui/issues/4271 (note the call block will only appear in the toolbox if you drag the define stack out of the backpack, not if you drag a call block out of the backpack, because in the latter case there is no definition. The toolbox only shows _defined_ custom blocks, and I do not think we have well-defined behavior in the situation of an undefined custom block.)

### Proposed Changes

_Describe what this Pull Request does_

Call update toolbox after doing the workspace refresh.

### Reason for Changes

_Explain why these changes should be made_

It is possible to add blocks (like variable/list blocks, or custom block definitions) that need to be shown in the toolbox, and so require a refresh.

### Test Coverage

_Please show how you have added tests to cover your changes_

Without a backpack available for integration testing, I'm not sure there is a way to cover this with an integration test. Possibly an integration test in www could confirm the backpack functionality?
