### PR TITLE
Keep URI correct when uploading project while signed out

### DIFF
--- a/src/containers/sb-file-uploader.jsx
+++ b/src/containers/sb-file-uploader.jsx
@@ -118,12 +118,6 @@ class SBFileUploader extends React.Component {
             const filename = this.fileToUpload && this.fileToUpload.name;
             this.props.vm.loadProject(this.reader.result)
                 .then(() => {
-                    // Remove the hash if any (without triggering a hash change event or a reload)
-                    try { // Can fail e.g. when GUI is loaded from static file (integration tests)
-                        history.replaceState({}, document.title, '.');
-                    } catch {
-                        // No fallback, just do not trigger promise catch below
-                    }
                     this.props.onLoadingFinished(this.props.loadingState, true);
                     // Reset the file input after project is loaded
                     // This is necessary in case the user wants to reload a project


### PR DESCRIPTION
### Resolves

- Resolves https://github.com/LLK/scratch-www/issues/2769

### See related

https://github.com/LLK/scratch-gui/issues/4708 , which points out a problem that makes this fix not totally testable in playground/standalone mode

### Proposed Changes

Previously, in `sb-file-uploader.js`, on uploading a project we would push to `window.history`  to clear the hash portion of the URI. This was a holdover from when Scratch 3.0 was only usable in playground mode; we would want to clear the hash project number from the URI to reflect the fact that it was no longer relevant.

We are not using hash project numbers in the URI format on the Scratch website, and even. in playground mode, we are not emphasizing them. Further, it appears that the `window.history` state management in gui's `hash-parser-hoc.js` should handle removing the hash portion of the URI anyway!

One caveat: it's not currently possible to test the functionality in playground mode because of a separate bug, https://github.com/LLK/scratch-gui/issues/4708 .

### Test Coverage

_Please show how you have added tests to cover your changes_

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
