### PR TITLE
Use "stable" tag on npm for master builds and "latest" for develop/smoke

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_deploy:
 - >
   if [ -z "$BEFORE_DEPLOY_RAN" ]; then
     npm --no-git-tag-version version 0.1.0-prerelease.$(date +%Y%m%d%H%M%S)
-    if [ "$TRAVIS_BRANCH" == "develop" ]; then export NPM_TAG=develop; fi
+    if [ "$TRAVIS_BRANCH" == "master" ]; then export NPM_TAG=stable; fi
     git config --global user.email $(git log --pretty=format:"%ae" -n1)
     git config --global user.name $(git log --pretty=format:"%an" -n1)
     export BEFORE_DEPLOY_RAN=true


### PR DESCRIPTION
This is different of what it is currently, where master/smoke goes to "latest" and develop goes to "develop"

/cc @rschamp this should make it easier to get greenkeeper on WWWto make a PR for the most recent builds for GUI