### PR TITLE
Make sure to save assets before sending them to the backpack

### DIFF
--- a/src/containers/backpack.jsx
+++ b/src/containers/backpack.jsx
@@ -83,12 +83,15 @@ class Backpack extends React.Component {
     }
     handleDrop (dragInfo) {
         let payloader = null;
+        let presaveAsset = null;
         switch (dragInfo.dragType) {
         case DragConstants.COSTUME:
             payloader = costumePayload;
+            presaveAsset = dragInfo.asset;
             break;
         case DragConstants.SOUND:
             payloader = soundPayload;
+            presaveAsset = dragInfo.asset;
             break;
         case DragConstants.SPRITE:
             payloader = spritePayload;
@@ -102,6 +105,14 @@ class Backpack extends React.Component {
         // Creating the payload is async, so set loading before starting
         this.setState({loading: true}, () => {
             payloader(dragInfo.payload, this.props.vm)
+                .then(payload => {
+                    // Force the asset to save to the asset server before storing in backpack
+                    // Ensures any asset present in the backpack is also on the asset server
+                    if (presaveAsset && !presaveAsset.clean) {
+                        return storage.store(presaveAsset).then(() => payload);
+                    }
+                    return payload;
+                })
                 .then(payload => saveBackpackObject({
                     host: this.props.host,
                     token: this.props.token,

--- a/src/containers/backpack.jsx
+++ b/src/containers/backpack.jsx
@@ -87,11 +87,11 @@ class Backpack extends React.Component {
         switch (dragInfo.dragType) {
         case DragConstants.COSTUME:
             payloader = costumePayload;
-            presaveAsset = dragInfo.asset;
+            presaveAsset = dragInfo.payload.asset;
             break;
         case DragConstants.SOUND:
             payloader = soundPayload;
-            presaveAsset = dragInfo.asset;
+            presaveAsset = dragInfo.payload.asset;
             break;
         case DragConstants.SPRITE:
             payloader = spritePayload;
@@ -109,7 +109,12 @@ class Backpack extends React.Component {
                     // Force the asset to save to the asset server before storing in backpack
                     // Ensures any asset present in the backpack is also on the asset server
                     if (presaveAsset && !presaveAsset.clean) {
-                        return storage.store(presaveAsset).then(() => payload);
+                        return storage.store(
+                            presaveAsset.assetType,
+                            presaveAsset.dataFormat,
+                            presaveAsset.data,
+                            presaveAsset.assetId
+                        ).then(() => payload);
                     }
                     return payload;
                 })


### PR DESCRIPTION
This prevents assets from existing in the backpack server without also existing in the asset server. Credit to @kchadha for coming up with this fix.

### Resolves

_What Github issue does this resolve (please include link)?_

A proposed change to prevent https://github.com/LLK/scratch-gui/issues/4649 from continuing in the future. 

### Proposed Changes

_Describe what this Pull Request does_

Makes sure to save any unsaved assets to the asset server prior to saving them to the backpack.

### Reason for Changes

_Explain why these changes should be made_

This makes it impossible to have an asset saved to the backpack that is not also saved to the asset server (the canonical asset storage location)

This only needs to be done for costumes and sounds, since the other types of backpack assets do not exist in the asset server.

---
/cc @kchadha this is one method for enforcing the implicit assumption about where assets live. Seems like a pretty good solution!