### PR TITLE
upload in current project id, rather than creating new project id

### DIFF
--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -393,19 +393,17 @@ class MenuBar extends React.Component {
                                     </MenuSection>
                                 )}
                                 <MenuSection>
-                                    <SBFileUploader onUpdateProjectTitle={this.props.onUpdateProjectTitle}>
+                                    <SBFileUploader
+                                        canSave={this.props.canSave}
+                                        userOwnsProject={this.props.userOwnsProject}
+                                        onUpdateProjectTitle={this.props.onUpdateProjectTitle}
+                                    >
                                         {(className, renderFileInput, loadProject) => (
                                             <MenuItem
                                                 className={className}
                                                 onClick={loadProject}
                                             >
-                                                <FormattedMessage
-                                                    defaultMessage="Load from your computer"
-                                                    description={
-                                                        'Menu bar item for uploading a project from your computer'
-                                                    }
-                                                    id="gui.menuBar.uploadFromComputer"
-                                                />
+                                                {this.props.intl.formatMessage(sharedMessages.loadFromComputerTitle)}
                                                 {renderFileInput()}
                                             </MenuItem>
                                         )}
@@ -774,7 +772,7 @@ MenuBar.defaultProps = {
     onShare: () => {}
 };
 
-const mapStateToProps = state => {
+const mapStateToProps = (state, ownProps) => {
     const loadingState = state.scratchGui.projectState.loadingState;
     const user = state.session && state.session.session && state.session.session.user;
     return {
@@ -791,6 +789,8 @@ const mapStateToProps = state => {
         projectTitle: state.scratchGui.projectTitle,
         sessionExists: state.session && typeof state.session.session !== 'undefined',
         username: user ? user.username : null,
+        userOwnsProject: ownProps.authorUsername && user &&
+            (ownProps.authorUsername === user.username),
         vm: state.scratchGui.vm
     };
 };

--- a/src/lib/shared-messages.js
+++ b/src/lib/shared-messages.js
@@ -25,5 +25,10 @@ export default defineMessages({
         id: 'gui.sharedMessages.replaceProjectWarning',
         defaultMessage: 'Replace contents of the current project?',
         description: 'Confirmation that user wants to overwrite the current project contents'
+    },
+    loadFromComputerTitle: {
+        id: 'gui.sharedMessages.loadFromComputerTitle',
+        defaultMessage: 'Load from your computer',
+        description: 'Title for uploading a project from your computer'
     }
 });

--- a/src/reducers/project-state.js
+++ b/src/reducers/project-state.js
@@ -10,7 +10,6 @@ const DONE_LOADING_VM_WITHOUT_ID = 'scratch-gui/project-state/DONE_LOADING_VM_WI
 const DONE_REMIXING = 'scratch-gui/project-state/DONE_REMIXING';
 const DONE_UPDATING = 'scratch-gui/project-state/DONE_UPDATING';
 const DONE_UPDATING_BEFORE_COPY = 'scratch-gui/project-state/DONE_UPDATING_BEFORE_COPY';
-const DONE_UPDATING_BEFORE_FILE_UPLOAD = 'scratch-gui/project-state/DONE_UPDATING_BEFORE_FILE_UPLOAD';
 const DONE_UPDATING_BEFORE_NEW = 'scratch-gui/project-state/DONE_UPDATING_BEFORE_NEW';
 const RETURN_TO_SHOWING = 'scratch-gui/project-state/RETURN_TO_SHOWING';
 const SET_PROJECT_ID = 'scratch-gui/project-state/SET_PROJECT_ID';
@@ -23,7 +22,6 @@ const START_MANUAL_UPDATING = 'scratch-gui/project-state/START_MANUAL_UPDATING';
 const START_REMIXING = 'scratch-gui/project-state/START_REMIXING';
 const START_UPDATING_BEFORE_CREATING_COPY = 'scratch-gui/project-state/START_UPDATING_BEFORE_CREATING_COPY';
 const START_UPDATING_BEFORE_CREATING_NEW = 'scratch-gui/project-state/START_UPDATING_BEFORE_CREATING_NEW';
-const START_UPDATING_BEFORE_FILE_UPLOAD = 'scratch-gui/project-state/START_UPDATING_BEFORE_FILE_UPLOAD';
 
 const defaultProjectId = '0'; // hardcoded id of default project
 
@@ -43,7 +41,6 @@ const LoadingState = keyMirror({
     SHOWING_WITH_ID: null,
     SHOWING_WITHOUT_ID: null,
     UPDATING_BEFORE_COPY: null,
-    UPDATING_BEFORE_FILE_UPLOAD: null,
     UPDATING_BEFORE_NEW: null
 });
 
@@ -91,7 +88,6 @@ const getIsUpdating = loadingState => (
     loadingState === LoadingState.AUTO_UPDATING ||
     loadingState === LoadingState.MANUAL_UPDATING ||
     loadingState === LoadingState.UPDATING_BEFORE_COPY ||
-    loadingState === LoadingState.UPDATING_BEFORE_FILE_UPLOAD ||
     loadingState === LoadingState.UPDATING_BEFORE_NEW
 );
 const getIsShowingProject = loadingState => (
@@ -200,13 +196,6 @@ const reducer = function (state, action) {
         if (state.loadingState === LoadingState.UPDATING_BEFORE_COPY) {
             return Object.assign({}, state, {
                 loadingState: LoadingState.CREATING_COPY
-            });
-        }
-        return state;
-    case DONE_UPDATING_BEFORE_FILE_UPLOAD:
-        if (state.loadingState === LoadingState.UPDATING_BEFORE_FILE_UPLOAD) {
-            return Object.assign({}, state, {
-                loadingState: LoadingState.LOADING_VM_FILE_UPLOAD
             });
         }
         return state;
@@ -333,13 +322,6 @@ const reducer = function (state, action) {
             });
         }
         return state;
-    case START_UPDATING_BEFORE_FILE_UPLOAD:
-        if (state.loadingState === LoadingState.SHOWING_WITH_ID) {
-            return Object.assign({}, state, {
-                loadingState: LoadingState.UPDATING_BEFORE_FILE_UPLOAD
-            });
-        }
-        return state;
     case START_ERROR:
         // fatal errors: there's no correct editor state for us to show
         if ([
@@ -360,7 +342,6 @@ const reducer = function (state, action) {
             LoadingState.MANUAL_UPDATING,
             LoadingState.REMIXING,
             LoadingState.UPDATING_BEFORE_COPY,
-            LoadingState.UPDATING_BEFORE_FILE_UPLOAD,
             LoadingState.UPDATING_BEFORE_NEW
         ].includes(state.loadingState)) {
             return Object.assign({}, state, {
@@ -471,10 +452,6 @@ const doneUpdatingProject = loadingState => {
         return {
             type: DONE_UPDATING_BEFORE_COPY
         };
-    case LoadingState.UPDATING_BEFORE_FILE_UPLOAD:
-        return {
-            type: DONE_UPDATING_BEFORE_FILE_UPLOAD
-        };
     case LoadingState.UPDATING_BEFORE_NEW:
         return {
             type: DONE_UPDATING_BEFORE_NEW
@@ -501,11 +478,8 @@ const requestNewProject = needSave => {
 
 const requestProjectUpload = loadingState => {
     switch (loadingState) {
-    case LoadingState.SHOWING_WITH_ID:
-        return {
-            type: START_UPDATING_BEFORE_FILE_UPLOAD
-        };
     case LoadingState.NOT_LOADED:
+    case LoadingState.SHOWING_WITH_ID:
     case LoadingState.SHOWING_WITHOUT_ID:
         return {
             type: START_LOADING_VM_FILE_UPLOAD

--- a/test/integration/menu-bar.test.js
+++ b/test/integration/menu-bar.test.js
@@ -41,7 +41,7 @@ describe('Menu bar settings', () => {
             '//div[contains(@class, "menu-bar_menu-bar-item") and ' +
             'contains(@class, "menu-bar_hoverable")][span[text()="File"]]'
         );
-        await findByXpath('//*[li[span[text()="Load from your computer"]] and not(@data-tip="tooltip")]');
+        await findByXpath('//*[li[text()="Load from your computer"] and not(@data-tip="tooltip")]');
     });
 
     test('File->Save should be enabled', async () => {

--- a/test/unit/reducers/project-state-reducer.test.js
+++ b/test/unit/reducers/project-state-reducer.test.js
@@ -250,7 +250,7 @@ test('requestProjectUpload when showing project with id should load', () => {
     };
     const action = requestProjectUpload(initialState.loadingState);
     const resultState = projectStateReducer(initialState, action);
-    expect(resultState.loadingState).toBe(LoadingState.UPDATING_BEFORE_FILE_UPLOAD);
+    expect(resultState.loadingState).toBe(LoadingState.LOADING_VM_FILE_UPLOAD);
 });
 
 test('requestProjectUpload when showing project without id should load', () => {


### PR DESCRIPTION
### Resolves

- Resolves https://github.com/LLK/scratch-gui/issues/3509

### Proposed Changes

* for logged in users, uploading a project gives it the same project id as the current project, rather than creating a new project id.
* confirm logic for upload is now: show confirm dialog if user owns current project, or project has been changed since it was opened.
* removed related code from `project-state.js` that will no longer be used
* sets the project filename from the upload file name (did not require code changes)
* confirms after showing the upload dialog (did not require code changes)
* shuts file menu if the confirm is cancelled
* changes “Creating project” to “Loading project” for the blue screen

### Still needs work

* we plan to replace the browser `confirm()` with a custom modal

### Note

1. The new confirm logic will *not* confirm if you do the following:
    1. be logged out
    2. upload a project (we'll call it "Project A")
    3. immediately upload another project ("Project B")
    The reason is that you haven't made any alterations to Project A; it's as if you just clicked see inside on a project, and then uploaded on top of that. 
 
2. Replacing the project keeps the extensions open that the previous project was using. This issue is filed in https://github.com/LLK/scratch-vm/issues/1731 and we do not plan on fixing it as part of this change.


### Test Coverage

Revised `test/unit/reducers/project-state-reducer.test.js` to reflect changes

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
