### PR TITLE
Make GUI integration tests reliable

### DIFF
--- a/test/helpers/selenium-helper.js
+++ b/test/helpers/selenium-helper.js
@@ -99,41 +99,34 @@ class SeleniumHelper {
         const WINDOW_WIDTH = 1024;
         const WINDOW_HEIGHT = 768;
 
-        // there's no meaningful common element rendered in all GUI pages, but we use "box" on all of them :)
-        // this just indicates that React has rendered something at least once
-        // this is the only Xpath I could find that works on all: index, player, blocks-only, compatibility-testing
-        const somethingRenderedXpath = '//body//*[starts-with(@class,"box_box_") or contains(@class," box_box_")]';
-        const loaderBackgroundXpath = '//body//*[starts-with(@class,"loader_background_")]';
-
         await this.driver.get(`file://${uri}`);
         const window = await this.driver.manage().window();
         await window.setSize(WINDOW_WIDTH, WINDOW_HEIGHT);
         await this.driver.executeScript('window.onbeforeunload = undefined;');
-
-        // wait for the app to exist
-        await this.findByXpath(somethingRenderedXpath);
-
-        // look for loader background(s), which if present will be in front of the editor wrapper
-        const loaderBackgrounds = await this.driver.findElements(By.xpath(loaderBackgroundXpath));
-
-        // if any were found, wait for it/them to go away
-        return Promise.all(loaderBackgrounds.map(
-            loaderBackground => this.waitUntilGone(loaderBackground)
-        ));
     }
 
     clickXpath (xpath) {
-        return this.findByXpath(xpath).then(el => el.click());
+        return this.driver.wait(async () => {
+            const element = await this.findByXpath(xpath);
+            return element.click().then(() => true, () => false);
+        });
     }
 
     clickText (text, scope) {
-        return this.findByText(text, scope).then(el => el.click());
+        return this.driver.wait(async () => {
+            const element = await this.findByText(text, scope);
+            return element.click().then(() => true, () => false);
+        });
     }
 
     rightClickText (text, scope) {
-        return this.findByText(text, scope).then(el => this.driver.actions()
-            .click(el, Button.RIGHT)
-            .perform());
+        return this.driver.wait(async () => {
+            const element = await this.findByText(text, scope);
+            return this.driver.actions()
+                .click(element, Button.RIGHT)
+                .perform()
+                .then(() => true, () => false);
+        });
     }
 
     clickButton (text) {

--- a/test/helpers/selenium-helper.js
+++ b/test/helpers/selenium-helper.js
@@ -7,7 +7,11 @@ import webdriver from 'selenium-webdriver';
 const {By, until, Button} = webdriver;
 
 const USE_HEADLESS = process.env.USE_HEADLESS !== 'no';
-const DEFAULT_TIMEOUT_MILLISECONDS = 5 * 1000;
+
+// The main reason for this timeout is so that we can control the timeout message and report details;
+// if we hit the Jasmine default timeout then we get a terse message that we can't control.
+// The Jasmine default timeout is 30 seconds so make sure this is lower.
+const DEFAULT_TIMEOUT_MILLISECONDS = 20 * 1000;
 
 class SeleniumHelper {
     constructor () {

--- a/test/integration/backdrops.test.js
+++ b/test/integration/backdrops.test.js
@@ -63,7 +63,6 @@ describe('Working with backdrops', () => {
         const el = await findByXpath(buttonXpath);
         await driver.actions().mouseMove(el)
             .perform();
-        await driver.sleep(500); // Wait for thermometer menu to come up
         const input = await findByXpath(fileXpath);
         await input.sendKeys(files.join('\n'));
 

--- a/test/integration/blocks.test.js
+++ b/test/integration/blocks.test.js
@@ -31,7 +31,6 @@ describe('Working with the blocks', () => {
         await loadUri(uri);
         await clickText('Code');
         await clickText('Operators', scope.blocksTab);
-        await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for scroll animation
         await clickText('join', scope.blocksTab); // Click "join <hello> <world>" block
         await findByText('apple banana', scope.reportedValue); // Tooltip with result
         const logs = await getLogs();
@@ -41,7 +40,6 @@ describe('Working with the blocks', () => {
     test('Switching sprites updates the block menus', async () => {
         await loadUri(uri);
         await clickText('Sound', scope.blocksTab);
-        await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for scroll animation
         // "Meow" sound block should be visible
         await findByText('Meow', scope.blocksTab);
         await clickText('Backdrops'); // Switch to the backdrop
@@ -58,7 +56,6 @@ describe('Working with the blocks', () => {
         await loadUri(uri);
         await clickText('Code');
         await clickText('Variables', scope.blocksTab);
-        await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for scroll animation
 
         // Expect a default variable "my variable" to be visible
         await clickText('my\u00A0variable', scope.blocksTab);
@@ -75,7 +72,6 @@ describe('Working with the blocks', () => {
 
         // Make sure reporting works on a new variable
         await clickText('Variables', scope.blocksTab);
-        await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for scroll animation
         await clickText('score', scope.blocksTab);
         await findByText('0', scope.reportedValue); // Tooltip with result
 
@@ -100,7 +96,6 @@ describe('Working with the blocks', () => {
         await loadUri(uri);
         await clickText('Code');
         await clickText('Variables', scope.blocksTab);
-        await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for scroll animation
 
         await clickText('Make a List');
         let el = await findByXpath("//input[@name='New list name:']");
@@ -133,7 +128,6 @@ describe('Working with the blocks', () => {
     test('Custom procedures', async () => {
         await loadUri(uri);
         await clickText('My Blocks');
-        await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for scroll animation
         await clickText('Make a Block');
         // Click on the "add an input" buttons
         await clickText('number or text', scope.modal);
@@ -153,7 +147,6 @@ describe('Working with the blocks', () => {
         await clickXpath('//button[@title="Add Extension"]');
 
         await clickText('Pen');
-        await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for scroll animation
         // Make sure toolbox has been scrolled to the pen extension
         await findByText('stamp', scope.blocksTab);
 
@@ -165,7 +158,6 @@ describe('Working with the blocks', () => {
         await loadUri(uri);
         await clickText('Code');
         await clickText('Sound', scope.blocksTab);
-        await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for scroll animation
         await clickText('Meow', scope.blocksTab); // Click "play sound <Meow> until done" block
         await clickText('record'); // Click "record..." option in the block's sound menu
         // Access has been force denied, so close the alert that comes up
@@ -188,7 +180,6 @@ describe('Working with the blocks', () => {
         // Make sure it is updated in the block menu
         await clickText('Code');
         await clickText('Looks', scope.blocksTab);
-        await driver.sleep(500); // Wait for scroll to finish
         await clickText('newname', scope.blocksTab);
     });
 
@@ -203,7 +194,6 @@ describe('Working with the blocks', () => {
         // Make sure it is updated in the block menu
         await clickText('Code');
         await clickText('Looks', scope.blocksTab);
-        await driver.sleep(500); // Wait for scroll to finish
         await clickText('<NewCostume>', scope.blocksTab);
 
         await clickText('Sound', scope.blocksTab);
@@ -216,7 +206,6 @@ describe('Working with the blocks', () => {
 
         // By default, costume1 is in the costume tab
         await clickText('Looks', scope.blocksTab);
-        await driver.sleep(500); // Wait for scroll to finish
         await clickText('costume1', scope.blocksTab);
 
         // Also check that adding a new costume does not update the list
@@ -224,7 +213,6 @@ describe('Working with the blocks', () => {
         const el = await findByXpath('//button[@aria-label="Choose a Costume"]');
         await driver.actions().mouseMove(el)
             .perform();
-        await driver.sleep(500); // Wait for thermometer menu to come up
         await clickXpath('//button[@aria-label="Paint"]');
         await clickText('costume3', scope.costumesTab);
         // Check that the menu has not been updated
@@ -241,7 +229,6 @@ describe('Working with the blocks', () => {
         await clickText('A Bass', scope.modal); // Should close the modal
         await clickText('Code');
         await clickText('Sound', scope.blocksTab);
-        await driver.sleep(500); // Wait for scroll to finish
         await clickText('Meow', scope.blocksTab); // Meow, not A Bass
     });
 
@@ -251,14 +238,12 @@ describe('Working with the blocks', () => {
         await loadUri(playerUri);
         await clickText('See inside');
         await clickText('Variables');
-        await driver.sleep(500); // Wait for scroll to finish
         await clickText('my\u00A0variable');
 
         await clickText('See Project Page');
         await clickText('See inside');
 
         await clickText('Variables');
-        await driver.sleep(500); // Wait for scroll to finish
         await clickText('my\u00A0variable');
     });
 
@@ -268,7 +253,6 @@ describe('Working with the blocks', () => {
         await clickText('Costumes');
         await clickText('Code');
         await clickText('Variables', scope.blocksTab);
-        await driver.sleep(500); // Wait for scroll
         await clickText('Make a List');
         const el = await findByXpath("//input[@name='New list name:']");
         await el.sendKeys('list1');

--- a/test/integration/connection-modal.test.js
+++ b/test/integration/connection-modal.test.js
@@ -1,18 +1,7 @@
 import path from 'path';
 import SeleniumHelper from '../helpers/selenium-helper';
 
-const {
-    clickText,
-    clickXpath,
-    findByText,
-    getDriver,
-    getLogs,
-    loadUri
-} = new SeleniumHelper();
-
 const uri = path.resolve(__dirname, '../../build/index.html');
-
-let driver;
 
 // The tests below require Scratch Link to be unavailable, so we can trigger
 // an error modal. To make sure this is always true, we came up with the idea of
@@ -24,17 +13,17 @@ const websocketFakeoutJs = `var RealWebSocket = WebSocket;
     }`;
 
 describe('Hardware extension connection modal', () => {
-    beforeAll(() => {
-        driver = getDriver();
-    });
-
-    afterAll(async () => {
-        await driver.quit();
-    });
-
     test('Message saying Scratch Link is unavailable (BLE)', async () => {
-        await driver.quit();
-        driver = getDriver();
+        const {
+            clickText,
+            clickXpath,
+            findByText,
+            getDriver,
+            getLogs,
+            loadUri
+        } = new SeleniumHelper();
+
+        const driver = getDriver();
 
         await loadUri(uri);
 
@@ -48,9 +37,21 @@ describe('Hardware extension connection modal', () => {
 
         const logs = await getLogs();
         await expect(logs).toEqual([]);
+        await driver.quit();
     });
 
     test('Message saying Scratch Link is unavailable (BT)', async () => {
+        const {
+            clickText,
+            clickXpath,
+            findByText,
+            getDriver,
+            getLogs,
+            loadUri
+        } = new SeleniumHelper();
+
+        const driver = getDriver();
+
         await loadUri(uri);
 
         await driver.executeScript(websocketFakeoutJs);
@@ -63,5 +64,6 @@ describe('Hardware extension connection modal', () => {
 
         const logs = await getLogs();
         await expect(logs).toEqual([]);
+        await driver.quit();
     });
 });

--- a/test/integration/connection-modal.test.js
+++ b/test/integration/connection-modal.test.js
@@ -32,7 +32,6 @@ describe('Hardware extension connection modal', () => {
         await clickXpath('//button[@title="Add Extension"]');
 
         await clickText('micro:bit');
-        await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for modal to open
         findByText('Scratch Link'); // Scratch Link is mentioned in the error modal
 
         const logs = await getLogs();
@@ -59,7 +58,6 @@ describe('Hardware extension connection modal', () => {
         await clickXpath('//button[@title="Add Extension"]');
 
         await clickText('EV3');
-        await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for modal to open
         findByText('Scratch Link'); // Scratch Link is mentioned in the error modal
 
         const logs = await getLogs();

--- a/test/integration/costumes.test.js
+++ b/test/integration/costumes.test.js
@@ -27,10 +27,6 @@ describe('Working with costumes', () => {
     });
 
     test('Adding a costume through the library', async () => {
-        // This is needed when running the tests all at once or it just fails...
-        await driver.quit();
-        driver = getDriver();
-
         await loadUri(uri);
         await driver.sleep(500);
         await clickText('Costumes');

--- a/test/integration/costumes.test.js
+++ b/test/integration/costumes.test.js
@@ -28,7 +28,6 @@ describe('Working with costumes', () => {
 
     test('Adding a costume through the library', async () => {
         await loadUri(uri);
-        await driver.sleep(500);
         await clickText('Costumes');
         await clickXpath('//button[@aria-label="Choose a Costume"]');
         const el = await findByXpath("//input[@placeholder='Search']");
@@ -45,7 +44,6 @@ describe('Working with costumes', () => {
         const el = await findByXpath('//button[@aria-label="Choose a Costume"]');
         await driver.actions().mouseMove(el)
             .perform();
-        await driver.sleep(500); // Wait for thermometer menu to come up
         await clickXpath('//button[@aria-label="Surprise"]');
         const logs = await getLogs();
         await expect(logs).toEqual([]);
@@ -57,7 +55,6 @@ describe('Working with costumes', () => {
         const el = await findByXpath('//button[@aria-label="Choose a Costume"]');
         await driver.actions().mouseMove(el)
             .perform();
-        await driver.sleep(500); // Wait for thermometer menu to come up
         await clickXpath('//button[@aria-label="Paint"]');
         const logs = await getLogs();
         await expect(logs).toEqual([]);
@@ -69,7 +66,6 @@ describe('Working with costumes', () => {
 
         await rightClickText('costume1', scope.costumesTab);
         await clickText('duplicate', scope.costumesTab);
-        await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for duplication to finish
 
         // Make sure the duplicated costume is named correctly.
         await clickText('costume3', scope.costumesTab);
@@ -121,7 +117,6 @@ describe('Working with costumes', () => {
         const el = await findByXpath('//button[@aria-label="Choose a Costume"]');
         await driver.actions().mouseMove(el)
             .perform();
-        await driver.sleep(500); // Wait for thermometer menu to come up
         const input = await findByXpath('//input[@type="file"]');
         await input.sendKeys(path.resolve(__dirname, '../fixtures/100-100.svg'));
         await clickText('100-100', scope.costumesTab); // Name from filename
@@ -136,7 +131,6 @@ describe('Working with costumes', () => {
         const el = await findByXpath('//button[@aria-label="Choose a Costume"]');
         await driver.actions().mouseMove(el)
             .perform();
-        await driver.sleep(500); // Wait for thermometer menu to come up
         const input = await findByXpath('//input[@type="file"]');
         await input.sendKeys(path.resolve(__dirname, '../fixtures/gh-3582-png.png'));
         await clickText('gh-3582-png', scope.costumesTab);
@@ -150,7 +144,6 @@ describe('Working with costumes', () => {
         const el = await findByXpath('//button[@aria-label="Choose a Costume"]');
         await driver.actions().mouseMove(el)
             .perform();
-        await driver.sleep(500); // Wait for thermometer menu to come up
         const input = await findByXpath('//input[@type="file"]');
         await input.sendKeys(path.resolve(__dirname, '../fixtures/paddleball.gif'));
 
@@ -204,7 +197,6 @@ describe('Working with costumes', () => {
         const el = await findByXpath('//button[@aria-label="Choose a Costume"]');
         await driver.actions().mouseMove(el)
             .perform();
-        await driver.sleep(500); // Wait for thermometer menu to come up
         const input = await findByXpath('//input[@type="file"]');
         await input.sendKeys(files.join('\n'));
 

--- a/test/integration/examples.test.js
+++ b/test/integration/examples.test.js
@@ -1,5 +1,3 @@
-/* globals Promise */
-
 import path from 'path';
 import SeleniumHelper from '../helpers/selenium-helper';
 
@@ -27,7 +25,6 @@ describe('player example', () => {
         const projectId = '96708228';
         await loadUri(`${uri}#${projectId}`);
         await clickXpath('//img[@title="Go"]');
-        await new Promise(resolve => setTimeout(resolve, 2000));
         await clickXpath('//img[@title="Stop"]');
         const logs = await getLogs();
         await expect(logs).toEqual([]);
@@ -68,9 +65,7 @@ describe('blocks example', () => {
     test('Load a project by ID', async () => {
         const projectId = '96708228';
         await loadUri(`${uri}#${projectId}`);
-        await new Promise(resolve => setTimeout(resolve, 2000));
         await clickXpath('//img[@title="Go"]');
-        await new Promise(resolve => setTimeout(resolve, 2000));
         await clickXpath('//img[@title="Stop"]');
         const logs = await getLogs();
         await expect(logs).toEqual([]);
@@ -93,7 +88,6 @@ describe('blocks example', () => {
         await clickText('Sensing');
         await clickText('Operators');
         await clickText('Variables');
-        await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for scroll animation
         await clickText('Make a Variable');
         let el = await findByXpath("//input[@name='New variable name:']");
         await el.sendKeys('score');

--- a/test/integration/examples.test.js
+++ b/test/integration/examples.test.js
@@ -3,22 +3,17 @@
 import path from 'path';
 import SeleniumHelper from '../helpers/selenium-helper';
 
-const {
-    findByText,
-    clickButton,
-    clickText,
-    clickXpath,
-    findByXpath,
-    getDriver,
-    getLogs,
-    loadUri,
-    waitUntilGone
-} = new SeleniumHelper();
-
-let driver;
-
 describe('player example', () => {
     const uri = path.resolve(__dirname, '../../build/player.html');
+
+    const {
+        clickXpath,
+        getDriver,
+        getLogs,
+        loadUri
+    } = new SeleniumHelper();
+
+    let driver;
 
     beforeAll(() => {
         driver = getDriver();
@@ -31,7 +26,6 @@ describe('player example', () => {
     test('Load a project by ID', async () => {
         const projectId = '96708228';
         await loadUri(`${uri}#${projectId}`);
-        await waitUntilGone(findByText('Loading'));
         await clickXpath('//img[@title="Go"]');
         await new Promise(resolve => setTimeout(resolve, 2000));
         await clickXpath('//img[@title="Stop"]');
@@ -50,6 +44,18 @@ describe('player example', () => {
 
 describe('blocks example', () => {
     const uri = path.resolve(__dirname, '../../build/blocks-only.html');
+
+    const {
+        clickButton,
+        clickText,
+        clickXpath,
+        findByXpath,
+        getDriver,
+        getLogs,
+        loadUri
+    } = new SeleniumHelper();
+
+    let driver;
 
     beforeAll(() => {
         driver = getDriver();

--- a/test/integration/localization.test.js
+++ b/test/integration/localization.test.js
@@ -25,8 +25,6 @@ describe('Localization', () => {
     });
 
     test('Switching languages', async () => {
-        await driver.quit();
-        driver = getDriver();
         await loadUri(uri);
 
         // Add a sprite to make sure it stays when switching languages

--- a/test/integration/localization.test.js
+++ b/test/integration/localization.test.js
@@ -35,11 +35,9 @@ describe('Localization', () => {
         await clickText('Code');
         await clickXpath('//*[@aria-label="language selector"]');
         await clickText('Deutsch');
-        await new Promise(resolve => setTimeout(resolve, 1000)); // wait for blocks refresh
 
         // Make sure the blocks are translating
         await clickText('Fühlen'); // Sensing category in German
-        await new Promise(resolve => setTimeout(resolve, 1000)); // wait for blocks to scroll
         await clickText('Antwort'); // Find the "answer" block in German
 
         // Change to the costumes tab to confirm other parts of the GUI are translating
@@ -59,7 +57,6 @@ describe('Localization', () => {
     test('Loading with locale shows correct blocks', async () => {
         await loadUri(`${uri}?locale=de`);
         await clickText('Fühlen'); // Sensing category in German
-        await new Promise(resolve => setTimeout(resolve, 1000)); // wait for blocks to scroll
         await clickText('Antwort'); // Find the "answer" block in German
         const logs = await getLogs();
         await expect(logs).toEqual([]);

--- a/test/integration/project-loading.test.js
+++ b/test/integration/project-loading.test.js
@@ -1,55 +1,54 @@
 import path from 'path';
 import SeleniumHelper from '../helpers/selenium-helper';
 
-const {
-    clickText,
-    clickXpath,
-    findByText,
-    findByXpath,
-    getDriver,
-    getLogs,
-    loadUri,
-    scope,
-    waitUntilGone
-} = new SeleniumHelper();
-
 const uri = path.resolve(__dirname, '../../build/index.html');
 
-let driver;
-
 describe('Loading scratch gui', () => {
-    beforeAll(() => {
-        driver = getDriver();
-    });
-
-    afterAll(async () => {
-        await driver.quit();
-    });
-
     describe('Loading projects by ID', () => {
 
         test('Nonexistent projects show error screen', async () => {
+            const {
+                clickText,
+                getDriver,
+                loadUri
+            } = new SeleniumHelper();
+
+            const driver = await getDriver();
+
             await loadUri(`${uri}#999999999999999999999`);
             await clickText('Oops! Something went wrong.');
+            await driver.quit();
         });
 
         test('Load a project by ID directly through url', async () => {
-            await driver.quit(); // Reset driver to test hitting # url directly
-            driver = getDriver();
+            const {
+                clickXpath,
+                getDriver,
+                getLogs,
+                loadUri
+            } = new SeleniumHelper();
+
+            const driver = await getDriver();
 
             const projectId = '96708228';
             await loadUri(`${uri}#${projectId}`);
-            await waitUntilGone(findByText('Loading'));
             await clickXpath('//img[@title="Go"]');
             await new Promise(resolve => setTimeout(resolve, 2000));
             await clickXpath('//img[@title="Stop"]');
             const logs = await getLogs();
             await expect(logs).toEqual([]);
+            await driver.quit();
         });
 
         test('Load a project by ID (fullscreen)', async () => {
-            await driver.quit(); // Reset driver to test hitting # url directly
-            driver = getDriver();
+            const {
+                clickXpath,
+                getDriver,
+                getLogs,
+                loadUri
+            } = new SeleniumHelper();
+
+            const driver = await getDriver();
 
             const prevSize = driver.manage()
                 .window()
@@ -60,7 +59,6 @@ describe('Loading scratch gui', () => {
                 .setSize(1920, 1080);
             const projectId = '96708228';
             await loadUri(`${uri}#${projectId}`);
-            await waitUntilGone(findByText('Loading'));
             await clickXpath('//img[@title="Full Screen Control"]');
             await new Promise(resolve => setTimeout(resolve, 500));
             await clickXpath('//img[@title="Go"]');
@@ -73,6 +71,28 @@ describe('Loading scratch gui', () => {
             });
             const logs = await getLogs();
             await expect(logs).toEqual([]);
+            await driver.quit();
+        });
+    });
+
+    describe('Creating new projects', () => {
+        const {
+            clickText,
+            clickXpath,
+            findByXpath,
+            getDriver,
+            loadUri,
+            scope
+        } = new SeleniumHelper();
+
+        let driver;
+
+        beforeAll(() => {
+            driver = getDriver();
+        });
+
+        afterAll(async () => {
+            await driver.quit();
         });
 
         test('Creating new project resets active tab to Code tab', async () => {

--- a/test/integration/project-loading.test.js
+++ b/test/integration/project-loading.test.js
@@ -33,7 +33,7 @@ describe('Loading scratch gui', () => {
             const projectId = '96708228';
             await loadUri(`${uri}#${projectId}`);
             await clickXpath('//img[@title="Go"]');
-            await new Promise(resolve => setTimeout(resolve, 2000));
+            await new Promise(resolve => setTimeout(resolve, 2000)); // let project run a bit
             await clickXpath('//img[@title="Stop"]');
             const logs = await getLogs();
             await expect(logs).toEqual([]);
@@ -53,16 +53,15 @@ describe('Loading scratch gui', () => {
             const prevSize = driver.manage()
                 .window()
                 .getSize();
-            await new Promise(resolve => setTimeout(resolve, 2000));
             driver.manage()
                 .window()
                 .setSize(1920, 1080);
             const projectId = '96708228';
             await loadUri(`${uri}#${projectId}`);
             await clickXpath('//img[@title="Full Screen Control"]');
-            await new Promise(resolve => setTimeout(resolve, 500));
+            await new Promise(resolve => setTimeout(resolve, 500)); // wait for full-screen layout change
             await clickXpath('//img[@title="Go"]');
-            await new Promise(resolve => setTimeout(resolve, 1000));
+            await new Promise(resolve => setTimeout(resolve, 1000)); // let project run a bit
             await clickXpath('//img[@title="Stop"]');
             prevSize.then(value => {
                 driver.manage()
@@ -97,7 +96,6 @@ describe('Loading scratch gui', () => {
 
         test('Creating new project resets active tab to Code tab', async () => {
             await loadUri(uri);
-            await new Promise(resolve => setTimeout(resolve, 2000));
             await findByXpath('//*[span[text()="Costumes"]]');
             await clickText('Costumes');
             await clickXpath(
@@ -111,7 +109,6 @@ describe('Loading scratch gui', () => {
 
         test('Not logged in->made no changes to project->create new project should not show alert', async () => {
             await loadUri(uri);
-            await new Promise(resolve => setTimeout(resolve, 2000));
             await clickXpath(
                 '//div[contains(@class, "menu-bar_menu-bar-item") and ' +
                 'contains(@class, "menu-bar_hoverable")][span[text()="File"]]'
@@ -123,7 +120,6 @@ describe('Loading scratch gui', () => {
 
         test('Not logged in->made a change to project->create new project should show alert', async () => {
             await loadUri(uri);
-            await new Promise(resolve => setTimeout(resolve, 2000));
             await clickText('Sounds');
             await clickXpath('//button[@aria-label="Choose a Sound"]');
             await clickText('A Bass', scope.modal); // Should close the modal
@@ -132,7 +128,7 @@ describe('Loading scratch gui', () => {
                 'contains(@class, "menu-bar_hoverable")][span[text()="File"]]'
             );
             await clickXpath('//li[span[text()="New"]]');
-            driver.switchTo()
+            await driver.switchTo()
                 .alert()
                 .accept();
             await findByXpath('//*[div[@class="scratchCategoryMenu"]]');

--- a/test/integration/sounds.test.js
+++ b/test/integration/sounds.test.js
@@ -32,7 +32,6 @@ describe('Working with sounds', () => {
 
         // Delete the sound
         await rightClickText('Meow', scope.soundsTab);
-        await driver.sleep(500); // Wait a moment for context menu; only needed for local testing
         await clickText('delete', scope.soundsTab);
 
         // Add it back
@@ -68,7 +67,6 @@ describe('Working with sounds', () => {
         const el = await findByXpath('//button[@aria-label="Choose a Sound"]');
         await driver.actions().mouseMove(el)
             .perform();
-        await driver.sleep(500); // Wait for thermometer menu to come up
         await clickXpath('//button[@aria-label="Surprise"]');
         const logs = await getLogs();
         await expect(logs).toEqual([]);
@@ -122,7 +120,6 @@ describe('Working with sounds', () => {
         const el = await findByXpath('//button[@aria-label="Choose a Sound"]');
         await driver.actions().mouseMove(el)
             .perform();
-        await driver.sleep(500); // Wait for thermometer menu to come up
         const input = await findByXpath('//input[@type="file"]');
         await input.sendKeys(files.join('\n'));
 

--- a/test/integration/sprites.test.js
+++ b/test/integration/sprites.test.js
@@ -43,7 +43,6 @@ describe('Working with sprites', () => {
         const el = await findByXpath('//button[@aria-label="Choose a Sprite"]');
         await driver.actions().mouseMove(el)
             .perform();
-        await driver.sleep(500); // Wait for thermometer menu to come up
         await clickXpath('//button[@aria-label="Surprise"]');
         const logs = await getLogs();
         await expect(logs).toEqual([]);
@@ -54,7 +53,6 @@ describe('Working with sprites', () => {
         const el = await findByXpath('//button[@aria-label="Choose a Sprite"]');
         await driver.actions().mouseMove(el)
             .perform();
-        await driver.sleep(500); // Wait for thermometer menu to come up
         await clickXpath('//button[@aria-label="Paint"]');
         await findByText('Convert to Bitmap'); // Make sure we are on the paint editor
         const logs = await getLogs();
@@ -63,7 +61,6 @@ describe('Working with sprites', () => {
 
     test('Deleting only sprite does not crash', async () => {
         await loadUri(uri);
-        await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for scroll animation
         await rightClickText('Sprite1', scope.spriteTile);
         await clickText('delete', scope.spriteTile);
         // Confirm that the stage has been switched to
@@ -74,7 +71,6 @@ describe('Working with sprites', () => {
 
     test('Deleting by x button on sprite tile', async () => {
         await loadUri(uri);
-        await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for scroll animation
         await clickXpath('//*[@aria-label="Close"]'); // Only visible close button is on the sprite
         // Confirm that the stage has been switched to
         await findByText('Stage selected: no motion blocks');
@@ -87,7 +83,6 @@ describe('Working with sprites', () => {
         const el = await findByXpath('//button[@aria-label="Choose a Sprite"]');
         await driver.actions().mouseMove(el)
             .perform();
-        await driver.sleep(500); // Wait for thermometer menu to come up
         const input = await findByXpath('//input[@type="file"]');
         await input.sendKeys(path.resolve(__dirname, '../fixtures/gh-3582-png.png'));
         await clickText('gh-3582-png', scope.spriteTile);
@@ -102,7 +97,6 @@ describe('Working with sprites', () => {
         const el = await findByXpath('//button[@aria-label="Choose a Sprite"]');
         await driver.actions().mouseMove(el)
             .perform();
-        await driver.sleep(500); // Wait for thermometer menu to come up
         const input = await findByXpath('//input[@type="file"]');
         await input.sendKeys(path.resolve(__dirname, '../fixtures/100-100.svg'));
         await clickText('100-100', scope.spriteTile); // Sprite is named for costume filename
@@ -120,7 +114,6 @@ describe('Working with sprites', () => {
         const el = await findByXpath('//button[@aria-label="Choose a Sprite"]');
         await driver.actions().mouseMove(el)
             .perform();
-        await driver.sleep(500); // Wait for thermometer menu to come up
         const input = await findByXpath('//input[@type="file"]');
         await input.sendKeys(path.resolve(__dirname, '../fixtures/paddleball.gif'));
         await clickText('paddleball', scope.spriteTile); // Sprite is named for costume filename
@@ -181,7 +174,6 @@ describe('Working with sprites', () => {
         const el = await findByXpath('//button[@aria-label="Choose a Sprite"]');
         await driver.actions().mouseMove(el)
             .perform();
-        await driver.sleep(500); // Wait for thermometer menu to come up
         const input = await findByXpath('//input[@type="file"]');
         await input.sendKeys(files.join('\n'));
 
@@ -191,5 +183,4 @@ describe('Working with sprites', () => {
         const logs = await getLogs();
         await expect(logs).toEqual([]);
     });
-
 });


### PR DESCRIPTION
### Resolves

Resolves #4653

### Proposed Changes

The most important change here is that `SeleniumHelper`'s `getDriver()` and `getSauceDriver()` no longer replace an existing driver if present. Also, `SeleniumHelper`'s `loadUri()` now checks if `loader_background` element(s) is/are present, and if so it waits for it/them to disappear.

### Reason for Changes

The previous implementation of `getDriver()` was sometimes causing trouble with tests running in parallel. The trouble shows up in cases like this pseudocode (note that I've made `helper` calls explicit for illustration purposes):
```js
let driver;
beforeAll(() => {
  driver = helper.getDriver();
}

test('test A', async () => {
  await helper.loadUri(somwhere);
  await helper.clickText('Fancy Button');
});

test('test B', async () => {
  await driver.quit();
  driver = helper.getDriver();
});
```

The above code may sometimes run without issue, but if `test B` runs `driver.quit()` after `test A` starts `loadUri()` but before `clickText()` finishes there will be trouble. The exact nature of the trouble depends on when exactly `driver = helper.getDriver()` finishes; since both `loadUri` and `clickText` contain multiple asynchronous steps which internally check `this.driver` the error can take several forms.

Now, tests which have a specific need for multiple sessions are responsible for creating a separate `SeleniumHelper` instance for each session. It's a bit of a pain, but it's reliable. I'm open to proposals for other ways to handle this.

After implementing the `getDriver()` change, I found that some tests were now less reliable than before -- or even were reliably failing. To fix this, I adjusted `SeleniumHelper`'s `loadUri()` method to wait until React has rendered at least once, then check if the `loader_background` element is present and if so wait for it to go away. A few tests included similar logic already, which I removed now that it's handled centrally.
