### PR TITLE
Set an initial message number to skip rendering a second time

### DIFF
--- a/src/components/loader/loader.jsx
+++ b/src/components/loader/loader.jsx
@@ -120,15 +120,13 @@ class LoaderComponent extends React.Component {
     constructor (props) {
         super(props);
         this.state = {
-            messageNumber: 0
+            messageNumber: this.chooseRandomMessage()
         };
     }
     componentDidMount () {
-        this.chooseRandomMessage();
-
         // Start an interval to choose a new message every 5 seconds
         this.intervalId = setInterval(() => {
-            this.chooseRandomMessage();
+            this.setState({messageNumber: this.chooseRandomMessage()});
         }, 5000);
     }
     componentWillUnmount () {
@@ -145,7 +143,7 @@ class LoaderComponent extends React.Component {
                 break;
             }
         }
-        this.setState({messageNumber});
+        return messageNumber;
     }
     render () {
         return (


### PR DESCRIPTION
### Resolves

Improve loading performance.

### Proposed Changes

Render Loader once on when added to DOM.

### Reason for Changes

Changing the state of Loader in Mount makes it render twice before it is drawn on screen. Set the messageNumber in the constructor and we can remove the second render.

Loader's impact is pretty small. A lot of the changes for making gui faster are pretty small. So it adds up.

### Benchmark Data

I'll probably link to a composite branch's data.

Pending ...

### Browser Coverage

Pending ...

Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
