### PR TITLE
Exclude greenkeeper builds from gh-pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ deploy:
 - provider: script
   on:
     all_branches: true
-    condition: $TRAVIS_EVENT_TYPE != cron
+    condition: $TRAVIS_EVENT_TYPE != cron && ! $TRAVIS_BRANCH =~ ^greenkeeper/
   skip_cleanup: true
   script: npm run deploy -- -x -e $TRAVIS_BRANCH -r https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
 - provider: script


### PR DESCRIPTION
They take up so much space and time, but aren't really looked at very much
/fyi @LLK/scratch-team 