### PR TITLE
Save picture of stage!

### DIFF
--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -60,6 +60,9 @@ import {
 } from '../../reducers/menus';
 
 import collectMetadata from '../../lib/collect-metadata';
+import getThumbnail from '../../lib/project-thumbnail';
+import dataURItoBlob from '../../lib/data-uri-to-blob';
+import downloadBlob from '../../lib/download-blob';
 
 import styles from './menu-bar.css';
 
@@ -151,6 +154,7 @@ class MenuBar extends React.Component {
             'handleClickSaveAsCopy',
             'handleClickSeeCommunity',
             'handleClickShare',
+            'handleClickThumbnail',
             'handleKeyPress',
             'handleLanguageMouseUp',
             'handleRestoreOption',
@@ -217,6 +221,13 @@ class MenuBar extends React.Component {
             restoreFun();
             this.props.onRequestCloseEdit();
         };
+    }
+    handleClickThumbnail () {
+        getThumbnail(this.props.vm, dataURI => {
+            const blob = dataURItoBlob(dataURI);
+            downloadBlob('stage.png', blob); // @todo: localization here?
+        });
+        this.props.onRequestCloseEdit();
     }
     handleKeyPress (event) {
         const modifier = bowser.mac ? event.metaKey : event.ctrlKey;
@@ -296,6 +307,13 @@ class MenuBar extends React.Component {
                 defaultMessage="New"
                 description="Menu bar item for creating a new project"
                 id="gui.menuBar.new"
+            />
+        );
+        const thumbnailMessage = (
+            <FormattedMessage
+                defaultMessage="Save picture of stage"
+                description="Menu bar for saving the picture of stage"
+                id="gui.menuBar.saveThumbnailStage"
             />
         );
         const remixButton = (
@@ -466,6 +484,14 @@ class MenuBar extends React.Component {
                                             )}
                                         </MenuItem>
                                     )}</TurboMode>
+                                </MenuSection>
+                                <MenuSection>
+                                    <MenuItem
+                                        isRtl={this.props.isRtl}
+                                        onClick={this.handleClickThumbnail}
+                                    >
+                                        {thumbnailMessage}
+                                    </MenuItem>
                                 </MenuSection>
                             </MenuBarMenu>
                         </div>

--- a/src/lib/project-saver-hoc.jsx
+++ b/src/lib/project-saver-hoc.jsx
@@ -9,6 +9,7 @@ import log from '../lib/log';
 import storage from '../lib/storage';
 import dataURItoBlob from '../lib/data-uri-to-blob';
 import saveProjectToServer from '../lib/save-project-to-server';
+import getThumbnail from '../lib/project-thumbnail';
 
 import {
     showAlertWithTimeout,
@@ -272,12 +273,7 @@ const ProjectSaverHOC = function (WrappedComponent) {
         }
 
         getProjectThumbnail (callback) {
-            this.props.vm.postIOData('video', {forceTransparentPreview: true});
-            this.props.vm.renderer.requestSnapshot(dataURI => {
-                this.props.vm.postIOData('video', {forceTransparentPreview: false});
-                callback(dataURI);
-            });
-            this.props.vm.renderer.draw();
+            getThumbnail(this.props.vm, callback);
         }
 
         /**

--- a/src/lib/project-thumbnail.js
+++ b/src/lib/project-thumbnail.js
@@ -1,0 +1,13 @@
+/**
+ * Utility to get thumbnail (aka picture of stage)
+ * @param {object} vm Scratch VM instance
+ * @param {function} callback callback function that takes data URI as an argument
+ */
+export default function getThumbnail (vm, callback) {
+    vm.postIOData('video', {forceTransparentPreview: true});
+    vm.renderer.requestSnapshot(dataURI => {
+        vm.postIOData('video', {forceTransparentPreview: false});
+        callback(dataURI);
+    });
+    vm.renderer.draw();
+}


### PR DESCRIPTION
### Resolves
Resolves #1629 (closed issue, but the issue is still on. Sorry for not doing help-wanteds.)

### Proposed Changes
Adds "Save picture of stage" to Edit menu.

### Reason for Changes
This feature was left out. On my Firefox (66) right-clicking and using native "save picture" just downloaded black picture.

### Questions
- Would this fit on File or Edit?
- or, context menu of stage?
