### PR TITLE
Add bounding box to prevent sprite overflow

### DIFF
--- a/src/components/stage/stage.css
+++ b/src/components/stage/stage.css
@@ -106,9 +106,19 @@ to adjust for the border using a different method */
     position: absolute;
     top: 0;
     left: 0;
-    z-index: $z-index-dragging-sprite;
     filter: drop-shadow(5px 5px 5px $ui-black-transparent);
- }
+}
+
+.dragging-sprite-wrapper {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    pointer-events: none;
+    z-index: $z-index-dragging-sprite;
+}
 
 .stage-bottom-wrapper {
     position: absolute;

--- a/src/components/stage/stage.jsx
+++ b/src/components/stage/stage.jsx
@@ -118,12 +118,16 @@ const StageComponent = props => {
                         </div>
                     )}
                 </div>
-                <canvas
-                    className={styles.draggingSprite}
-                    height={0}
-                    ref={dragRef}
-                    width={0}
-                />
+                <div
+                    className={styles.draggingSpriteWrapper}
+                >
+                    <canvas
+                        className={styles.draggingSprite}
+                        height={0}
+                        ref={dragRef}
+                        width={0}
+                    />
+                </div>
             </Box>
             {isColorPicking ? (
                 <Box

--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -312,9 +312,11 @@ class Stage extends React.Component {
         this.dragCanvas.style.display = 'none';
     }
     positionDragCanvas (mouseX, mouseY) {
-        // mouseX/Y are relative to stage top/left, and dragCanvas is already
-        // positioned so that the pick location is at (0,0).
-        this.dragCanvas.style.transform = `translate(${mouseX}px, ${mouseY}px)`;
+        // mouseX/Y are relative to stage top/left, but dragCanvas is
+        // positioned at top left of the whole viewport, so account for this.
+        const x = this.rect.x + mouseX;
+        const y = this.rect.y + mouseY;
+        this.dragCanvas.style.transform = `translate(${x}px, ${y}px)`;
     }
     onStartDrag (x, y) {
         if (this.state.dragId) return;

--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -314,8 +314,8 @@ class Stage extends React.Component {
     positionDragCanvas (mouseX, mouseY) {
         // mouseX/Y are relative to stage top/left, but dragCanvas is
         // positioned at top left of the whole viewport, so account for this.
-        const x = this.rect.x + mouseX;
-        const y = this.rect.y + mouseY;
+        const x = this.rect.left + mouseX;
+        const y = this.rect.top + mouseY;
         this.dragCanvas.style.transform = `translate(${x}px, ${y}px)`;
     }
     onStartDrag (x, y) {


### PR DESCRIPTION
### Resolves

Resolves #1791, where dragging a sprite past the edge of the screen would cause a scrollbar to show up.

### Proposed Changes

Adds a wrapper `<div>` around the canvas element, which covers the entire screen and has `overflow: hidden`, so the translated canvas doesn't show up past the screen edges. (Z-indexes should still work; I had to move the `z-index` property onto the wrapper, but this matches all the original behavior as far as I can tell - sprites still get dragged over the menu bar, etc.) I also adjusted the math for positioning the canvas, since it's now placed relative to the top-left of the screen instead of to the stage rectangle.

### Reason for Changes

Fixes a peculiar (though basically harmless) issue, to make the editor feel a little more bug-free.

### Test Coverage

Tested manually. Everything still works, even when the screen is very small (which makes you have to scroll to navigate the entire gui).

### Browser Coverage

Linux Firefox and Chromium.