### PR TITLE
Delay loading and rendering gui

### DIFF
--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -129,7 +129,11 @@ const GUIComponent = props => {
     };
 
     if (isRendererSupported === null) {
-        isRendererSupported = Renderer.isSupported();
+        if (vm.renderer) {
+            isRendererSupported = true;
+        } else {
+            isRendererSupported = Renderer.isSupported();
+        }
     }
 
     return (<MediaQuery minWidth={layout.fullSizeMinWidth}>{isFullSize => {

--- a/src/containers/gui.jsx
+++ b/src/containers/gui.jsx
@@ -35,9 +35,12 @@ import storage from '../lib/storage';
 import vmListenerHOC from '../lib/vm-listener-hoc.jsx';
 import vmManagerHOC from '../lib/vm-manager-hoc.jsx';
 import cloudManagerHOC from '../lib/cloud-manager-hoc.jsx';
+import Loader from '../components/loader/loader.jsx';
 
-import GUIComponent from '../components/gui/gui.jsx';
+// import GUIComponent from '../components/gui/gui.jsx';
 import {setIsScratchDesktop} from '../lib/isScratchDesktop.js';
+
+import VideoProvider from '../lib/video/video-provider';
 
 const messages = defineMessages({
     defaultProjectTitle: {
@@ -52,6 +55,22 @@ class GUI extends React.Component {
         setIsScratchDesktop(this.props.isScratchDesktop);
         this.setReduxTitle(this.props.projectTitle);
         this.props.onStorageInit(storage);
+
+        // Use setTimeout. Do not use requestAnimationFrame or a resolved
+        // Promise. We want this work delayed until after the data request is
+        // made.
+        setTimeout(this.ensureRenderer.bind(this));
+
+        // Once the GUI component has been rendered, always render GUI and do
+        // not revert back to a Loader in this component.
+        //
+        // This makes GUI container not a pure component. We don't want to use
+        // state for this. That would possibly cause a full second render of GUI
+        // after the first one.
+        const {fontsLoaded, fetchingProject, isLoading} = this.props;
+        this.isAfterGUI = this.isAfterGUI || (
+            fontsLoaded && !fetchingProject && !isLoading
+        );
     }
     componentDidUpdate (prevProps) {
         if (this.props.projectId !== prevProps.projectId && this.props.projectId !== null) {
@@ -65,6 +84,17 @@ class GUI extends React.Component {
             // At this time the project view in www doesn't need to know when a project is unloaded
             this.props.onProjectLoaded();
         }
+
+        // Once the GUI component has been rendered, always render GUI and do
+        // not revert back to a Loader in this component.
+        //
+        // This makes GUI container not a pure component. We don't want to use
+        // state for this. That would possibly cause a full second render of GUI
+        // after the first one.
+        const {fontsLoaded, fetchingProject, isLoading} = this.props;
+        this.isAfterGUI = this.isAfterGUI || (
+            fontsLoaded && !fetchingProject && !isLoading
+        );
     }
     setReduxTitle (newTitle) {
         if (newTitle === null || typeof newTitle === 'undefined') {
@@ -74,6 +104,36 @@ class GUI extends React.Component {
         } else {
             this.props.onUpdateReduxProjectTitle(newTitle);
         }
+    }
+    ensureRenderer () {
+        if (this.props.vm.renderer) {
+            return;
+        }
+
+        // Wait to load svg-renderer and render after the data request. This
+        // way the data request is made earlier.
+        const Renderer = require('scratch-render');
+        const {
+            SVGRenderer: V2SVGAdapter,
+            BitmapAdapter: V2BitmapAdapter
+        } = require('scratch-svg-renderer');
+
+        const vm = this.props.vm;
+        this.canvas = document.createElement('canvas');
+        this.renderer = new Renderer(this.canvas);
+        vm.attachRenderer(this.renderer);
+
+        vm.attachV2SVGAdapter(new V2SVGAdapter());
+        vm.attachV2BitmapAdapter(new V2BitmapAdapter());
+
+        // Only attach a video provider once because it is stateful
+        vm.setVideoProvider(new VideoProvider());
+
+        // Calling draw a single time before any project is loaded just
+        // makes the canvas white instead of solid black–needed because it
+        // is not possible to use CSS to style the canvas to have a
+        // different default color
+        vm.renderer.draw();
     }
     render () {
         if (this.props.isError) {
@@ -85,6 +145,7 @@ class GUI extends React.Component {
             assetHost,
             cloudHost,
             error,
+            fontsLoaded,
             isError,
             isScratchDesktop,
             isShowingProject,
@@ -102,6 +163,16 @@ class GUI extends React.Component {
             loadingStateVisible,
             ...componentProps
         } = this.props;
+
+        if (!this.isAfterGUI && (
+            !fontsLoaded || fetchingProject || isLoading
+        )) {
+            // Make sure a renderer exists.
+            if (fontsLoaded && !fetchingProject) this.ensureRenderer();
+            return <Loader />;
+        }
+
+        const GUIComponent = require('../components/gui/gui.jsx').default;
         return (
             <GUIComponent
                 loading={fetchingProject || isLoading || loadingStateVisible}
@@ -119,6 +190,7 @@ GUI.propTypes = {
     cloudHost: PropTypes.string,
     error: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
     fetchingProject: PropTypes.bool,
+    fontsLoaded: PropTypes.bool,
     intl: intlShape,
     isError: PropTypes.bool,
     isLoading: PropTypes.bool,
@@ -157,6 +229,7 @@ const mapStateToProps = state => {
         costumeLibraryVisible: state.scratchGui.modals.costumeLibrary,
         costumesTabVisible: state.scratchGui.editorTab.activeTabIndex === COSTUMES_TAB_INDEX,
         error: state.scratchGui.projectState.error,
+        fontsLoaded: state.scratchGui.fontsLoaded,
         isError: getIsError(loadingState),
         isFullScreen: state.scratchGui.mode.isFullScreen,
         isPlayerOnly: state.scratchGui.mode.isPlayerOnly,


### PR DESCRIPTION
### Resolves

Faster project load time when loading a project by id.

### Proposed Changes

Related https://github.com/LLK/scratch-gui/pull/4722.

- Create the scratch renderer earlier in the GUI container/HOC stack
- Delay evaluating and rendering the GUI component until after project assets have been fetched

### Reason for Changes

When loading a project by id scratch needs to load a data file and then load assets referenced by that data file. Since these requests work asynchronously outside the javascript event loop, they make events to announce to javascript when they have completed some work. GUI does a lot of work that first blocks the data request from being sent and then blocks the response events from being emitted. Delaying this GUI work until the data and assets have loaded significantly improves load time.

This PR follows #4722 by delaying some work. In this case it creates the scratch renderer earlier and delays all other GUI work until after the project loads. #4722 by comparison optionally breaks up GUI into smaller 

#### Further Work

This idea can be taken further. A future change could move creating the scratch storage out of the react + redux stack. Loading the project data only requires the Storage instance. Loading the project assets requires the Renderer, AudioEngine and VirtualMachine.

#### TODO

- [ ] Loading screen

The loading screens are currently embedded in the components that are in a sense being loaded. Needing to render the component to render its loading screen makes it happen too late when combined with this PR. How should we solve this?

- [ ] When can the GUI be rendered

Currently it is best that most of the GUI not be evaluated or rendered until after the asset requests are made. Currently there is no state available know when this has happened. To best know when the GUI can be rendered we need this state. Alternatively we can render the GUI when the project has finished loading (as this PR currently does).

- [ ] Loading a second project will unmount the GUI

How does the container know that we have already rendered the GUI before?

I think the best answer would be two "loading screens" wrapping the container or a higher component. One that renders while there is a renderer and isLoading is true and then never render again. And a second that always renders while isLoading is true.

The easy solution here would probably be to unmount the GUI and render a loading screen here.

- [ ] Should Renderer and AudioEngine be initialized in React

This question is "too big" for this PR. But I find myself asking it since its moving Renderer's creation point. Since the VM is in the redux store, maybe Renderer and AudioEngine should be initialized by a redux middleware.

### Benchmarks

<details>
<summary>Benchmark methodology source</summary>

```diff
diff --git a/src/lib/vm-manager-hoc.jsx b/src/lib/vm-manager-hoc.jsx
index fd7e3ed3..2599c8b6 100644
--- a/src/lib/vm-manager-hoc.jsx
+++ b/src/lib/vm-manager-hoc.jsx
@@ -55,6 +55,8 @@ const vmManagerHOC = function (WrappedComponent) {
             return this.props.vm.loadProject(this.props.projectData)
                 .then(() => {
                     this.props.onLoadedProject(this.props.loadingState, this.props.canSave);
+                    window.LOAD_END = Date.now();
+                    console.log('load', window.LOAD_END - window.LOAD_START);
                     // Wrap in a setTimeout because skin loading in
                     // the renderer can be async.
                     setTimeout(() => this.props.onSetProjectUnchanged());
diff --git a/src/playground/index.jsx b/src/playground/index.jsx
index dcf6fa18..674bce7f 100644
--- a/src/playground/index.jsx
+++ b/src/playground/index.jsx
@@ -1,3 +1,5 @@
+import './start-time';
+
 // Polyfills
 import 'es6-object-assign/auto';
 import 'core-js/fn/array/includes';
diff --git a/src/playground/start-time.js b/src/playground/start-time.js
new file mode 100644
index 00000000..999c795f
--- /dev/null
+++ b/src/playground/start-time.js
@@ -0,0 +1 @@
+window.LOAD_START = Date.now();
```

</details>

|  environment | device | project id | develop | delay-gui | difference | change |
| --- | --- | --- | --- | --- | --- | --- |
|  without devtools | chrome | 173918262 | 2229 | 1556 | 673 | 30.21% |
|  devtools and no cache | chrome | 173918262 | 3429 | 2313 | 1116 | 32.55% |

Performance is a little better in this PR, delay-gui, when compared to the dynamic-stage PR #4722. Primarily this is because delay-gui performs its delay at an earlier time than the other PR. Optimistically that will load faster by making the async requests earlier. A similar change could be made for #4722 to add an earlier delay breakpoint.

<details>
<summary>Detailed Chart</summary>

|  environment | device | project id | branch | run 1 | run 2 | run 3 | run 4 | run 5 | average | standard deviation |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
|  without devtools | chrome | 173918262 | develop | 2286 | 2231 | 2272 | 2179 | 2177 | 2229 | 51 |
|  without devtools | chrome | 173918262 | dynamic-stage | 1677 | 1670 | 1782 | 1658 | 1598 | 1677 | 66 |
|  without devtools | chrome | 173918262 | delay-gui | 1522 | 1537 | 1622 | 1561 | 1536 | 1556 | 40 |
|  devtools + disable cache | chrome | 173918262 | develop | 3275 | 3544 | 3459 | 3419 | 3450 | 3429 | 98 |
|  devtools + disable cache | chrome | 173918262 | dynamic-stage | 2478 | 2335 | 2480 | 2310 |  | 2401 | 91 |
|  devtools + disable cache | chrome | 173918262 | delay-gui | 2398 | 2359 | 2146 | 2280 | 2382 | 2313 | 104 |

</details>

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [x] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
