### PR TITLE
Call hideChaff when user mouses-down outside Blockly

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -66,6 +66,7 @@ class Blocks extends React.Component {
             'onBlockGlowOff',
             'handleExtensionAdded',
             'handleBlocksInfoUpdate',
+            'onDocumentMouseDown',
             'onTargetsUpdate',
             'onVisualReport',
             'onWorkspaceUpdate',
@@ -112,6 +113,8 @@ class Blocks extends React.Component {
         // @todo change this when blockly supports UI events
         addFunctionListener(this.workspace, 'translate', this.onWorkspaceMetricsChange);
         addFunctionListener(this.workspace, 'zoom', this.onWorkspaceMetricsChange);
+
+        document.addEventListener('mousedown', this.onDocumentMouseDown);
 
         this.attachVM();
         // Only update blocks/vm locale when visible to avoid sizing issues
@@ -177,6 +180,7 @@ class Blocks extends React.Component {
         this.detachVM();
         this.workspace.dispose();
         clearTimeout(this.toolboxUpdateTimeout);
+        document.removeEventListener('mousedown', this.onDocumentMouseDown);
     }
 
     setLocale () {
@@ -271,6 +275,26 @@ class Blocks extends React.Component {
                 block.inputList[0].fieldRow[0].setValue(value);
             }
         });
+    }
+
+    onDocumentMouseDown (evt) {
+        // When the user clicks not inside the Blockly injection div *or* a widget/etc, the click certainly happened
+        // outside of Blockly, so call hideChaff to hide inputs, menus, etc. (If the click happened inside one of those
+        // elements, Blockly will handle relevant logic itself.
+
+        const injectionDiv = this.workspace.getInjectionDiv();
+        let el = evt.target;
+        while (el) {
+            if (el === injectionDiv) {
+                return;
+            }
+            if (Array.from(el.classList).find(cls => /blockly(.*)Div/.test(cls))) {
+                return;
+            }
+            el = el.parentElement;
+        }
+
+        this.ScratchBlocks.hideChaff();
     }
 
     onTargetsUpdate () {


### PR DESCRIPTION
### Resolves

Fixes #1081.

### Proposed Changes

Calls `hideChaff` whenever the user mouses-down anywhere outside of Blockly.

### Reason for Changes

Users don't expect context menus to stay visible when they click outside the menu. It'll already be hidden if the user clicks anywhere inside of Blockly, but outside, it isn't.

We explicitly check that the mouse-down doesn't happen inside Blockly (or any related elements) because Blockly handles relevant logic when it does.

### Test Coverage

Tested manually, but not *super* extensively. Clicking menu options still works, for certain, and the PR does call `hideChaff` at the proper times.

### Browser Coverage

Linux Firefox, Chromium.