### PR TITLE
Run pify package through babel loader.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,7 +36,11 @@ const base = {
         rules: [{
             test: /\.jsx?$/,
             loader: 'babel-loader',
-            include: [path.resolve(__dirname, 'src'), /node_modules[\\/]scratch-[^\\/]+[\\/]src/],
+            include: [
+                path.resolve(__dirname, 'src'),
+                /node_modules[\\/]scratch-[^\\/]+[\\/]src/,
+                /node_modules[\\/]pify/
+            ],
             options: {
                 // Explicitly disable babelrc so we don't catch various config
                 // in much lower dependencies.


### PR DESCRIPTION
### Resolves

Resolves an issue where es6 source files make it into built GUI preventing www from building correctly.

### Proposed Changes

Run the 'pify' package (introduced as a dependency of scratch-parser in LLK/scratch-parser#52) through the babel loader.
