### PR TITLE
Show an "Importing..." alert during file import

### DIFF
--- a/src/containers/costume-tab.jsx
+++ b/src/containers/costume-tab.jsx
@@ -215,7 +215,7 @@ class CostumeTab extends React.Component {
                         this.props.onCloseImporting();
                     }
                 });
-            });
+            }, this.props.onCloseImporting);
         }, this.props.onCloseImporting);
     }
     handleCameraBuffer (buffer) {

--- a/src/containers/costume-tab.jsx
+++ b/src/containers/costume-tab.jsx
@@ -161,13 +161,12 @@ class CostumeTab extends React.Component {
     handleNewCostume (costume, fromCostumeLibrary) {
         const costumes = Array.isArray(costume) ? costume : [costume];
 
-        costumes.forEach(c => {
+        return Promise.all(costumes.map(c => {
             if (fromCostumeLibrary) {
-                this.props.vm.addCostumeFromLibrary(c.md5, c);
-            } else {
-                this.props.vm.addCostume(c.md5, c);
+                return this.props.vm.addCostumeFromLibrary(c.md5, c);
             }
-        });
+            return this.props.vm.addCostume(c.md5, c);
+        }));
     }
     handleNewBlankCostume () {
         const name = this.props.vm.editingTarget.isStage ?
@@ -211,10 +210,11 @@ class CostumeTab extends React.Component {
                 vmCostumes.forEach((costume, i) => {
                     costume.name = `${fileName}${i ? i + 1 : ''}`;
                 });
-                this.handleNewCostume(vmCostumes);
-                if (fileIndex === fileCount - 1) {
-                    this.props.onCloseAlert('importingAsset');
-                }
+                this.handleNewCostume(vmCostumes).then(() => {
+                    if (fileIndex === fileCount - 1) {
+                        this.props.onCloseAlert('importingAsset');
+                    }
+                });
             });
         });
     }

