### PR TITLE
Fix issue #4431 by change 'dserver' to 'server'

### DIFF
--- a/src/lib/cloud-manager-hoc.jsx
+++ b/src/lib/cloud-manager-hoc.jsx
@@ -15,7 +15,7 @@ import {
 } from '../reducers/alerts';
 
 /*
- * Higher Order Component to manage the connection to the cloud dserver.
+ * Higher Order Component to manage the connection to the cloud server.
  * @param {React.Component} WrappedComponent component to manage VM events for
  * @returns {React.Component} connected component with vm events bound to redux
  */


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves #4431 

### Proposed Changes

change 'dserver' to 'server'

### Reason for Changes

fix typo

### Test Coverage

only removed one letter from comment...

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [x] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
