### PR TITLE
wrap some parts of gui in a hoc to delay rendering if possible

### DIFF
--- a/src/components/bootstrap-loader/bootstrap-loader.jsx
+++ b/src/components/bootstrap-loader/bootstrap-loader.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import {FormattedMessage} from 'react-intl';
+import classNames from 'classnames';
+import styles from './loader.css';
+import PropTypes from 'prop-types';
+
+const mainMessage = (
+    <FormattedMessage
+        defaultMessage="Bootstrapping"
+        description="Main loading message"
+        id="gui.bootstapLoader.headline"
+    />
+);
+
+class LoaderComponent extends React.Component {
+    render () {
+        return (
+            <div
+                className={classNames(styles.background, {
+                    [styles.fullscreen]: this.props.isFullScreen
+                })}
+                dir={this.props.dir}
+            >
+                <div className={styles.container}>
+                    {this.props.children}
+                </div>
+            </div>
+        );
+    }
+}
+
+LoaderComponent.propTypes = {
+    isFullScreen: PropTypes.bool
+};
+LoaderComponent.defaultProps = {
+    isFullScreen: false
+};
+
+export default LoaderComponent;

--- a/src/components/bootstrap-loader/loader.css
+++ b/src/components/bootstrap-loader/loader.css
@@ -1,0 +1,50 @@
+@import "../../css/colors.css";
+@import "../../css/z-index.css";
+
+.background {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: $z-index-loader;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: $motion-primary;
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    text-align: center;
+    color: white;
+}
+
+.fullscreen {
+    /* Break out of the layout using position: fixed to cover the whole screen */
+    position: fixed;
+    /* Use the fullscreen stage z-index to allow covering full-screen mode */
+    z-index: $z-index-stage-wrapper-overlay;
+}
+
+.block-animation {
+    width: 125px;
+    height: 150px;
+    margin: 50px auto 0px;
+}
+
+.block-animation img {
+    display: block;
+    position: relative;
+    height: 30%;
+    margin-top: -4px;
+}
+
+.top-block,
+.middle-block,
+.bottom-block {
+    visibility: hidden;
+}
+
+.title {
+    font-size: 2rem;
+    font-weight: bold;
+    margin: 0.75rem 0;
+}

--- a/src/components/stage-wrapper/stage-wrapper.jsx
+++ b/src/components/stage-wrapper/stage-wrapper.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import VM from 'scratch-vm';
 
 import Box from '../box/box.jsx';
+import conditionHOC from '../../lib/condition-hoc.jsx';
 import {STAGE_DISPLAY_SIZES} from '../../lib/layout-constants.js';
 import StageHeader from '../../containers/stage-header.jsx';
 import Stage from '../../containers/stage.jsx';
@@ -10,12 +11,13 @@ import Loader from '../loader/loader.jsx';
 
 import styles from './stage-wrapper.css';
 
