### PR TITLE
Pause video on tutorial window shrink

### DIFF
--- a/src/components/cards/card.css
+++ b/src/components/cards/card.css
@@ -275,14 +275,6 @@
     margin-right: 0.5rem;
 }
 
-.video-cover {
-    width: 100%;
-    height: 100%;
-    position: absolute;
-    top: 0;
-    left: 0;
-}
-
 .steps-list {
     display: flex;
     flex-direction: row;

--- a/src/components/cards/cards.jsx
+++ b/src/components/cards/cards.jsx
@@ -86,10 +86,6 @@ const CardHeader = ({onCloseCards, onShrinkExpandCards, onShowAll, totalSteps, s
 );
 
 class VideoStep extends React.Component {
-    // eslint-disable-next-line no-useless-constructor
-    constructor (props) {
-        super(props);
-    }
     componentDidMount () {
         const script = document.createElement('script');
         script.src = `https://fast.wistia.com/embed/medias/${this.props.video}.jsonp`;

--- a/src/components/cards/cards.jsx
+++ b/src/components/cards/cards.jsx
@@ -86,33 +86,35 @@ const CardHeader = ({onCloseCards, onShrinkExpandCards, onShowAll, totalSteps, s
     </div>
 );
 
-// Video step needs to know if the card is being dragged to cover the video
-// so that the mouseup is not swallowed by the iframe.
 class VideoStep extends React.Component {
     // eslint-disable-next-line no-useless-constructor
     constructor (props) {
         super(props);
     }
     componentDidMount () {
-        console.log('Video1 step did mount.');
         const script = document.createElement('script');
-
         script.src = `https://fast.wistia.com/embed/medias/${this.props.video}.jsonp`;
         script.async = true;
-    
         document.body.appendChild(script);
 
         const script2 = document.createElement('script');
-
+        script2.onload = () => {
+            window._wq = window._wq || [];
+            window._wq.push({
+                id: `${this.props.video}`,
+                onReady: function (video) {
+                    console.log('I got a handle to the video!', video);
+                }
+            });
+        };
         script2.src = 'https://fast.wistia.com/assets/external/E-v1.js';
         script2.async = true;
-    
         document.body.appendChild(script2);
     }
     render () {
         return (
-            // var video1 = Wistia.api("ir0j8ljsgm");
-            // ir0j8ljsgm
+            // Video step needs to know if the card is being dragged to cover the video
+            // so that the mouseup is not swallowed by the iframe.
             <div className={styles.stepVideo}>
                 {this.props.dragging ? (
                     <div className={styles.videoCover} />

--- a/src/components/cards/cards.jsx
+++ b/src/components/cards/cards.jsx
@@ -114,17 +114,12 @@ class VideoStep extends React.Component {
     }
     render () {
         return (
-            // Video step needs to know if the card is being dragged to cover the video
-            // so that the mouseup is not swallowed by the iframe.
             <div className={styles.stepVideo}>
                 <div
                     className={`wistia_embed wistia_async_${this.props.video}`}
+                    id="video-div"
                     style={{height: `257px`, width: `466px`}}
                 >
-                    {//this.props.dragging ? (
-                        //<div className={styles.videoCover} />
-                        //) : null
-                    }
                     &nbsp;
                 </div>
             </div>
@@ -133,7 +128,6 @@ class VideoStep extends React.Component {
 }
 
 VideoStep.propTypes = {
-    dragging: PropTypes.bool.isRequired,
     expanded: PropTypes.bool.isRequired,
     video: PropTypes.string.isRequired
 };
@@ -322,6 +316,7 @@ const Cards = props => {
         >
             <Draggable
                 bounds="parent"
+                cancel="#video-div" // disable dragging on video div
                 position={{x: x, y: y}}
                 onDrag={onDrag}
                 onStart={onStartDrag}

--- a/src/components/cards/cards.jsx
+++ b/src/components/cards/cards.jsx
@@ -98,8 +98,7 @@ class VideoStep extends React.Component {
         document.body.appendChild(script2);
     }
     componentDidUpdate () {
-        // eslint-disable-next-line no-undef
-        const video = Wistia.api(`${this.props.video}`);
+        const video = window.Wistia.api(`${this.props.video}`);
         if (this.props.expanded) {
             video.play();
         } else {

--- a/src/components/cards/cards.jsx
+++ b/src/components/cards/cards.jsx
@@ -3,6 +3,7 @@ import React, {Fragment} from 'react';
 import classNames from 'classnames';
 import {FormattedMessage} from 'react-intl';
 import Draggable from 'react-draggable';
+import bindAll from 'lodash.bindall';
 
 import styles from './card.css';
 
@@ -108,6 +109,54 @@ const VideoStep = ({video, dragging}) => (
         />
     </div>
 );
+
+/* class VideoStep extends React.Component {
+    constructor (props) {
+        super(props);
+        bindAll(this, [
+            'handleLoadIFrame'
+        ]);
+    }
+    componentDidMount () {
+        console.log('Video1 step did mount.');
+    }
+    handleLoadIFrame () {
+        console.log('iframe loaded!!!');
+        // window._wq = window._wq || [];
+        window._wq.push({
+            id: 'ir0j8ljsgm',
+            onReady: function (video) {
+                console.log('I got a handle to the video!', video);
+            }
+        });
+        // console.log('Wistia', document.getElementsByTagName('iframe')[0].contentWindow.location.href);
+    }
+    render () {
+        return (
+            <div className={styles.stepVideo}>
+                {this.props.dragging ? (
+                    <div className={styles.videoCover} />
+                ) : null}
+                <iframe
+                    allowFullScreen
+                    allowTransparency="true"
+                    frameBorder="0"
+                    height="257"
+                    scrolling="no"
+                    src={`https://fast.wistia.net/embed/iframe/${this.props.video}?seo=false&videoFoam=true`}
+                    title="📹"
+                    width="466"
+                    onLoad={this.handleLoadIFrame}
+                />
+                <script
+                    async
+                    src="https://fast.wistia.net/assets/external/E-v1.js"
+                />
+            </div>
+        );
+
+    }
+} */
 
 VideoStep.propTypes = {
     dragging: PropTypes.bool.isRequired,

--- a/src/components/cards/cards.jsx
+++ b/src/components/cards/cards.jsx
@@ -99,9 +99,7 @@ class VideoStep extends React.Component {
     }
     componentDidUpdate () {
         const video = window.Wistia.api(`${this.props.video}`);
-        if (this.props.expanded) {
-            video.play();
-        } else {
+        if (!this.props.expanded) {
             video.pause();
         }
     }

--- a/src/components/cards/cards.jsx
+++ b/src/components/cards/cards.jsx
@@ -111,6 +111,14 @@ class VideoStep extends React.Component {
         script2.async = true;
         document.body.appendChild(script2);
     }
+    componentDidUpdate () {
+        // if not expanded, pause video?
+        if (!this.props.expanded) {
+            // eslint-disable-next-line no-undef
+            const video = Wistia.api(`${this.props.video}`);
+            video.pause();
+        }
+    }
     render () {
         return (
             // Video step needs to know if the card is being dragged to cover the video
@@ -132,6 +140,7 @@ class VideoStep extends React.Component {
 
 VideoStep.propTypes = {
     dragging: PropTypes.bool.isRequired,
+    expanded: PropTypes.bool.isRequired,
     video: PropTypes.string.isRequired
 };
 

--- a/src/components/cards/cards.jsx
+++ b/src/components/cards/cards.jsx
@@ -88,75 +88,45 @@ const CardHeader = ({onCloseCards, onShrinkExpandCards, onShowAll, totalSteps, s
 
 // Video step needs to know if the card is being dragged to cover the video
 // so that the mouseup is not swallowed by the iframe.
-const VideoStep = ({video, dragging}) => (
-    <div className={styles.stepVideo}>
-        {dragging ? (
-            <div className={styles.videoCover} />
-        ) : null}
-        <iframe
-            allowFullScreen
-            allowTransparency="true"
-            frameBorder="0"
-            height="257"
-            scrolling="no"
-            src={`https://fast.wistia.net/embed/iframe/${video}?seo=false&videoFoam=true`}
-            title="📹"
-            width="466"
-        />
-        <script
-            async
-            src="https://fast.wistia.net/assets/external/E-v1.js"
-        />
-    </div>
-);
-
-/* class VideoStep extends React.Component {
+class VideoStep extends React.Component {
+    // eslint-disable-next-line no-useless-constructor
     constructor (props) {
         super(props);
-        bindAll(this, [
-            'handleLoadIFrame'
-        ]);
     }
     componentDidMount () {
         console.log('Video1 step did mount.');
-    }
-    handleLoadIFrame () {
-        console.log('iframe loaded!!!');
-        // window._wq = window._wq || [];
-        window._wq.push({
-            id: 'ir0j8ljsgm',
-            onReady: function (video) {
-                console.log('I got a handle to the video!', video);
-            }
-        });
-        // console.log('Wistia', document.getElementsByTagName('iframe')[0].contentWindow.location.href);
+        const script = document.createElement('script');
+
+        script.src = `https://fast.wistia.com/embed/medias/${this.props.video}.jsonp`;
+        script.async = true;
+    
+        document.body.appendChild(script);
+
+        const script2 = document.createElement('script');
+
+        script2.src = 'https://fast.wistia.com/assets/external/E-v1.js';
+        script2.async = true;
+    
+        document.body.appendChild(script2);
     }
     render () {
         return (
+            // var video1 = Wistia.api("ir0j8ljsgm");
+            // ir0j8ljsgm
             <div className={styles.stepVideo}>
                 {this.props.dragging ? (
                     <div className={styles.videoCover} />
                 ) : null}
-                <iframe
-                    allowFullScreen
-                    allowTransparency="true"
-                    frameBorder="0"
-                    height="257"
-                    scrolling="no"
-                    src={`https://fast.wistia.net/embed/iframe/${this.props.video}?seo=false&videoFoam=true`}
-                    title="📹"
-                    width="466"
-                    onLoad={this.handleLoadIFrame}
-                />
-                <script
-                    async
-                    src="https://fast.wistia.net/assets/external/E-v1.js"
-                />
+                <div
+                    className={`wistia_embed wistia_async_${this.props.video}`}
+                    style={{height: `257px`, width: `466px`}}
+                >
+                    &nbsp;
+                </div>
             </div>
         );
-
     }
-} */
+}
 
 VideoStep.propTypes = {
     dragging: PropTypes.bool.isRequired,

--- a/src/components/cards/cards.jsx
+++ b/src/components/cards/cards.jsx
@@ -90,11 +90,13 @@ class VideoStep extends React.Component {
         const script = document.createElement('script');
         script.src = `https://fast.wistia.com/embed/medias/${this.props.video}.jsonp`;
         script.async = true;
+        script.setAttribute('id', 'wistia-video-content');
         document.body.appendChild(script);
 
         const script2 = document.createElement('script');
         script2.src = 'https://fast.wistia.com/assets/external/E-v1.js';
         script2.async = true;
+        script2.setAttribute('id', 'wistia-video-api');
         document.body.appendChild(script2);
     }
     componentDidUpdate () {
@@ -103,18 +105,26 @@ class VideoStep extends React.Component {
             video.pause();
         }
     }
+    componentWillUnmount () {
+        const script = document.getElementById('wistia-video-content');
+        script.parentNode.removeChild(script);
+
+        const script2 = document.getElementById('wistia-video-api');
+        script2.parentNode.removeChild(script2);
+    }
     render () {
         return (
             // Video step needs to know if the card is being dragged to cover the video
             // so that the mouseup is not swallowed by the iframe.
             <div className={styles.stepVideo}>
-                {this.props.dragging ? (
-                    <div className={styles.videoCover} />
-                ) : null}
                 <div
                     className={`wistia_embed wistia_async_${this.props.video}`}
                     style={{height: `257px`, width: `466px`}}
                 >
+                    {//this.props.dragging ? (
+                        //<div className={styles.videoCover} />
+                        //) : null
+                    }
                     &nbsp;
                 </div>
             </div>

--- a/src/components/cards/cards.jsx
+++ b/src/components/cards/cards.jsx
@@ -3,7 +3,6 @@ import React, {Fragment} from 'react';
 import classNames from 'classnames';
 import {FormattedMessage} from 'react-intl';
 import Draggable from 'react-draggable';
-import bindAll from 'lodash.bindall';
 
 import styles from './card.css';
 

--- a/src/components/cards/cards.jsx
+++ b/src/components/cards/cards.jsx
@@ -98,24 +98,16 @@ class VideoStep extends React.Component {
         document.body.appendChild(script);
 
         const script2 = document.createElement('script');
-        script2.onload = () => {
-            window._wq = window._wq || [];
-            window._wq.push({
-                id: `${this.props.video}`,
-                onReady: function (video) {
-                    console.log('I got a handle to the video!', video);
-                }
-            });
-        };
         script2.src = 'https://fast.wistia.com/assets/external/E-v1.js';
         script2.async = true;
         document.body.appendChild(script2);
     }
     componentDidUpdate () {
-        // if not expanded, pause video?
-        if (!this.props.expanded) {
-            // eslint-disable-next-line no-undef
-            const video = Wistia.api(`${this.props.video}`);
+        // eslint-disable-next-line no-undef
+        const video = Wistia.api(`${this.props.video}`);
+        if (this.props.expanded) {
+            video.play();
+        } else {
             video.pause();
         }
     }
@@ -355,6 +347,7 @@ const Cards = props => {
                                 steps[step].video ? (
                                     <VideoStep
                                         dragging={dragging}
+                                        expanded={expanded}
                                         video={translateVideo(steps[step].video, locale)}
                                     />
                                 ) : (


### PR DESCRIPTION
### Resolves

- Resolves #4766: Clicking "shrink" on tutorial window should pause the video

### Proposed Changes

To access the `Wistia` API object on the `window`, we need to switch the video embed from an iframe (which prevents access to its window for security reasons), to the inline-embedding style that Wistia suggests. (https://wistia.com/support/embed-and-share/video-on-your-website). Wistia video player API docs for reference: https://wistia.com/support/developers/player-api.

This also required upgrading the VideoStep React component from a functional one to a normal one, to handle the video-pausing in `componentDidUpdate`.

