### PR TITLE
Remove focus selecting in slider prompt

### DIFF
--- a/src/components/slider-prompt/slider-prompt.jsx
+++ b/src/components/slider-prompt/slider-prompt.jsx
@@ -45,7 +45,6 @@ const SliderPromptComponent = props => (
                     type="text"
                     value={props.minValue}
                     onChange={props.onChangeMin}
-                    onFocus={props.onFocus}
                     onKeyPress={props.onKeyPress}
                 />
             </Box>
@@ -60,7 +59,6 @@ const SliderPromptComponent = props => (
                     type="text"
                     value={props.maxValue}
                     onChange={props.onChangeMax}
-                    onFocus={props.onFocus}
                     onKeyPress={props.onKeyPress}
                 />
             </Box>
@@ -97,7 +95,6 @@ SliderPromptComponent.propTypes = {
     onCancel: PropTypes.func.isRequired,
     onChangeMax: PropTypes.func.isRequired,
     onChangeMin: PropTypes.func.isRequired,
-    onFocus: PropTypes.func.isRequired,
     onKeyPress: PropTypes.func.isRequired,
     onOk: PropTypes.func.isRequired
 };

--- a/src/containers/slider-prompt.jsx
+++ b/src/containers/slider-prompt.jsx
@@ -27,9 +27,6 @@ class SliderPrompt extends React.Component {
     handleKeyPress (event) {
         if (event.key === 'Enter') this.handleOk();
     }
-    handleFocus (event) {
-        event.target.select();
-    }
     handleOk () {
         const {minValue, maxValue} = this.state;
         if (!this.validates(minValue, maxValue)) {
@@ -64,7 +61,6 @@ class SliderPrompt extends React.Component {
                 onCancel={this.handleCancel}
                 onChangeMax={this.handleChangeMax}
                 onChangeMin={this.handleChangeMin}
-                onFocus={this.handleFocus}
                 onKeyPress={this.handleKeyPress}
                 onOk={this.handleOk}
             />


### PR DESCRIPTION
It is not reliably selecting the input and is making it hard to type into.

Fixes the issue @BryceLTaylor found testing the new slider range feature

/cc @apple502j might be interesting to you. Using select can sometimes be helpful, but it can interfere with typing. For example, if you click to the left of the number, it selects the whole thing but places the cursor on the beginning which is very strange.