### PR TITLE
use Collator.compare in place of localeCompare

### DIFF
--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -246,10 +246,7 @@ export default function (vm) {
                     lookupBlocks = vm.runtime.flyoutBlocks;
                 }
                 const sort = function (options) {
-                    options.sort((str1, str2) => str1.localeCompare(str2, [], {
-                        sensitivity: 'base',
-                        numeric: true
-                    }));
+                    options.sort(ScratchBlocks.scratchBlocksUtils.compareStrings);
                 };
                 // Get all the stage variables (no lists) so we can add them to menu when the stage is selected.
                 const stageVariableOptions = vm.runtime.getTargetForStage().getAllVariableNamesInScopeByType('');
@@ -321,6 +318,17 @@ export default function (vm) {
 
     ScratchBlocks.FieldNote.playNote_ = function (noteNum, extensionId) {
         vm.runtime.emit('PLAY_NOTE', noteNum, extensionId);
+    };
+
+    // Use a collator's compare instead of localeCompare which internally
+    // creates a collator. Using this is a lot faster in browsers that create a
+    // collator for every localeCompare call.
+    const collator = new Intl.Collator([], {
+        sensitivity: 'base',
+        numeric: true
+    });
+    ScratchBlocks.scratchBlocksUtils.compareStrings = function (str1, str2) {
+        return collator.compare(str1, str2);
     };
 
     return ScratchBlocks;


### PR DESCRIPTION
### Resolves

Faster Blocks rendering.

### Proposed Changes

Use Intl.Collator in place of localeCompare.

### Reason for Changes

Blocks compares strings in sensing_of and data category's variables list with localeCompare. localeCompare needs to do or have done some kind of work that is like creating a Collator to do the comparison. Collator takes the same options and lets us cache its internal contents. We can use the same collator and compare strings faster.

In the cases of the sensing_of block and the data category variable list we can make the list sorting much faster.

I did some quick performance benchmarks for this PR in Chrome on a 2017 15" MBP. I measured  sensing_of in 173918262 with about 40 variables on the first library sprite. Rendering the workspace for that sprite spends **79ms over 6 sort operations** for sensing_of. This PR changes that to 0.720ms or **720us over 6 sort operations** for sensing_of.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [x] Safari
