### PR TITLE
Check conditions before autoscrolling flyout when custom procedures dialog is closed

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -445,6 +445,12 @@ class Blocks extends React.Component {
     }
     handleCustomProceduresClose (data) {
         this.props.onRequestCloseCustomProcedures(data);
+
+        // No data: the user cancelled the dialog, so don't do anything to the workspace.
+        if (!data) {
+            return;
+        }
+
         const ws = this.workspace;
         ws.refreshToolboxSelection_();
         ws.toolbox_.scrollToCategoryById('myBlocks');

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -453,7 +453,12 @@ class Blocks extends React.Component {
 
         const ws = this.workspace;
         ws.refreshToolboxSelection_();
-        ws.toolbox_.scrollToCategoryById('myBlocks');
+
+        // Only scroll to My Blocks section if the action is creating a new custom block - not when editing
+        // an existing one.
+        if (!this.props.customProceduresIsEdit) {
+            ws.toolbox_.scrollToCategoryById('myBlocks');
+        }
     }
     handleDrop (dragInfo) {
         fetch(dragInfo.payload.bodyUrl)
@@ -612,12 +617,15 @@ const mapStateToProps = state => ({
     locale: state.locales.locale,
     messages: state.locales.messages,
     toolboxXML: state.scratchGui.toolbox.toolboxXML,
+    customProceduresIsEdit: state.scratchGui.customProcedures.isEdit,
     customProceduresVisible: state.scratchGui.customProcedures.active
 });
 
 const mapDispatchToProps = dispatch => ({
     onActivateColorPicker: callback => dispatch(activateColorPicker(callback)),
-    onActivateCustomProcedures: (data, callback) => dispatch(activateCustomProcedures(data, callback)),
+    onActivateCustomProcedures: (mutator, isEdit, callback) => {
+        dispatch(activateCustomProcedures(mutator, isEdit, callback));
+    },
     onOpenConnectionModal: id => {
         dispatch(setConnectionModalExtensionId(id));
         dispatch(openConnectionModal());
@@ -629,8 +637,8 @@ const mapDispatchToProps = dispatch => ({
     onRequestCloseExtensionLibrary: () => {
         dispatch(closeExtensionLibrary());
     },
-    onRequestCloseCustomProcedures: data => {
-        dispatch(deactivateCustomProcedures(data));
+    onRequestCloseCustomProcedures: mutator => {
+        dispatch(deactivateCustomProcedures(mutator));
     },
     updateToolboxState: toolboxXML => {
         dispatch(updateToolbox(toolboxXML));

--- a/src/reducers/custom-procedures.js
+++ b/src/reducers/custom-procedures.js
@@ -5,6 +5,7 @@ const SET_CALLBACK = 'scratch-gui/custom-procedures/SET_CALLBACK';
 const initialState = {
     active: false,
     mutator: null,
+    isEdit: false,
     callback: null
 };
 
@@ -15,6 +16,7 @@ const reducer = function (state, action) {
         return Object.assign({}, state, {
             active: true,
             mutator: action.mutator,
+            isEdit: action.isEdit,
             callback: action.callback
         });
     case DEACTIVATE_CUSTOM_PROCEDURES:
@@ -26,6 +28,7 @@ const reducer = function (state, action) {
         return Object.assign({}, state, {
             active: false,
             mutator: null,
+            isEdit: false,
             callback: null
         });
     case SET_CALLBACK:
@@ -38,13 +41,15 @@ const reducer = function (state, action) {
 /**
  * Action creator to open the custom procedures modal.
  * @param {!Element} mutator The XML node of the mutator for the procedure.
+ * @param {!boolean} isEdit True if editing an existing custom procedure.
  * @param {!function(!Element)} callback The function to call when done editing procedure.
  *     Expect the callback to be a function that takes a new XML mutator node.
  * @returns {object} An action object with type ACTIVATE_CUSTOM_PROCEDURES.
  */
-const activateCustomProcedures = (mutator, callback) => ({
+const activateCustomProcedures = (mutator, isEdit, callback) => ({
     type: ACTIVATE_CUSTOM_PROCEDURES,
     mutator: mutator,
+    isEdit: isEdit,
     callback: callback
 });
 


### PR DESCRIPTION
### Resolves

Depends on LLK/scratch-blocks#1901. That PR should be merged first!

Fixes LLK/scratch-blocks#1856. Also fixes the issue where selecting "Cancel" would scroll the flyout. I can't find an issue filed for that, though. (But I could've sworn one existed..)

### Proposed Changes

Adds two conditions which are checked when the custom procedure dialog ("Make a Block") is closed:

1. Check if the dialog was cancelled.
2. Check if the dialog was for editing an existing custom block (rather than creating a new one).

If either of these are true, the flyout is *not* automatically scrolled. (Also, if the former, the workspace isn't updated, either, since no changes were made.)

### Reason for Changes

To make the custom procedure dialog and related autoscrolling feel more intuitive!

### Test Coverage

Tested manually.

### Browser Coverage

Linux Firefox, Chromium.