### PR TITLE
Remove most of the GA events

### DIFF
--- a/src/components/library/library.jsx
+++ b/src/components/library/library.jsx
@@ -9,7 +9,6 @@ import Modal from '../../containers/modal.jsx';
 import Divider from '../divider/divider.jsx';
 import Filter from '../filter/filter.jsx';
 import TagButton from '../../containers/tag-button.jsx';
-import analytics from '../../lib/analytics';
 
 import styles from './library.css';
 

--- a/src/components/library/library.jsx
+++ b/src/components/library/library.jsx
@@ -60,7 +60,6 @@ class LibraryComponent extends React.Component {
     }
     handleClose () {
         this.props.onRequestClose();
-        analytics.pageview(`/${this.props.id}/search?q=${this.state.filterQuery}`);
     }
     handleTagClick (tag) {
         this.setState({

--- a/src/containers/backdrop-library.jsx
+++ b/src/containers/backdrop-library.jsx
@@ -5,7 +5,6 @@ import {defineMessages, injectIntl, intlShape} from 'react-intl';
 import {connect} from 'react-redux';
 import VM from 'scratch-vm';
 
-import analytics from '../lib/analytics';
 import backdropLibraryContent from '../lib/libraries/backdrops.json';
 import backdropTags from '../lib/libraries/backdrop-tags';
 import LibraryComponent from '../components/library/library.jsx';

--- a/src/containers/backdrop-library.jsx
+++ b/src/containers/backdrop-library.jsx
@@ -36,11 +36,6 @@ class BackdropLibrary extends React.Component {
         };
         this.props.vm.setEditingTarget(this.props.stageID);
         this.props.vm.addBackdrop(item.md5, vmBackdrop);
-        analytics.event({
-            category: 'library',
-            action: 'Select Backdrop',
-            label: item.name
-        });
     }
     render () {
         return (

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -85,6 +85,7 @@ class Blocks extends React.Component {
         this.toolboxUpdateQueue = [];
     }
     componentDidMount () {
+        window.vm = this.props.vm;
         this.ScratchBlocks.FieldColourSlider.activateEyedropper_ = this.props.onActivateColorPicker;
         this.ScratchBlocks.Procedures.externalProcedureDefCallback = this.props.onActivateCustomProcedures;
         this.ScratchBlocks.ScratchMsgs.setLocale(this.props.locale);

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -85,7 +85,6 @@ class Blocks extends React.Component {
         this.toolboxUpdateQueue = [];
     }
     componentDidMount () {
-        window.vm = this.props.vm;
         this.ScratchBlocks.FieldColourSlider.activateEyedropper_ = this.props.onActivateColorPicker;
         this.ScratchBlocks.Procedures.externalProcedureDefCallback = this.props.onActivateCustomProcedures;
         this.ScratchBlocks.ScratchMsgs.setLocale(this.props.locale);

--- a/src/containers/controls.jsx
+++ b/src/containers/controls.jsx
@@ -4,7 +4,6 @@ import React from 'react';
 import VM from 'scratch-vm';
 import {connect} from 'react-redux';
 
-import analytics from '../lib/analytics';
 import ControlsComponent from '../components/controls/controls.jsx';
 
 class Controls extends React.Component {

--- a/src/containers/controls.jsx
+++ b/src/containers/controls.jsx
@@ -24,19 +24,11 @@ class Controls extends React.Component {
                 this.props.vm.start();
             }
             this.props.vm.greenFlag();
-            analytics.event({
-                category: 'general',
-                action: 'Green Flag'
-            });
         }
     }
     handleStopAllClick (e) {
         e.preventDefault();
         this.props.vm.stopAll();
-        analytics.event({
-            category: 'general',
-            action: 'Stop Button'
-        });
     }
     render () {
         const {

--- a/src/containers/costume-library.jsx
+++ b/src/containers/costume-library.jsx
@@ -38,11 +38,6 @@ class CostumeLibrary extends React.PureComponent {
             skinId: null
         };
         this.props.vm.addCostumeFromLibrary(item.md5, vmCostume);
-        analytics.event({
-            category: 'library',
-            action: 'Select Costume',
-            label: item.name
-        });
     }
     render () {
         return (

--- a/src/containers/costume-library.jsx
+++ b/src/containers/costume-library.jsx
@@ -4,7 +4,6 @@ import React from 'react';
 import {defineMessages, injectIntl, intlShape} from 'react-intl';
 import VM from 'scratch-vm';
 
-import analytics from '../lib/analytics';
 import costumeLibraryContent from '../lib/libraries/costumes.json';
 import spriteTags from '../lib/libraries/sprite-tags';
 import LibraryComponent from '../components/library/library.jsx';

--- a/src/containers/extension-library.jsx
+++ b/src/containers/extension-library.jsx
@@ -6,7 +6,6 @@ import {defineMessages, injectIntl, intlShape} from 'react-intl';
 
 import extensionLibraryContent from '../lib/libraries/extensions/index.jsx';
 
-import analytics from '../lib/analytics';
 import LibraryComponent from '../components/library/library.jsx';
 import extensionIcon from '../components/action-menu/icon--sprite.svg';
 

--- a/src/containers/extension-library.jsx
+++ b/src/containers/extension-library.jsx
@@ -46,18 +46,6 @@ class ExtensionLibrary extends React.PureComponent {
                 });
             }
         }
-        let gaLabel = '';
-        if (typeof (item.name) === 'string') {
-            gaLabel = item.name;
-        } else {
-            // Name is localized, get the default message for the gaLabel
-            gaLabel = item.name.props.defaultMessage;
-        }
-        analytics.event({
-            category: 'library',
-            action: 'Select Extension',
-            label: gaLabel
-        });
     }
     render () {
         const extensionLibraryThumbnailData = extensionLibraryContent.map(extension => ({

--- a/src/containers/sb-file-uploader.jsx
+++ b/src/containers/sb-file-uploader.jsx
@@ -4,7 +4,6 @@ import React from 'react';
 import {connect} from 'react-redux';
 import {defineMessages, injectIntl, intlShape} from 'react-intl';
 
-import analytics from '../lib/analytics';
 import log from '../lib/log';
 import sharedMessages from '../lib/shared-messages';
 

--- a/src/containers/sb-file-uploader.jsx
+++ b/src/containers/sb-file-uploader.jsx
@@ -119,11 +119,6 @@ class SBFileUploader extends React.Component {
             const filename = this.fileToUpload && this.fileToUpload.name;
             this.props.vm.loadProject(this.reader.result)
                 .then(() => {
-                    analytics.event({
-                        category: 'project',
-                        action: 'Import Project File',
-                        nonInteraction: true
-                    });
                     // Remove the hash if any (without triggering a hash change event or a reload)
                     try { // Can fail e.g. when GUI is loaded from static file (integration tests)
                         history.replaceState({}, document.title, '.');

--- a/src/containers/sound-library.jsx
+++ b/src/containers/sound-library.jsx
@@ -5,7 +5,6 @@ import {defineMessages, injectIntl, intlShape} from 'react-intl';
 import VM from 'scratch-vm';
 import AudioEngine from 'scratch-audio';
 
-import analytics from '../lib/analytics';
 import LibraryComponent from '../components/library/library.jsx';
 
 import soundIcon from '../components/asset-panel/icon--sound.svg';

--- a/src/containers/sound-library.jsx
+++ b/src/containers/sound-library.jsx
@@ -125,11 +125,6 @@ class SoundLibrary extends React.PureComponent {
         this.props.vm.addSound(vmSound).then(() => {
             this.props.onNewSound();
         });
-        analytics.event({
-            category: 'library',
-            action: 'Select Sound',
-            label: soundItem.name
-        });
     }
     render () {
         // @todo need to use this hack to avoid library using md5 for image

--- a/src/containers/sprite-library.jsx
+++ b/src/containers/sprite-library.jsx
@@ -32,11 +32,6 @@ class SpriteLibrary extends React.PureComponent {
         this.props.vm.addSprite(JSON.stringify(item.json)).then(() => {
             this.props.onActivateBlocksTab();
         });
-        analytics.event({
-            category: 'library',
-            action: 'Select Sprite',
-            label: item.name
-        });
     }
     render () {
         return (

--- a/src/containers/sprite-library.jsx
+++ b/src/containers/sprite-library.jsx
@@ -4,7 +4,6 @@ import React from 'react';
 import {injectIntl, intlShape, defineMessages} from 'react-intl';
 import VM from 'scratch-vm';
 
-import analytics from '../lib/analytics';
 import spriteLibraryContent from '../lib/libraries/sprites.json';
 import randomizeSpritePosition from '../lib/randomize-sprite-position';
 import spriteTags from '../lib/libraries/sprite-tags';


### PR DESCRIPTION
/cc @thisandagain @rschamp 

Per discussion offline, these were causing too much traffic for not enough usefulness. Leaving stuff having to do with tips library/tutorial card navigation as well as hardware extension connectivity, as those help us find issues with Scratch.