### PR TITLE
Add support for custom context menu items for dynamic extension blocks.

### DIFF
--- a/src/lib/define-dynamic-block.js
+++ b/src/lib/define-dynamic-block.js
@@ -24,7 +24,7 @@ const setupCustomContextMenu = (ScratchBlocks, contextMenuInfo, extendedOpcode) 
                                 break;
                             }
                         } else if (contextOption.callback) {
-                            contextOption.callback();
+                            contextOption.callback({blockInfo: JSON.parse(this.blockInfoText)});
                         }
                     }
                 };

--- a/src/lib/define-dynamic-block.js
+++ b/src/lib/define-dynamic-block.js
@@ -8,6 +8,13 @@ import log from './log.js';
 const setupCustomContextMenu = (ScratchBlocks, contextMenuInfo, extendedOpcode) => {
     // Handle custom context menu options
     const customContextMenuForBlock = {
+        /**
+         * Add any custom context menu options to the dynamic block being defined.
+         * See Blockly.Extensions.apply in scratch-blocks/core/extensions.js
+         * for how the block becomes `this` behind the scenes.
+         * @param {!Array} options List of menu options to add to.
+         * @this Blockly.Block
+         */
         customContextMenu: function (options) {
             contextMenuInfo.forEach(contextOption => {
                 const option = {

--- a/src/lib/define-dynamic-block.js
+++ b/src/lib/define-dynamic-block.js
@@ -5,6 +5,60 @@ import BlockType from 'scratch-vm/src/extension-support/block-type';
 import ContextMenuContext from 'scratch-vm/src/extension-support/context-menu-context';
 import log from './log.js';
 
+const setupCustomContextMenu = (ScratchBlocks, contextMenuInfo, extendedOpcode) => {
+    // Handle custom context menu options
+    const customContextMenuForBlock = {
+        customContextMenu: function (options) {
+            contextMenuInfo.forEach(contextOption => {
+                const option = {
+                    enabled: true,
+                    text: contextOption.text,
+                    callback: () => {
+                        if (contextOption.builtInCallback) {
+                            switch (contextOption.builtInCallback) {
+                            case 'EDIT_A_PROCEDURE':
+                                // TODO FILL THIS IN
+                                break;
+                            case 'RENAME_A_VARIABLE':
+                                // TODO FILL THIS IN
+                                break;
+                            }
+                        } else if (contextOption.callback) {
+                            contextOption.callback();
+                        }
+                    }
+                };
+
+                // Decide whether to add this item to the context menu
+                // based on the context that the block is in and the
+                // provided `context` property of the item.
+                switch (contextOption.context) {
+                case ContextMenuContext.TOOLBOX_ONLY:
+                    if (this.isInFlyout) options.push(option);
+                    break;
+                case ContextMenuContext.WORKSPACE_ONLY:
+                    if (!this.isInFlyout) options.push(option);
+                    break;
+                case ContextMenuContext.ALL:
+                default:
+                    options.push(option);
+                }
+            });
+        }
+    };
+    const contextMenuName = `${extendedOpcode}_context_menu`;
+    // TODO we need some way of registering a context menu option only once for
+    // each block (see try catch below)
+    // This is similar to the issue we have with re-registering block definitions.
+    // See todo in containers/blocks.jsx, in `handleBlocksInfoUpdate`
+    try {
+        ScratchBlocks.Extensions.registerMixin(contextMenuName, customContextMenuForBlock);
+    } catch (e) {
+        log.warn("Context menu callback was already registered, but we're going to ignore this for now");
+    }
+    return contextMenuName;
+};
+
 /**
  * Define a block using extension info which has the ability to dynamically determine (and update) its layout.
  * This functionality is used for extension blocks which can change its properties based on different state
@@ -16,150 +70,108 @@ import log from './log.js';
  * @param {string} extendedOpcode - The opcode for the block (including the extension ID).
  */
 // TODO: grow this until it can fully replace `_convertForScratchBlocks` in the VM runtime
-const defineDynamicBlock = (ScratchBlocks, categoryInfo, staticBlockInfo, extendedOpcode) => ({
-    init: function () {
-        const blockJson = {
-            type: extendedOpcode,
-            inputsInline: true,
-            category: categoryInfo.name,
-            colour: categoryInfo.color1,
-            colourSecondary: categoryInfo.color2,
-            colourTertiary: categoryInfo.color3
-        };
-        // There is a scratch-blocks / Blockly extension called "scratch_extension" which adjusts the styling of
-        // blocks to allow for an icon, a feature of Scratch extension blocks. However, Scratch "core" extension
-        // blocks don't have icons and so they should not use 'scratch_extension'. Adding a scratch-blocks / Blockly
-        // extension after `jsonInit` isn't fully supported (?), so we decide now whether there will be an icon.
-        if (staticBlockInfo.blockIconURI || categoryInfo.blockIconURI) {
-            blockJson.extensions = ['scratch_extension'];
-        }
+const defineDynamicBlock = (ScratchBlocks, categoryInfo, staticBlockInfo, extendedOpcode) => {
+    // Set up context menus if any
+    const contextMenuInfo = staticBlockInfo.info.customContextMenu;
+    const contextMenuName = contextMenuInfo ?
+        setupCustomContextMenu(ScratchBlocks, staticBlockInfo.info.customContextMenu, extendedOpcode) : '';
 
-        // Handle custom context menu options
-        // TODO this should probably not live here in the future, or at least
-        // we need some way of registering a context menu option only once for
-        // each block (see try catch below)
-        if (staticBlockInfo.info.customContextMenu) {
-            const customContextMenuForBlock = {
-                customContextMenu: function (options) {
-                    staticBlockInfo.info.customContextMenu.forEach(contextOption => {
-                        const option = {
-                            enabled: true,
-                            text: contextOption.text,
-                            callback: () => {
-                                if (contextOption.builtInCallback) {
-                                    switch (contextOption.builtInCallback) {
-                                    case 'EDIT_A_PROCEDURE':
-                                        // TODO FILL THIS IN
-                                        break;
-                                    case 'RENAME_A_VARIABLE':
-                                        // TODO FILL THIS IN
-                                        break;
-                                    }
-                                } else if (contextOption.callback) {
-                                    contextOption.callback();
-                                }
-                            }
-                        };
-
-                        // Decide whether to add this item to the context menu
-                        // based on the context that the block is in and the
-                        // provided `context` property of the item.
-                        switch (contextOption.context) {
-                        case ContextMenuContext.TOOLBOX_ONLY:
-                            if (this.isInFlyout) options.push(option);
-                            break;
-                        case ContextMenuContext.WORKSPACE_ONLY:
-                            if (!this.isInFlyout) options.push(option);
-                            break;
-                        case ContextMenuContext.ALL:
-                        default:
-                            options.push(option);
-                        }
-                    });
-                }
+    return ({
+        init: function () {
+            const blockJson = {
+                type: extendedOpcode,
+                inputsInline: true,
+                category: categoryInfo.name,
+                colour: categoryInfo.color1,
+                colourSecondary: categoryInfo.color2,
+                colourTertiary: categoryInfo.color3
             };
-            const contextMenuName = `${extendedOpcode}_context_menu`;
-            try {
-                ScratchBlocks.Extensions.registerMixin(contextMenuName, customContextMenuForBlock);
-            } catch (e) {
-                log.warn("Context menu callback was already registered, but we're going to ignore this for now");
+            // There is a scratch-blocks / Blockly extension called "scratch_extension" which adjusts the styling of
+            // blocks to allow for an icon, a feature of Scratch extension blocks. However, Scratch "core" extension
+            // blocks don't have icons and so they should not use 'scratch_extension'. Adding a scratch-blocks / Blockly
+            // extension after `jsonInit` isn't fully supported (?), so we decide now whether there will be an icon.
+            if (staticBlockInfo.blockIconURI || categoryInfo.blockIconURI) {
+                blockJson.extensions = ['scratch_extension'];
             }
-            blockJson.extensions = blockJson.extensions || [];
-            blockJson.extensions.push(contextMenuName);
-        }
 
-        // initialize the basics of the block, to be overridden & extended later by `domToMutation`
-        this.jsonInit(blockJson);
-        // initialize the cached block info used to carry block info from `domToMutation` to `mutationToDom`
-        this.blockInfoText = '{}';
-        // we need a block info update (through `domToMutation`) before we have a completely initialized block
-        this.needsBlockInfoUpdate = true;
-    },
-    mutationToDom: function () {
-        const container = document.createElement('mutation');
-        container.setAttribute('blockInfo', this.blockInfoText);
-        return container;
-    },
-    domToMutation: function (xmlElement) {
-        const blockInfoText = xmlElement.getAttribute('blockInfo');
-        if (!blockInfoText) return;
-        if (!this.needsBlockInfoUpdate) {
-            throw new Error('Attempted to update block info twice');
-        }
-        delete this.needsBlockInfoUpdate;
-        this.blockInfoText = blockInfoText;
-        const blockInfo = JSON.parse(blockInfoText);
-
-        switch (blockInfo.blockType) {
-        case BlockType.COMMAND:
-        case BlockType.CONDITIONAL:
-        case BlockType.LOOP:
-            this.setOutputShape(ScratchBlocks.OUTPUT_SHAPE_SQUARE);
-            this.setPreviousStatement(true);
-            this.setNextStatement(!blockInfo.isTerminal);
-            break;
-        case BlockType.REPORTER:
-            this.setOutput(true);
-            this.setOutputShape(ScratchBlocks.OUTPUT_SHAPE_ROUND);
-            if (!blockInfo.disableMonitor) {
-                this.setCheckboxInFlyout(true);
+            if (contextMenuInfo) {
+                blockJson.extensions = blockJson.extensions || [];
+                blockJson.extensions.push(contextMenuName);
             }
-            break;
-        case BlockType.BOOLEAN:
-            this.setOutput(true);
-            this.setOutputShape(ScratchBlocks.OUTPUT_SHAPE_HEXAGONAL);
-            break;
-        case BlockType.HAT:
-        case BlockType.EVENT:
-            this.setOutputShape(ScratchBlocks.OUTPUT_SHAPE_SQUARE);
-            this.setNextStatement(true);
-            break;
-        }
 
-        if (blockInfo.color1 || blockInfo.color2 || blockInfo.color3) {
-            // `setColour` handles undefined parameters by adjusting defined colors
-            this.setColour(blockInfo.color1, blockInfo.color2, blockInfo.color3);
-        }
+            // initialize the basics of the block, to be overridden & extended later by `domToMutation`
+            this.jsonInit(blockJson);
+            // initialize the cached block info used to carry block info from `domToMutation` to `mutationToDom`
+            this.blockInfoText = '{}';
+            // we need a block info update (through `domToMutation`) before we have a completely initialized block
+            this.needsBlockInfoUpdate = true;
+        },
+        mutationToDom: function () {
+            const container = document.createElement('mutation');
+            container.setAttribute('blockInfo', this.blockInfoText);
+            return container;
+        },
+        domToMutation: function (xmlElement) {
+            const blockInfoText = xmlElement.getAttribute('blockInfo');
+            if (!blockInfoText) return;
+            if (!this.needsBlockInfoUpdate) {
+                throw new Error('Attempted to update block info twice');
+            }
+            delete this.needsBlockInfoUpdate;
+            this.blockInfoText = blockInfoText;
+            const blockInfo = JSON.parse(blockInfoText);
 
-        // Layout block arguments
-        // TODO handle E/C Blocks
-        const blockText = blockInfo.text;
-        const args = [];
-        let argCount = 0;
-        const scratchBlocksStyleText = blockText.replace(/\[(.+?)]/g, (match, argName) => {
-            const arg = blockInfo.arguments[argName];
-            switch (arg.type) {
-            case ArgumentType.STRING:
-                args.push({type: 'input_value', name: argName});
+            switch (blockInfo.blockType) {
+            case BlockType.COMMAND:
+            case BlockType.CONDITIONAL:
+            case BlockType.LOOP:
+                this.setOutputShape(ScratchBlocks.OUTPUT_SHAPE_SQUARE);
+                this.setPreviousStatement(true);
+                this.setNextStatement(!blockInfo.isTerminal);
                 break;
-            case ArgumentType.BOOLEAN:
-                args.push({type: 'input_value', name: argName, check: 'Boolean'});
+            case BlockType.REPORTER:
+                this.setOutput(true);
+                this.setOutputShape(ScratchBlocks.OUTPUT_SHAPE_ROUND);
+                if (!blockInfo.disableMonitor) {
+                    this.setCheckboxInFlyout(true);
+                }
+                break;
+            case BlockType.BOOLEAN:
+                this.setOutput(true);
+                this.setOutputShape(ScratchBlocks.OUTPUT_SHAPE_HEXAGONAL);
+                break;
+            case BlockType.HAT:
+            case BlockType.EVENT:
+                this.setOutputShape(ScratchBlocks.OUTPUT_SHAPE_SQUARE);
+                this.setNextStatement(true);
                 break;
             }
-            return `%${++argCount}`;
-        });
-        this.interpolate_(scratchBlocksStyleText, args);
-    }
-});
+
+            if (blockInfo.color1 || blockInfo.color2 || blockInfo.color3) {
+                // `setColour` handles undefined parameters by adjusting defined colors
+                this.setColour(blockInfo.color1, blockInfo.color2, blockInfo.color3);
+            }
+
+            // Layout block arguments
+            // TODO handle E/C Blocks
+            const blockText = blockInfo.text;
+            const args = [];
+            let argCount = 0;
+            const scratchBlocksStyleText = blockText.replace(/\[(.+?)]/g, (match, argName) => {
+                const arg = blockInfo.arguments[argName];
+                switch (arg.type) {
+                case ArgumentType.STRING:
+                    args.push({type: 'input_value', name: argName});
+                    break;
+                case ArgumentType.BOOLEAN:
+                    args.push({type: 'input_value', name: argName, check: 'Boolean'});
+                    break;
+                }
+                return `%${++argCount}`;
+            });
+            this.interpolate_(scratchBlocksStyleText, args);
+        }
+    });
+};
 
 export default defineDynamicBlock;

--- a/test/unit/util/define-dynamic-block.test.js
+++ b/test/unit/util/define-dynamic-block.test.js
@@ -88,8 +88,7 @@ class MockBlock {
     constructor (staticBlockInfo, extendedOpcode) {
         // mimic Closure-style inheritance by mixing in `defineDynamicBlock` output as this instance's prototype
         // see also the `Blockly.Block` constructor
-        const ddb = defineDynamicBlock.bind(this);
-        const prototype = ddb(MockScratchBlocks, categoryInfo, staticBlockInfo, extendedOpcode);
+        const prototype = defineDynamicBlock(MockScratchBlocks, categoryInfo, staticBlockInfo, extendedOpcode);
         mixin(this, prototype);
         this.init();
 


### PR DESCRIPTION
### Resolves

Towards LLK/scratch-vm#2120.

Depends on LLK/scratch-vm#2163.

### Proposed Changes

Add support for creating custom context menu items for dynamic extension blocks. This includes support for built in functionality like opening a custom procedure edit modal as well as a callback completely controlled by the extension.

Currently the custom context menu is registered as a ScratchBlocks extension when initializing the block. This throws an error which we are currently catching and ignoring, but in the future, we need to handle registering the context menu callbacks only once.

### Reason for Changes

Extensionification project!

### Test Coverage

Together with LLK/scratch-vm#2163, adds a custom context menu item to the core example extension.
