### PR TITLE
Raise z-index of block drag surface wrapper

### DIFF
--- a/src/components/blocks/blocks.css
+++ b/src/components/blocks/blocks.css
@@ -1,5 +1,6 @@
 @import "../../css/units.css";
 @import "../../css/colors.css";
+@import "../../css/z-index.css";
 
 .blocks {
     height: 100%;
@@ -80,6 +81,10 @@
         This does not prevent user interaction on the blocks themselves.
     */
     pointer-events: none;
+}
+
+:global(.blocklyDragSurfaceWrapper) {
+    z-index: $z-index-blockly-drag-surface;
 }
 
 /*

--- a/src/css/z-index.css
+++ b/src/css/z-index.css
@@ -18,6 +18,7 @@ $z-index-menu-bar: 491; /* menu-bar should go over monitors, alerts and tutorial
 $z-index-loader: 500;
 $z-index-modal: 510;
 
+$z-index-blockly-drag-surface: 1000;
 $z-index-drag-layer: 1000;
 $z-index-monitor-dragging: 1010;
 $z-index-dragging-sprite: 1020; /* so it is draggable into other panes */


### PR DESCRIPTION
### Resolves

Fixes #1792. Should be merged after LLK/scratch-blocks#1895. (The other PR's fixes stands fine on their own too, though.)

### Proposed Changes

Raises the z-index of the block drag surface wrapper to match that of other drag surfaces. (Are we supposed to have each z-index be unique? I figured setting it equal is fine, since there's no reason for it to be unequal; you can never drag both a block and something else at the same time.)

### Reason for Changes

Fixes a bug to make the editor feel more sensible.

### Test Coverage

Tested manually by dragging a block over the tool bar.

### Browser Coverage

Linux Firefox and Chromium.