### PR TITLE
[master] Hotfix/toolbox language

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -87,6 +87,7 @@ class Blocks extends React.Component {
     componentDidMount () {
         this.ScratchBlocks.FieldColourSlider.activateEyedropper_ = this.props.onActivateColorPicker;
         this.ScratchBlocks.Procedures.externalProcedureDefCallback = this.props.onActivateCustomProcedures;
+        this.ScratchBlocks.ScratchMsgs.setLocale(this.props.locale);
 
         const workspaceConfig = defaultsDeep({},
             Blocks.defaultOptions,
@@ -526,7 +527,7 @@ Blocks.propTypes = {
     extensionLibraryVisible: PropTypes.bool,
     isRtl: PropTypes.bool,
     isVisible: PropTypes.bool,
-    locale: PropTypes.string,
+    locale: PropTypes.string.isRequired,
     messages: PropTypes.objectOf(PropTypes.string),
     onActivateColorPicker: PropTypes.func,
     onActivateCustomProcedures: PropTypes.func,

--- a/test/integration/localization.test.js
+++ b/test/integration/localization.test.js
@@ -24,7 +24,7 @@ describe('Localization', () => {
         await driver.quit();
     });
 
-    test('Localization', async () => {
+    test('Switching languages', async () => {
         await loadUri(uri);
         await clickXpath('//button[@title="Try It"]');
 
@@ -49,6 +49,17 @@ describe('Localization', () => {
         // After switching languages, make sure Apple sprite still exists
         await rightClickText('Apple', scope.spriteTile); // Make sure it is there
 
+        const logs = await getLogs();
+        await expect(logs).toEqual([]);
+    });
+
+    // Regression test for #4476, blocks in wrong language when loaded with locale
+    test('Loading with locale shows correct blocks', async () => {
+        await loadUri(`${uri}?locale=de`);
+        await clickXpath('//button[@title="Ausprobieren!"]'); // "Try It"
+        await clickText('Fühlen'); // Sensing category in German
+        await new Promise(resolve => setTimeout(resolve, 1000)); // wait for blocks to scroll
+        await clickText('Antwort'); // Find the "answer" block in German
         const logs = await getLogs();
         await expect(logs).toEqual([]);
     });


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/LLK/scratch-gui/issues/4476

### Proposed Changes

_Describe what this Pull Request does_

1. Make sure to load the initial locale into scratch blocks messages before rendering toolbox.
2. Mark the `locale` as a required prop, since it is being used on mount. This works because it is passed in from mapStateToProps, and the reducer has a default value (en).
3. Add an integration test to make sure this is working.

### Reason for Changes

_Explain why these changes should be made_

The toolbox was not being refreshed correctly if the initial locale was not english. Make sure to load the initial locale so that the toolbox does not have to first be generated in english, then again in your language.

### Test Coverage

_Please show how you have added tests to cover your changes_

Added an integration test to `localization`. The previous test checked the blocks, but only after switching languages. This new test checks the blocks using the `locale=...` url, to ensure it works on initial load. 

---

@chrisgarrity I updated master to be the version that is currently deployed on WWW and made this as hotfix against master, so that we can publish a new GUI version and update WWW as a hotfix. This issue seems big enough to want to hotfix, and it seems like the fix is low risk. We can talk about whether or not to hotfix this offline though.