### PR TITLE
Prevent crash on load hardware ext without assets

### DIFF
--- a/src/components/connection-modal/connection-modal.jsx
+++ b/src/components/connection-modal/connection-modal.jsx
@@ -44,7 +44,7 @@ const ConnectionModalComponent = props => (
 );
 
 ConnectionModalComponent.propTypes = {
-    connectingMessage: PropTypes.node,
+    connectingMessage: PropTypes.node.isRequired,
     connectionSmallIconURL: PropTypes.string,
     connectionTipIconURL: PropTypes.string,
     name: PropTypes.node,
@@ -53,6 +53,10 @@ ConnectionModalComponent.propTypes = {
     phase: PropTypes.oneOf(Object.keys(PHASES)).isRequired,
     title: PropTypes.string.isRequired,
     useAutoScan: PropTypes.bool.isRequired
+};
+
+ConnectionModalComponent.defaultProps = {
+    connectingMessage: 'Connecting'
 };
 
 export {

--- a/src/containers/connection-modal.jsx
+++ b/src/containers/connection-modal.jsx
@@ -107,15 +107,15 @@ class ConnectionModal extends React.Component {
     render () {
         return (
             <ConnectionModalComponent
-                connectingMessage={this.state.extension.connectingMessage}
-                connectionIconURL={this.state.extension.connectionIconURL}
-                connectionSmallIconURL={this.state.extension.connectionSmallIconURL}
-                connectionTipIconURL={this.state.extension.connectionTipIconURL}
+                connectingMessage={this.state.extension && this.state.extension.connectingMessage}
+                connectionIconURL={this.state.extension && this.state.extension.connectionIconURL}
+                connectionSmallIconURL={this.state.extension && this.state.extension.connectionSmallIconURL}
+                connectionTipIconURL={this.state.extension && this.state.extension.connectionTipIconURL}
                 extensionId={this.props.extensionId}
-                name={this.state.extension.name}
+                name={this.state.extension && this.state.extension.name}
                 phase={this.state.phase}
                 title={this.props.extensionId}
-                useAutoScan={this.state.extension.useAutoScan}
+                useAutoScan={this.state.extension && this.state.extension.useAutoScan}
                 vm={this.props.vm}
                 onCancel={this.handleCancel}
                 onConnected={this.handleConnected}


### PR DESCRIPTION
This is really a developer ergonomics improvement, but it does make loading hardware extensions more robust. Thanks to @rschamp for the idea. 

Basically, during development, you may want to load an extension from a saved file, which will work if the extension is loaded in the VM, even if it is not in the GUI extension library. Previously, with hardware extensions, this would cause a crash when you tried to connect to the device, because GUI expected the metadata used to render the connection modal to exist. This PR allows you to use the hardware extension (with various icons missing from the connection modal). 

