### PR TITLE
Put the ask blocks text input above the monitors on the stage.

### DIFF
--- a/src/components/stage/stage.css
+++ b/src/components/stage/stage.css
@@ -128,6 +128,7 @@ to adjust for the border using a different method */
 }
 
 .question-wrapper {
+    z-index: $z-index-stage-question;
     pointer-events: auto;
 }
 

--- a/src/css/z-index.css
+++ b/src/css/z-index.css
@@ -10,6 +10,7 @@ $z-index-stage-indicator: 45;
 $z-index-add-button: 46;
 $z-index-tooltip: 47; /* tooltips should go over add buttons if they overlap */
 $z-index-monitor: 48; /* monitors go over add buttons */
+$z-index-stage-question: 49; /* "ask" block text input goes above monitors */
 
 $z-index-card: 480;
 $z-index-alerts: 490;


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/LLK/scratch-gui/issues/4269

### Proposed Changes

_Describe what this Pull Request does_

Puts the question component on the correct z-index, above the monitors.

Test by showing a monitor and using the `ask` block.