+const IsLoadingLoader = conditionHOC(conditionHOC.loading)(Loader);
+
 const StageWrapperComponent = function (props) {
     const {
         isFullScreen,
         isRtl,
         isRendererSupported,
-        loading,
         stageSize,
         vm
     } = props;
@@ -41,9 +43,7 @@ const StageWrapperComponent = function (props) {
                         null
                 }
             </Box>
-            {loading ? (
-                <Loader isFullScreen={isFullScreen} />
-            ) : null}
+            <IsLoadingLoader isFullScreen={isFullScreen} />
         </Box>
     );
 };

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -199,8 +199,10 @@ class Blocks extends React.Component {
 
         const categoryId = this.workspace.toolbox_.getSelectedCategoryId();
         const offset = this.workspace.toolbox_.getCategoryScrollOffset();
-        this.workspace.updateToolbox(this.props.toolboxXML);
-        this._renderedToolboxXML = this.props.toolboxXML;
+        if (this._renderedToolboxXML !== this.props.toolboxXML) {
+            this.workspace.updateToolbox(this.props.toolboxXML);
+            this._renderedToolboxXML = this.props.toolboxXML;
+        }
 
         // In order to catch any changes that mutate the toolbox during "normal runtime"
         // (variable changes/etc), re-enable toolbox refresh.

--- a/src/containers/gui.inner.jsx
+++ b/src/containers/gui.inner.jsx
@@ -1,0 +1,287 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import {compose} from 'redux';
+import {connect} from 'react-redux';
+import ReactModal from 'react-modal';
+import VM from 'scratch-vm';
+import {defineMessages, injectIntl, intlShape} from 'react-intl';
+
+import ErrorBoundaryHOC from '../lib/error-boundary-hoc.jsx';
+import {
+    getIsError,
+    getIsShowingProject
+} from '../reducers/project-state';
+import {setProjectTitle} from '../reducers/project-title';
+import {
+    activateTab,
+    BLOCKS_TAB_INDEX,
+    COSTUMES_TAB_INDEX,
+    SOUNDS_TAB_INDEX
+} from '../reducers/editor-tab';
+
+import {
+    closeCostumeLibrary,
+    closeBackdropLibrary,
+    closeTelemetryModal,
+    openExtensionLibrary
+} from '../reducers/modals';
+
+import FontLoaderHOC from '../lib/font-loader-hoc.jsx';
+import LocalizationHOC from '../lib/localization-hoc.jsx';
+import ProjectFetcherHOC from '../lib/project-fetcher-hoc.jsx';
+import ProjectSaverHOC from '../lib/project-saver-hoc.jsx';
+import QueryParserHOC from '../lib/query-parser-hoc.jsx';
+import storage from '../lib/storage';
+import vmListenerHOC from '../lib/vm-listener-hoc.jsx';
+import vmManagerHOC from '../lib/vm-manager-hoc.jsx';
+import cloudManagerHOC from '../lib/cloud-manager-hoc.jsx';
+import delayHOC from '../lib/delay-hoc.jsx';
+
+import {setIsScratchDesktop} from '../lib/isScratchDesktop.js';
+
+import Box from '../components/box/box.jsx';
+import BootstrapLoader from '../components/bootstrap-loader/bootstrap-loader.jsx';
+
+const messages = defineMessages({
+    defaultProjectTitle: {
+        id: 'gui.gui.defaultProjectTitle',
+        description: 'Default title for project',
+        defaultMessage: 'Scratch Project'
+    }
+});
+
+const PreevaluateGUI = delayHOC({
+    ready: true,
+    stall: true,
+    weight: 1
+})(delayHOC.loadChildren);
+
+const GUIPlaceholder = ({isRtl}) => (
+    <BootstrapLoader dir={isRtl ? 'rtl' : 'ltr'}>
+        {/* If we are waiting we can evaluate pieces before rendering the gui.
+            So we can evaluate pain and the gui component in separate steps. If
+            before any of the steps what we are waiting on finishes, these
+            pre-evaluations will be removed from delay's queue and instead their
+            modules will be evaluated as part of the normal application path.
+            So if we wait long enough we'll evaluate early and take less time
+            to render the gui component, or we don't wait long enough and
+            evaluate anyways on demand. This way we are doing some amount of
+            work while the application is idle, waiting on the network, during
+            the loading process. */}
+        <PreevaluateGUI>{() => require('scratch-paint')}</PreevaluateGUI>
+        <PreevaluateGUI>{() => require('../components/gui/gui.jsx')}</PreevaluateGUI>
+    </BootstrapLoader>
+);
+
+const InnerGUIComponent = delayHOC({
+    ready: true,
+    stall: delayHOC.loading,
+    // Its best that we render the gui component after we complete fetching but
+    // not immediately when fetch is complete. A stall of weight 0 will perform
+    // the gui component load when the next setTimeout callback executes. So if
+    // we are still fetching, we'll wait our turn. After fetching we'll run
+    // after the initial deserialization has occured.
+    //
+    // This way if we haven't rendered the gui component yet, we will after
+    // deserializing and be able to render the Loader component.
+    weight: state => delayHOC.fetching(state) ? 10 : 0,
+    placeholder: GUIPlaceholder
+})(delayHOC.loadComponent(() => require('../components/gui/gui.jsx')));
+
+// This will live somewhere else in a proper PR. This is placed here to
+// illustrate its separate nature from Stage.
+//
+// Scratch needs 4 things to load a project, a vm, a storage, an audio engine,
+// and a renderer (with related svg and bitmap adapters). If we can create those
+// without rendering more GUI we can load the project earlier and then render
+// parts of the gui while project loading is idle or all at once when the
+// project is ready.
+const buildRenderer = vm => {
+    if (vm.renderer) {
+        return;
+    }
+
+    const Renderer = require('scratch-render');
+
+    const canvas = document.createElement('canvas');
+    const isRendererSupported = Renderer.isSupported(canvas);
+    if (isRendererSupported) {
+        // Sharing the canvas that is used to check if renderer is supported
+        // lets us reuse the WebGL context produced in isSupported. That reuse
+        // can save a good bit of time.
+        const renderer = new Renderer(canvas);
+        vm.attachRenderer(renderer);
+
+        const {SVGRenderer: V2SVGAdapter} = require('scratch-svg-renderer');
+        const {BitmapAdapter: V2BitmapAdapter} = require('scratch-svg-renderer');
+
+        vm.attachV2SVGAdapter(new V2SVGAdapter());
+        vm.attachV2BitmapAdapter(new V2BitmapAdapter());
+    }
+};
+
+const RendererPlaceholder = ({isRtl, vm}) => (
+    <BootstrapLoader dir={isRtl ? 'rtl' : 'ltr'}>
+        <PreevaluateGUI>{() => require('scratch-svg-renderer')}</PreevaluateGUI>
+        <PreevaluateGUI>{() => require('scratch-render')}</PreevaluateGUI>
+        <PreevaluateGUI>{() => buildRenderer(vm)}</PreevaluateGUI>
+    </BootstrapLoader>
+);
+
+const GUIComponent = delayHOC({
+    ready: true,
+    stall: delayHOC.fetching,
+    weight: 5,
+    placeholder: RendererPlaceholder
+})(({children, ...props}) => {
+    buildRenderer(props.vm);
+    return <InnerGUIComponent {...props}>{children}</InnerGUIComponent>;
+});
+
+class GUI extends React.Component {
+    componentDidMount () {
+        setIsScratchDesktop(this.props.isScratchDesktop);
+        this.setReduxTitle(this.props.projectTitle);
+    }
+    componentDidUpdate (prevProps) {
+        if (this.props.projectId !== prevProps.projectId && this.props.projectId !== null) {
+            this.props.onUpdateProjectId(this.props.projectId);
+        }
+        if (this.props.projectTitle !== prevProps.projectTitle) {
+            this.setReduxTitle(this.props.projectTitle);
+        }
+        if (this.props.isShowingProject && !prevProps.isShowingProject) {
+            // this only notifies container when a project changes from not yet loaded to loaded
+            // At this time the project view in www doesn't need to know when a project is unloaded
+            this.props.onProjectLoaded();
+        }
+    }
+    setReduxTitle (newTitle) {
+        if (newTitle === null || typeof newTitle === 'undefined') {
+            this.props.onUpdateReduxProjectTitle(
+                this.props.intl.formatMessage(messages.defaultProjectTitle)
+            );
+        } else {
+            this.props.onUpdateReduxProjectTitle(newTitle);
+        }
+    }
+    render () {
+        if (this.props.isError) {
+            throw new Error(
+                `Error in Scratch GUI [location=${window.location}]: ${this.props.error}`);
+        }
+        const {
+            /* eslint-disable no-unused-vars */
+            assetHost,
+            cloudHost,
+            error,
+            isError,
+            isScratchDesktop,
+            isShowingProject,
+            onProjectLoaded,
+            onStorageInit,
+            onUpdateProjectId,
+            onUpdateReduxProjectTitle,
+            projectHost,
+            projectId,
+            projectTitle,
+            /* eslint-enable no-unused-vars */
+            children,
+            fetchingProject,
+            isBootstrapping,
+            loadingStateVisible,
+            ...componentProps
+        } = this.props;
+        return (<GUIComponent
+            {...componentProps}
+        >
+            {children}
+        </GUIComponent>);
+    }
+}
+
+GUI.propTypes = {
+    assetHost: PropTypes.string,
+    children: PropTypes.node,
+    cloudHost: PropTypes.string,
+    error: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
+    fetchingProject: PropTypes.bool,
+    intl: intlShape,
+    isError: PropTypes.bool,
+    isScratchDesktop: PropTypes.bool,
+    isShowingProject: PropTypes.bool,
+    loadingStateVisible: PropTypes.bool,
+    onProjectLoaded: PropTypes.func,
+    onSeeCommunity: PropTypes.func,
+    onStorageInit: PropTypes.func,
+    onUpdateProjectId: PropTypes.func,
+    onUpdateProjectTitle: PropTypes.func,
+    onUpdateReduxProjectTitle: PropTypes.func,
+    projectHost: PropTypes.string,
+    projectId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    projectTitle: PropTypes.string,
+    telemetryModalVisible: PropTypes.bool,
+    vm: PropTypes.instanceOf(VM).isRequired
+};
+
+GUI.defaultProps = {
+    isScratchDesktop: false,
+    onStorageInit: storageInstance => storageInstance.addOfficialScratchWebStores(),
+    onProjectLoaded: () => {},
+    onUpdateProjectId: () => {}
+};
+
+const mapStateToProps = state => {
+    const loadingState = state.scratchGui.projectState.loadingState;
+    return {
+        activeTabIndex: state.scratchGui.editorTab.activeTabIndex,
+        alertsVisible: state.scratchGui.alerts.visible,
+        backdropLibraryVisible: state.scratchGui.modals.backdropLibrary,
+        blocksTabVisible: state.scratchGui.editorTab.activeTabIndex === BLOCKS_TAB_INDEX,
+        cardsVisible: state.scratchGui.cards.visible,
+        connectionModalVisible: state.scratchGui.modals.connectionModal,
+        costumeLibraryVisible: state.scratchGui.modals.costumeLibrary,
+        costumesTabVisible: state.scratchGui.editorTab.activeTabIndex === COSTUMES_TAB_INDEX,
+        error: state.scratchGui.projectState.error,
+        isError: getIsError(loadingState),
+        isFullScreen: state.scratchGui.mode.isFullScreen,
+        isPlayerOnly: state.scratchGui.mode.isPlayerOnly,
+        isRtl: state.locales.isRtl,
+        isShowingProject: getIsShowingProject(loadingState),
+        loadingStateVisible: state.scratchGui.modals.loadingProject,
+        projectId: state.scratchGui.projectState.projectId,
+        soundsTabVisible: state.scratchGui.editorTab.activeTabIndex === SOUNDS_TAB_INDEX,
+        telemetryModalVisible: state.scratchGui.modals.telemetryModal,
+        tipsLibraryVisible: state.scratchGui.modals.tipsLibrary,
+        vm: state.scratchGui.vm
+    };
+};
+
+const mapDispatchToProps = dispatch => ({
+    onExtensionButtonClick: () => dispatch(openExtensionLibrary()),
+    onActivateTab: tab => dispatch(activateTab(tab)),
+    onActivateCostumesTab: () => dispatch(activateTab(COSTUMES_TAB_INDEX)),
+    onActivateSoundsTab: () => dispatch(activateTab(SOUNDS_TAB_INDEX)),
+    onRequestCloseBackdropLibrary: () => dispatch(closeBackdropLibrary()),
+    onRequestCloseCostumeLibrary: () => dispatch(closeCostumeLibrary()),
+    onRequestCloseTelemetryModal: () => dispatch(closeTelemetryModal()),
+    onUpdateReduxProjectTitle: title => dispatch(setProjectTitle(title))
+});
+
+const ConnectedGUI = injectIntl(connect(
+    mapStateToProps,
+    mapDispatchToProps,
+)(GUI));
+
+// note that redux's 'compose' function is just being used as a general utility to make
+// the hierarchy of HOC constructor calls clearer here; it has nothing to do with redux's
+// ability to compose reducers.
+const WrappedGui = compose(
+    ProjectSaverHOC,
+    vmListenerHOC,
+    vmManagerHOC,
+    cloudManagerHOC
+)(ConnectedGUI);
+
+WrappedGui.setAppElement = ReactModal.setAppElement;
+export default WrappedGui;

--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -5,13 +5,12 @@ import Renderer from 'scratch-render';
 import VM from 'scratch-vm';
 import {connect} from 'react-redux';
 
+import delayHOC from '../lib/delay-hoc.jsx';
 import {STAGE_DISPLAY_SIZES} from '../lib/layout-constants';
 import {getEventXY} from '../lib/touch-utils';
 import VideoProvider from '../lib/video/video-provider';
 import {SVGRenderer as V2SVGAdapter} from 'scratch-svg-renderer';
 import {BitmapAdapter as V2BitmapAdapter} from 'scratch-svg-renderer';
-
-import StageComponent from '../components/stage/stage.jsx';
 
 import {
     activateColorPicker,
@@ -20,6 +19,12 @@ import {
 
 const colorPickerRadius = 20;
 const dragThreshold = 3; // Same as the block drag threshold
+
+const StageComponent = delayHOC({
+    ready: true,
+    stall: delayHOC.loading,
+    weight: 2
+})(delayHOC.loadComponent(() => require('../components/stage/stage.jsx')));
 
 class Stage extends React.Component {
     constructor (props) {

--- a/src/lib/app-state-hoc.jsx
+++ b/src/lib/app-state-hoc.jsx
@@ -53,7 +53,14 @@ const AppStateHOC = function (WrappedComponent, localesOnly) {
                     initPlayer,
                     initTelemetryModal
                 } = guiRedux;
-                const {ScratchPaintReducer} = require('scratch-paint');
+
+                // We can save time at this point by loading just the reducer.
+                // The rest of scratch-paint is loaded when its needed. We'll
+                // probably want a better api to handle the relationship here
+                // and in src/index.js.
+
+                // const {ScratchPaintReducer} = require('scratch-paint');
+                const ScratchPaintReducer = require('scratch-paint/src/reducers/scratch-paint-reducer').default;
 
                 let initializedGui = guiInitialState;
                 if (props.isFullScreen || props.isPlayerOnly) {

--- a/src/lib/condition-hoc.jsx
+++ b/src/lib/condition-hoc.jsx
@@ -1,0 +1,47 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import {connect} from 'react-redux';
+
+import {
+    getIsFetchingWithId,
+    getIsLoadingWithId
+} from '../reducers/project-state';
+
+const loadingState = state => state.scratchGui.projectState.loadingState;
+
+const fetching = state => getIsFetchingWithId(loadingState(state));
+
+const loading = state => (
+    fetching(state) ||
+    getIsLoadingWithId(loadingState(state)) ||
+    !state.scratchGui.fontsLoaded ||
+    state.scratchGui.modals.loadingProject
+);
+
+const Condition = function (test) {
+    return function (WrappedComponent) {
+        const Condition = ({test, children, ...props}) => (
+            test ?
+                <WrappedComponent {...props}>{children}</WrappedComponent> :
+                null
+        );
+
+        Condition.propTypes = {
+            if: PropTypes.bool,
+            children: PropTypes.node
+        };
+
+        const mapStateToProps = (state, props) => {
+            return {
+                test: test(state, props)
+            };
+        };
+
+        return connect(mapStateToProps)(Condition);
+    };
+};
+
+Condition.fetching = fetching;
+Condition.loading = loading;
+
+export default Condition;

--- a/src/lib/delay-hoc.jsx
+++ b/src/lib/delay-hoc.jsx
@@ -1,0 +1,274 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import {connect} from 'react-redux';
+
+import {
+    LoadingState,
+    getIsFetchingWithId,
+    getIsLoadingWithId
+} from '../reducers/project-state';
+
+// This is similar to VM's TaskQueue but tries to be aware of other activity,
+// delaying execution, and uses a priority value, weight, instead of cost.
+
+const pool = [];
+
+const nextInPool = (function () {
+    let _nextInPoolTimeout = null;
+    let last = Date.now();
+    const step = () => {
+        if (pool.length && pool[0][0] === 0) {
+            return;
+        }
+        // If it took too long for our callback to occur, JS or the browser are
+        // trying to do some work. Lets wait a little more to let it run as much
+        // of that work as possible.
+        if (Date.now() - last > 20) {
+            last = Date.now();
+            return new Promise(resolve => {
+                _nextInPoolTimeout = setTimeout(resolve, 5);
+            })
+                .then(step);
+        }
+    };
+    return fn => {
+        clearTimeout(_nextInPoolTimeout);
+
+        last = Date.now();
+        new Promise(resolve => {
+            _nextInPoolTimeout = setTimeout(resolve, 5);
+        })
+            .then(step)
+            .then(fn);
+    };
+}());
+
+const removeFromPool = target => {
+    const old = pool.findIndex(item => item[1] === target);
+    if (old > -1) {
+        pool.splice(old, 1);
+    }
+};
+
+const addToPool = (weight, target) => {
+    return new Promise(resolve => {
+        removeFromPool();
+
+        let i;
+        for (i = pool.length - 1; i >= 0; i--) {
+            if (pool[i][0] <= weight) {
+                pool.splice(i + 1, 0, [weight, target, resolve]);
+                break;
+            }
+        }
+        if (i === -1) {
+            pool.unshift([weight, target, resolve]);
+        }
+        if (pool.length === 1) {
+            nextInPool(() => {
+                if (pool.length > 0) {
+                    pool[0][2]();
+                }
+            });
+        }
+    })
+        .then(() => {
+            removeFromPool(target);
+            nextInPool(() => {
+                if (pool.length > 0) {
+                    pool[0][2]();
+                }
+            });
+        });
+};
+
+// Selectors here can provide a descriptive interface for when delay arguments
+// should be which values. If we use only these common functions we can use that
+// as a way to shortcut all of the delays gates. By replacing the functions on
+// Delay with ones that return true.
+
+const loadingState = state => state.scratchGui.projectState.loadingState;
+
+const fetching = state => (
+    loadingState(state) === LoadingState.NOT_LOADED ||
+    getIsFetchingWithId(loadingState(state))
+);
+
+const isLoading = state => getIsLoadingWithId(loadingState(state));
+
+const loadingStateVisible = state => state.scratchGui.modals.loadingProject;
+
+const loading = state => (
+    fetching(state) ||
+    isLoading(state) ||
+    loadingStateVisible(state)
+);
+
+// A set of extra HOCs to handle some annoying details of this interface.
+
+const loadNull = function (load) {
+    return function () {
+        load();
+        return null;
+    };
+};
+
+const loadChildren = function ({children}) {
+    if (children) {
+        children();
+    }
+    return null;
+};
+
+const loadComponent = function (load) {
+    return function ({children, ...props}) {
+        const _Component = load();
+        const Component = _Component.default || _Component;
+        return <Component {...props}>{children}</Component>;
+    };
+};
+
+// A HOC to delay rendering a part of the app. It keeps a boolean state and once
+// true will always render the passed component and props.
+//
+// ready: true when we want to render
+// stall: false if we want to render immediately, true if it is ok to wait
+// weight:
+//   - 0 if we should render on the next setTimeout callback
+//   - >0 if we want the delayed renders to be render from lowest to highest
+
+const Delay = ({ready, stall, weight, placeholder: _placeholder}) => (WrappedComponent) => {
+    const _ready = typeof ready !== 'function' ? ready : false;
+    const _stall = typeof stall !== 'function' ? stall : false;
+    const _weight = typeof weight !== 'function' ? weight : 0;
+
+    class Delay extends React.Component {
+        constructor (props) {
+            super(props);
+
+            this.state = {
+                shouldRender: null
+            };
+
+            this.operate(this.props);
+
+            if (!this.state.shouldRender) {
+                this.state.shouldRender = false;
+            }
+        }
+
+        componentWillUnmount () {
+            removeFromPool(this);
+            this.state.shouldRender = true;
+        }
+
+        componentWillReceiveProps (newProps) {
+            this.operate(newProps);
+        }
+
+        shouldComponentUpdate (newProps, newState) {
+            if (this.state.shouldRender !== newState.shouldRender) {
+                return true;
+            }
+            const {
+                ready,
+                stall,
+                weight,
+                placeholder,
+                ...nonHocProps
+            } = newProps;
+            for (const key in nonHocProps) {
+                if (nonHocProps[key] !== this.props[key]) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        operate (newProps) {
+            const {ready = _ready} = newProps;
+            if (!this.state.shouldRender && ready) {
+                const {stall = _stall, weight = _weight} = newProps;
+
+                if (stall) {
+                    addToPool(weight, this)
+                        .then(() => {
+                            if (!this.state.shouldRender) {
+                                this.setState({
+                                    shouldRender: true
+                                });
+                            }
+                        });
+                    return;
+                }
+
+                removeFromPool(this);
+
+                if (this.state.shouldRender === false) {
+                    this.setState({
+                        shouldRender: true
+                    });
+                } else {
+                    this.state.shouldRender = true;
+                }
+            }
+        }
+
+        render () {
+            if (this.state.shouldRender) {
+                const {
+                    ready,
+                    stall,
+                    weight,
+                    placeholder,
+                    children,
+                    ...componentProps
+                } = this.props;
+                return (<WrappedComponent {...componentProps}>
+                    {children}
+                </WrappedComponent>);
+            }
+
+            const {placeholder = _placeholder} = this.props;
+            return placeholder ? placeholder(this.props) : null;
+        }
+    }
+
+    Delay.propTypes = {
+        placeholder: PropTypes.func,
+        ready: PropTypes.bool,
+        stall: PropTypes.bool,
+        weight: PropTypes.number
+    };
+
+    if (typeof ready === 'function' || typeof stall === 'function' || typeof weight === 'function') {
+        const mapStateToProps = (state, props) => {
+            const result = {};
+            if (typeof ready === 'function') {
+                result.ready = ready(state, props);
+            }
+            if (typeof stall === 'function') {
+                result.stall = stall(state, props);
+            }
+            if (typeof weight === 'function') {
+                result.weight = weight(state, props);
+            }
+            return result;
+        };
+        return connect(mapStateToProps)(Delay);
+    }
+    return Delay;
+};
+
+Delay.loadingState = loadingState;
+Delay.fetching = fetching;
+Delay.isLoading = isLoading;
+Delay.loadingStateVisible = loadingStateVisible;
+Delay.loading = loading;
+
+Delay.loadNull = loadNull;
+Delay.loadChildren = loadChildren;
+Delay.loadComponent = loadComponent;
+
+export default Delay;
+

--- a/src/lib/project-fetcher-hoc.jsx
+++ b/src/lib/project-fetcher-hoc.jsx
@@ -105,7 +105,6 @@ const ProjectFetcherHOC = function (WrappedComponent) {
             } = this.props;
             return (
                 <WrappedComponent
-                    fetchingProject={isFetchingWithIdProp}
                     {...componentProps}
                 />
             );

--- a/src/lib/vm-listener-hoc.jsx
+++ b/src/lib/vm-listener-hoc.jsx
@@ -75,7 +75,13 @@ const vmListenerHOC = function (WrappedComponent) {
         }
         handleProjectChanged () {
             if (this.props.shouldEmitUpdates) {
-                this.props.onProjectChanged();
+                if (!this._projectChangedPromise) {
+                    this._projectChangedPromise = Promise.resolve()
+                        .then(() => {
+                            this._projectChangedPromise = null;
+                        })
+                        .then(() => this.props.onProjectChanged());
+                }
             }
         }
         handleTargetsUpdate (data) {

--- a/src/lib/vm-manager-hoc.jsx
+++ b/src/lib/vm-manager-hoc.jsx
@@ -37,13 +37,20 @@ const vmManagerHOC = function (WrappedComponent) {
             if (!this.props.isPlayerOnly && !this.props.isStarted) {
                 this.props.vm.start();
             }
+
+            if (this.props.isLoadingWithId) {
+                Promise.resolve().then(() => {
+                this.loadProject();
+                });
+            }
         }
         componentDidUpdate (prevProps) {
             // if project is in loading state, AND fonts are loaded,
             // and they weren't both that way until now... load project!
-            if (this.props.isLoadingWithId && this.props.fontsLoaded &&
-                (!prevProps.isLoadingWithId || !prevProps.fontsLoaded)) {
+            if (this.props.isLoadingWithId && !prevProps.isLoadingWithId) {
+                Promise.resolve().then(() => {
                 this.loadProject();
+                });
             }
             // Start the VM if entering editor mode with an unstarted vm
             if (!this.props.isPlayerOnly && !this.props.isStarted) {
@@ -76,7 +83,7 @@ const vmManagerHOC = function (WrappedComponent) {
         render () {
             const {
                 /* eslint-disable no-unused-vars */
-                fontsLoaded,
+                // fontsLoaded,
                 loadingState,
                 isStarted,
                 onError: onErrorProp,
@@ -90,7 +97,6 @@ const vmManagerHOC = function (WrappedComponent) {
             } = this.props;
             return (
                 <WrappedComponent
-                    isLoading={isLoadingWithIdProp}
                     vm={vm}
                     {...componentProps}
                 />
@@ -117,7 +123,7 @@ const vmManagerHOC = function (WrappedComponent) {
     const mapStateToProps = state => {
         const loadingState = state.scratchGui.projectState.loadingState;
         return {
-            fontsLoaded: state.scratchGui.fontsLoaded,
+            // fontsLoaded: state.scratchGui.fontsLoaded,
             isLoadingWithId: getIsLoadingWithId(loadingState),
             projectData: state.scratchGui.projectState.projectData,
             projectId: state.scratchGui.projectState.projectId,

--- a/src/reducers/project-state.js
+++ b/src/reducers/project-state.js
@@ -25,6 +25,7 @@ const START_UPDATING_BEFORE_CREATING_COPY = 'scratch-gui/project-state/START_UPD
 const START_UPDATING_BEFORE_CREATING_NEW = 'scratch-gui/project-state/START_UPDATING_BEFORE_CREATING_NEW';
 const START_UPDATING_BEFORE_FILE_UPLOAD = 'scratch-gui/project-state/START_UPDATING_BEFORE_FILE_UPLOAD';
 
+
 const defaultProjectId = '0'; // hardcoded id of default project
 
 const LoadingState = keyMirror({


### PR DESCRIPTION
This is a Proof of Concept PR for https://github.com/LLK/scratch-gui/issues/4580.

I don't think this PR will be merged but instead we'll pick apart the pieces we want or replace them with entirely new work but probably fulfilling the same goal.

This PR works towards the goal of improving the initial page load time by targeting four points during the loading process.

1. Project data file is requested.
2. Data starts deserializing and project assets are requested.
3. Loader component is renderered.
4. Project is fully loaded.

As an example of how this Proof of Concept improves loading, the first step on develop can take a 2017 Macbook Pro 1.5 seconds to execute. This PR separates the work so the first step can take about 0.3 seconds on the same machine. Step 2 with this change can take 0.2 seconds. So when the data request is made if it completes in 0.2 seconds we can be fetching assets by the time develop is making the first data request. Since the current loading process has network caused idle time, this PR uses that idle time to render the GUI in pieces. So we can see improved load times by 1 second on the same machine. Then when we get to other devices like a Chromebook we can see larger improvements since that first 1.5 seconds on develop may take 3 seconds on a Chromebook.

This PR breaks apart the work performed before the data is requested into 17 parts. The first is a technical minimum (optimistically it could be further decomposed) that creates a vm, storage, redux store, and renders some of the top level HOCs with a blue background. This is what is needed in this PR to perform the first loading point.

The next 5 are needed to deserialize the project data and start asset requests. The first of these 5 steps renders the remaining top level HOCs and creates the AudioEngine. The next two evaluate scratch-svg-renderer and scratch-render separately. The next builds the renderer. In develop, the Stage container creates the renderer. If we can move that point earlier to here we can render less before deserializing the project data. The last part prepares the next set of code to load, it needs to do this so that once the data is deserliazing the next group is able to immediately render after that.

The next 3 render the animated Loader component. The first two evaluate scratch-paint and scratch-gui/src/components/gui/gui.jsx separately. The last renders the GUIComponent, thus rendering the Loader and many other components. If the project data is deserialized before these steps, they are immediately executed once deserialization completes. This way the Loader component is render no later than when the assets are requested, but if the data request is taking too long, the Loader will still be rendered to assure scratchers that gui is in fact loading.

The next 7 evaluate and render 4 parts of the GUI: MenuBar, TargetPane, CostumeTab, and SoundTab.

Up to this point, the 15 parts after the first are allowed to render as long as JS seems to be idle. The final part renders scratch-blocks. It is left unrendered until after the data is deserialized and the assets are requested.

All together this lets the project data be requested as soon as possible, after the first part. Then the data can be serialized after the next 5. The Loader component will render as soon as it can or immediately after the data has been deserialized. And the remaining parts can fill in over time or immediately when the project is fully loaded.

```js
<StageWrapper
    isRendererSupported={isRendererSupported}
    isRtl={isRtl}
    stageSize={stageSize}
    vm={vm}
/>
```

This is a use of the work in this PR. The react element is actually left unmodified.

For this to load on demand or asynchronously when not yet needed, this PR currently performs a few steps to wrapp StageWrapper.

```js
const LoadStageWrapper =
    delayHOC.loadComponent(() => require('../../containers/stage-wrapper.jsx'));
```

First we wrap it in a HOC that takes a callback that called returns the intended to component. Then it renders that lazily evaluated component by passing the properties that are passed to StageWrapper in its use as a ReactElement.

```js
const AsyncStageWrapper = delayHOC({
    ready: true,
    stall: delayHOC.loading,
    weight: 2
})(LoadStageWrapper);
```

Next we wrap the Load component. This next component uses three values to determine if and when it renders. If ready is true and stall is falsy, the wrapped component renders immediately which causes the load component to evaluate StageWrapper and render it. If stall is true, weight determines the order the wrapper is eventially rendered in relation to other delayed elements in the React application.

Ready, stall, and weight can be functions that are given the redux state. Those functions should return booleans for ready and stall and numbers for weight based on changes in the redux state. With these functions the wrapper can determine when to render the wrapped component based on values and not just time passing.

The next step the work takes is to separate evaluating the component's module and rendering the component.

```js
const EvalStageWrapper =
    delayHOC.loadNull(() => require('../../containers/stage-wrapper.jsx'));
```

This component when rendered will evaluate stage-wrapper.jsx but renders nothing.

```js
const AsyncEvalStageWrapper = delayHOC({
    ready: true,
    stall: true,
    weight: 1
})(EvalStageWrapper);
```

And this will render Eval which will evaluate stage-wrapper.jsx shortly after being inserted into the DOM.

We can add this to the AsyncStageWrapper component.

```js
const AsyncStageWrapper = delayHOC({
    ready: true,
    stall: delayHOC.loading,
    weight: 2,
    placeholder: () => <AsyncEvalStageWrapper />
})(LoadStageWrapper);
```

All together this delays evaluation and rendering the StageWrapper while stall is true. During that the placeholder is rendered instead of LoadStageWrapper. The placeholder will then shortly after evaluate stage-wrapper.jsx. And after that Async will render Load, and so render the full component.

Most of the uses of delayHOC in this PR follow this pattern to break evaluating modules and rendering the components of those modules. There is one other important use.

https://github.com/mzgoddard/scratch-gui/blob/poc-20190222/src/containers/gui.inner.jsx#L99-L121

This function and its lazy execution serve two purposes. As mentioned we need four objects to load a project. The last one created in the GUI is the Renderer. In the develop branch this is done in containers/stage.jsx. If we move its creation to this point we can delay rendering components/gui/gui.jsx and thereby delay containers/stage.jsx until after we start fetching assets. That way we are fetching the assets sooner.

The second purpose is reusing the canvas that tests is the Renderer is supported. Testing for support and creating the Renderer need to construct a webgl context with the same details to make sure its supported. As isSupported(canvas) creates the WebGL context, passing that canvas to the Renderer constructor reuses the WebGL context. This is an additional small performance improvement by de-duplicating that work.

### Other Things

This PR includes a behaviour like delayHOC called conditionHOC.

There are two properties to components/gui/gui.jsx that are more active than the other properties: loading and targetIsStage. When only these properties change the GUI component and its children are re-rendered or considered for rendering. This means when we show or hide the Loader component, much of GUI re-renders.

Similarly targetIsStage changes when we clear the VM add the Stage to the VM, select the editingTarget if it isn't the Stage, or when a scratcher selects the stage or a sprite after selecting the stage. These cases cause much of GUI to re-render.

If we move those properties out of the set passed to components/gui/gui.jsx we can remove these extra re-renders and update smaller parts of the application for these state changes. Most of the remaining properties passed to GUI are far less likely to change (especially while loading).

conditionHOC offers a way we could use to test if something should be rendered based on redux state. It's a small wrapper like delay's ready, to test a redux selector on whether the wrapped component should be rendered.

#### Extract CSS

This change benefits from extracted CSS. In development builds, the lazy evaluated modules insert their CSS into style tags. This forces the page to recalculate style and layout even if the rest of the page's DOM remains absolutely unchanged.

With the CSS extracted, or other method that puts the CSS into the page at one time, those re-calculations and layouts do not happen.

In practice while the network is busy and JS is idle, the async work will take more time than with the css extracted. But if the network is quick, loading time will have little difference with or without CSS extracted. This is in regards to the work proposed here. There are still other reasons to extract the css.

### Other Other Things

I wanted to give some mentions to changes that I think we can more immediately implement that I discovered by looking into this work.

<details>
<summary>onProjectChanged repeats</summary>

```js
handleProjectChanged () {
    if (this.props.shouldEmitUpdates) {
        if (!this._projectChangedPromise) {
            this._projectChangedPromise = Promise.resolve()
                .then(() => {
                    this._projectChangedPromise = null;
                })
                .then(() => this.props.onProjectChanged());
        }
    }
}
```

Deserializing projects and sprites from the backpack create a lot of block instances in each Sprite's Blocks. Each block created emits a project changed event. Connected to vm-listener-hoc, it then dispatches a redux change for each event. Redux will re-render components connected to the projectChange state once, but it still has to check all of the currently rendered Redux connected components, create their state derived props, merge those props, and shallow compare them. This is pretty fast, but multiply that by the hundreds, thousands, tens of thousdands of blocks created deserializing a project and it adds a obvious amount of time.

A simple option we might do here is debounce until the end of the microtask queue, that redux dispatch. A slightly more involved change would for vm-listener-hoc to connect to projectChanged and not dispatch the change if the project is already marked changed.

</details>

<details>
<summary>projectChanged is state only</summary>

```js
handleClickNew () {
    let readyToReplaceProject = true;
    // if the project is dirty, and user owns the project, we will autosave.
    // but if they are not logged in and can't save, user should consider
    // downloading or logging in first.
    // Note that if user is logged in and editing someone else's project,
    // they'll lose their work.
    if (this.props.projectChanged && !this.props.canCreateNew) {
```

Relatedly, components connected to projectChanged seem to use it for behaviour and not for rendering. But they still re-render as they don't have a shouldComponentUpdate or other behaviour to separate the application state change from the rendering state. MenuBar as one example re-renders much of its hierarchy when projectChanged changes. MenuBar uses projectChanged to determine behaviour instead of rendering. We probably don't need to hunt down all the cases of this. Many of them are pretty small. MenuBar is one example we should probably change as its at a high enough level it causes enough work to be done to clearly show up in a flame chart.

</details>

<details>
<summary>border-radius layers</summary>

```css
.stage {
    /*
        Fixes a few extra pixels of margin/padding, that adds on to the bottom
        of the element, which messes up the chrome padding consistency
    */
    display: block;

    border-radius: $space;
    border: $stage-standard-border-width solid $ui-black-transparent;
```

We can reduce the time browsers spend compositing layers by making this stage element with border-radius its own layer with will-change or translatez.

</details>

<details>
<summary>scratch-parser Buffer.toString</summary>

```js
// Validate input type
var typeError = 'Input must be a Buffer or a string.';
if (!Buffer.isBuffer(input)) {
    try {
        input = new Buffer(input);
```

This is part of scratch-parser but related to loading performance changes around step 2. In the case that input is a utf8 encoded string of json, we are doing an expensive copy her. Many projects have json in the hundreds of thousands of KB in Scratch 3. Instead we only need the first 3 bytes to determine how to handle input.

```js
return callback(null, [input.toString('utf-8'), null]);
```

In one case once we can assume the input is a utf-8 string we are using a function that calls a function called slowToString. It is a slow function. Like many other places we can replace this with TextDecoder and in the case we are on a system that doesn't support that (Edge) we can use the polyfill that 4 other scratch repos are using.

</details>

<details>
<summary>workspaceMetrics repeats</summary>

```js
const workspaceMetrics = Object.assign({}, this.state.workspaceMetrics, {
    [target.id]: {
        scrollX: this.workspace.scrollX,
        scrollY: this.workspace.scrollY,
        scale: this.workspace.scale
    }
});
this.setState({workspaceMetrics});
```

Blocks.onWorkspaceMetricsChange seems to be called 4 times after a drag in blocks.jsx during the same mouseup even. The metrics values haven't changed from a drag block, and probably never changes while handling one mouseup event.

I'm not sure why those four times are happening but I'd look first to the setState call here. We can easily test if the values have changed. And then only setState if they have. So even if we get extra calls to the method we won't cause a partial react render each time.

</details>

<details>
<summary>Stage makes renders for block drags</summary>

```js
onMouseUp (e) {
    const {x, y} = getEventXY(e);
    const mousePosition = [x - this.rect.left, y - this.rect.top];
    this.cancelMouseDownTimeout();
    this.setState({
        mouseDown: false,
        mouseDownPosition: null
    });
```

Stage.mouseUp is bound to the document. So after a mouseUp from dragging a block, it also runs. I don't think we need to change the bind, but the logic in cancelMouseDownTimeout and the logic to setState here, should check that they will change the state first. setState is called here when the state will not change and there are also two setStates happening in quick succession. As cancelMouseDownTimeout also calls setState the is rendered twice when it should be once.

First thing would be to check that the values are changing before calling here. We don't need to always check. But in the case of here in Stage, Blocks, and others they execute enough unnecessary work that we probably improve the situation.

</details>

<details>
<summary>Backpack makes renders for block drags</summary>

```js
handleBlockDragUpdate (isOutsideWorkspace) {
    this.setState({
        blockDragOutsideWorkspace: isOutsideWorkspace
    });
}
```

Same thing here in Backpack.handleBlockDragUpdate. I'm not sure if we want to use some kind of common helper for this.

</details>
