### PR TITLE
removed confirm prompt if you are editing someone else's project and then do file -> upload

### DIFF
--- a/src/containers/sb-file-uploader.jsx
+++ b/src/containers/sb-file-uploader.jsx
@@ -10,6 +10,7 @@ import sharedMessages from '../lib/shared-messages';
 import {
     LoadingStates,
     getIsLoadingUpload,
+    getIsShowingWithoutId,
     onLoadedProject,
     requestProjectUpload
 } from '../reducers/project-state';
@@ -91,6 +92,7 @@ class SBFileUploader extends React.Component {
     handleChange (e) {
         const {
             intl,
+            isShowingWithoutId,
             loadingState,
             projectChanged,
             userOwnsProject
@@ -104,7 +106,7 @@ class SBFileUploader extends React.Component {
             // we must confirm with the user that they really intend to replace it.
             // (If they don't own the project and haven't changed it, no need to confirm.)
             let uploadAllowed = true;
-            if (userOwnsProject || projectChanged) {
+            if (userOwnsProject || (projectChanged && isShowingWithoutId)) {
                 uploadAllowed = confirm( // eslint-disable-line no-alert
                     intl.formatMessage(sharedMessages.replaceProjectWarning)
                 );
@@ -172,6 +174,7 @@ SBFileUploader.propTypes = {
     closeFileMenu: PropTypes.func,
     intl: intlShape.isRequired,
     isLoadingUpload: PropTypes.bool,
+    isShowingWithoutId: PropTypes.bool,
     loadingState: PropTypes.oneOf(LoadingStates),
     onLoadingFinished: PropTypes.func,
     onLoadingStarted: PropTypes.func,
@@ -190,6 +193,7 @@ const mapStateToProps = state => {
     const loadingState = state.scratchGui.projectState.loadingState;
     return {
         isLoadingUpload: getIsLoadingUpload(loadingState),
+        isShowingWithoutId: getIsShowingWithoutId(loadingState),
         loadingState: loadingState,
         projectChanged: state.scratchGui.projectChanged,
         vm: state.scratchGui.vm


### PR DESCRIPTION
### Resolves

Fix to https://github.com/LLK/scratch-gui/pull/4700

### Proposed Changes

Does NOT show user a "Replace contents of the current project?" modal if they are logged in, viewing someone else's project, and do File->Load from your computer.

This restores current functionality, rather than introducing a change to it like https://github.com/LLK/scratch-gui/pull/4700 did.

### Reason for Changes

We found this message very confusing, since your upload does NOT replace the project at the id you're looking at when you do File->Load from your computer. (And it shouldn't!)
