### PR TITLE
Add stand-alone player to playground

### DIFF
--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -2,6 +2,9 @@ import ScratchStorage from 'scratch-storage';
 
 import defaultProject from './default-project';
 
+const DEFAULT_ASSET_SERVER = 'https://assets.scratch.mit.edu';
+const DEFAULT_PROJECT_SERVER = 'https://projects.scratch.mit.edu';
+
 /**
  * Wrapper for ScratchStorage which adds default web sources.
  * @todo make this more configurable
@@ -10,6 +13,8 @@ class Storage extends ScratchStorage {
     constructor () {
         super();
         this.cacheDefaultProject();
+        this.projectHost = DEFAULT_PROJECT_SERVER;
+        this.assetHost = DEFAULT_ASSET_SERVER;
     }
     addOfficialScratchWebStores () {
         this.addWebStore(

--- a/src/playground/standalone-player.html.js
+++ b/src/playground/standalone-player.html.js
@@ -1,0 +1,23 @@
+export default `<!doctype html>
+<html>
+  <style>
+  .body {
+    height: 100%;
+    margin: 0;
+    overflow: hidden;
+    text-align: center;
+    width: 100%;
+  }
+  .stage {
+    display: inline-block;
+    height: 100vh;
+    margin: 0 auto;
+    width: 133vh;
+  }
+  </style>
+  <head><meta charset="UTF-8"></head>
+  <body class="body">
+    <canvas class="stage" id="scratch-stage" width="480" height="360"></canvas>
+  </body>
+</html>
+`;

--- a/src/playground/standalone-player.html.js
+++ b/src/playground/standalone-player.html.js
@@ -1,22 +1,35 @@
 export default `<!doctype html>
 <html>
-  <style>
-  .body {
-    height: 100%;
-    margin: 0;
-    overflow: hidden;
-    text-align: center;
-    width: 100%;
-  }
-  .stage {
-    display: inline-block;
-    height: 100vh;
-    margin: 0 auto;
-    width: 133vh;
-    touch-action: manipulation;
-  }
-  </style>
-  <head><meta charset="UTF-8"></head>
+  <head>
+    <meta charset="UTF-8">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <style>
+    .body {
+      height: 100%;
+      margin: 0;
+      overflow: hidden;
+      text-align: center;
+      background-color: black;
+      color: #cccccc;
+    }
+
+    .stage {
+      display: inline-block;
+      width: 133.33333vh;
+      height: 100vh;
+      margin: 0 auto;
+      touch-action: manipulation;
+    }
+  
+    @media ( max-aspect-ratio: 4/3 ) {
+      .stage {
+        width: 100vw;
+        height: 75vw;
+        margin-top: calc(50vh - 37.5vw)
+      }
+    }
+    </style>
+  </head>
   <body class="body">
     <canvas class="stage" id="scratch-stage" width="480" height="360"></canvas>
   </body>

--- a/src/playground/standalone-player.html.js
+++ b/src/playground/standalone-player.html.js
@@ -13,6 +13,7 @@ export default `<!doctype html>
     height: 100vh;
     margin: 0 auto;
     width: 133vh;
+    touch-action: manipulation;
   }
   </style>
   <head><meta charset="UTF-8"></head>

--- a/src/playground/standalone-player.html.js
+++ b/src/playground/standalone-player.html.js
@@ -13,16 +13,39 @@ export default `<!doctype html>
       color: #cccccc;
     }
 
-    .stage {
+    .stage-container {
       display: inline-block;
       width: 133.33333vh;
       height: 100vh;
       margin: 0 auto;
-      touch-action: manipulation;
     }
-  
+
+    .stage {
+      touch-action: manipulation;
+      width: inherit;
+    }
+
+    .hidden {
+      visibility: hidden;
+    }
+
+    #overlay {
+      position: absolute;
+      height: inherit;
+      width: inherit;
+      background-color: rgba(0, 0, 0, .35);
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
+
+    .green-flag-container {
+      width: 15vh;
+      height: 15vh;
+    }
+
     @media ( max-aspect-ratio: 4/3 ) {
-      .stage {
+      .stage-container {
         width: 100vw;
         height: 75vw;
         margin-top: calc(50vh - 37.5vw)
@@ -31,7 +54,15 @@ export default `<!doctype html>
     </style>
   </head>
   <body class="body">
+  <div class="stage-container">
+    <div id="overlay" class="hidden">
+      <div class="green-flag-container">
+        <svg id="green-flag" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16.63 17.5"><defs><style>.cls-1,.cls-2{fill:#4cbf56;stroke:#45993d;stroke-linecap:round;stroke-linejoin:round;}.cls-2{stroke-width:1.5px;}</style></defs><title>icon--green-flag</title><path class="cls-1" d="M.75,2A6.44,6.44,0,0,1,8.44,2h0a6.44,6.44,0,0,0,7.69,0V12.4a6.44,6.44,0,0,1-7.69,0h0a6.44,6.44,0,0,0-7.69,0"/><line class="cls-2" x1="0.75" y1="16.75" x2="0.75" y2="0.75"/>
+        </svg>
+      </div>
+    </div>
     <canvas class="stage" id="scratch-stage" width="480" height="360"></canvas>
+  </div>
   </body>
 </html>
 `;

--- a/src/playground/standalone-player.jsx
+++ b/src/playground/standalone-player.jsx
@@ -55,7 +55,7 @@ window.onload = function () {
     let attemptFullscreen = Boolean(document.body.requestFullscreen);
     document.getElementById('green-flag').addEventListener('click', () => {
         document.getElementById('overlay').classList.add('hidden');
-        vm.greenFlag()
+        vm.greenFlag();
         if (attemptFullscreen) {
             document.body.requestFullscreen();
             attemptFullscreen = false;

--- a/src/playground/standalone-player.jsx
+++ b/src/playground/standalone-player.jsx
@@ -41,6 +41,24 @@ window.onload = function () {
     const audioEngine = new AudioEngine();
     vm.attachAudioEngine(audioEngine);
 
+    // Resets size of canvas directly for proper image calcuations
+    // when the window is resized
+    const resize = () => {
+      renderer.resize(canvas.clientWidth, canvas.clientHeight);
+    };
+    window.addEventListener('resize', resize);
+
+    resize();
+
+    // Browser fullscreen mode
+    let attemptFullscreen = Boolean(document.body.requestFullscreen);
+    document.body.addEventListener('click', e => {
+        if (attemptFullscreen) {
+            document.body.requestFullscreen();
+            attemptFullscreen = false;
+        }
+    });
+
     // Feed mouse events as VM I/O events.
     document.body.addEventListener('mousemove', e => {
         const rect = canvas.getBoundingClientRect();

--- a/src/playground/standalone-player.jsx
+++ b/src/playground/standalone-player.jsx
@@ -8,9 +8,6 @@ import storage from '../lib/storage';
 // minimal scratch player without the editor view.
 
 const EXAMPLE_PROJECT = 10128067; // 'Make it Dance' Project
-const loadProject = function () {
-    Scratch.vm.downloadProjectId(EXAMPLE_PROJECT);
-};
 
 window.onload = function () {
 
@@ -22,7 +19,7 @@ window.onload = function () {
     storage.addOfficialScratchWebStores();
     vm.attachStorage(storage);
 
-    loadProject();
+    vm.downloadProjectId(EXAMPLE_PROJECT);
 
     vm.on('workspaceUpdate', () => {
         setTimeout(() => vm.greenFlag(), 1000);
@@ -98,5 +95,6 @@ window.onload = function () {
 
     // Run threads
     vm.start();
+
     vm.greenFlag();
 };

--- a/src/playground/standalone-player.jsx
+++ b/src/playground/standalone-player.jsx
@@ -1,0 +1,102 @@
+import VirtualMachine from 'scratch-vm';
+import RenderWebGL from 'scratch-render';
+import AudioEngine from 'scratch-audio';
+import {BitmapAdapter} from 'scratch-svg-renderer';
+import storage from '../lib/storage';
+
+// This file is an example of how to create a standalone, full screen
+// minimal scratch player without the editor view.
+
+const EXAMPLE_PROJECT = 10128067; // 'Make it Dance' Project
+const loadProject = function () {
+    Scratch.vm.downloadProjectId(EXAMPLE_PROJECT);
+};
+
+window.onload = function () {
+
+    // Instantiate the VM.
+    const vm = new VirtualMachine();
+    vm.attachV2BitmapAdapter(new BitmapAdapter());
+
+    // Initialize storage
+    storage.addOfficialScratchWebStores();
+    vm.attachStorage(storage);
+
+    loadProject();
+
+    vm.on('workspaceUpdate', () => {
+        setTimeout(() => vm.greenFlag(), 1000);
+    });
+
+    // Instantiate the renderer and connect it to the VM.
+    const canvas = document.getElementById('scratch-stage');
+    const renderer = new RenderWebGL(canvas);
+    vm.attachRenderer(renderer);
+    const audioEngine = new AudioEngine();
+    vm.attachAudioEngine(audioEngine);
+
+    // Feed mouse events as VM I/O events.
+    document.addEventListener('mousemove', e => {
+        const rect = canvas.getBoundingClientRect();
+        const coordinates = {
+            x: e.clientX - rect.left,
+            y: e.clientY - rect.top,
+            canvasWidth: rect.width,
+            canvasHeight: rect.height
+        };
+        vm.postIOData('mouse', coordinates);
+    });
+    canvas.addEventListener('mousedown', e => {
+        const rect = canvas.getBoundingClientRect();
+        const data = {
+            isDown: true,
+            x: e.clientX - rect.left,
+            y: e.clientY - rect.top,
+            canvasWidth: rect.width,
+            canvasHeight: rect.height
+        };
+        vm.postIOData('mouse', data);
+        e.preventDefault();
+    });
+    canvas.addEventListener('mouseup', e => {
+        const rect = canvas.getBoundingClientRect();
+        const data = {
+            isDown: false,
+            x: e.clientX - rect.left,
+            y: e.clientY - rect.top,
+            canvasWidth: rect.width,
+            canvasHeight: rect.height
+        };
+        vm.postIOData('mouse', data);
+        e.preventDefault();
+    });
+
+    // Feed keyboard events as VM I/O events.
+    document.addEventListener('keydown', e => {
+        // Don't capture keys intended for Blockly inputs.
+        if (e.target !== document && e.target !== document.body) {
+            return;
+        }
+        vm.postIOData('keyboard', {
+            key: e.keyCode,
+            isDown: true
+        });
+        e.preventDefault();
+    });
+    document.addEventListener('keyup', e => {
+        // Always capture up events,
+        // even those that have switched to other targets.
+        vm.postIOData('keyboard', {
+            key: e.keyCode,
+            isDown: false
+        });
+        // E.g., prevent scroll.
+        if (e.target !== document && e.target !== document.body) {
+            e.preventDefault();
+        }
+    });
+
+    // Run threads
+    vm.start();
+    vm.greenFlag();
+};

--- a/src/playground/standalone-player.jsx
+++ b/src/playground/standalone-player.jsx
@@ -19,6 +19,9 @@ window.onload = function () {
     // Initialize storage
     storage.addOfficialScratchWebStores();
     vm.attachStorage(storage);
+
+    // Compatibility mode will set the frame rate to 30 TPS,
+    // which is the standard for the scratch player.
     vm.setCompatibilityMode(true);
 
     vm.downloadProjectId(EXAMPLE_PROJECT);
@@ -46,7 +49,6 @@ window.onload = function () {
         vm.postIOData('mouse', coordinates);
     });
     canvas.addEventListener('mousedown', e => {
-        console.log('mousedown');
         const rect = canvas.getBoundingClientRect();
         const data = {
             isDown: true,
@@ -59,7 +61,6 @@ window.onload = function () {
         e.preventDefault();
     });
     canvas.addEventListener('mouseup', e => {
-        console.log('mouseup');
         const rect = canvas.getBoundingClientRect();
         const data = {
             isDown: false,

--- a/src/playground/standalone-player.jsx
+++ b/src/playground/standalone-player.jsx
@@ -1,11 +1,21 @@
 import VirtualMachine from 'scratch-vm';
 import RenderWebGL from 'scratch-render';
 import AudioEngine from 'scratch-audio';
+import Storage from 'scratch-storage';
 import {SVGRenderer, BitmapAdapter} from 'scratch-svg-renderer';
-import storage from '../lib/storage';
 
-// This file is an example of how to create a standalone, full screen
-// minimal scratch player without the editor view.
+/**
+ * This file is an example of how to create a standalone, full screen
+ * minimal scratch player without the editor view.
+ * This file does not presentally include monitors, which are drawn by the GUI.
+ */
+
+const projectGetConfig = function (projectAsset) {
+    return `https://projects.scratch.mit.edu/${projectAsset.assetId}`;
+};
+const assetGetConfig = function (asset) {
+    return `https://assets.scratch.mit.edu/internalapi/asset/${asset.assetId}.${asset.dataFormat}/get/`;
+};
 
 window.onload = function () {
 
@@ -21,7 +31,11 @@ window.onload = function () {
     vm.attachV2SVGAdapter(new SVGRenderer());
 
     // Initialize storage
-    storage.addOfficialScratchWebStores();
+    const storage = new Storage();
+    const AssetType = storage.AssetType;
+    storage.addWebSource([AssetType.Project], projectGetConfig);
+    storage.addWebSource([AssetType.ImageVector, AssetType.ImageBitmap, AssetType.Sound], assetGetConfig);
+
     vm.attachStorage(storage);
 
     // Compatibility mode will set the frame rate to 30 TPS,

--- a/src/playground/standalone-player.jsx
+++ b/src/playground/standalone-player.jsx
@@ -7,9 +7,13 @@ import storage from '../lib/storage';
 // This file is an example of how to create a standalone, full screen
 // minimal scratch player without the editor view.
 
-const EXAMPLE_PROJECT = 10128067; // 'Make it Dance' Project
-
 window.onload = function () {
+
+    // Get the project id from the hash, or use the default project.
+    let projectId = 0;
+    if (window.location.hash) {
+        projectId = window.location.hash.substring(1);
+    }
 
     // Instantiate the VM.
     const vm = new VirtualMachine();
@@ -24,7 +28,7 @@ window.onload = function () {
     // which is the standard for the scratch player.
     vm.setCompatibilityMode(true);
 
-    vm.downloadProjectId(EXAMPLE_PROJECT);
+    vm.downloadProjectId(projectId);
 
     vm.on('workspaceUpdate', () => {
         setTimeout(() => vm.greenFlag(), 1000);
@@ -100,6 +104,4 @@ window.onload = function () {
 
     // Run threads
     vm.start();
-
-    vm.greenFlag();
 };

--- a/src/playground/standalone-player.jsx
+++ b/src/playground/standalone-player.jsx
@@ -31,7 +31,7 @@ window.onload = function () {
     vm.downloadProjectId(projectId);
 
     vm.on('workspaceUpdate', () => {
-        setTimeout(() => vm.greenFlag(), 1000);
+        document.getElementById('overlay').classList.remove('hidden');
     });
 
     // Instantiate the renderer and connect it to the VM.
@@ -44,15 +44,18 @@ window.onload = function () {
     // Resets size of canvas directly for proper image calcuations
     // when the window is resized
     const resize = () => {
-      renderer.resize(canvas.clientWidth, canvas.clientHeight);
+        renderer.resize(canvas.clientWidth, canvas.clientHeight);
     };
     window.addEventListener('resize', resize);
 
     resize();
 
-    // Browser fullscreen mode
+    // Start project after green flag clicked and attempt to go
+    // fullscreen
     let attemptFullscreen = Boolean(document.body.requestFullscreen);
-    document.body.addEventListener('click', e => {
+    document.getElementById('green-flag').addEventListener('click', () => {
+        document.getElementById('overlay').classList.add('hidden');
+        vm.greenFlag()
         if (attemptFullscreen) {
             document.body.requestFullscreen();
             attemptFullscreen = false;

--- a/src/playground/standalone-player.jsx
+++ b/src/playground/standalone-player.jsx
@@ -1,7 +1,7 @@
 import VirtualMachine from 'scratch-vm';
 import RenderWebGL from 'scratch-render';
 import AudioEngine from 'scratch-audio';
-import {BitmapAdapter} from 'scratch-svg-renderer';
+import {SVGRenderer, BitmapAdapter} from 'scratch-svg-renderer';
 import storage from '../lib/storage';
 
 // This file is an example of how to create a standalone, full screen
@@ -14,10 +14,12 @@ window.onload = function () {
     // Instantiate the VM.
     const vm = new VirtualMachine();
     vm.attachV2BitmapAdapter(new BitmapAdapter());
+    vm.attachV2SVGAdapter(new SVGRenderer());
 
     // Initialize storage
     storage.addOfficialScratchWebStores();
     vm.attachStorage(storage);
+    vm.setCompatibilityMode(true);
 
     vm.downloadProjectId(EXAMPLE_PROJECT);
 
@@ -33,7 +35,7 @@ window.onload = function () {
     vm.attachAudioEngine(audioEngine);
 
     // Feed mouse events as VM I/O events.
-    document.addEventListener('mousemove', e => {
+    document.body.addEventListener('mousemove', e => {
         const rect = canvas.getBoundingClientRect();
         const coordinates = {
             x: e.clientX - rect.left,
@@ -44,6 +46,7 @@ window.onload = function () {
         vm.postIOData('mouse', coordinates);
     });
     canvas.addEventListener('mousedown', e => {
+        console.log('mousedown');
         const rect = canvas.getBoundingClientRect();
         const data = {
             isDown: true,
@@ -56,6 +59,7 @@ window.onload = function () {
         e.preventDefault();
     });
     canvas.addEventListener('mouseup', e => {
+        console.log('mouseup');
         const rect = canvas.getBoundingClientRect();
         const data = {
             isDown: false,
@@ -69,22 +73,22 @@ window.onload = function () {
     });
 
     // Feed keyboard events as VM I/O events.
-    document.addEventListener('keydown', e => {
+    document.body.addEventListener('keydown', e => {
         // Don't capture keys intended for Blockly inputs.
         if (e.target !== document && e.target !== document.body) {
             return;
         }
         vm.postIOData('keyboard', {
-            key: e.keyCode,
+            key: e.code,
             isDown: true
         });
         e.preventDefault();
     });
-    document.addEventListener('keyup', e => {
+    document.body.addEventListener('keyup', e => {
         // Always capture up events,
         // even those that have switched to other targets.
         vm.postIOData('keyboard', {
-            key: e.keyCode,
+            key: e.code,
             isDown: false
         });
         // E.g., prevent scroll.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -108,7 +108,8 @@ module.exports = [
             'gui': './src/playground/index.jsx',
             'blocksonly': './src/playground/blocks-only.jsx',
             'compatibilitytesting': './src/playground/compatibility-testing.jsx',
-            'player': './src/playground/player.jsx'
+            'player': './src/playground/player.jsx',
+            'standalone-player': './src/playground/standalone-player.jsx'
         },
         output: {
             path: path.resolve(__dirname, 'build'),
@@ -167,6 +168,12 @@ module.exports = [
                 template: 'src/playground/index.ejs',
                 filename: 'player.html',
                 title: 'Scratch 3.0 GUI: Player Example'
+            }),
+            new HtmlWebpackPlugin({
+                chunks: ['lib.min', 'standalone-player'],
+                template: 'src/playground/standalone-player.html.js',
+                filename: 'standalone-player.html',
+                title: 'Scratch 3.0 GUI: Single Project Player Without Editor Example'
             }),
             new CopyWebpackPlugin([{
                 from: 'static',


### PR DESCRIPTION
### Proposed Changes

This PR adds a experimental "standalone player" to the GUI's playground. The `standalone-player.html` is example of how to create minimalist scratch project player without the editor view. I hoping to get feedback and continue to work to make the example more robust -- this is just a first draft! I'll also be looking to contribute back to the various repos to make including a player for scratch projects easier to embed in websites.

### Reason for Changes

There is no standard or recommended way to use the scratch player alone.

### Test Coverage

No tests, this is just a draft.

