### PR TITLE
render only new toolbox xmls

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -180,13 +180,19 @@ class Blocks extends React.Component {
     componentWillUnmount () {
         this.detachVM();
         this.workspace.dispose();
-        clearTimeout(this.toolboxUpdateTimeout);
+        if (this.toolboxUpdateTimeout) this.toolboxUpdateTimeout.cancel();
     }
     requestToolboxUpdate () {
-        clearTimeout(this.toolboxUpdateTimeout);
-        this.toolboxUpdateTimeout = setTimeout(() => {
-            this.updateToolbox();
-        }, 0);
+        if (this.toolboxUpdateTimeout) this.toolboxUpdateTimeout.cancel();
+        let running = true;
+        this.toolboxUpdateTimeout = Promise.resolve().then(() => {
+            if (running) {
+                this.updateToolbox();
+            }
+        });
+        this.toolboxUpdateTimeout.cancel = () => {
+            running = false;
+        };
     }
     setLocale () {
         this.ScratchBlocks.ScratchMsgs.setLocale(this.props.locale);

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -199,8 +199,11 @@ class Blocks extends React.Component {
 
         const categoryId = this.workspace.toolbox_.getSelectedCategoryId();
         const offset = this.workspace.toolbox_.getCategoryScrollOffset();
-        this.workspace.updateToolbox(this.props.toolboxXML);
-        this._renderedToolboxXML = this.props.toolboxXML;
+
+        if (this._renderedToolboxXML !== this.props.toolboxXML) {
+            this.workspace.updateToolbox(this.props.toolboxXML);
+            this._renderedToolboxXML = this.props.toolboxXML;
+        }
 
         // In order to catch any changes that mutate the toolbox during "normal runtime"
         // (variable changes/etc), re-enable toolbox refresh.


### PR DESCRIPTION
### Resolves

Faster loading.

### Proposed Changes

Check if toolbox needs to be updated with new XML during updateToolbox.

### Reason for Changes

src/containers/Blocks.jsx:updateToolbox may be called when the xml hasn't changed. Calling this.ScratchBlocks.updateToolbox with the unchanged XML does a lot of work for no change.

### Benchmark Data

|  device | before (ms) | after (ms) | difference (ms) | change (%) |
| --- | --- | --- | --- | --- |
|  chrome | 117 | 1 | 116 | 99.15% |
|  firefox | 143 | 1 | 142 | 99.30% |
|  safari | 99 | 1 | 98 | 98.79% |
|  chromebook | 425 | 2 | 422 | 99.43% |