### PR TITLE
Position blocks added from "share the love" within the viewport

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -14,7 +14,7 @@ import ExtensionLibrary from './extension-library.jsx';
 import extensionData from '../lib/libraries/extensions/index.jsx';
 import CustomProcedures from './custom-procedures.jsx';
 import errorBoundaryHOC from '../lib/error-boundary-hoc.jsx';
-import {STAGE_DISPLAY_SIZES} from '../lib/layout-constants';
+import {BLOCKS_DEFAULT_SCALE, STAGE_DISPLAY_SIZES} from '../lib/layout-constants';
 import DropAreaHOC from '../lib/drop-area-hoc.jsx';
 import DragConstants from '../lib/drag-constants';
 import defineDynamicBlock from '../lib/define-dynamic-block';
@@ -509,7 +509,7 @@ class Blocks extends React.Component {
             });
     }
     render () {
-        /* eslint-disable no-unused-vars, no-shadow */
+        /* eslint-disable no-unused-vars */
         const {
             anyModalVisible,
             canUseCloud,
@@ -528,11 +528,11 @@ class Blocks extends React.Component {
             onRequestCloseExtensionLibrary,
             onRequestCloseCustomProcedures,
             toolboxXML,
+            updateMetrics: updateMetricsProp,
             workspaceMetrics,
-            updateMetrics,
             ...props
         } = this.props;
-        /* eslint-enable no-unused-vars, no-shadow */
+        /* eslint-enable no-unused-vars */
         return (
             <React.Fragment>
                 <DroppableBlocks
@@ -612,15 +612,19 @@ Blocks.propTypes = {
     }),
     stageSize: PropTypes.oneOf(Object.keys(STAGE_DISPLAY_SIZES)).isRequired,
     toolboxXML: PropTypes.string,
+    updateMetrics: PropTypes.func,
     updateToolboxState: PropTypes.func,
-    vm: PropTypes.instanceOf(VM).isRequired
+    vm: PropTypes.instanceOf(VM).isRequired,
+    workspaceMetrics: PropTypes.shape({
+        targets: PropTypes.objectOf(PropTypes.object)
+    })
 };
 
 Blocks.defaultOptions = {
     zoom: {
         controls: true,
         wheel: true,
-        startScale: 0.675
+        startScale: BLOCKS_DEFAULT_SCALE
     },
     grid: {
         spacing: 40,

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -301,12 +301,17 @@ class Blocks extends React.Component {
     onWorkspaceMetricsChange () {
         const target = this.props.vm.editingTarget;
         if (target && target.id) {
-            this.props.updateMetrics({
-                targetID: target.id,
-                scrollX: this.workspace.scrollX,
-                scrollY: this.workspace.scrollY,
-                scale: this.workspace.scale
-            });
+            // Dispatch updateMetrics later, since onWorkspaceMetricsChange may be (very indirectly)
+            // called from a reducer, i.e. when you create a custom procedure.
+            // TODO: Is this a vehement hack?
+            setTimeout(() => {
+                this.props.updateMetrics({
+                    targetID: target.id,
+                    scrollX: this.workspace.scrollX,
+                    scrollY: this.workspace.scrollY,
+                    scale: this.workspace.scale
+                });
+            }, 0);
         }
     }
     onScriptGlowOn (data) {
@@ -353,7 +358,7 @@ class Blocks extends React.Component {
             this.props.updateToolboxState(toolboxXML);
         }
 
-        if (this.props.vm.editingTarget && !this.props.workspaceMetrics[this.props.vm.editingTarget.id]) {
+        if (this.props.vm.editingTarget && !this.props.workspaceMetrics.targets[this.props.vm.editingTarget.id]) {
             this.onWorkspaceMetricsChange();
         }
 
@@ -379,8 +384,8 @@ class Blocks extends React.Component {
         }
         this.workspace.addChangeListener(this.props.vm.blockListener);
 
-        if (this.props.vm.editingTarget && this.props.workspaceMetrics[this.props.vm.editingTarget.id]) {
-            const {scrollX, scrollY, scale} = this.props.workspaceMetrics[this.props.vm.editingTarget.id];
+        if (this.props.vm.editingTarget && this.props.workspaceMetrics.targets[this.props.vm.editingTarget.id]) {
+            const {scrollX, scrollY, scale} = this.props.workspaceMetrics.targets[this.props.vm.editingTarget.id];
             this.workspace.scrollX = scrollX;
             this.workspace.scrollY = scrollY;
             this.workspace.scale = scale;

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -25,6 +25,7 @@ import {activateColorPicker} from '../reducers/color-picker';
 import {closeExtensionLibrary, openSoundRecorder, openConnectionModal} from '../reducers/modals';
 import {activateCustomProcedures, deactivateCustomProcedures} from '../reducers/custom-procedures';
 import {setConnectionModalExtensionId} from '../reducers/connection-modal';
+import {updateMetrics} from '../reducers/workspace-metrics';
 
 import {
     activateTab,
@@ -79,7 +80,6 @@ class Blocks extends React.Component {
         this.ScratchBlocks.recordSoundCallback = this.handleOpenSoundRecorder;
 
         this.state = {
-            workspaceMetrics: {},
             prompt: null
         };
         this.onTargetsUpdate = debounce(this.onTargetsUpdate, 100);
@@ -301,14 +301,12 @@ class Blocks extends React.Component {
     onWorkspaceMetricsChange () {
         const target = this.props.vm.editingTarget;
         if (target && target.id) {
-            const workspaceMetrics = Object.assign({}, this.state.workspaceMetrics, {
-                [target.id]: {
-                    scrollX: this.workspace.scrollX,
-                    scrollY: this.workspace.scrollY,
-                    scale: this.workspace.scale
-                }
+            this.props.updateMetrics({
+                targetID: target.id,
+                scrollX: this.workspace.scrollX,
+                scrollY: this.workspace.scrollY,
+                scale: this.workspace.scale
             });
-            this.setState({workspaceMetrics});
         }
     }
     onScriptGlowOn (data) {
@@ -355,7 +353,7 @@ class Blocks extends React.Component {
             this.props.updateToolboxState(toolboxXML);
         }
 
-        if (this.props.vm.editingTarget && !this.state.workspaceMetrics[this.props.vm.editingTarget.id]) {
+        if (this.props.vm.editingTarget && !this.props.workspaceMetrics[this.props.vm.editingTarget.id]) {
             this.onWorkspaceMetricsChange();
         }
 
@@ -381,8 +379,8 @@ class Blocks extends React.Component {
         }
         this.workspace.addChangeListener(this.props.vm.blockListener);
 
-        if (this.props.vm.editingTarget && this.state.workspaceMetrics[this.props.vm.editingTarget.id]) {
-            const {scrollX, scrollY, scale} = this.state.workspaceMetrics[this.props.vm.editingTarget.id];
+        if (this.props.vm.editingTarget && this.props.workspaceMetrics[this.props.vm.editingTarget.id]) {
+            const {scrollX, scrollY, scale} = this.props.workspaceMetrics[this.props.vm.editingTarget.id];
             this.workspace.scrollX = scrollX;
             this.workspace.scrollY = scrollY;
             this.workspace.scale = scale;
@@ -506,7 +504,7 @@ class Blocks extends React.Component {
             });
     }
     render () {
-        /* eslint-disable no-unused-vars */
+        /* eslint-disable no-unused-vars, no-shadow */
         const {
             anyModalVisible,
             canUseCloud,
@@ -525,9 +523,11 @@ class Blocks extends React.Component {
             onRequestCloseExtensionLibrary,
             onRequestCloseCustomProcedures,
             toolboxXML,
+            workspaceMetrics,
+            updateMetrics,
             ...props
         } = this.props;
-        /* eslint-enable no-unused-vars */
+        /* eslint-enable no-unused-vars, no-shadow */
         return (
             <React.Fragment>
                 <DroppableBlocks
@@ -654,7 +654,8 @@ const mapStateToProps = state => ({
     locale: state.locales.locale,
     messages: state.locales.messages,
     toolboxXML: state.scratchGui.toolbox.toolboxXML,
-    customProceduresVisible: state.scratchGui.customProcedures.active
+    customProceduresVisible: state.scratchGui.customProcedures.active,
+    workspaceMetrics: state.scratchGui.workspaceMetrics
 });
 
 const mapDispatchToProps = dispatch => ({
@@ -676,6 +677,9 @@ const mapDispatchToProps = dispatch => ({
     },
     updateToolboxState: toolboxXML => {
         dispatch(updateToolbox(toolboxXML));
+    },
+    updateMetrics: metrics => {
+        dispatch(updateMetrics(metrics));
     }
 });
 

--- a/src/containers/target-pane.jsx
+++ b/src/containers/target-pane.jsx
@@ -14,6 +14,7 @@ import {showStandardAlert, closeAlertWithId} from '../reducers/alerts';
 import {setRestore} from '../reducers/restore-deletion';
 import DragConstants from '../lib/drag-constants';
 import TargetPaneComponent from '../components/target-pane/target-pane.jsx';
+import {BLOCKS_DEFAULT_SCALE} from '../lib/layout-constants';
 import spriteLibraryContent from '../lib/libraries/sprites.json';
 import {handleFileUpload, spriteUpload} from '../lib/file-uploader.js';
 import sharedMessages from '../lib/shared-messages';
@@ -171,7 +172,7 @@ class TargetPane extends React.Component {
                 metrics = {
                     scrollX: 0,
                     scrollY: 0,
-                    scale: 0.675 // TODO: Define this in a constant somewhere.
+                    scale: BLOCKS_DEFAULT_SCALE
                 };
             }
 

--- a/src/containers/target-pane.jsx
+++ b/src/containers/target-pane.jsx
@@ -179,11 +179,11 @@ class TargetPane extends React.Component {
             const {scrollX, scrollY, scale} = metrics;
             const {width} = this.props.workspaceMetrics.dimensions;
             const posY = -scrollY + 30;
-            let posX = -scrollX;
+            let posX;
             if (this.props.isRtl) {
-                posX += width - 30;
+                posX = scrollX + 30;
             } else {
-                posX += 30;
+                posX = -scrollX + 30;
             }
 
             // Actually apply the position!

--- a/src/containers/target-pane.jsx
+++ b/src/containers/target-pane.jsx
@@ -177,7 +177,6 @@ class TargetPane extends React.Component {
 
             // Determine position of the top-level block based on the target's workspace metrics.
             const {scrollX, scrollY, scale} = metrics;
-            const {width} = this.props.workspaceMetrics.dimensions;
             const posY = -scrollY + 30;
             let posX;
             if (this.props.isRtl) {

--- a/src/lib/layout-constants.js
+++ b/src/lib/layout-constants.js
@@ -37,6 +37,9 @@ const STAGE_DISPLAY_SIZES = keyMirror({
     small: null
 });
 
+// zoom level to start with
+const BLOCKS_DEFAULT_SCALE = 0.675;
+
 const STAGE_DISPLAY_SCALES = {};
 STAGE_DISPLAY_SCALES[STAGE_DISPLAY_SIZES.large] = 1; // large mode, wide browser (standard)
 STAGE_DISPLAY_SCALES[STAGE_DISPLAY_SIZES.largeConstrained] = 0.85; // large mode but narrow browser
@@ -50,6 +53,7 @@ export default {
 };
 
 export {
+    BLOCKS_DEFAULT_SCALE,
     STAGE_DISPLAY_SCALES,
     STAGE_DISPLAY_SIZES,
     STAGE_SIZE_MODES

--- a/src/reducers/gui.js
+++ b/src/reducers/gui.js
@@ -25,6 +25,7 @@ import timeoutReducer, {timeoutInitialState} from './timeout';
 import toolboxReducer, {toolboxInitialState} from './toolbox';
 import vmReducer, {vmInitialState} from './vm';
 import vmStatusReducer, {vmStatusInitialState} from './vm-status';
+import workspaceMetricsReducer, {workspaceMetricsInitialState} from './workspace-metrics';
 import throttle from 'redux-throttle';
 
 import decks from '../lib/libraries/decks/index.jsx';
@@ -57,7 +58,8 @@ const guiInitialState = {
     timeout: timeoutInitialState,
     toolbox: toolboxInitialState,
     vm: vmInitialState,
-    vmStatus: vmStatusInitialState
+    vmStatus: vmStatusInitialState,
+    workspaceMetrics: workspaceMetricsInitialState
 };
 
 const initPlayer = function (currentState) {
@@ -155,7 +157,8 @@ const guiReducer = combineReducers({
     timeout: timeoutReducer,
     toolbox: toolboxReducer,
     vm: vmReducer,
-    vmStatus: vmStatusReducer
+    vmStatus: vmStatusReducer,
+    workspaceMetrics: workspaceMetricsReducer
 });
 
 export {

--- a/src/reducers/workspace-metrics.js
+++ b/src/reducers/workspace-metrics.js
@@ -1,22 +1,45 @@
+const UPDATE_DIMENSIONS = 'scratch-gui/workspace-metrics/UPDATE_DIMENSIONS';
 const UPDATE_METRICS = 'scratch-gui/workspace-metrics/UPDATE_METRICS';
 
-const initialState = {};
+const initialState = {
+    dimensions: {
+        width: 0,
+        height: 0
+    },
+    targets: {}
+};
 
 const reducer = function (state, action) {
     if (typeof state === 'undefined') state = initialState;
 
     switch (action.type) {
+    case UPDATE_DIMENSIONS:
+        return Object.assign({}, state, {
+            dimensions: {
+                width: action.width,
+                height: action.height
+            }
+        });
     case UPDATE_METRICS:
         return Object.assign({}, state, {
-            [action.targetID]: {
-                scrollX: action.scrollX,
-                scrollY: action.scrollY,
-                scale: action.scale
-            }
+            targets: Object.assign({}, state.targets, {
+                [action.targetID]: {
+                    scrollX: action.scrollX,
+                    scrollY: action.scrollY,
+                    scale: action.scale
+                }
+            })
         });
     default:
         return state;
     }
+};
+
+const updateDimensions = function (dimensions) {
+    return {
+        type: UPDATE_DIMENSIONS,
+        ...dimensions
+    };
 };
 
 const updateMetrics = function (metrics) {

--- a/src/reducers/workspace-metrics.js
+++ b/src/reducers/workspace-metrics.js
@@ -1,0 +1,33 @@
+const UPDATE_METRICS = 'scratch-gui/workspace-metrics/UPDATE_METRICS';
+
+const initialState = {};
+
+const reducer = function (state, action) {
+    if (typeof state === 'undefined') state = initialState;
+
+    switch (action.type) {
+    case UPDATE_METRICS:
+        return Object.assign({}, state, {
+            [action.targetID]: {
+                scrollX: action.scrollX,
+                scrollY: action.scrollY,
+                scale: action.scale
+            }
+        });
+    default:
+        return state;
+    }
+};
+
+const updateMetrics = function (metrics) {
+    return {
+        type: UPDATE_METRICS,
+        ...metrics
+    };
+};
+
+export {
+    reducer as default,
+    initialState as workspaceMetricsInitialState,
+    updateMetrics
+};

--- a/src/reducers/workspace-metrics.js
+++ b/src/reducers/workspace-metrics.js
@@ -1,11 +1,6 @@
-const UPDATE_DIMENSIONS = 'scratch-gui/workspace-metrics/UPDATE_DIMENSIONS';
 const UPDATE_METRICS = 'scratch-gui/workspace-metrics/UPDATE_METRICS';
 
 const initialState = {
-    dimensions: {
-        width: 0,
-        height: 0
-    },
     targets: {}
 };
 
@@ -13,13 +8,6 @@ const reducer = function (state, action) {
     if (typeof state === 'undefined') state = initialState;
 
     switch (action.type) {
-    case UPDATE_DIMENSIONS:
-        return Object.assign({}, state, {
-            dimensions: {
-                width: action.width,
-                height: action.height
-            }
-        });
     case UPDATE_METRICS:
         return Object.assign({}, state, {
             targets: Object.assign({}, state.targets, {
@@ -33,13 +21,6 @@ const reducer = function (state, action) {
     default:
         return state;
     }
-};
-
-const updateDimensions = function (dimensions) {
-    return {
-        type: UPDATE_DIMENSIONS,
-        ...dimensions
-    };
 };
 
 const updateMetrics = function (metrics) {

--- a/test/unit/reducers/workspace-metrics-reducer.test.js
+++ b/test/unit/reducers/workspace-metrics-reducer.test.js
@@ -1,0 +1,25 @@
+/* eslint-env jest */
+import workspaceMetricsReducer, {updateMetrics} from '../../../src/reducers/workspace-metrics';
+
+test('initialState', () => {
+    let defaultState;
+    /* workspaceMetricsReducer(state, action) */
+    expect(workspaceMetricsReducer(defaultState, {type: 'anything'})).toBeDefined();
+    expect(workspaceMetricsReducer(defaultState, {type: 'anything'})).toEqual({targets: {}});
+});
+
+test('updateMetrics action creator', () => {
+    let defaultState;
+    const action = updateMetrics({
+        targetID: 'abcde',
+        scrollX: 225,
+        scrollY: 315,
+        scale: 1.25
+    });
+    const resultState = workspaceMetricsReducer(defaultState, action);
+    expect(Object.keys(resultState.targets).length).toBe(1);
+    expect(resultState.targets.abcde).toBeDefined();
+    expect(resultState.targets.abcde.scrollX).toBe(225);
+    expect(resultState.targets.abcde.scrollY).toBe(315);
+    expect(resultState.targets.abcde.scale).toBe(1.25);
+});


### PR DESCRIPTION
### Resolves

Resolves LLK/scratch-vm#1739. Hopefully resolves #4270, too, but I can't test that to be certain (I don't know how to use the backpack while offline).

*(Tangentially related to #4400; I noticed while testing the repros I described [here](https://github.com/LLK/scratch-gui/issues/4400#issuecomment-462994133) that switching the sprite no longer messed with the workspace scroll while zoomed in, and it still does in scratch-gui/develop. There's still lag, presumably from generating the menu item elements, though. /cc @kchadha)*

### Proposed Changes

Takes `workspaceMetrics`, previously stored in the `<Blocks>` container's state, and changes it to be stored in global state via a reducer. Changes the `<TargetPane>` container so that, when it handles dropped blocks, it repositions them to fit within the viewport of the target sprite's workspace. (This behavior is in a new function that is also used when receiving blocks dropped from the backpack, so it should work in that case too, but I don't know how to test the backpack offline.)

### Reason for Changes

To make "share the love" (and backpacked scripts) a much more useful feature when working in large projects (sprites with lots of scripts).

### Test Coverage

Tested manually. (Would unit tests be helpful here? There's quite a bit of tweaked code, but it was mostly just simple substitutions and the typical react/redux stuff for making use of global state; and I'm not sure if the added behavior should take unit tests or not.)

### Browser Coverage

Linux Firefox, Chromium.