### PR TITLE
Export costumes without inlined fonts for now

### DIFF
--- a/src/containers/costume-tab.jsx
+++ b/src/containers/costume-tab.jsx
@@ -14,7 +14,6 @@ import DragConstants from '../lib/drag-constants';
 import {emptyCostume} from '../lib/empty-assets';
 import sharedMessages from '../lib/shared-messages';
 import download from '../lib/download-url';
-import getCostumeUrl from '../lib/get-costume-url';
 
 import {
     closeCameraCapture,
@@ -139,12 +138,6 @@ class CostumeTab extends React.Component {
             this.setState({selectedCostumeIndex: target.currentCostume});
         }
     }
-    getCostumeData (costumeItem) {
-        if (costumeItem.url) return costumeItem.url;
-        if (!costumeItem.asset) return null;
-
-        return getCostumeUrl(costumeItem.asset);
-    }
     handleSelectCostume (costumeIndex) {
         this.props.vm.editingTarget.setCostume(costumeIndex);
         this.setState({selectedCostumeIndex: costumeIndex});
@@ -161,7 +154,7 @@ class CostumeTab extends React.Component {
     }
     handleExportCostume (costumeIndex) {
         const item = this.props.vm.editingTarget.sprite.costumes[costumeIndex];
-        download(`${item.name}.${item.asset.dataFormat}`, this.getCostumeData(item));
+        download(`${item.name}.${item.asset.dataFormat}`, item.asset.encodeDataURI());
     }
     handleNewCostume (costume, fromCostumeLibrary) {
         if (fromCostumeLibrary) {


### PR DESCRIPTION
Since the common use-case is download/edit/re-upload, and we do not want to explode the storage size of assets (which are considerably larger with fonts inlined), just do what scratch2 did and do not inline the fonts. This is not ideal if kids want to use the costumes for other purposes, but until we can create a way to strip inlined fonts before uploading to the asset server, this is the conservative way to go.

And, the code is simpler :) 

/cc @thisandagain 