### PR TITLE
require text-encoding only if it is needed

### DIFF
--- a/src/lib/default-project/index.js
+++ b/src/lib/default-project/index.js
@@ -1,4 +1,3 @@
-import {TextEncoder} from 'text-encoding';
 import projectData from './project-data';
 
 /* eslint-disable import/no-unresolved */
@@ -9,8 +8,16 @@ import costume1 from '!raw-loader!./09dc888b0b7df19f70d81588ae73420e.svg';
 import costume2 from '!raw-loader!./3696356a03a8d938318876a593572843.svg';
 /* eslint-enable import/no-unresolved */
 
-const encoder = new TextEncoder();
 const defaultProject = translator => {
+    let _TextEncoder;
+    if (typeof TextEncoder === 'undefined') {
+        _TextEncoder = require('text-encoding').TextEncoder;
+    } else {
+        /* global TextEncoder */
+        _TextEncoder = TextEncoder;
+    }
+    const encoder = new _TextEncoder();
+
     const projectJson = projectData(translator);
     return [{
         id: 0,


### PR DESCRIPTION
### Resolves

Improve loading performance.

### Proposed Changes

Evaluate text-encoding for platforms that need it.

### Reason for Changes

Most platforms provide TextEncoder. The provided TextEncoder is normally implemented natively and so much faster. Also text-encoding is about 610KB (unminified + unzipped), not evaluating it saves a small bit of performance and memory.

### Benchmark Data

This is a small improvement a I'll probably produce a table with a build including multiple other changes.

### Browser Coverage

Pending ...

Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
