### PR TITLE
Retain showBranding mode property after SET_FULL_SCREEN action is dispatched

### DIFF
--- a/src/reducers/mode.js
+++ b/src/reducers/mode.js
@@ -2,26 +2,24 @@ const SET_FULL_SCREEN = 'scratch-gui/mode/SET_FULL_SCREEN';
 const SET_PLAYER = 'scratch-gui/mode/SET_PLAYER';
 
 const initialState = {
+    isAdmin: true,
     showBranding: false,
     isFullScreen: false,
     isPlayerOnly: false,
     hasEverEnteredEditor: true
 };
 
-const reducer = function (state, action) {
-    if (typeof state === 'undefined') state = initialState;
+const reducer = function (state = initialState, action) {
     switch (action.type) {
     case SET_FULL_SCREEN:
-        return {
-            isFullScreen: action.isFullScreen,
-            isPlayerOnly: state.isPlayerOnly
-        };
+        return Object.assign(state, {
+            isFullScreen: action.isFullScreen
+        });
     case SET_PLAYER:
-        return {
-            isFullScreen: state.isFullScreen,
+        return Object.assign(state, {
             isPlayerOnly: action.isPlayerOnly,
             hasEverEnteredEditor: state.hasEverEnteredEditor || !action.isPlayerOnly
-        };
+        });
     default:
         return state;
     }

--- a/src/reducers/mode.js
+++ b/src/reducers/mode.js
@@ -9,14 +9,15 @@ const initialState = {
     hasEverEnteredEditor: true
 };
 
-const reducer = function (state = initialState, action) {
+const reducer = function (state, action) {
+    if (typeof state === 'undefined') state = initialState;
     switch (action.type) {
     case SET_FULL_SCREEN:
-        return Object.assign(state, {
+        return Object.assign({}, state, {
             isFullScreen: action.isFullScreen
         });
     case SET_PLAYER:
-        return Object.assign(state, {
+        return Object.assign({}, state, {
             isPlayerOnly: action.isPlayerOnly,
             hasEverEnteredEditor: state.hasEverEnteredEditor || !action.isPlayerOnly
         });

--- a/src/reducers/mode.js
+++ b/src/reducers/mode.js
@@ -2,7 +2,6 @@ const SET_FULL_SCREEN = 'scratch-gui/mode/SET_FULL_SCREEN';
 const SET_PLAYER = 'scratch-gui/mode/SET_PLAYER';
 
 const initialState = {
-    isAdmin: true,
     showBranding: false,
     isFullScreen: false,
     isPlayerOnly: false,

--- a/test/unit/reducers/mode-reducer.test.js
+++ b/test/unit/reducers/mode-reducer.test.js
@@ -12,7 +12,6 @@ test('initialState', () => {
 
 test('set full screen mode', () => {
     const previousState = {
-        isAdmin: true,
         showBranding: false,
         isFullScreen: false,
         isPlayerOnly: false,
@@ -23,7 +22,6 @@ test('set full screen mode', () => {
         isFullScreen: true
     };
     const newState = {
-        isAdmin: true,
         showBranding: false,
         isFullScreen: true,
         isPlayerOnly: false,
@@ -35,7 +33,6 @@ test('set full screen mode', () => {
 
 test('set player mode', () => {
     const previousState = {
-        isAdmin: true,
         showBranding: false,
         isFullScreen: false,
         isPlayerOnly: false,
@@ -46,7 +43,6 @@ test('set player mode', () => {
         isPlayerOnly: true
     };
     const newState = {
-        isAdmin: true,
         showBranding: false,
         isFullScreen: false,
         isPlayerOnly: true,

--- a/test/unit/reducers/mode-reducer.test.js
+++ b/test/unit/reducers/mode-reducer.test.js
@@ -1,0 +1,57 @@
+/* eslint-env jest */
+import modeReducer from '../../../src/reducers/mode';
+
+const SET_FULL_SCREEN = 'scratch-gui/mode/SET_FULL_SCREEN';
+const SET_PLAYER = 'scratch-gui/mode/SET_PLAYER';
+
+test('initialState', () => {
+    let defaultState;
+    /* modeReducer(state, action) */
+    expect(modeReducer(defaultState, {type: 'anything'})).toBeDefined();
+});
+
+test('set full screen mode', () => {
+    const previousState = {
+        isAdmin: true,
+        showBranding: false,
+        isFullScreen: false,
+        isPlayerOnly: false,
+        hasEverEnteredEditor: true
+    };
+    const action = {
+        type: SET_FULL_SCREEN,
+        isFullScreen: true
+    };
+    const newState = {
+        isAdmin: true,
+        showBranding: false,
+        isFullScreen: true,
+        isPlayerOnly: false,
+        hasEverEnteredEditor: true
+    };
+    /* modeReducer(state, action) */
+    expect(modeReducer(previousState, action)).toEqual(newState);
+});
+
+test('set player mode', () => {
+    const previousState = {
+        isAdmin: true,
+        showBranding: false,
+        isFullScreen: false,
+        isPlayerOnly: false,
+        hasEverEnteredEditor: true
+    };
+    const action = {
+        type: SET_PLAYER,
+        isPlayerOnly: true
+    };
+    const newState = {
+        isAdmin: true,
+        showBranding: false,
+        isFullScreen: false,
+        isPlayerOnly: true,
+        hasEverEnteredEditor: true
+    };
+    /* modeReducer(state, action) */
+    expect(modeReducer(previousState, action)).toEqual(newState);
+});


### PR DESCRIPTION
### Proposed Changes

Retains the entire state upon a `SET_FULL_SCREEN` or `SET_PLAYER` redux action.

### Reason for Changes

In some cases, these were dropping `showBranding` and I would get a missing prop showBranding (requires a boolean but got undefined)

### Test Coverage

I have added a test file for the mode reducer.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
