### PR TITLE
add timeouts & messages to all driver.wait calls

### DIFF
--- a/test/helpers/selenium-helper.js
+++ b/test/helpers/selenium-helper.js
@@ -8,6 +8,11 @@ const {By, until, Button} = webdriver;
 
 const USE_HEADLESS = process.env.USE_HEADLESS !== 'no';
 
+// The main reason for this timeout is so that we can control the timeout message and report details;
+// if we hit the Jasmine default timeout then we get a terse message that we can't control.
+// The Jasmine default timeout is 30 seconds so make sure this is lower.
+const DEFAULT_TIMEOUT_MILLISECONDS = 20 * 1000;
+
 class SeleniumHelper {
     constructor () {
         bindAll(this, [
@@ -26,8 +31,11 @@ class SeleniumHelper {
         ]);
     }
 
-    elementIsVisible (element) {
-        return this.driver.wait(until.elementIsVisible(element));
+    elementIsVisible (element, {
+        message = 'elementIsVisible timed out',
+        timeout = DEFAULT_TIMEOUT_MILLISECONDS
+    } = {}) {
+        return this.driver.wait(until.elementIsVisible(element), timeout, message);
     }
 
     get scope () {
@@ -79,8 +87,11 @@ class SeleniumHelper {
         return this.driver;
     }
 
-    findByXpath (xpath) {
-        return this.driver.wait(until.elementLocated(By.xpath(xpath), 5 * 1000));
+    findByXpath (xpath, {
+        message = `findByXpath timed out for path: ${xpath}`,
+        timeout = DEFAULT_TIMEOUT_MILLISECONDS
+    } = {}) {
+        return this.driver.wait(until.elementLocated(By.xpath(xpath)), timeout, message);
     }
 
     findByText (text, scope) {
@@ -120,8 +131,11 @@ class SeleniumHelper {
         return this.clickXpath(`//button//*[contains(text(), '${text}')]`);
     }
 
-    waitUntilGone (element) {
-        return this.driver.wait(until.stalenessOf(element));
+    waitUntilGone (element, {
+        message = 'waitUntilGone timed out',
+        timeout = DEFAULT_TIMEOUT_MILLISECONDS
+    } = {}) {
+        return this.driver.wait(until.stalenessOf(element), timeout, message);
     }
 
     getLogs (whitelist) {

--- a/test/helpers/selenium-helper.js
+++ b/test/helpers/selenium-helper.js
@@ -31,11 +31,8 @@ class SeleniumHelper {
         ]);
     }
 
-    elementIsVisible (element, {
-        message = 'elementIsVisible timed out',
-        timeout = DEFAULT_TIMEOUT_MILLISECONDS
-    } = {}) {
-        return this.driver.wait(until.elementIsVisible(element), timeout, message);
+    elementIsVisible (element, timeoutMessage = 'elementIsVisible timed out') {
+        return this.driver.wait(until.elementIsVisible(element), DEFAULT_TIMEOUT_MILLISECONDS, timeoutMessage);
     }
 
     get scope () {
@@ -87,11 +84,8 @@ class SeleniumHelper {
         return this.driver;
     }
 
-    findByXpath (xpath, {
-        message = `findByXpath timed out for path: ${xpath}`,
-        timeout = DEFAULT_TIMEOUT_MILLISECONDS
-    } = {}) {
-        return this.driver.wait(until.elementLocated(By.xpath(xpath)), timeout, message);
+    findByXpath (xpath, timeoutMessage = `findByXpath timed out for path: ${xpath}`) {
+        return this.driver.wait(until.elementLocated(By.xpath(xpath)), DEFAULT_TIMEOUT_MILLISECONDS, timeoutMessage);
     }
 
     findByText (text, scope) {
@@ -131,11 +125,8 @@ class SeleniumHelper {
         return this.clickXpath(`//button//*[contains(text(), '${text}')]`);
     }
 
-    waitUntilGone (element, {
-        message = 'waitUntilGone timed out',
-        timeout = DEFAULT_TIMEOUT_MILLISECONDS
-    } = {}) {
-        return this.driver.wait(until.stalenessOf(element), timeout, message);
+    waitUntilGone (element, timeoutMessage = 'waitUntilGone timed out') {
+        return this.driver.wait(until.stalenessOf(element), DEFAULT_TIMEOUT_MILLISECONDS, timeoutMessage);
     }
 
     getLogs (whitelist) {


### PR DESCRIPTION
### Resolves

Should help debug multiple issues with the GUI integration tests such as #4653

### Proposed Changes

For each call to Selenium's `wait` method, set a timeout which is shorter than the overall Jasmine timeout and also include a custom message to help indicate which call timed out.

### Reason for Changes

Without these changes every timeout displays the same message with the same call stack -- a call stack which doesn't include any of our test files:

```
Timeout - Async callback was not invoked within timeout specified by jasmine.DEFAULT_TIMEOUT_INTERVAL.
      
      at node_modules/jest-jasmine2/build/queue_runner.js:64:21
      at Timeout.callback [as _onTimeout] (node_modules/jsdom/lib/jsdom/browser/Window.js:523:19)
      at ontimeout (timers.js:498:11)
      at tryOnTimeout (timers.js:323:5)
      at Timer.listOnTimeout (timers.js:290:5)
```

The new message for a timeout during `findByXpath` looks something like this:
```
    TimeoutError: findByXpath timed out for path: //body//*//*[contains(text(), 'Code')]
    Wait timed out after 20014ms

      at node_modules/selenium-webdriver/lib/promise.js:2201:17
      at ManagedPromise.invokeCallback_ (node_modules/selenium-webdriver/lib/promise.js:1376:14)
      at TaskQueue.execute_ (node_modules/selenium-webdriver/lib/promise.js:3084:14)
      at TaskQueue.executeNext_ (node_modules/selenium-webdriver/lib/promise.js:3067:27)
      at asyncRun (node_modules/selenium-webdriver/lib/promise.js:2927:27)
      at node_modules/selenium-webdriver/lib/promise.js:668:7
      at process._tickCallback (internal/process/next_tick.js:68:7)
      From: Task: findByXpath timed out for path: //body//*//*[contains(text(), 'Code')]
      at scheduleWait (node_modules/selenium-webdriver/lib/promise.js:2188:20)
      at ControlFlow.wait (node_modules/selenium-webdriver/lib/promise.js:2517:12)
      at thenableWebDriverProxy.wait (node_modules/selenium-webdriver/lib/webdriver.js:934:29)
      at SeleniumHelper.findByXpath (test/helpers/selenium-helper.js:89:26)
      at SeleniumHelper.wrapper [as findByXpath] (node_modules/lodash.bindall/index.js:550:15)
      at SeleniumHelper.findByText (test/helpers/selenium-helper.js:94:19)
      at SeleniumHelper.wrapper [as findByText] (node_modules/lodash.bindall/index.js:550:15)
      at SeleniumHelper.clickText (test/helpers/selenium-helper.js:117:19)
      at wrapper (node_modules/lodash.bindall/index.js:550:15)
      at _callee2$ (test/integration/blocks.test.js:32:15)
```

An earlier version of this change included detailed messages for element-based timeouts as well (`waitUntilGone` and `elementVisible`) but they failed in some cases. I started trying to make them work for all cases and the complexity started growing rapidly so I decided to leave that as future work. This version still reports which function timed out (`waitUntilGone` for example) along with a call stack, which is better than what we had before.