### PR TITLE
Remove prune step from deployment for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,11 +60,6 @@ deploy:
   script: npm run deploy -- -x -e $TRAVIS_BRANCH -r https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
 - provider: script
   on:
-    all_branches: true
-    condition: $TRAVIS_EVENT_TYPE != cron
-  script: npm run prune -- https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
-- provider: script
-  on:
     branch: develop
     condition: $TRAVIS_EVENT_TYPE == cron
   skip_cleanup: true


### PR DESCRIPTION
It doesn't affect greenkeeper subdirectories, which are the ones that cause the most issues. And now the prune step itself is breaking builds. So until it works better, remove this step.
