### PR TITLE
Share, See-project-page buttons will only save if project has changed

### DIFF
--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -194,7 +194,7 @@ class MenuBar extends React.Component {
         this.props.onRequestCloseFile();
     }
     handleClickSeeCommunity (waitForUpdate) {
-        if (this.props.canSave) { // save before transitioning to project page
+        if (this.props.canSave && this.props.projectChanged) { // save before transitioning to project page
             this.props.autoUpdateProject();
             waitForUpdate(true); // queue the transition to project page
         } else {


### PR DESCRIPTION
### Resolves

- Resolves https://github.com/LLK/scratch-gui/issues/4604

### Proposed Changes

Instead of auto-saving whenever a logged in user clicks the `Share` or `See project page` buttons, before sharing or navigating to the project page, only auto-save if the project has changed.

### Reason for Changes

It's slow to auto-save unnecessarily. This is part of the larger effort to make saving happen at the right times, and only at the right times.

### Test Coverage

No tests written yet; should write some

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
