### PR TITLE
Make SeleniumHelper retry clicks

### DIFF
--- a/test/helpers/selenium-helper.js
+++ b/test/helpers/selenium-helper.js
@@ -79,12 +79,16 @@ class SeleniumHelper {
         return this.driver;
     }
 
+    getXpathForText (text, scope) {
+        return `//body//${scope || '*'}//*[contains(text(), '${text}')]`;
+    }
+
     findByXpath (xpath) {
         return this.driver.wait(until.elementLocated(By.xpath(xpath), 5 * 1000));
     }
 
     findByText (text, scope) {
-        return this.findByXpath(`//body//${scope || '*'}//*[contains(text(), '${text}')]`);
+        return this.findByXpath(this.getXpathForText(text, scope));
     }
 
     loadUri (uri) {
@@ -102,18 +106,29 @@ class SeleniumHelper {
             ));
     }
 
+    clickLocator (locator, button = Button.LEFT) {
+        return this.driver.wait(async () => {
+            const element = await this.driver.findElement(locator);
+            if (!element) {
+                return false;
+            }
+            return this.driver.actions()
+                .click(element, button)
+                .perform()
+                .then(() => true, () => false);
+        });
+    }
+
     clickXpath (xpath) {
-        return this.findByXpath(xpath).then(el => el.click());
+        return this.clickLocator(By.xpath(xpath));
     }
 
     clickText (text, scope) {
-        return this.findByText(text, scope).then(el => el.click());
+        return this.clickXpath(this.getXpathForText(text, scope));
     }
 
     rightClickText (text, scope) {
-        return this.findByText(text, scope).then(el => this.driver.actions()
-            .click(el, Button.RIGHT)
-            .perform());
+        return this.clickXpath(this.getXpathForText(text, scope), Button.RIGHT);
     }
 
     clickButton (text) {

--- a/test/helpers/selenium-helper.js
+++ b/test/helpers/selenium-helper.js
@@ -7,7 +7,7 @@ import webdriver from 'selenium-webdriver';
 const {By, until, Button} = webdriver;
 
 const USE_HEADLESS = process.env.USE_HEADLESS !== 'no';
-const DEFAULT_TIMEOUT_MILLISECONDS = 5 * 1000;
+const DEFAULT_TIMEOUT_MILLISECONDS = 20 * 1000;
 
 class SeleniumHelper {
     constructor () {


### PR DESCRIPTION
### Resolves

Partial solution for #4653 

This PR (partially?) replaces #4795 

### Proposed Changes

* The click-related methods in `SeleniumHelper` keep retrying their clicks until success or timeout
* Methods in `SeleniumHelper` which use `wait` provide more detail on timeout

### Reason for Changes

This should make GUI integration tests more reliable and provide help for debugging failures.
