### PR TITLE
Revert storage update due to asset saving errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "scratch-l10n": "3.1.20190410143750",
     "scratch-paint": "0.2.0-prerelease.20190318170811",
     "scratch-render": "0.1.0-prerelease.20190410184112",
-    "scratch-storage": "1.3.1",
+    "scratch-storage": "1.2.2",
     "scratch-svg-renderer": "0.2.0-prerelease.20190329052730",
     "scratch-vm": "0.2.0-prerelease.20190410143927",
     "selenium-webdriver": "3.6.0",


### PR DESCRIPTION
/cc @BryceLTaylor 

we were seeing new errors when saving project assets like this:
![image](https://user-images.githubusercontent.com/654102/55968850-cd1bd780-5c4a-11e9-82d5-7e6f37e056dc.png)
