### PR TITLE
Stop passing showPreviewInfo to WrappedGui in render-gui

### DIFF
--- a/src/playground/render-gui.jsx
+++ b/src/playground/render-gui.jsx
@@ -77,7 +77,6 @@ export default appTarget => {
             <WrappedGui
                 backpackVisible
                 showComingSoon
-                showPreviewInfo
                 backpackHost={backpackHost}
                 canSave={false}
                 onClickLogo={onClickLogo}

--- a/test/integration/backdrops.test.js
+++ b/test/integration/backdrops.test.js
@@ -26,7 +26,6 @@ describe('Working with backdrops', () => {
 
     test('Adding a backdrop from the library', async () => {
         await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
 
         // Start on the sounds tab of sprite1 to test switching behavior
         await clickText('Sounds');

--- a/test/integration/backpack.test.js
+++ b/test/integration/backpack.test.js
@@ -3,7 +3,6 @@ import SeleniumHelper from '../helpers/selenium-helper';
 
 const {
     clickText,
-    clickXpath,
     getDriver,
     getLogs,
     loadUri
@@ -24,7 +23,6 @@ describe('Working with the how-to library', () => {
 
     test('Backpack is "Coming Soon" without backpack host param', async () => {
         await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
         // Check that the backpack header is visible and wrapped in a coming soon tooltip
         await clickText('Backpack', '*[@data-for="backpack-tooltip"]');
         const logs = await getLogs();
@@ -33,7 +31,6 @@ describe('Working with the how-to library', () => {
 
     test('Backpack can be expanded with backpack host param', async () => {
         await loadUri(`${uri}?backpack_host=some-value`);
-        await clickXpath('//button[@title="Try It"]');
 
         // Try activating the backpack from the costumes tab to make sure it isn't pushed off
         await clickText('Costumes');

--- a/test/integration/blocks.test.js
+++ b/test/integration/blocks.test.js
@@ -29,7 +29,6 @@ describe('Working with the blocks', () => {
 
     test('Blocks report when clicked in the toolbox', async () => {
         await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
         await clickText('Code');
         await clickText('Operators', scope.blocksTab);
         await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for scroll animation
@@ -41,7 +40,6 @@ describe('Working with the blocks', () => {
 
     test('Switching sprites updates the block menus', async () => {
         await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
         await clickText('Sound', scope.blocksTab);
         await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for scroll animation
         // "Meow" sound block should be visible
@@ -58,7 +56,6 @@ describe('Working with the blocks', () => {
 
     test('Creating variables', async () => {
         await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
         await clickText('Code');
         await clickText('Variables', scope.blocksTab);
         await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for scroll animation
@@ -92,7 +89,6 @@ describe('Working with the blocks', () => {
 
     test('Creating a list', async () => {
         await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
         await clickText('Code');
         await clickText('Variables', scope.blocksTab);
         await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for scroll animation
@@ -127,7 +123,6 @@ describe('Working with the blocks', () => {
 
     test('Custom procedures', async () => {
         await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
         await clickText('My Blocks');
         await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for scroll animation
         await clickText('Make a Block');
@@ -146,7 +141,6 @@ describe('Working with the blocks', () => {
 
     test('Adding an extension', async () => {
         await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
         await clickXpath('//button[@title="Add Extension"]');
 
         await clickText('Pen');
@@ -160,7 +154,6 @@ describe('Working with the blocks', () => {
 
     test('Record option from sound block menu opens sound recorder', async () => {
         await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
         await clickText('Code');
         await clickText('Sound', scope.blocksTab);
         await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for scroll animation
@@ -177,7 +170,6 @@ describe('Working with the blocks', () => {
 
     test('Renaming costume changes the default costume name in the toolbox', async () => {
         await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
 
         // Rename the costume
         await clickText('Costumes');
@@ -193,7 +185,6 @@ describe('Working with the blocks', () => {
 
     test('Renaming costume with a special character should not break toolbox', async () => {
         await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
 
         // Rename the costume
         await clickText('Costumes');
@@ -213,7 +204,6 @@ describe('Working with the blocks', () => {
     // introduced inadvertly, but I know this is not the desired behavior
     test('Adding costumes DOES NOT update the default costume name in the toolbox', async () => {
         await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
 
         // By default, costume1 is in the costume tab
         await clickText('Looks', scope.blocksTab);
@@ -237,7 +227,6 @@ describe('Working with the blocks', () => {
     // introduced inadvertly, but I know this is not the desired behavior
     test('Adding a sound DOES NOT update the default sound name in the toolbox', async () => {
         await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
         await clickText('Sounds');
         await clickXpath('//button[@aria-label="Choose a Sound"]');
         await clickText('A Bass', scope.modal); // Should close the modal

--- a/test/integration/connection-modal.test.js
+++ b/test/integration/connection-modal.test.js
@@ -34,7 +34,6 @@ describe('Hardware extension connection modal', () => {
 
     test('Message saying Scratch Link is unavailable (BLE)', async () => {
         await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
 
         await driver.executeScript(websocketFakeoutJs);
 
@@ -50,7 +49,6 @@ describe('Hardware extension connection modal', () => {
 
     test('Message saying Scratch Link is unavailable (BT)', async () => {
         await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
 
         await driver.executeScript(websocketFakeoutJs);
 

--- a/test/integration/costumes.test.js
+++ b/test/integration/costumes.test.js
@@ -27,7 +27,6 @@ describe('Working with costumes', () => {
 
     test('Adding a costume through the library', async () => {
         await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
         await clickText('Costumes');
         await clickXpath('//button[@aria-label="Choose a Costume"]');
         const el = await findByXpath("//input[@placeholder='Search']");
@@ -40,7 +39,6 @@ describe('Working with costumes', () => {
 
     test('Adding a costume by surprise button', async () => {
         await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
         await clickText('Costumes');
         const el = await findByXpath('//button[@aria-label="Choose a Costume"]');
         await driver.actions().mouseMove(el)
@@ -53,7 +51,6 @@ describe('Working with costumes', () => {
 
     test('Adding a costume by paint button', async () => {
         await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
         await clickText('Costumes');
         const el = await findByXpath('//button[@aria-label="Choose a Costume"]');
         await driver.actions().mouseMove(el)
@@ -66,7 +63,6 @@ describe('Working with costumes', () => {
 
     test('Duplicating a costume', async () => {
         await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
         await clickText('Costumes');
 
         await rightClickText('costume1', scope.costumesTab);
@@ -82,7 +78,6 @@ describe('Working with costumes', () => {
 
     test('Converting bitmap/vector in paint editor', async () => {
         await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
         await clickText('Costumes');
 
         // Convert the first costume to bitmap.
@@ -106,7 +101,6 @@ describe('Working with costumes', () => {
 
     test('Undo/redo in the paint editor', async () => {
         await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
         await clickText('Costumes');
         await clickText('costume1', scope.costumesTab);
         await clickText('Convert to Bitmap', scope.costumesTab);
@@ -121,7 +115,6 @@ describe('Working with costumes', () => {
 
     test('Adding an svg from file', async () => {
         await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
         await clickText('Costumes');
         const el = await findByXpath('//button[@aria-label="Choose a Costume"]');
         await driver.actions().mouseMove(el)
@@ -137,7 +130,6 @@ describe('Working with costumes', () => {
 
     test('Adding a png from file (gh-3582)', async () => {
         await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
         await clickText('Costumes');
         const el = await findByXpath('//button[@aria-label="Choose a Costume"]');
         await driver.actions().mouseMove(el)
@@ -155,7 +147,6 @@ describe('Working with costumes', () => {
         await driver.manage()
             .window()
             .setSize(1244, 768); // Letters filter not visible at 1024 width
-        await clickXpath('//button[@title="Try It"]');
         await clickText('Costumes');
         await clickXpath('//button[@aria-label="Choose a Costume"]');
         await clickText('Letters');
@@ -167,7 +158,6 @@ describe('Working with costumes', () => {
 
     test('Costumes animate on mouseover', async () => {
         await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
         await clickXpath('//button[@aria-label="Choose a Sprite"]');
         const searchElement = await findByXpath("//input[@placeholder='Search']");
         await searchElement.sendKeys('abb');

--- a/test/integration/how-tos.test.js
+++ b/test/integration/how-tos.test.js
@@ -25,7 +25,6 @@ describe('Working with the how-to library', () => {
 
     test('Choosing a how-to', async () => {
         await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
         await clickText('Costumes');
         await clickXpath('//*[@aria-label="Tutorials"]');
         await clickText('Getting Started'); // Modal should close

--- a/test/integration/localization.test.js
+++ b/test/integration/localization.test.js
@@ -26,7 +26,6 @@ describe('Localization', () => {
 
     test('Switching languages', async () => {
         await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
 
         // Add a sprite to make sure it stays when switching languages
         await clickText('Costumes');
@@ -59,7 +58,6 @@ describe('Localization', () => {
     // Regression test for #4476, blocks in wrong language when loaded with locale
     test('Loading with locale shows correct blocks', async () => {
         await loadUri(`${uri}?locale=de`);
-        await clickXpath('//button[@title="Ausprobieren!"]'); // "Try It"
         await clickText('Fühlen'); // Sensing category in German
         await new Promise(resolve => setTimeout(resolve, 1000)); // wait for blocks to scroll
         await clickText('Antwort'); // Find the "answer" block in German

--- a/test/integration/menu-bar.test.js
+++ b/test/integration/menu-bar.test.js
@@ -24,7 +24,6 @@ describe('Menu bar settings', () => {
 
     test('File->New should be enabled', async () => {
         await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
         await clickXpath(
             '//div[contains(@class, "menu-bar_menu-bar-item") and ' +
             'contains(@class, "menu-bar_hoverable")][span[text()="File"]]'
@@ -34,7 +33,6 @@ describe('Menu bar settings', () => {
 
     test('File->Load should be enabled', async () => {
         await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
         await clickXpath(
             '//div[contains(@class, "menu-bar_menu-bar-item") and ' +
             'contains(@class, "menu-bar_hoverable")][span[text()="File"]]'
@@ -44,7 +42,6 @@ describe('Menu bar settings', () => {
 
     test('File->Save should be enabled', async () => {
         await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
         await clickXpath(
             '//div[contains(@class, "menu-bar_menu-bar-item") and ' +
             'contains(@class, "menu-bar_hoverable")][span[text()="File"]]'
@@ -54,13 +51,11 @@ describe('Menu bar settings', () => {
 
     test('Share button should NOT be enabled', async () => {
         await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
         await findByXpath('//div[span[div[span[text()="Share"]]] and @data-tip="tooltip"]');
     });
 
     test('Logo should be clickable', async () => {
         await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
         await clickXpath('//img[@alt="Scratch"]');
         const currentUrl = await driver.getCurrentUrl();
         await expect(currentUrl).toEqual('https://scratch.mit.edu/');
@@ -68,7 +63,6 @@ describe('Menu bar settings', () => {
 
     test('(GH#4064) Project name should be editable', async () => {
         await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
         const el = await findByXpath('//input[@value="Scratch Project"]');
         await el.sendKeys(' - Personalized');
         await clickText('Costumes'); // just to blur the input

--- a/test/integration/sounds.test.js
+++ b/test/integration/sounds.test.js
@@ -27,7 +27,6 @@ describe('Working with sounds', () => {
 
     test('Adding a sound through the library', async () => {
         await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
         await clickText('Sounds');
 
         // Delete the sound
@@ -64,7 +63,6 @@ describe('Working with sounds', () => {
 
     test('Adding a sound by surprise button', async () => {
         await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
         await clickText('Sounds');
         const el = await findByXpath('//button[@aria-label="Choose a Sound"]');
         await driver.actions().mouseMove(el)
@@ -77,7 +75,6 @@ describe('Working with sounds', () => {
 
     test('Duplicating a sound', async () => {
         await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
         await clickText('Sounds');
 
         await rightClickText('Meow', scope.soundsTab);
@@ -94,7 +91,6 @@ describe('Working with sounds', () => {
     // Regression test for gui issue #1320
     test('Switching sprites with different numbers of sounds', async () => {
         await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
 
         // Add a sound so this sprite has 2 sounds.
         await clickText('Sounds');

--- a/test/integration/sprites.test.js
+++ b/test/integration/sprites.test.js
@@ -29,7 +29,6 @@ describe('Working with sprites', () => {
 
     test('Adding a sprite through the library', async () => {
         await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
         await clickText('Costumes');
         await clickXpath('//button[@aria-label="Choose a Sprite"]');
         await clickText('Apple', scope.modal); // Closes modal
@@ -41,7 +40,6 @@ describe('Working with sprites', () => {
 
     test('Adding a sprite by surprise button', async () => {
         await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
         const el = await findByXpath('//button[@aria-label="Choose a Sprite"]');
         await driver.actions().mouseMove(el)
             .perform();
@@ -53,7 +51,6 @@ describe('Working with sprites', () => {
 
     test('Adding a sprite by paint button', async () => {
         await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
         const el = await findByXpath('//button[@aria-label="Choose a Sprite"]');
         await driver.actions().mouseMove(el)
             .perform();
@@ -66,7 +63,6 @@ describe('Working with sprites', () => {
 
     test('Deleting only sprite does not crash', async () => {
         await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
         await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for scroll animation
         await rightClickText('Sprite1', scope.spriteTile);
         await clickText('delete', scope.spriteTile);
@@ -78,7 +74,6 @@ describe('Working with sprites', () => {
 
     test('Deleting by x button on sprite tile', async () => {
         await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
         await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for scroll animation
         await clickXpath('//*[@aria-label="Close"]'); // Only visible close button is on the sprite
         // Confirm that the stage has been switched to
@@ -89,7 +84,6 @@ describe('Working with sprites', () => {
 
     test('Adding a sprite by uploading a png', async () => {
         await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
         const el = await findByXpath('//button[@aria-label="Choose a Sprite"]');
         await driver.actions().mouseMove(el)
             .perform();
@@ -105,7 +99,6 @@ describe('Working with sprites', () => {
     // Enable when this is fixed issues/3608
     test('Adding a sprite by uploading an svg (gh-3608)', async () => {
         await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
         const el = await findByXpath('//button[@aria-label="Choose a Sprite"]');
         await driver.actions().mouseMove(el)
             .perform();
@@ -127,7 +120,6 @@ describe('Working with sprites', () => {
         await driver.manage()
             .window()
             .setSize(1244, 768); // Letters filter not visible at 1024 width
-        await clickXpath('//button[@title="Try It"]');
         await clickText('Costumes');
         await clickXpath('//button[@aria-label="Choose a Sprite"]');
         await clickText('Letters');
@@ -140,7 +132,6 @@ describe('Working with sprites', () => {
     test('Use browser back button to close library', async () => {
         await driver.get('https://www.google.com');
         await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
         await clickText('Costumes');
         await clickXpath('//button[@aria-label="Choose a Sprite"]');
         const abbyElement = await findByText('Abby'); // Should show editor for new costume

--- a/test/integration/stage-size.test.js
+++ b/test/integration/stage-size.test.js
@@ -26,7 +26,6 @@ describe('Loading scratch gui', () => {
 
     test('Switching small/large stage after highlighting and deleting sprite', async () => {
         await loadUri(uri);
-        await clickXpath('//button[@title="Try It"]');
 
         // Highlight the sprite
         await clickText('Sprite1', scope.spriteTile);


### PR DESCRIPTION
### Resolves

Remove the preview modal now that 3.0 has launched. (And load faster)

### Proposed Changes

- Stop passing showPreviewInfo to WrappedGui

### Reason for Changes

The PreviewModal added to load time in a few ways.

- Forces the dom to layout once in all cases
- Forces a second layout if the gui starts fetching the project by id
- Creating and removing DOM thats never shown if fetching the project by id
- (It seems to be correlated but maybe not causing a delay after the first render and presenting that to the screen as the first frame.)

### Browser Coverage / Benchmark Data

Collected while loading a project by id. This measures the duration of the first react render pass.

platform | branch | run 1 | run 2 | run 3 | run 4 | avg
-------- | ------ | ----- | ----- | ----- | ----- | ---
chrome | develop | 743.68 | 716.86 | 773.80 | 710.29 | 736.1575
chrome | no-preview | 700.09 | 715.21 | 631.64 | 656.94 | 675.97
chromebook | develop | 1752.88 | 1564.82 | 1525.09 | 1786.57 | 1657.34
chromebook | no-preview | 1652.79 | 1444.67 | 1513.69 | 1700.21 | 1577.84
