### PR TITLE
Add vernier module to webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,7 +41,8 @@ const base = {
             include: [
                 path.resolve(__dirname, 'src'),
                 /node_modules[\\/]scratch-[^\\/]+[\\/]src/,
-                /node_modules[\\/]pify/
+                /node_modules[\\/]pify/,
+                /node_modules[\\/]@vernier[\\/]godirect/
             ],
             options: {
                 // Explicitly disable babelrc so we don't catch various config


### PR DESCRIPTION
Use babel on the @vernier/godirect dependency of VM (used by the Vernier Force and Acceleration extension). That module uses a conditional `require` for `text-encoding`, as a polyfill for MS Edge, but it does not include `text-encoding` in its `package.json` (e.g. [here](https://github.com/VernierST/godirect-js/blob/80a5ceffdc670be8eade16e6ac3067e2b6fd3105/src/Device.js#L24)). As a result (I think), we need to run it through babel in order to make sure it works on Edge in our code. 
