### PR TITLE
Always display whitespace in list monitors

### DIFF
--- a/src/components/monitor/monitor.css
+++ b/src/components/monitor/monitor.css
@@ -149,7 +149,7 @@
     overflow: hidden; /* Don't let long values escape container */
     text-overflow: ellipsis;
     user-select: text; /* Allow selecting list values for 2.0 compatibility, only relevant in player */
-    white-space: nowrap;
+    white-space: pre;
 }
 
 .list-input {

--- a/src/components/monitor/monitor.css
+++ b/src/components/monitor/monitor.css
@@ -43,6 +43,7 @@
     margin: 0 5px;
     border-radius: calc($space / 2);
     padding: 0 2px;
+    white-space: pre-wrap;
     transform: translateZ(0); /* Fixes flickering in Safari */
 }
 
@@ -53,6 +54,7 @@
     text-align: center;
     color: white;
     font-size: 1rem;
+    white-space: pre-wrap;
     transform: translateZ(0); /* Fixes flickering in Safari */
 }
 


### PR DESCRIPTION
### Resolves

Fixes #4823.

### Proposed Changes

Changes the whitespace CSS on the element from `nowrap` to `pre`.

### Reason for Changes

We want to display the whitespace in lists exactly as it was added!

### Test Coverage

Tested manually:

![Four items: "a b", "c  d" (2 spaces), "e   f" (3 spaces), "very long item" (cut off with an ellipsis after "it")](https://user-images.githubusercontent.com/9948030/58383050-52174200-7fa8-11e9-8adf-c155068f598f.png)

Note that `white-space: pre` prevents the text from wrapping, just as we want ([until this is fixed](https://github.com/LLK/scratch-gui/issues/2744)). (We'd want `white-space: pre-wrap` to wrap it.)

### Browser Coverage

Linux Firefox, Chromium.