### PR TITLE
Move blocks z-index up to match gui

### DIFF
--- a/src/components/blocks/blocks.css
+++ b/src/components/blocks/blocks.css
@@ -1,5 +1,6 @@
 @import "../../css/units.css";
 @import "../../css/colors.css";
+@import "../../css/z-index.css";
 
 .blocks {
     height: 100%;
@@ -80,6 +81,7 @@
         This does not prevent user interaction on the blocks themselves.
     */
     pointer-events: none;
+    z-index: $z-index-drag-layer; /* make blocks match gui drag layer */
 }
 
 /*

--- a/src/css/z-index.css
+++ b/src/css/z-index.css
@@ -10,7 +10,6 @@ $z-index-stage-indicator: 45;
 $z-index-add-button: 46;
 $z-index-tooltip: 47; /* tooltips should go over add buttons if they overlap */
 $z-index-monitor: 48; /* monitors go over add buttons */
-/* Block drag z-index: 50; set in scratch-blocks */
 
 $z-index-card: 480;
 $z-index-alerts: 490;
@@ -19,6 +18,7 @@ $z-index-loader: 500;
 $z-index-modal: 510;
 
 $z-index-drag-layer: 1000;
+/* Block drag z-index: 1000; default 50 is overriden in blocks.css */
 $z-index-monitor-dragging: 1010;
 $z-index-dragging-sprite: 1020; /* so it is draggable into other panes */
 


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_
Resolving various gui and www z-index issues

### Proposed Changes

_Describe what this Pull Request does_
Override the z-index for the blocks drag layer. At 1000, it will be over everything in the gui other than the navbar itself (monitors on the stage, tutorials, alerts, dropdown menus, etc.)

### Reason for Changes

Ideally any block being dragged is over the rest of the UI. It returns to its normal layer when dropped.

### Test Coverage

_Please show how you have added tests to cover your changes_
No functional changes.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [x] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
