### PR TITLE
Fixes #4253 by telling the vm the langauge when it is initialized.  B…

### DIFF
--- a/src/lib/vm-manager-hoc.jsx
+++ b/src/lib/vm-manager-hoc.jsx
@@ -33,6 +33,7 @@ const vmManagerHOC = function (WrappedComponent) {
                 this.props.vm.attachAudioEngine(this.audioEngine);
                 this.props.vm.setCompatibilityMode(true);
                 this.props.vm.initialized = true;
+                this.props.vm.setLocale(this.props.locale, this.props.messages);
             }
             if (!this.props.isPlayerOnly && !this.props.isStarted) {
                 this.props.vm.start();
@@ -105,6 +106,8 @@ const vmManagerHOC = function (WrappedComponent) {
         isLoadingWithId: PropTypes.bool,
         isPlayerOnly: PropTypes.bool,
         loadingState: PropTypes.oneOf(LoadingStates),
+        locale: PropTypes.string,
+        messages: PropTypes.objectOf(PropTypes.string),
         onError: PropTypes.func,
         onLoadedProject: PropTypes.func,
         onSetProjectUnchanged: PropTypes.func,
@@ -119,6 +122,8 @@ const vmManagerHOC = function (WrappedComponent) {
         return {
             fontsLoaded: state.scratchGui.fontsLoaded,
             isLoadingWithId: getIsLoadingWithId(loadingState),
+            locale: state.locales.locale,
+            messages: state.locales.messages,
             projectData: state.scratchGui.projectState.projectData,
             projectId: state.scratchGui.projectState.projectId,
             loadingState: loadingState,

--- a/src/lib/vm-manager-hoc.jsx
+++ b/src/lib/vm-manager-hoc.jsx
@@ -79,6 +79,8 @@ const vmManagerHOC = function (WrappedComponent) {
                 /* eslint-disable no-unused-vars */
                 fontsLoaded,
                 loadingState,
+                locale,
+                messages,
                 isStarted,
                 onError: onErrorProp,
                 onLoadedProject: onLoadedProjectProp,

--- a/test/unit/util/vm-manager-hoc.test.jsx
+++ b/test/unit/util/vm-manager-hoc.test.jsx
@@ -19,11 +19,16 @@ describe('VMManagerHOC', () => {
                 projectState: {},
                 mode: {},
                 vmStatus: {}
+            },
+            locales: {
+                locale: '',
+                messages: {}
             }
         });
         vm = new VM();
         vm.attachAudioEngine = jest.fn();
         vm.setCompatibilityMode = jest.fn();
+        vm.setLocale = jest.fn();
         vm.start = jest.fn();
     });
     test('when it mounts in player mode, the vm is initialized but not started', () => {
@@ -39,6 +44,7 @@ describe('VMManagerHOC', () => {
         );
         expect(vm.attachAudioEngine.mock.calls.length).toBe(1);
         expect(vm.setCompatibilityMode.mock.calls.length).toBe(1);
+        expect(vm.setLocale.mock.calls.length).toBe(1);
         expect(vm.initialized).toBe(true);
 
         // But vm should not be started automatically
@@ -57,6 +63,7 @@ describe('VMManagerHOC', () => {
         );
         expect(vm.attachAudioEngine.mock.calls.length).toBe(1);
         expect(vm.setCompatibilityMode.mock.calls.length).toBe(1);
+        expect(vm.setLocale.mock.calls.length).toBe(1);
         expect(vm.initialized).toBe(true);
 
         expect(vm.start).toHaveBeenCalled();
@@ -75,6 +82,7 @@ describe('VMManagerHOC', () => {
         );
         expect(vm.attachAudioEngine.mock.calls.length).toBe(0);
         expect(vm.setCompatibilityMode.mock.calls.length).toBe(0);
+        expect(vm.setLocale.mock.calls.length).toBe(0);
         expect(vm.initialized).toBe(true);
 
         expect(vm.start).toHaveBeenCalled();


### PR DESCRIPTION
…efore it didn't get the language until the blocks component mounted.

### Resolves

Resolves #4253 

### Proposed Changes

Tells the VM the locale when initializing it.