### PR TITLE
Escape special characters in toolbox xml

### DIFF
--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -138,6 +138,18 @@ const motion = function (isStage, targetId) {
     `;
 };
 
+const xmlEscape = function (unsafe) {
+    return unsafe.replace(/[<>&'"]/g, c => {
+        switch (c) {
+        case '<': return '&lt;';
+        case '>': return '&gt;';
+        case '&': return '&amp;';
+        case '\'': return '&apos;';
+        case '"': return '&quot;';
+        }
+    });
+};
+
 const looks = function (isStage, targetId, costumeName, backdropName) {
     const hello = ScratchBlocks.ScratchMsgs.translate('LOOKS_HELLO', 'Hello!');
     const hmm = ScratchBlocks.ScratchMsgs.translate('LOOKS_HMM', 'Hmm...');
@@ -713,6 +725,10 @@ const xmlClose = '</xml>';
 const makeToolboxXML = function (isStage, targetId, categoriesXML,
     costumeName = '', backdropName = '', soundName = '') {
     const gap = [categorySeparator];
+
+    costumeName = xmlEscape(costumeName);
+    backdropName = xmlEscape(backdropName);
+    soundName = xmlEscape(soundName);
 
     const everything = [
         xmlOpen,

--- a/test/integration/blocks.test.js
+++ b/test/integration/blocks.test.js
@@ -191,6 +191,24 @@ describe('Working with the blocks', () => {
         await clickText('newname', scope.blocksTab);
     });
 
+    test('Renaming costume with a special character should not break toolbox', async () => {
+        await loadUri(uri);
+        await clickXpath('//button[@title="Try It"]');
+
+        // Rename the costume
+        await clickText('Costumes');
+        const el = await findByXpath("//input[@value='costume1']");
+        await el.sendKeys('<NewCostume>');
+
+        // Make sure it is updated in the block menu
+        await clickText('Code');
+        await clickText('Looks', scope.blocksTab);
+        await driver.sleep(500); // Wait for scroll to finish
+        await clickText('<NewCostume>', scope.blocksTab);
+
+        await clickText('Sound', scope.blocksTab);
+    });
+
     // NOTE: This test describes the current behavior so that changes are not
     // introduced inadvertly, but I know this is not the desired behavior
     test('Adding costumes DOES NOT update the default costume name in the toolbox', async () => {


### PR DESCRIPTION
Related to LLK/scratch-vm#1077 and LLK/scratch-vm#1973

### Proposed Changes

Thanks to @picklesrus for pairing on this!

Fixes a recent issue related to LLK/scratch-vm#1077 introduced by the changes in #4449, where adding an xml-unsafe character to a costume or sound name breaks the toolbox (see gif below).

![broken-toolbox](https://user-images.githubusercontent.com/1786240/52250470-215eb000-28c6-11e9-9ddf-a9aa9aadbf43.gif)


### Test Coverage

Added test to ensure that you can still get to the sounds tab after renaming the first costume to an XML unsafe character.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
