### PR TITLE
Remove beforeunload callback that was breaking tests

### DIFF
--- a/test/integration/localization.test.js
+++ b/test/integration/localization.test.js
@@ -49,6 +49,9 @@ describe('Localization', () => {
         // After switching languages, make sure Apple sprite still exists
         await rightClickText('Apple', scope.spriteTile); // Make sure it is there
 
+        // Remounting re-attaches the beforeunload callback. Make sure to remove it
+        driver.executeScript('window.onbeforeunload = undefined;');
+
         const logs = await getLogs();
         await expect(logs).toEqual([]);
     });


### PR DESCRIPTION
Previous hotfix was tested independently, but didn't realize that the other localization test would cause this one to fail because of the beforeunload callback being reattached by switching languages.