### PR TITLE
Fix number in a variable monitor is vertically misaligned.

### DIFF
--- a/src/components/monitor/monitor.css
+++ b/src/components/monitor/monitor.css
@@ -37,6 +37,9 @@
 }
 
 .value {
+    display: flex;
+    justify-content: center;
+    align-items: center;
     min-width: 40px;
     text-align: center;
     color: white;


### PR DESCRIPTION
### Resolves

- Resolves #4073

### Proposed Changes

variable monitor changes for Flexible Box.
The vertical alignment of the number in monitors is center when variable name is Japanese.

<img width="129" alt="スクリーンショット 2019-05-10 21 56 04" src="https://user-images.githubusercontent.com/19832604/57529013-cb8b1f80-736e-11e9-8443-43eae115e3cd.png">

### Reason for Changes

The vertical alignment of the number in monitors is offset when variable name is Japanese.

<img width="161" alt="スクリーンショット 2019-05-10 21 45 56" src="https://user-images.githubusercontent.com/19832604/57528393-363b5b80-736d-11e9-889e-d9861298b10b.png">

Sorry, I can't test cloud variable.
Please tell me that how to test cloud variable.

### Browser Coverage
Mac Chrome and Safari and Firefox