### PR TITLE
Fix issue #2256 by disable text input auto capitalize feature on IOS devices

### DIFF
--- a/src/components/filter/filter.jsx
+++ b/src/components/filter/filter.jsx
@@ -26,6 +26,8 @@ const FilterComponent = props => {
                 src={filterIcon}
             />
             <input
+                autoCapitalize={'none'}
+                autoCorrect={'off'}
                 className={classNames(styles.filterInput, inputClassName)}
                 placeholder={placeholderText}
                 type="text"

--- a/src/components/filter/filter.jsx
+++ b/src/components/filter/filter.jsx
@@ -26,8 +26,8 @@ const FilterComponent = props => {
                 src={filterIcon}
             />
             <input
-                autoCapitalize={'none'}
-                autoCorrect={'off'}
+                autoCapitalize="none"
+                autoCorrect="off"
                 className={classNames(styles.filterInput, inputClassName)}
                 placeholder={placeholderText}
                 type="text"

--- a/src/components/forms/input.jsx
+++ b/src/components/forms/input.jsx
@@ -9,6 +9,8 @@ const Input = props => {
     return (
         <input
             {...componentProps}
+            autoCapitalize={'none'}
+            autoCorrect={'off'}
             className={classNames(
                 styles.inputForm,
                 props.className,

--- a/src/components/forms/input.jsx
+++ b/src/components/forms/input.jsx
@@ -9,8 +9,8 @@ const Input = props => {
     return (
         <input
             {...componentProps}
-            autoCapitalize={'none'}
-            autoCorrect={'off'}
+            autoCapitalize="none"
+            autoCorrect="off"
             className={classNames(
                 styles.inputForm,
                 props.className,

--- a/src/components/monitor/list-monitor-scroller.jsx
+++ b/src/components/monitor/list-monitor-scroller.jsx
@@ -48,9 +48,9 @@ class ListMonitorScroller extends React.Component {
                         <div className={styles.inputWrapper}>
                             <input
                                 autoFocus
-                                autoCapitalize={'none'}
+                                autoCapitalize="none"
                                 autoComplete={false}
-                                autoCorrect={'off'}
+                                autoCorrect="off"
                                 className={classNames(styles.listInput, 'no-drag')}
                                 spellCheck={false}
                                 type="text"

--- a/src/components/monitor/list-monitor-scroller.jsx
+++ b/src/components/monitor/list-monitor-scroller.jsx
@@ -48,7 +48,9 @@ class ListMonitorScroller extends React.Component {
                         <div className={styles.inputWrapper}>
                             <input
                                 autoFocus
+                                autoCapitalize={'none'}
                                 autoComplete={false}
+                                autoCorrect={'off'}
                                 className={classNames(styles.listInput, 'no-drag')}
                                 spellCheck={false}
                                 type="text"

--- a/src/components/prompt/prompt.jsx
+++ b/src/components/prompt/prompt.jsx
@@ -46,6 +46,8 @@ const PromptComponent = props => (
             <Box>
                 <input
                     autoFocus
+                    autoCapitalize={'none'}
+                    autoCorrect={'off'}
                     className={styles.variableNameTextInput}
                     defaultValue={props.defaultValue}
                     name={props.label}

--- a/src/components/prompt/prompt.jsx
+++ b/src/components/prompt/prompt.jsx
@@ -46,8 +46,8 @@ const PromptComponent = props => (
             <Box>
                 <input
                     autoFocus
-                    autoCapitalize={'none'}
-                    autoCorrect={'off'}
+                    autoCapitalize="none"
+                    autoCorrect="off"
                     className={styles.variableNameTextInput}
                     defaultValue={props.defaultValue}
                     name={props.label}

--- a/test/unit/components/__snapshots__/sound-editor.test.jsx.snap
+++ b/test/unit/components/__snapshots__/sound-editor.test.jsx.snap
@@ -19,6 +19,8 @@ exports[`Sound Editor Component matches snapshot 1`] = `
           Sound
         </span>
         <input
+          autoCapitalize="none"
+          autoCorrect="off"
           className=""
           onBlur={[Function]}
           onChange={[Function]}

--- a/test/unit/components/sound-editor.test.jsx
+++ b/test/unit/components/sound-editor.test.jsx
@@ -6,6 +6,8 @@ describe('Sound Editor Component', () => {
     let props;
     beforeEach(() => {
         props = {
+            autoCapitalize: 'none',
+            autoCorrect: 'off',
             canUndo: true,
             canRedo: false,
             chunkLevels: [1, 2, 3],

--- a/test/unit/components/sound-editor.test.jsx
+++ b/test/unit/components/sound-editor.test.jsx
@@ -6,7 +6,6 @@ describe('Sound Editor Component', () => {
     let props;
     beforeEach(() => {
         props = {
-            autoCapitalize: 'none',
             autoCorrect: 'off',
             canUndo: true,
             canRedo: false,


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves #2256 

### Proposed Changes

added two attributes to every text input (4 places: project title, assets filter, variable name, list item) to disable text input auto capitalize feature on IOS devices

### Test Coverage

updated unit/components/sound-editor.test.jsx

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [x] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [x] Safari

Android Tablet
* [x] Chrome
