### PR TITLE
constrain stage size to window width

### DIFF
--- a/src/components/stage-wrapper/stage-wrapper.jsx
+++ b/src/components/stage-wrapper/stage-wrapper.jsx
@@ -17,7 +17,8 @@ const StageWrapperComponent = function (props) {
         isRendererSupported,
         loading,
         stageSize,
-        vm
+        vm,
+        windowWidth
     } = props;
 
     return (
@@ -29,6 +30,7 @@ const StageWrapperComponent = function (props) {
                 <StageHeader
                     stageSize={stageSize}
                     vm={vm}
+                    windowWidth={windowWidth}
                 />
             </Box>
             <Box className={styles.stageCanvasWrapper}>
@@ -37,6 +39,7 @@ const StageWrapperComponent = function (props) {
                         <Stage
                             stageSize={stageSize}
                             vm={vm}
+                            windowWidth={windowWidth}
                         /> :
                         null
                 }
@@ -54,7 +57,8 @@ StageWrapperComponent.propTypes = {
     isRtl: PropTypes.bool.isRequired,
     loading: PropTypes.bool,
     stageSize: PropTypes.oneOf(Object.keys(STAGE_DISPLAY_SIZES)).isRequired,
-    vm: PropTypes.instanceOf(VM).isRequired
+    vm: PropTypes.instanceOf(VM).isRequired,
+    windowWidth: PropTypes.number
 };
 
 export default StageWrapperComponent;

--- a/src/containers/stage-header.jsx
+++ b/src/containers/stage-header.jsx
@@ -48,7 +48,8 @@ StageHeader.propTypes = {
     onSetStageUnFull: PropTypes.func.isRequired,
     showBranding: PropTypes.bool,
     stageSizeMode: PropTypes.oneOf(Object.keys(STAGE_SIZE_MODES)),
-    vm: PropTypes.instanceOf(VM).isRequired
+    vm: PropTypes.instanceOf(VM).isRequired,
+    windowWidth: PropTypes.number
 };
 
 const mapStateToProps = state => ({

--- a/src/containers/stage-wrapper.jsx
+++ b/src/containers/stage-wrapper.jsx
@@ -1,10 +1,39 @@
+import bindAll from 'lodash.bindall';
 import PropTypes from 'prop-types';
 import React from 'react';
 import VM from 'scratch-vm';
 import {STAGE_DISPLAY_SIZES} from '../lib/layout-constants.js';
 import StageWrapperComponent from '../components/stage-wrapper/stage-wrapper.jsx';
 
-const StageWrapper = props => <StageWrapperComponent {...props} />;
+class StageWrapper extends React.Component {
+    constructor (props) {
+        super(props);
+        bindAll(this, [
+            'updateWindow'
+        ]);
+        this.state = {
+            windowWidth: 0
+        };
+    }
+    componentDidMount () {
+        this.updateWindow();
+        window.addEventListener('resize', this.updateWindow);
+    }
+    componentWillUnmount () {
+        window.removeEventListener('resize', this.updateWindow);
+    }
+    updateWindow () {
+        this.setState({windowWidth: window.outerWidth});
+    }
+    render () {
+        return (
+            <StageWrapperComponent
+                windowWidth={this.state.windowWidth}
+                {...this.props}
+            />
+        );
+    }
+}
 
 StageWrapper.propTypes = {
     isRendererSupported: PropTypes.bool.isRequired,

--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -85,7 +85,8 @@ class Stage extends React.Component {
             this.props.isFullScreen !== nextProps.isFullScreen ||
             this.state.question !== nextState.question ||
             this.props.micIndicator !== nextProps.micIndicator ||
-            this.props.isStarted !== nextProps.isStarted;
+            this.props.isStarted !== nextProps.isStarted ||
+            this.props.windowWidth !== nextProps.windowWidth;
     }
     componentDidUpdate (prevProps) {
         if (this.props.isColorPicking && !prevProps.isColorPicking) {
@@ -429,7 +430,9 @@ Stage.propTypes = {
     onDeactivateColorPicker: PropTypes.func,
     stageSize: PropTypes.oneOf(Object.keys(STAGE_DISPLAY_SIZES)).isRequired,
     useEditorDragStyle: PropTypes.bool,
-    vm: PropTypes.instanceOf(VM).isRequired
+    vm: PropTypes.instanceOf(VM).isRequired,
+    windowWidth: PropTypes.number
+
 };
 
 Stage.defaultProps = {

--- a/src/lib/screen-utils.js
+++ b/src/lib/screen-utils.js
@@ -11,9 +11,13 @@ import layout, {STAGE_DISPLAY_SCALES, STAGE_SIZE_MODES, STAGE_DISPLAY_SIZES} fro
 
 const STAGE_DIMENSION_DEFAULTS = {
     // referencing css/units.css,
-    // spacingBorderAdjustment = 2 * $full-screen-top-bottom-margin +
-    //   2 * $full-screen-border-width
+    // fullScreenSpacingBorderAdjustment = 2 * $stage-full-screen-stage-padding +
+    //   2 * $stage-full-screen-border-width
     fullScreenSpacingBorderAdjustment: 12,
+    // if width is constrained by window, use this total margin
+    // referencing css/units.css,
+    // widthConstrainedMargin = 2 * $space
+    widthConstrainedMargin: 16,
     // referencing css/units.css,
     // menuHeightAdjustment = $stage-menu-height
     menuHeightAdjustment: 44
@@ -57,16 +61,20 @@ const getStageDimensions = (stageSize, isFullScreen) => {
 
         stageDimensions.width = stageDimensions.height + (stageDimensions.height / 3);
 
-        if (stageDimensions.width > window.innerWidth) {
-            stageDimensions.width = window.innerWidth;
-            stageDimensions.height = stageDimensions.width * .75;
-        }
-
         stageDimensions.scale = stageDimensions.width / stageDimensions.widthDefault;
     } else {
         stageDimensions.scale = STAGE_DISPLAY_SCALES[stageSize];
         stageDimensions.height = stageDimensions.scale * stageDimensions.heightDefault;
         stageDimensions.width = stageDimensions.scale * stageDimensions.widthDefault;
+    }
+
+    // constrain width to window size, whether in fullscreen or not
+    const minStageWidth = Math.min(window.outerWidth, window.innerWidth) -
+        STAGE_DIMENSION_DEFAULTS.widthConstrainedMargin;
+    if (stageDimensions.width > minStageWidth) {
+        stageDimensions.width = minStageWidth;
+        stageDimensions.height = stageDimensions.width * .75;
+        stageDimensions.scale = stageDimensions.width / stageDimensions.widthDefault;
     }
 
     // Round off dimensions to prevent resampling/blurriness


### PR DESCRIPTION
Note, needs to be merged alongside a www PR

### Resolves

- Hopefully helps resolve https://github.com/LLK/scratch-www/issues/2513

### Proposed Changes

* constrain stage size to window width for all size settings, not just fullscreen
* update effective stage size, header size on window resize or rotate
* Introduce widthConstrainedMargin for sizing stage

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
