### PR TITLE
replace Blocks.utils.is3dSupported with constant value function

### DIFF
--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -331,5 +331,15 @@ export default function (vm) {
         return collator.compare(str1, str2);
     };
 
+    // Blocks wants to know if 3D CSS transforms are supported. The cross
+    // section of browsers Scratch supports and browsers that support 3D CSS
+    // transforms will make the return always true.
+    //
+    // Shortcutting to true lets us skip an expensive style recalculation when
+    // first loading the Scratch editor.
+    ScratchBlocks.utils.is3dSupported = function () {
+        return true;
+    };
+
     return ScratchBlocks;
 }


### PR DESCRIPTION
### Resolves

Faster initial render of ScratchBlocks.

### Proposed Changes

Always return true from `ScratchBlocks.utils.is3dSupported`.

### Reason for Changes

The browsers that Scratch supports will always support 3D CSS Transform.

This change provides a minor performance improvement but one that can accumulate with other changes to reduce style and layout recalculations.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [x] Safari
 