### PR TITLE
fix(css): fix css value has mixed support warning

### DIFF
--- a/src/components/alerts/inline-message.css
+++ b/src/components/alerts/inline-message.css
@@ -5,7 +5,7 @@
     color: $ui-white;
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
     display: flex;
-    justify-content: end;
+    justify-content: flex-end;
     align-items: center;
     font-size: .8125rem;
 }

--- a/src/components/menu-bar/author-info.css
+++ b/src/components/menu-bar/author-info.css
@@ -5,7 +5,7 @@
     color: $ui-white;
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
     display: flex;
-    justify-content: start;
+    justify-content: flex-start;
     align-items: center;
     cursor: default;
 }


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves #4559 

### Proposed Changes

use 'flex-end' & 'flex-start' instead of 'end' & 'start'

### Reason for Changes

solved warnings

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [x] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [x] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