--- a/src/containers/costume-tab.jsx
+++ b/src/containers/costume-tab.jsx
@@ -204,7 +204,7 @@ class CostumeTab extends React.Component {
     }
     handleCostumeUpload (e) {
         const storage = this.props.vm.runtime.storage;
-        this.props.onShowAlert('importingAsset');
+        this.props.onShowImporting();
         handleFileUpload(e.target, (buffer, fileType, fileName, fileIndex, fileCount) => {
             costumeUpload(buffer, fileType, storage, vmCostumes => {
                 vmCostumes.forEach((costume, i) => {
@@ -212,11 +212,11 @@ class CostumeTab extends React.Component {
                 });
                 this.handleNewCostume(vmCostumes).then(() => {
                     if (fileIndex === fileCount - 1) {
-                        this.props.onCloseAlert('importingAsset');
+                        this.props.onCloseImporting();
                     }
                 });
             });
-        });
+        }, this.props.onCloseImporting);
     }
     handleCameraBuffer (buffer) {
         const storage = this.props.vm.runtime.storage;
@@ -363,12 +363,12 @@ CostumeTab.propTypes = {
     intl: intlShape,
     isRtl: PropTypes.bool,
     onActivateSoundsTab: PropTypes.func.isRequired,
-    onCloseAlert: PropTypes.func.isRequired,
+    onCloseImporting: PropTypes.func.isRequired,
     onNewCostumeFromCameraClick: PropTypes.func.isRequired,
     onNewLibraryBackdropClick: PropTypes.func.isRequired,
     onNewLibraryCostumeClick: PropTypes.func.isRequired,
     onRequestCloseCameraModal: PropTypes.func.isRequired,
-    onShowAlert: PropTypes.func.isRequired,
+    onShowImporting: PropTypes.func.isRequired,
     sprites: PropTypes.shape({
         id: PropTypes.shape({
             costumes: PropTypes.arrayOf(PropTypes.shape({
@@ -414,8 +414,8 @@ const mapDispatchToProps = dispatch => ({
     dispatchUpdateRestore: restoreState => {
         dispatch(setRestore(restoreState));
     },
-    onCloseAlert: id => dispatch(closeAlertWithId(id)),
-    onShowAlert: id => dispatch(showStandardAlert(id))
+    onCloseImporting: () => dispatch(closeAlertWithId('importingAsset')),
+    onShowImporting: () => dispatch(showStandardAlert('importingAsset'))
 });
 
 export default errorBoundaryHOC('Costume Tab')(

--- a/src/containers/costume-tab.jsx
+++ b/src/containers/costume-tab.jsx
@@ -28,6 +28,7 @@ import {
 } from '../reducers/editor-tab';
 
 import {setRestore} from '../reducers/restore-deletion';
+import {showStandardAlert, closeAlertWithId} from '../reducers/alerts';
 
 import addLibraryBackdropIcon from '../components/asset-panel/icon--add-backdrop-lib.svg';
 import addLibraryCostumeIcon from '../components/asset-panel/icon--add-costume-lib.svg';
@@ -204,12 +205,16 @@ class CostumeTab extends React.Component {
     }
     handleCostumeUpload (e) {
         const storage = this.props.vm.runtime.storage;
-        handleFileUpload(e.target, (buffer, fileType, fileName) => {
+        this.props.onShowAlert('importingAsset');
+        handleFileUpload(e.target, (buffer, fileType, fileName, fileIndex, fileCount) => {
             costumeUpload(buffer, fileType, storage, vmCostumes => {
                 vmCostumes.forEach((costume, i) => {
                     costume.name = `${fileName}${i ? i + 1 : ''}`;
                 });
                 this.handleNewCostume(vmCostumes);
+                if (fileIndex === fileCount - 1) {
+                    this.props.onCloseAlert('importingAsset');
+                }
             });
         });
     }
@@ -358,10 +363,12 @@ CostumeTab.propTypes = {
     intl: intlShape,
     isRtl: PropTypes.bool,
     onActivateSoundsTab: PropTypes.func.isRequired,
+    onCloseAlert: PropTypes.func.isRequired,
     onNewCostumeFromCameraClick: PropTypes.func.isRequired,
     onNewLibraryBackdropClick: PropTypes.func.isRequired,
     onNewLibraryCostumeClick: PropTypes.func.isRequired,
     onRequestCloseCameraModal: PropTypes.func.isRequired,
+    onShowAlert: PropTypes.func.isRequired,
     sprites: PropTypes.shape({
         id: PropTypes.shape({
             costumes: PropTypes.arrayOf(PropTypes.shape({
@@ -406,7 +413,9 @@ const mapDispatchToProps = dispatch => ({
     },
     dispatchUpdateRestore: restoreState => {
         dispatch(setRestore(restoreState));
-    }
+    },
+    onCloseAlert: id => dispatch(closeAlertWithId(id)),
+    onShowAlert: id => dispatch(showStandardAlert(id))
 });
 
 export default errorBoundaryHOC('Costume Tab')(

--- a/src/containers/sound-tab.jsx
+++ b/src/containers/sound-tab.jsx
@@ -37,6 +37,7 @@ import {
 } from '../reducers/editor-tab';
 
 import {setRestore} from '../reducers/restore-deletion';
+import {showStandardAlert, closeAlertWithId} from '../reducers/alerts';
 
 class SoundTab extends React.Component {
     constructor (props) {
@@ -129,10 +130,16 @@ class SoundTab extends React.Component {
 
     handleSoundUpload (e) {
         const storage = this.props.vm.runtime.storage;
-        handleFileUpload(e.target, (buffer, fileType, fileName) => {
+        this.props.onShowAlert('importingAsset');
+        handleFileUpload(e.target, (buffer, fileType, fileName, fileIndex, fileCount) => {
             soundUpload(buffer, fileType, storage, newSound => {
                 newSound.name = fileName;
-                this.props.vm.addSound(newSound).then(this.handleNewSound);
+                this.props.vm.addSound(newSound).then(() => {
+                    this.handleNewSound();
+                    if (fileIndex === fileCount - 1) {
+                        this.props.onCloseAlert('importingAsset');
+                    }
+                });
             });
         });
     }
@@ -274,9 +281,11 @@ SoundTab.propTypes = {
     intl: intlShape,
     isRtl: PropTypes.bool,
     onActivateCostumesTab: PropTypes.func.isRequired,
+    onCloseAlert: PropTypes.func.isRequired,
     onNewSoundFromLibraryClick: PropTypes.func.isRequired,
     onNewSoundFromRecordingClick: PropTypes.func.isRequired,
     onRequestCloseSoundLibrary: PropTypes.func.isRequired,
+    onShowAlert: PropTypes.func.isRequired,
     soundLibraryVisible: PropTypes.bool,
     soundRecorderVisible: PropTypes.bool,
     sprites: PropTypes.shape({
@@ -317,7 +326,9 @@ const mapDispatchToProps = dispatch => ({
     },
     dispatchUpdateRestore: restoreState => {
         dispatch(setRestore(restoreState));
-    }
+    },
+    onCloseAlert: id => dispatch(closeAlertWithId(id)),
+    onShowAlert: id => dispatch(showStandardAlert(id))
 });
 
 export default errorBoundaryHOC('Sound Tab')(

--- a/src/containers/sound-tab.jsx
+++ b/src/containers/sound-tab.jsx
@@ -130,18 +130,18 @@ class SoundTab extends React.Component {
 
     handleSoundUpload (e) {
         const storage = this.props.vm.runtime.storage;
-        this.props.onShowAlert('importingAsset');
+        this.props.onShowImporting();
         handleFileUpload(e.target, (buffer, fileType, fileName, fileIndex, fileCount) => {
             soundUpload(buffer, fileType, storage, newSound => {
                 newSound.name = fileName;
                 this.props.vm.addSound(newSound).then(() => {
                     this.handleNewSound();
                     if (fileIndex === fileCount - 1) {
-                        this.props.onCloseAlert('importingAsset');
+                        this.props.onCloseImporting();
                     }
                 });
             });
-        });
+        }, this.props.onCloseImporting);
     }
 
     handleDrop (dropInfo) {
@@ -281,11 +281,11 @@ SoundTab.propTypes = {
     intl: intlShape,
     isRtl: PropTypes.bool,
     onActivateCostumesTab: PropTypes.func.isRequired,
-    onCloseAlert: PropTypes.func.isRequired,
+    onCloseImporting: PropTypes.func.isRequired,
     onNewSoundFromLibraryClick: PropTypes.func.isRequired,
     onNewSoundFromRecordingClick: PropTypes.func.isRequired,
     onRequestCloseSoundLibrary: PropTypes.func.isRequired,
-    onShowAlert: PropTypes.func.isRequired,
+    onShowImporting: PropTypes.func.isRequired,
     soundLibraryVisible: PropTypes.bool,
     soundRecorderVisible: PropTypes.bool,
     sprites: PropTypes.shape({
@@ -327,8 +327,8 @@ const mapDispatchToProps = dispatch => ({
     dispatchUpdateRestore: restoreState => {
         dispatch(setRestore(restoreState));
     },
-    onCloseAlert: id => dispatch(closeAlertWithId(id)),
-    onShowAlert: id => dispatch(showStandardAlert(id))
+    onCloseImporting: () => dispatch(closeAlertWithId('importingAsset')),
+    onShowImporting: () => dispatch(showStandardAlert('importingAsset'))
 });
 
 export default errorBoundaryHOC('Sound Tab')(

--- a/src/containers/stage-selector.jsx
+++ b/src/containers/stage-selector.jsx
@@ -7,6 +7,7 @@ import {intlShape, injectIntl} from 'react-intl';
 import {connect} from 'react-redux';
 import {openBackdropLibrary} from '../reducers/modals';
 import {activateTab, COSTUMES_TAB_INDEX} from '../reducers/editor-tab';
+import {showStandardAlert, closeAlertWithId} from '../reducers/alerts';
 import {setHoveredSprite} from '../reducers/hovered-target';
 import DragConstants from '../lib/drag-constants';
 import DropAreaHOC from '../lib/drop-area-hoc.jsx';
@@ -65,7 +66,7 @@ class StageSelector extends React.Component {
     }
     handleNewBackdrop (backdrops_) {
         const backdrops = Array.isArray(backdrops_) ? backdrops_ : [backdrops_];
-        Promise.all(backdrops.map(backdrop =>
+        return Promise.all(backdrops.map(backdrop =>
             this.props.vm.addBackdrop(backdrop.md5, backdrop)
         )).then(() =>
             this.props.onActivateTab(COSTUMES_TAB_INDEX)
@@ -81,12 +82,17 @@ class StageSelector extends React.Component {
     }
     handleBackdropUpload (e) {
         const storage = this.props.vm.runtime.storage;
-        handleFileUpload(e.target, (buffer, fileType, fileName) => {
+        this.props.onShowAlert('importingAsset');
+        handleFileUpload(e.target, (buffer, fileType, fileName, fileIndex, fileCount) => {
             costumeUpload(buffer, fileType, storage, vmCostumes => {
                 vmCostumes.forEach((costume, i) => {
                     costume.name = `${fileName}${i ? i + 1 : ''}`;
                 });
-                this.handleNewBackdrop(vmCostumes);
+                this.handleNewBackdrop(vmCostumes).then(() => {
+                    if (fileIndex === fileCount - 1) {
+                        this.props.onCloseAlert('importingAsset');
+                    }
+                });
             });
         });
     }
@@ -126,7 +132,8 @@ class StageSelector extends React.Component {
     }
     render () {
         const componentProps = omit(this.props, [
-            'asset', 'dispatchSetHoveredSprite', 'id', 'intl', 'onActivateTab', 'onSelect']);
+            'asset', 'dispatchSetHoveredSprite', 'id', 'intl',
+            'onActivateTab', 'onSelect', 'onShowAlert', 'onCloseAlert']);
         return (
             <DroppableThrottledStage
                 fileInputRef={this.setFileInput}
@@ -147,7 +154,9 @@ StageSelector.propTypes = {
     ...StageSelectorComponent.propTypes,
     id: PropTypes.string,
     intl: intlShape.isRequired,
-    onSelect: PropTypes.func
+    onCloseAlert: PropTypes.func,
+    onSelect: PropTypes.func,
+    onShowAlert: PropTypes.func
 };
 
 const mapStateToProps = (state, {asset, id}) => ({
@@ -168,7 +177,9 @@ const mapDispatchToProps = dispatch => ({
     },
     dispatchSetHoveredSprite: spriteId => {
         dispatch(setHoveredSprite(spriteId));
-    }
+    },
+    onCloseAlert: id => dispatch(closeAlertWithId(id)),
+    onShowAlert: id => dispatch(showStandardAlert(id))
 });
 
 export default injectIntl(connect(

--- a/src/containers/stage-selector.jsx
+++ b/src/containers/stage-selector.jsx
@@ -82,7 +82,7 @@ class StageSelector extends React.Component {
     }
     handleBackdropUpload (e) {
         const storage = this.props.vm.runtime.storage;
-        this.props.onShowAlert('importingAsset');
+        this.props.onShowImporting();
         handleFileUpload(e.target, (buffer, fileType, fileName, fileIndex, fileCount) => {
             costumeUpload(buffer, fileType, storage, vmCostumes => {
                 vmCostumes.forEach((costume, i) => {
@@ -90,11 +90,11 @@ class StageSelector extends React.Component {
                 });
                 this.handleNewBackdrop(vmCostumes).then(() => {
                     if (fileIndex === fileCount - 1) {
-                        this.props.onCloseAlert('importingAsset');
+                        this.props.onCloseImporting();
                     }
                 });
             });
-        });
+        }, this.props.onCloseImporting);
     }
     handleFileUploadClick () {
         this.fileInput.click();
@@ -133,7 +133,7 @@ class StageSelector extends React.Component {
     render () {
         const componentProps = omit(this.props, [
             'asset', 'dispatchSetHoveredSprite', 'id', 'intl',
-            'onActivateTab', 'onSelect', 'onShowAlert', 'onCloseAlert']);
+            'onActivateTab', 'onSelect', 'onShowImporting', 'onCloseImporting']);
         return (
             <DroppableThrottledStage
                 fileInputRef={this.setFileInput}
@@ -154,9 +154,9 @@ StageSelector.propTypes = {
     ...StageSelectorComponent.propTypes,
     id: PropTypes.string,
     intl: intlShape.isRequired,
-    onCloseAlert: PropTypes.func,
+    onCloseImporting: PropTypes.func,
     onSelect: PropTypes.func,
-    onShowAlert: PropTypes.func
+    onShowImporting: PropTypes.func
 };
 
 const mapStateToProps = (state, {asset, id}) => ({
@@ -178,8 +178,8 @@ const mapDispatchToProps = dispatch => ({
     dispatchSetHoveredSprite: spriteId => {
         dispatch(setHoveredSprite(spriteId));
     },
-    onCloseAlert: id => dispatch(closeAlertWithId(id)),
-    onShowAlert: id => dispatch(showStandardAlert(id))
+    onCloseImporting: () => dispatch(closeAlertWithId('importingAsset')),
+    onShowImporting: () => dispatch(showStandardAlert('importingAsset'))
 });
 
 export default injectIntl(connect(

--- a/src/containers/stage-selector.jsx
+++ b/src/containers/stage-selector.jsx
@@ -93,7 +93,7 @@ class StageSelector extends React.Component {
                         this.props.onCloseImporting();
                     }
                 });
-            });
+            }, this.props.onCloseImporting);
         }, this.props.onCloseImporting);
     }
     handleFileUploadClick () {

--- a/src/containers/target-pane.jsx
+++ b/src/containers/target-pane.jsx
@@ -127,7 +127,7 @@ class TargetPane extends React.Component {
         this.props.onActivateTab(BLOCKS_TAB_INDEX);
     }
     handleNewSprite (spriteJSONString) {
-        this.props.vm.addSprite(spriteJSONString)
+        return this.props.vm.addSprite(spriteJSONString)
             .then(this.handleActivateBlocksTab);
     }
     handleFileUploadClick () {
@@ -138,10 +138,11 @@ class TargetPane extends React.Component {
         this.props.onShowAlert('importingAsset');
         handleFileUpload(e.target, (buffer, fileType, fileName, fileIndex, fileCount) => {
             spriteUpload(buffer, fileType, fileName, storage, newSprite => {
-                this.handleNewSprite(newSprite);
-                if (fileIndex === fileCount - 1) {
-                    this.props.onCloseAlert('importingAsset');
-                }
+                this.handleNewSprite(newSprite).then(() => {
+                    if (fileIndex === fileCount - 1) {
+                        this.props.onCloseAlert('importingAsset');
+                    }
+                });
             });
         });
     }

--- a/src/containers/target-pane.jsx
+++ b/src/containers/target-pane.jsx
@@ -135,16 +135,16 @@ class TargetPane extends React.Component {
     }
     handleSpriteUpload (e) {
         const storage = this.props.vm.runtime.storage;
-        this.props.onShowAlert('importingAsset');
+        this.props.onShowImporting();
         handleFileUpload(e.target, (buffer, fileType, fileName, fileIndex, fileCount) => {
             spriteUpload(buffer, fileType, fileName, storage, newSprite => {
                 this.handleNewSprite(newSprite).then(() => {
                     if (fileIndex === fileCount - 1) {
-                        this.props.onCloseAlert('importingAsset');
+                        this.props.onCloseImporting();
                     }
                 });
             });
-        });
+        }, this.props.onCloseImporting);
     }
     setFileInput (input) {
         this.fileInput = input;
@@ -203,8 +203,8 @@ class TargetPane extends React.Component {
             onReceivedBlocks, // eslint-disable-line no-unused-vars
             onHighlightTarget, // eslint-disable-line no-unused-vars
             dispatchUpdateRestore, // eslint-disable-line no-unused-vars
-            onShowAlert, // eslint-disable-line no-unused-vars
-            onCloseAlert, // eslint-disable-line no-unused-vars
+            onShowImporting, // eslint-disable-line no-unused-vars
+            onCloseImporting, // eslint-disable-line no-unused-vars
             ...componentProps
         } = this.props;
         return (
@@ -241,8 +241,8 @@ const {
 
 TargetPane.propTypes = {
     intl: intlShape.isRequired,
-    onCloseAlert: PropTypes.func,
-    onShowAlert: PropTypes.func,
+    onCloseImporting: PropTypes.func,
+    onShowImporting: PropTypes.func,
     ...targetPaneProps
 };
 
@@ -275,8 +275,8 @@ const mapDispatchToProps = dispatch => ({
     onHighlightTarget: id => {
         dispatch(highlightTarget(id));
     },
-    onCloseAlert: id => dispatch(closeAlertWithId(id)),
-    onShowAlert: id => dispatch(showStandardAlert(id))
+    onCloseImporting: () => dispatch(closeAlertWithId('importingAsset')),
+    onShowImporting: () => dispatch(showStandardAlert('importingAsset'))
 });
 
 export default injectIntl(connect(

--- a/src/containers/target-pane.jsx
+++ b/src/containers/target-pane.jsx
@@ -143,7 +143,7 @@ class TargetPane extends React.Component {
                         this.props.onCloseImporting();
                     }
                 });
-            });
+            }, this.props.onCloseImporting);
         }, this.props.onCloseImporting);
     }
     setFileInput (input) {

--- a/src/containers/target-pane.jsx
+++ b/src/containers/target-pane.jsx
@@ -1,6 +1,6 @@
 import bindAll from 'lodash.bindall';
 import React from 'react';
-
+import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import {intlShape, injectIntl} from 'react-intl';
 
@@ -8,9 +8,9 @@ import {
     openSpriteLibrary,
     closeSpriteLibrary
 } from '../reducers/modals';
-
 import {activateTab, COSTUMES_TAB_INDEX, BLOCKS_TAB_INDEX} from '../reducers/editor-tab';
 import {setReceivedBlocks} from '../reducers/hovered-target';
+import {showStandardAlert, closeAlertWithId} from '../reducers/alerts';
 import {setRestore} from '../reducers/restore-deletion';
 import DragConstants from '../lib/drag-constants';
 import TargetPaneComponent from '../components/target-pane/target-pane.jsx';
@@ -135,8 +135,14 @@ class TargetPane extends React.Component {
     }
     handleSpriteUpload (e) {
         const storage = this.props.vm.runtime.storage;
-        handleFileUpload(e.target, (buffer, fileType, fileName) => {
-            spriteUpload(buffer, fileType, fileName, storage, this.handleNewSprite);
+        this.props.onShowAlert('importingAsset');
+        handleFileUpload(e.target, (buffer, fileType, fileName, fileIndex, fileCount) => {
+            spriteUpload(buffer, fileType, fileName, storage, newSprite => {
+                this.handleNewSprite(newSprite);
+                if (fileIndex === fileCount - 1) {
+                    this.props.onCloseAlert('importingAsset');
+                }
+            });
         });
     }
     setFileInput (input) {
@@ -196,6 +202,8 @@ class TargetPane extends React.Component {
             onReceivedBlocks, // eslint-disable-line no-unused-vars
             onHighlightTarget, // eslint-disable-line no-unused-vars
             dispatchUpdateRestore, // eslint-disable-line no-unused-vars
+            onShowAlert, // eslint-disable-line no-unused-vars
+            onCloseAlert, // eslint-disable-line no-unused-vars
             ...componentProps
         } = this.props;
         return (
@@ -232,6 +240,8 @@ const {
 
 TargetPane.propTypes = {
     intl: intlShape.isRequired,
+    onCloseAlert: PropTypes.func,
+    onShowAlert: PropTypes.func,
     ...targetPaneProps
 };
 
@@ -263,7 +273,9 @@ const mapDispatchToProps = dispatch => ({
     },
     onHighlightTarget: id => {
         dispatch(highlightTarget(id));
-    }
+    },
+    onCloseAlert: id => dispatch(closeAlertWithId(id)),
+    onShowAlert: id => dispatch(showStandardAlert(id))
 });
 
 export default injectIntl(connect(

--- a/src/lib/alerts/index.jsx
+++ b/src/lib/alerts/index.jsx
@@ -198,6 +198,20 @@ const alerts = [
         closeButton: true,
         level: AlertLevels.SUCCESS,
         maxDisplaySecs: 15
+    },
+    {
+        alertId: 'importingAsset',
+        alertType: AlertTypes.STANDARD,
+        clearList: [],
+        content: (
+            <FormattedMessage
+                defaultMessage="Importing…"
+                description="Message indicating that project is in process of importing"
+                id="gui.alerts.importing"
+            />
+        ),
+        iconSpinner: true,
+        level: AlertLevels.SUCCESS
     }
 ];
 

--- a/src/lib/file-uploader.js
+++ b/src/lib/file-uploader.js
@@ -20,8 +20,9 @@ const extractFileName = function (nameExt) {
  * and a function to handle loading the file.
  * @param {Input} fileInput The <input/> element that contains the file being loaded
  * @param {Function} onload The function that handles loading the file
+ * @param {Function} onerror The function that handles any error loading the file
  */
-const handleFileUpload = function (fileInput, onload) {
+const handleFileUpload = function (fileInput, onload, onerror) {
     const readFile = (i, files) => {
         if (i === files.length) {
             // Reset the file input value now that we have everything we need
@@ -38,6 +39,7 @@ const handleFileUpload = function (fileInput, onload) {
             onload(reader.result, fileType, fileName, i, files.length);
             readFile(i + 1, files);
         };
+        reader.onerror = onerror;
         reader.readAsArrayBuffer(file);
     };
     readFile(0, fileInput.files);

--- a/src/lib/file-uploader.js
+++ b/src/lib/file-uploader.js
@@ -35,7 +35,7 @@ const handleFileUpload = function (fileInput, onload) {
         reader.onload = () => {
             const fileType = file.type;
             const fileName = extractFileName(file.name);
-            onload(reader.result, fileType, fileName);
+            onload(reader.result, fileType, fileName, i, files.length);
             readFile(i + 1, files);
         };
         reader.readAsArrayBuffer(file);

--- a/src/reducers/alerts.js
+++ b/src/reducers/alerts.js
@@ -6,6 +6,7 @@ const SHOW_ALERT = 'scratch-gui/alerts/SHOW_ALERT';
 const SHOW_EXTENSION_ALERT = 'scratch-gui/alerts/SHOW_EXTENSION_ALERT';
 const CLOSE_ALERT = 'scratch-gui/alerts/CLOSE_ALERT';
 const CLOSE_ALERTS_WITH_ID = 'scratch-gui/alerts/CLOSE_ALERTS_WITH_ID';
+const CLOSE_ALERT_WITH_ID = 'scratch-gui/alerts/CLOSE_ALERT_WITH_ID';
 
 /**
  * Initial state of alerts reducer
@@ -99,7 +100,12 @@ const reducer = function (state, action) {
         }
         return state; // if alert not found, show nothing
     }
+    case CLOSE_ALERT_WITH_ID:
     case CLOSE_ALERT: {
+        if (action.alertId) {
+            action.index = state.alertsList.findIndex(a => a.alertId === action.alertId);
+            if (action.index === -1) return state;
+        }
         const newList = state.alertsList.slice();
         newList.splice(action.index, 1);
         return Object.assign({}, state, {
@@ -140,6 +146,19 @@ const closeAlert = function (index) {
 const closeAlertsWithId = function (alertId) {
     return {
         type: CLOSE_ALERTS_WITH_ID,
+        alertId
+    };
+};
+
+/**
+ * Action creator to close a single alert with a given ID.
+ *
+ * @param {string} alertId - id string of the alert to close
+ * @return {object} - an object to be passed to the reducer.
+ */
+const closeAlertWithId = function (alertId) {
+    return {
+        type: CLOSE_ALERT_WITH_ID,
         alertId
     };
 };
@@ -195,6 +214,7 @@ export {
     reducer as default,
     initialState as alertsInitialState,
     closeAlert,
+    closeAlertWithId,
     filterInlineAlerts,
     filterPopupAlerts,
     showAlertWithTimeout,

--- a/test/unit/reducers/alerts-reducer.test.js
+++ b/test/unit/reducers/alerts-reducer.test.js
@@ -5,6 +5,7 @@ import {AlertTypes, AlertLevels} from '../../../src/lib/alerts/index.jsx';
 import alertsReducer from '../../../src/reducers/alerts';
 import {
     closeAlert,
+    closeAlertWithId,
     filterInlineAlerts,
     filterPopupAlerts,
     showStandardAlert
@@ -83,6 +84,35 @@ test('can close alerts by index', () => {
     resultState = alertsReducer(initialState, closeAction);
     expect(resultState.alertsList.length).toBe(0);
     resultState = alertsReducer(resultState, createAction);
+});
+
+test('can close a single alert by id', () => {
+    const initialState = {
+        visible: true,
+        alertsList: [
+            {alertId: 'saving'},
+            {alertId: 'creating'},
+            {alertId: 'saving'},
+            {alertId: 'saving'}
+        ]
+    };
+    const closeAction = closeAlertWithId('saving');
+    let resultState = alertsReducer(initialState, closeAction);
+    expect(resultState.alertsList.map(a => a.alertId)).toEqual([
+        'creating', 'saving', 'saving'
+    ]);
+    resultState = alertsReducer(resultState, closeAction);
+    expect(resultState.alertsList.map(a => a.alertId)).toEqual([
+        'creating', 'saving'
+    ]);
+    resultState = alertsReducer(resultState, closeAction);
+    expect(resultState.alertsList.map(a => a.alertId)).toEqual([
+        'creating'
+    ]);
+    resultState = alertsReducer(resultState, closeAction);
+    expect(resultState.alertsList.map(a => a.alertId)).toEqual([
+        'creating'
+    ]);
 });
 
 test('related alerts can clear each other', () => {


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves a UX issue with importing where importing multiple files, or importing gifs, would leave the editor in a loading state for an indeterminate amount of time depending on the files, but gave no indication that something was happening. After chatting with @carljbowman, we decided the existing alert system with a spinner would be a good first step.

With sprites

![sprite-multi-import-alert](https://user-images.githubusercontent.com/654102/52644514-fc150780-2eac-11e9-811e-8f3aba979fde.gif)


With costumes

![costume-multi-import-alert](https://user-images.githubusercontent.com/654102/52644571-10f19b00-2ead-11e9-9109-60eaa241449b.gif)

### Proposed Changes

_Describe what this Pull Request does_

Make the file uploader return information about which file has been processed, and use that to decide when to close the alert. Add an HOC for the show/close to avoid code repetition.

---

@carljbowman just an FYI, this only creates a single alert that is closed after all files have been processed, instead of the stacking multi alerts that I showed you in the prototype. I assume this is strictly better, but just wanted to get your thoughts.


@rschamp This is a WIP since we talked about different ways to refactor this, and i wanted to show you what it would look like to just add the index info to handleFileUpload. The biggest functionality issue to me is that there is no error handling. If the file fails to parse, or if the costume/sprite fails to upload, there is no way to close the importing spinner. Promises definitely make error propagation easier in async situations, so I would definitely like to refactor just for that. Maybe we can pair on this?