### PR TITLE
Allow for both bluetooth and internet connection icons in extensions

### DIFF
--- a/src/components/library-item/library-item.css
+++ b/src/components/library-item/library-item.css
@@ -178,6 +178,10 @@
     font-weight: bold;
 }
 
+.featured-extension-metadata-detail img{
+    margin-right: 0.25rem;
+}
+
 .coming-soon-text {
     position: absolute;
     background-color: $data-primary;

--- a/src/components/library-item/library-item.jsx
+++ b/src/components/library-item/library-item.jsx
@@ -78,6 +78,12 @@ class LibraryItemComponent extends React.PureComponent {
                                                 internetConnectionIconURL
                                             }
                                         />
+                                        <img
+                                            src={this.props.bluetoothRequired ?
+                                                bluetoothIconURL :
+                                                internetConnectionIconURL
+                                            }
+                                        />
                                     </div>
                                 </div>
                             ) : null}

--- a/src/components/library-item/library-item.jsx
+++ b/src/components/library-item/library-item.jsx
@@ -72,18 +72,12 @@ class LibraryItemComponent extends React.PureComponent {
                                     <div
                                         className={styles.featuredExtensionMetadataDetail}
                                     >
-                                        <img
-                                            src={this.props.bluetoothRequired ?
-                                                bluetoothIconURL :
-                                                internetConnectionIconURL
-                                            }
-                                        />
-                                        <img
-                                            src={this.props.bluetoothRequired ?
-                                                bluetoothIconURL :
-                                                internetConnectionIconURL
-                                            }
-                                        />
+                                        {this.props.bluetoothRequired ? (
+                                            <img src={bluetoothIconURL} />
+                                        ) : null}
+                                        {this.props.internetConnectionRequired ? (
+                                            <img src={internetConnectionIconURL} />
+                                        ) : null}
                                     </div>
                                 </div>
                             ) : null}

--- a/src/lib/libraries/extensions/index.jsx
+++ b/src/lib/libraries/extensions/index.jsx
@@ -163,6 +163,7 @@ export default [
         featured: true,
         disabled: false,
         bluetoothRequired: true,
+        internetConnectionRequired: true,
         launchPeripheralConnectionFlow: true,
         useAutoScan: false,
         peripheralImage: microbitPeripheralImage,
@@ -192,6 +193,7 @@ export default [
         featured: true,
         disabled: false,
         bluetoothRequired: true,
+        internetConnectionRequired: true,
         launchPeripheralConnectionFlow: true,
         useAutoScan: false,
         peripheralImage: ev3PeripheralImage,
@@ -221,6 +223,7 @@ export default [
         featured: true,
         disabled: false,
         bluetoothRequired: true,
+        internetConnectionRequired: true,
         launchPeripheralConnectionFlow: true,
         useAutoScan: true,
         peripheralImage: wedoPeripheralImage,
@@ -250,6 +253,7 @@ export default [
         ),
         featured: true,
         disabled: true,
-        bluetoothRequired: true
+        bluetoothRequired: true,
+        internetConnectionRequired: true
     }
 ];


### PR DESCRIPTION
### Resolves

- Resolves #4620: Allow extension tiles to display both internet and bluetooth requirement icons

### Proposed Changes

Make it possible to show both bluetooth and wifi icons in extension library item tiles.

<img width="947" alt="Screen Shot 2019-03-12 at 10 09 42 AM" src="https://user-images.githubusercontent.com/699840/54206804-68d0f100-44af-11e9-93e1-c87e9b578733.png">


### Reason for Changes

Some extensions require both things.
