### PR TITLE
Give code from the backpack new IDs before loading into the VM

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -454,6 +454,7 @@ class Blocks extends React.Component {
             .then(blocks => this.props.vm.shareBlocksToTarget(blocks, this.props.vm.editingTarget.id))
             .then(() => {
                 this.props.vm.refreshWorkspace();
+                this.updateToolbox(); // To show new variables/custom blocks
             });
     }
     render () {

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -24,6 +24,7 @@ import {activateColorPicker} from '../reducers/color-picker';
 import {closeExtensionLibrary, openSoundRecorder, openConnectionModal} from '../reducers/modals';
 import {activateCustomProcedures, deactivateCustomProcedures} from '../reducers/custom-procedures';
 import {setConnectionModalExtensionId} from '../reducers/connection-modal';
+import newBlockIds from '../lib/new-block-ids';
 
 import {
     activateTab,
@@ -451,7 +452,8 @@ class Blocks extends React.Component {
     handleDrop (dragInfo) {
         fetch(dragInfo.payload.bodyUrl)
             .then(response => response.json())
-            .then(blocks => this.props.vm.shareBlocksToTarget(blocks, this.props.vm.editingTarget.id))
+            .then(blocks => this.props.vm.shareBlocksToTarget(
+                newBlockIds(blocks), this.props.vm.editingTarget.id))
             .then(() => {
                 this.props.vm.refreshWorkspace();
                 this.updateToolbox(); // To show new variables/custom blocks

--- a/src/lib/new-block-ids.js
+++ b/src/lib/new-block-ids.js
@@ -1,0 +1,31 @@
+const uid = () => String(Math.floor(1000000 * Math.random()));
+
+
+export default blocks => {
+    const oldToNew = {};
+
+    // First update all top-level IDs and create old-to-new mapping
+    for (let i = 0; i < blocks.length; i++) {
+        const newId = uid();
+        const oldId = blocks[i].id;
+        blocks[i].id = oldToNew[oldId] = newId;
+    }
+
+    // Then go back through and update inputs (block/shadow)
+    // and next/parent properties
+    for (let i = 0; i < blocks.length; i++) {
+        for (const key in blocks[i].inputs) {
+            const input = blocks[i].inputs[key];
+            input.block = oldToNew[input.block];
+            input.shadow = oldToNew[input.shadow];
+        }
+        if (blocks[i].parent) {
+            blocks[i].parent = oldToNew[blocks[i].parent];
+        }
+        if (blocks[i].next) {
+            blocks[i].next = oldToNew[blocks[i].next];
+        }
+    }
+
+    return blocks;
+};

--- a/test/fixtures/blocks.js
+++ b/test/fixtures/blocks.js
@@ -1,0 +1,69 @@
+const simpleStack = [
+    {
+        id: '1ZGd(W8DvU?vI1RN)e0E',
+        opcode: 'motion_goto',
+        inputs: {
+            TO: {
+                name: 'TO',
+                block: 'Ht(rOKMe0@sB3n4(b3;=',
+                shadow: '-C=c-_TI_7d(l3ii2[wh'
+            }
+        },
+        fields: {
+
+        },
+        next: 'l.JBk`WcXE+A@i9y1tCU',
+        topLevel: true,
+        parent: null,
+        shadow: false
+    },
+    {
+        id: 'Ht(rOKMe0@sB3n4(b3;=',
+        opcode: 'looks_size',
+        inputs: {
+
+        },
+        fields: {
+
+        },
+        next: null,
+        topLevel: false,
+        parent: '1ZGd(W8DvU?vI1RN)e0E',
+        shadow: false
+    },
+    {
+        id: '-C=c-_TI_7d(l3ii2[wh',
+        opcode: 'motion_goto_menu',
+        inputs: {
+
+        },
+        fields: {
+            TO: {
+                name: 'TO',
+                value: '_random_'
+            }
+        },
+        next: null,
+        topLevel: false,
+        parent: '1ZGd(W8DvU?vI1RN)e0E',
+        shadow: true
+    },
+    {
+        id: 'l.JBk`WcXE+A@i9y1tCU',
+        opcode: 'sound_stopallsounds',
+        inputs: {
+
+        },
+        fields: {
+
+        },
+        next: null,
+        topLevel: false,
+        parent: '1ZGd(W8DvU?vI1RN)e0E',
+        shadow: false
+    }
+];
+
+export default {
+    simpleStack
+};

--- a/test/unit/util/new-block-ids.test.js
+++ b/test/unit/util/new-block-ids.test.js
@@ -1,0 +1,62 @@
+import newBlockIds from '../../../src/lib/new-block-ids';
+import fixtures from '../../fixtures/blocks';
+
+describe('newBlockIds', () => {
+    let originals;
+    let newBlocks;
+
+    beforeEach(() => {
+        originals = fixtures.simpleStack;
+        newBlocks = JSON.parse(JSON.stringify(fixtures.simpleStack));
+        newBlockIds(newBlocks);
+    });
+
+    /**
+     * The structure of the simple stack is:
+     *      moveTo (looks_size) -> stopAllSounds
+     * The list of blocks is
+     *      0: moveTo (TO input block: 1, shadow: 2)
+     *      1: looks_size (parent: 0)
+     *      2: obscured shadow for moveTo input (parent: 0)
+     *      3: stopAllSounds (parent: 0)
+     * Inspect fixtures/blocks for the full object.
+     */
+
+    test('top-level block IDs have all changed', () => {
+        newBlocks.forEach((block, i) => {
+            expect(block.id).not.toEqual(originals[i].id);
+        });
+    });
+
+    test('input reference is maintained on parent for attached block', () => {
+        expect(newBlocks[0].inputs.TO.block).toEqual(newBlocks[1].id);
+    });
+
+    test('input reference is maintained on parent for obscured shadow', () => {
+        expect(newBlocks[0].inputs.TO.shadow).toEqual(newBlocks[2].id);
+    });
+
+    test('parent reference is maintained for attached input', () => {
+        expect(newBlocks[1].parent).toEqual(newBlocks[0].id);
+    });
+
+    test('parent reference is maintained for obscured shadow', () => {
+        expect(newBlocks[2].parent).toEqual(newBlocks[0].id);
+    });
+
+    test('parent reference is maintained for next block', () => {
+        expect(newBlocks[3].parent).toEqual(newBlocks[0].id);
+    });
+
+    test('next reference is maintained for previous block', () => {
+        expect(newBlocks[0].next).toEqual(newBlocks[3].id);
+    });
+
+    test('general smoke test: old IDs should not be in new blocks', () => {
+        const newBlocksStr = JSON.stringify(newBlocks);
+
+        originals.forEach(block => {
+            expect(newBlocksStr.indexOf(block.id)).toEqual(-1);
+        });
+    });
+});


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/LLK/scratch-gui/issues/4458

Note that I based this on the commit from https://github.com/LLK/scratch-gui/pull/4467 since it is hard to see what is going on without it, but the code is completely separate, so that PR should be merged first then I can remove it from this PR.

### Proposed Changes

_Describe what this Pull Request does_

Code stored in the backpack has a new set of IDs from the code it was originally generated from, but in order to add the same code multiple times it needs to get new IDs each time. 

I wrote a simple utility for mutating the blocks array in two passes to give new IDs then update the input references and next/parent references to heal the connections.

### Reason for Changes

_Explain why these changes should be made_

This is a unique problem that is not currently addressed by the VM, where code as JSON needs to be uniquified on the block level (rather than the variable ID reference level, e.g.), so I put the utility in the GUI and added tests for each type reference that might need to be healed. 

I generated a bunch of block JSON and then looked at all the fields that could contain ID references, and added a test for each of them. 

@kchadha could you confirm that the only block properties that contain IDs are:
- block.next
- block.parent
- block.inputs[inputName].block
- block.inputs[inputName].shadow

### Test Coverage

_Please show how you have added tests to cover your changes_

Added a unit test for the new utility.

Manually I tested a few cases I was concerned might be particularly bad:
- Add a new variable, drag the "change by" into the backpack, switch to the stage and drag it back out onto the stage. Confirmed new block changes the same variable as the old blocks.
- After above test, change the name of the new variable to something else. Drag the "change by <old name>" block out of the backpack again, and see that it magically updates to be "change by <new name>". Cool! I hope...
- Put a custom block definition in the backpack that contains usage of its parameters in the definition stack. Drag that stack out of the backpack to a new sprite or new project. Make sure the param references still work right.
- Pulling a custom block definition out of the backpack more than once... creates multiple definitions, and multiple call blocks in the toolbox, but all the call blocks only use a single definition stack. This is a pre-existing issue with custom blocks that can have the same names (and can currently be replicated with share-the-love), so I don't think it needs fixing here.