### PR TITLE
update scratch-l10n to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "rimraf": "^2.6.1",
     "scratch-audio": "0.1.0-prerelease.20190114210212",
     "scratch-blocks": "0.1.0-prerelease.1552662801",
-    "scratch-l10n": "3.1.20190220143732",
+    "scratch-l10n": "3.1.20190328114324",
     "scratch-paint": "0.2.0-prerelease.20190318170811",
     "scratch-render": "0.1.0-prerelease.20190312125229",
     "scratch-storage": "1.2.2",


### PR DESCRIPTION
Update to the latest release of scratch-l10n.
Due to translation errors l10n had not built for several weeks. This fixes translations and bring in updates.

I'll check that the tests pass then merge.