### PR TITLE
Fix "See Inside" not showing variables

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -142,11 +142,7 @@ class Blocks extends React.Component {
         // different from the previously rendered toolbox xml.
         // Do not check against prevProps.toolboxXML because that may not have been rendered.
         if (this.props.isVisible && this.props.toolboxXML !== this._renderedToolboxXML) {
-            // rather than update the toolbox "sync" -- update it in the next frame
-            clearTimeout(this.toolboxUpdateTimeout);
-            this.toolboxUpdateTimeout = setTimeout(() => {
-                this.updateToolbox();
-            }, 0);
+            this.requestToolboxUpdate();
         }
 
         if (this.props.isVisible === prevProps.isVisible) {
@@ -178,15 +174,19 @@ class Blocks extends React.Component {
         this.workspace.dispose();
         clearTimeout(this.toolboxUpdateTimeout);
     }
-
+    requestToolboxUpdate () {
+        clearTimeout(this.toolboxUpdateTimeout);
+        this.toolboxUpdateTimeout = setTimeout(() => {
+            this.updateToolbox();
+        }, 0);
+    }
     setLocale () {
         this.ScratchBlocks.ScratchMsgs.setLocale(this.props.locale);
         this.props.vm.setLocale(this.props.locale, this.props.messages)
             .then(() => {
                 this.workspace.getFlyout().setRecyclingEnabled(false);
                 this.props.vm.refreshWorkspace();
-                // refreshWorkspace will cause a toolbox update
-                // wait for update to go through before reenabling recycling
+                this.requestToolboxUpdate();
                 this.withToolboxUpdates(() => {
                     this.workspace.getFlyout().setRecyclingEnabled(true);
                 });

--- a/src/playground/player.css
+++ b/src/playground/player.css
@@ -2,6 +2,14 @@
     width: calc(480px + 1rem);
 }
 
+.editor {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 100%;
+}
+
 .stage-only * {
     box-sizing: border-box;
 }

--- a/src/playground/player.jsx
+++ b/src/playground/player.jsx
@@ -21,11 +21,7 @@ if (process.env.NODE_ENV === 'production' && typeof window === 'object') {
 import styles from './player.css';
 
 const Player = ({isPlayerOnly, onSeeInside, projectId}) => (
-    <Box
-        className={classNames({
-            [styles.stageOnly]: isPlayerOnly
-        })}
-    >
+    <Box className={classNames(isPlayerOnly ? styles.stageOnly : styles.editor)}>
         {isPlayerOnly && <button onClick={onSeeInside}>{'See inside'}</button>}
         <GUI
             enableCommunity

--- a/test/integration/blocks.test.js
+++ b/test/integration/blocks.test.js
@@ -228,4 +228,21 @@ describe('Working with the blocks', () => {
         await driver.sleep(500); // Wait for scroll to finish
         await clickText('Meow', scope.blocksTab); // Meow, not A Bass
     });
+
+    // Regression test for switching between editor/player causing toolbox to stop updating
+    test('"See inside" after being on project page re-initializing variables', async () => {
+        const playerUri = path.resolve(__dirname, '../../build/player.html');
+        await loadUri(playerUri);
+        await clickText('See inside');
+        await clickText('Variables');
+        await driver.sleep(500); // Wait for scroll to finish
+        await clickText('my\u00A0variable');
+
+        await clickText('See Project Page');
+        await clickText('See inside');
+
+        await clickText('Variables');
+        await driver.sleep(500); // Wait for scroll to finish
+        await clickText('my\u00A0variable');
+    });
 });


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves a regression where the toolbox would not show variables after toggling between player and editor mode more than once

### Proposed Changes

_Describe what this Pull Request does_

Make sure to always enqueue a toolbox update after calling refresh workspace. This is because any time we are consuming a new workspace from the VM, we might have new variables that are not currently being shown, and those are not in the toolbox XML. So we need to make sure a refresh happens. 

This is not a reversion of the performance improvement that removed the explicit `updateToolbox`, because that was causing it to happen twice: once sync and once async. This makes it always async, so it is safe to call `requestUpdateToolbox` after calling `refreshWorkspace`, and know that only a single toolbox update will happen.

### Reason for Changes

_Explain why these changes should be made_

Opening the editor after the toolboxXML has been initialized (i.e. see inside -> see project page -> see inside) was not causing the toolbox update that was required.

### Test Coverage

_Please show how you have added tests to cover your changes_

Added an integration test using the "player.html" example build. Changed some CSS to make that playground useable in editor mode.

---

paired with @kchadha on the code and @picklesrus on the test, so tagging @picklesrus in the code review.