### PR TITLE
Only change monitor mode on primary (left) double click

### DIFF
--- a/src/containers/monitor.jsx
+++ b/src/containers/monitor.jsx
@@ -108,7 +108,10 @@ class Monitor extends React.Component {
             y: newY
         }));
     }
-    handleNextMode () {
+    handleNextMode (event) {
+        if (event && event.button !== 0) {
+            return;
+        }
         const modes = availableModes(this.props.opcode);
         const modeIndex = modes.indexOf(this.props.mode);
         const newMode = modes[(modeIndex + 1) % modes.length];


### PR DESCRIPTION
### Resolves

Fixes #2089 (also fixes #3863).

### Proposed Changes

Makes double-clicking a monitor only change the mode if done with the primary (left) mouse button.

### Reason for Changes

Other buttons (right, middle/scrollwheel) usually aren't used for double clicking, so generally, users don't expect programs to respond to those buttons acting as double clicks.

### Test Coverage

Tested manually.

### Browser Coverage

Linux Firefox, Chromium.