### PR TITLE
dispatch projectChange redux action when project has not changed

### DIFF
--- a/src/lib/vm-listener-hoc.jsx
+++ b/src/lib/vm-listener-hoc.jsx
@@ -74,7 +74,7 @@ const vmListenerHOC = function (WrappedComponent) {
             }
         }
         handleProjectChanged () {
-            if (this.props.shouldEmitUpdates) {
+            if (this.props.shouldEmitUpdates && !this.props.projectChanged) {
                 this.props.onProjectChanged();
             }
         }
@@ -117,6 +117,7 @@ const vmListenerHOC = function (WrappedComponent) {
             const {
                 /* eslint-disable no-unused-vars */
                 attachKeyboardEvents,
+                projectChanged,
                 shouldEmitUpdates,
                 onBlockDragUpdate,
                 onGreenFlag,
@@ -154,6 +155,7 @@ const vmListenerHOC = function (WrappedComponent) {
         onTargetsUpdate: PropTypes.func.isRequired,
         onTurboModeOff: PropTypes.func.isRequired,
         onTurboModeOn: PropTypes.func.isRequired,
+        projectChanged: PropTypes.bool,
         shouldEmitUpdates: PropTypes.bool,
         username: PropTypes.string,
         vm: PropTypes.instanceOf(VM).isRequired
@@ -163,6 +165,7 @@ const vmListenerHOC = function (WrappedComponent) {
         onGreenFlag: () => ({})
     };
     const mapStateToProps = state => ({
+        projectChanged: state.scratchGui.projectChanged,
         // Do not emit target or project updates in fullscreen or player only mode
         // or when recording sounds (it leads to garbled recordings on low-power machines)
         shouldEmitUpdates: !state.scratchGui.mode.isFullScreen && !state.scratchGui.mode.isPlayerOnly &&


### PR DESCRIPTION
### Resolves

Faster project loading.

### Proposed Changes

Make VMListenerHOC aware of the scratchGui.projectChanged state and only call onProjectChanged when the project is in the unchanged state.

### Reason for Changes

Dispatching a message through redux makes it reconsider all currently listening components. Dispatching for each block, while loading, can mean dispatching and reconsidering thousands of times if not more while deserializing a project or creating a sprite from the backpack. While dispatching is pretty quick doing this for every block ends up taking a lot of time.

### Benchmark Data

Here is some data testing the effected deserialization performance while loading 173918262.

|  device | before (ms) | after (ms) | difference (ms) | change (%) |
| --- | --- | --- | --- | --- |
|  chrome | 283 | 59 | 224 | 79.12% |
|  firefox | 496 | 137 | 359 | 72.35% |
|  safari | 458 | 65 | 393 | 85.90% |
|  chromebook | 817 | 202 | 615 | 75.32% |

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [x] Safari
 
Chromebook
 * [x] Chrome
 