### PR TITLE
Mouse move drag perf

### DIFF
--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -320,7 +320,6 @@ class Stage extends React.Component {
         if (this.state.dragId) return;
         const drawableId = this.renderer.pick(x, y);
         if (drawableId === null) return;
-        const drawableData = this.renderer.extractDrawable(drawableId, x, y);
         const targetId = this.props.vm.getTargetIdForDrawableId(drawableId);
         if (targetId === null) return;
 
@@ -331,6 +330,9 @@ class Stage extends React.Component {
 
         // Dragging always brings the target to the front
         target.goToFront();
+
+        // Extract the drawable art
+        const drawableData = this.renderer.extractDrawable(drawableId, x, y);
 
         this.props.vm.startDrag(targetId);
         this.setState({


### PR DESCRIPTION
### Resolves

https://github.com/LLK/scratch-vm/issues/1992#issuecomment-461877798

Implements the first suggestion in the above comment.

### Proposed Changes

Extract the draggable's art a little later.

### Reason for Changes

As it is when the gui is fullscreen or player only or the target is not draggable the function returns before setting that a drag is starting. So each mouse movement during a drag in fullscreen or player only and targets that are not draggable extract for every mouse movement.

That looks like this in a chrome devtools performance flame chart:

<img width="691" alt="screen shot 0031-02-14 at 4 11 50 pm" src="https://user-images.githubusercontent.com/833298/52819478-64afe000-3077-11e9-860b-2ab63bb377b5.png">

Depending on the system performing this work this can become very laggy.

By reordering the extraction until later we can change this to either never perform the readPixels work or for draggable targets, do it once at the beginning of the drag. (A further improvement will be to not extract in this case and only extract when we are in the editor gui.)

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
