### PR TITLE
Sort variable options in "of" block

### DIFF
--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -247,6 +247,7 @@ export default function (vm) {
                 }
                 // Get all the stage variables (no lists) so we can add them to menu when the stage is selected.
                 const stageVariableOptions = vm.runtime.getTargetForStage().getAllVariableNamesInScopeByType('');
+                stageVariableOptions.sort(ScratchBlocks.scratchBlocksUtils.compareStrings);
                 const stageVariableMenuItems = stageVariableOptions.map(variable => [variable, variable]);
                 if (sensingOfBlock.inputs.OBJECT.shadow !== sensingOfBlock.inputs.OBJECT.block) {
                     // There's a block dropped on top of the menu. It'd be nice to evaluate it and
@@ -265,6 +266,7 @@ export default function (vm) {
                 // The target should exist, but there are ways for it not to (e.g. #4203).
                 if (target) {
                     spriteVariableOptions = target.getAllVariableNamesInScopeByType('', true);
+                    spriteVariableOptions.sort(ScratchBlocks.scratchBlocksUtils.compareStrings);
                 }
                 const spriteVariableMenuItems = spriteVariableOptions.map(variable => [variable, variable]);
                 return spriteOptions.concat(spriteVariableMenuItems);

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -245,9 +245,15 @@ export default function (vm) {
                     // The block was in the flyout so look up future block info there.
                     lookupBlocks = vm.runtime.flyoutBlocks;
                 }
+                const sort = function (options) {
+                    options.sort((str1, str2) => str1.localeCompare(str2, [], {
+                        sensitivity: 'base',
+                        numeric: true
+                    }));
+                };
                 // Get all the stage variables (no lists) so we can add them to menu when the stage is selected.
                 const stageVariableOptions = vm.runtime.getTargetForStage().getAllVariableNamesInScopeByType('');
-                stageVariableOptions.sort(ScratchBlocks.scratchBlocksUtils.compareStrings);
+                sort(stageVariableOptions);
                 const stageVariableMenuItems = stageVariableOptions.map(variable => [variable, variable]);
                 if (sensingOfBlock.inputs.OBJECT.shadow !== sensingOfBlock.inputs.OBJECT.block) {
                     // There's a block dropped on top of the menu. It'd be nice to evaluate it and
@@ -266,7 +272,7 @@ export default function (vm) {
                 // The target should exist, but there are ways for it not to (e.g. #4203).
                 if (target) {
                     spriteVariableOptions = target.getAllVariableNamesInScopeByType('', true);
-                    spriteVariableOptions.sort(ScratchBlocks.scratchBlocksUtils.compareStrings);
+                    sort(spriteVariableOptions);
                 }
                 const spriteVariableMenuItems = spriteVariableOptions.map(variable => [variable, variable]);
                 return spriteOptions.concat(spriteVariableMenuItems);


### PR DESCRIPTION
### Resolves

Fixes #4397.

### Proposed Changes

Sorts the variable options in the "(attribute) of (sprite)" block:

![The dropdown attribute of an "of" block with a sprite selected; the options read the usual sprite properties, then "a, Ax, b, Bx, z".](https://user-images.githubusercontent.com/9948030/52233884-9dd99a80-2896-11e9-8e20-c95feedebfd2.png)

Also sorts variables on the stage (i.e. "for all sprite" variables) when the stage is selected:

![The same menu but with the stage selected; the options read "a global, b global, my variable, z global".](https://user-images.githubusercontent.com/9948030/52233943-c8c3ee80-2896-11e9-8437-3d3c9e8f80ab.png)

### Reason for Changes

To make the "of" block considerably more useful in projects where there are lots of variables; and to make it more consistent with other blocks that have variable dropdowns.

### Test Coverage

No new unit tests. Tested manually.