### PR TITLE
Extract css from the JS

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "lodash.omit": "4.5.0",
     "lodash.pick": "4.4.0",
     "lodash.throttle": "4.0.1",
+    "mini-css-extract-plugin": "^0.5.0",
     "minilog": "3.1.0",
     "mkdirp": "^0.5.1",
     "papaparse": "4.6.2",


### PR DESCRIPTION
### Resolves

Loading feels faster. And a small memory and speed performance improvement.

### Proposed Changes

- Extract CSS from the output JS

### Reason for Changes

Extracting the CSS provides a few benefits:
- The CSS can then style the body tag before JS executes.

  Chrome and Firefox (seem to?) render the page when it reaches the first javascript to evaluate. Since that is at the bottom of the body tag, the page will render the empty body tag. If the CSS set a background color on body we would see that rendered until JS evaluates and the first render completes with JS produced DOM. (This can be achieved other ways, but this is kind of a free win with the other benefits.)
- The CSS appears fewer times in memory. Loading the CSS with JavaScript is useful during development. In production extracting the CSS we remove two copies of it from JS memory. We save its appearance in the full script source code. We save its appearance as the string to the module that is evaluated as a function.
- Skips evaluating as JS before evaluating as CSS. Skips creating style tags for each css file.

Here are some examples with the CSS setting the background color:

![0031-02-08 14 06 09](https://user-images.githubusercontent.com/833298/52501057-68da8a00-2bad-11e9-8672-863edc9ca57f.gif)

![0031-02-08 14 16 59](https://user-images.githubusercontent.com/833298/52501061-6bd57a80-2bad-11e9-8e75-8a88040bdac9.gif)

### Browser Coverage

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [x] Safari
 