### PR TITLE
Set static asset path (publicPath) with environment var

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,6 +12,8 @@ var autoprefixer = require('autoprefixer');
 var postcssVars = require('postcss-simple-vars');
 var postcssImport = require('postcss-import');
 
+const STATIC_PATH = process.env.STATIC_PATH || '/static';
+
 const base = {
     mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
     devtool: 'cheap-module-source-map',
@@ -195,7 +197,7 @@ module.exports = [
             output: {
                 libraryTarget: 'umd',
                 path: path.resolve('dist'),
-                publicPath: '/static/'
+                publicPath: `${STATIC_PATH}/`
             },
             externals: {
                 React: 'react',
@@ -208,7 +210,7 @@ module.exports = [
                         loader: 'file-loader',
                         options: {
                             outputPath: 'static/assets/',
-                            publicPath: '/static/assets/'
+                            publicPath: `${STATIC_PATH}/assets/`
                         }
                     }
                 ])


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_
Part of #4598 

### Proposed Changes

Allows consumers of gui (desktop, android, etc) to rebuild gui with a relative path for static assets. Default is an absolute path as that is what is required for www.

### Test Coverage

_Please show how you have added tests to cover your changes_
The default will build for www. With no changes to the build process it worked for my local www, and running gui locally (localhost:8601)

The android prototype npm linked to my local scratch-gui, all assets were fine after building gui with:
```
STATIC_PATH=static BUILD_MODE=dist npm run watch
```
Assets checked:
- UI elements (icons etc)
- tutorial animated gifs (including spanish)
- icons on blocks
- icons on extension blocks
- library images (including sprite costume animation)

/cc @rschamp @cwillisf 

Note: we will have to figure out how to modify the scratch-desktop build process to automatically rebuild gui.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [x] Chrome (as webview in app)
