### PR TITLE
Request a toolbox refresh after switching between tabs to fix #4561

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -162,6 +162,7 @@ class Blocks extends React.Component {
                 this.setLocale();
             } else {
                 this.props.vm.refreshWorkspace();
+                this.requestToolboxUpdate();
             }
 
             window.dispatchEvent(new Event('resize'));

--- a/test/integration/blocks.test.js
+++ b/test/integration/blocks.test.js
@@ -252,4 +252,18 @@ describe('Working with the blocks', () => {
         await driver.sleep(500); // Wait for scroll to finish
         await clickText('my\u00A0variable');
     });
+
+    // Regression test for switching editor tabs causing toolbox to stop updating
+    test('Creating variables after adding extensions updates the toolbox', async () => {
+        await loadUri(uri);
+        await clickText('Costumes');
+        await clickText('Code');
+        await clickText('Variables', scope.blocksTab);
+        await driver.sleep(500); // Wait for scroll
+        await clickText('Make a List');
+        const el = await findByXpath("//input[@name='New list name:']");
+        await el.sendKeys('list1');
+        await clickButton('OK');
+        await clickText('list1', scope.blocksTab);
+    });
 });


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/LLK/scratch-gui/issues/4561

### Proposed Changes

_Describe what this Pull Request does_

### Reason for Changes

_Explain why these changes should be made_

Make sure to enqueue a toolbox update any time the workspace is refreshed, so that the toolbox can continue updating.

### Test Coverage

_Please show how you have added tests to cover your changes_

Added an integration test for this case.

---

/cc @picklesrus sigh... I think this basically brings us full-circle toolbox update-wise, with the one benefit that because we are enqueuing instead of updating directly, we avoid a couple cases of double updating, because refreshing the workspace apparently cannot happen without a corresponding toolbox update because it then forever disables the toolbox from refreshing. Oh also we now have several more integration tests to cover the toolbox not updating. So hopefully we can do some real refactoring now that we have tests.

