### PR TITLE
Add a way for GUI consumer to retrieve snapshots of the stage

### DIFF
--- a/test/unit/util/project-saver-hoc.test.jsx
+++ b/test/unit/util/project-saver-hoc.test.jsx
@@ -439,4 +439,27 @@ describe('projectSaverHOC', () => {
         });
         expect(mockedOnRemixing).toHaveBeenCalledWith(false);
     });
+
+    test('uses onSetProjectThumbnailer on mount/unmount', () => {
+        const Component = () => <div />;
+        const WrappedComponent = projectSaverHOC(Component);
+        const setThumb = jest.fn();
+        const mounted = mount(
+            <WrappedComponent
+                store={store}
+                vm={vm}
+                onSetProjectThumbnailer={setThumb}
+            />
+        );
+        // Set project thumbnailer should be called on mount
+        expect(setThumb).toHaveBeenCalledTimes(1);
+
+        // And it should not pass that function on to wrapped element
+        expect(mounted.find(Component).props().onSetProjectThumbnailer).toBeUndefined();
+
+        // Unmounting should call it again with null
+        mounted.unmount();
+        expect(setThumb).toHaveBeenCalledTimes(2);
+        expect(setThumb.mock.calls[1][0]).toBe(null);
+    });
 });


### PR DESCRIPTION
@rschamp this is the result of what we were working on to allow consumers of the GUI to get a function that can be called to retrieve a stage snapshot.

Has a default prop value, so if nothing is passed in nothing should be wrong