### PR TITLE
Stabilize integration tests

### DIFF
--- a/test/helpers/selenium-helper.js
+++ b/test/helpers/selenium-helper.js
@@ -85,7 +85,11 @@ class SeleniumHelper {
     }
 
     findByXpath (xpath, timeoutMessage = `findByXpath timed out for path: ${xpath}`) {
-        return this.driver.wait(until.elementLocated(By.xpath(xpath)), DEFAULT_TIMEOUT_MILLISECONDS, timeoutMessage);
+        return this.driver.wait(until.elementLocated(By.xpath(xpath)), DEFAULT_TIMEOUT_MILLISECONDS, timeoutMessage)
+            .then(el => (
+                this.driver.wait(el.isDisplayed(), DEFAULT_TIMEOUT_MILLISECONDS, `${xpath} is not visible`)
+                    .then(() => el)
+            ));
     }
 
     findByText (text, scope) {

--- a/test/helpers/selenium-helper.js
+++ b/test/helpers/selenium-helper.js
@@ -26,8 +26,7 @@ class SeleniumHelper {
             'getSauceDriver',
             'getLogs',
             'loadUri',
-            'rightClickText',
-            'waitUntilGone'
+            'rightClickText'
         ]);
     }
 
@@ -127,10 +126,6 @@ class SeleniumHelper {
 
     clickButton (text) {
         return this.clickXpath(`//button//*[contains(text(), '${text}')]`);
-    }
-
-    waitUntilGone (element, timeoutMessage = 'waitUntilGone timed out') {
-        return this.driver.wait(until.stalenessOf(element), DEFAULT_TIMEOUT_MILLISECONDS, timeoutMessage);
     }
 
     getLogs (whitelist) {

--- a/test/integration/examples.test.js
+++ b/test/integration/examples.test.js
@@ -11,8 +11,7 @@ const {
     findByXpath,
     getDriver,
     getLogs,
-    loadUri,
-    waitUntilGone
+    loadUri
 } = new SeleniumHelper();
 
 let driver;
@@ -31,7 +30,6 @@ describe('player example', () => {
     test('Load a project by ID', async () => {
         const projectId = '96708228';
         await loadUri(`${uri}#${projectId}`);
-        await waitUntilGone(findByText('Loading'));
         await clickXpath('//img[@title="Go"]');
         await new Promise(resolve => setTimeout(resolve, 2000));
         await clickXpath('//img[@title="Stop"]');

--- a/test/integration/examples.test.js
+++ b/test/integration/examples.test.js
@@ -4,7 +4,6 @@ import path from 'path';
 import SeleniumHelper from '../helpers/selenium-helper';
 
 const {
-    findByText,
     clickButton,
     clickText,
     clickXpath,

--- a/test/integration/menu-bar.test.js
+++ b/test/integration/menu-bar.test.js
@@ -9,8 +9,7 @@ const {
     getDriver,
     loadUri,
     rightClickText,
-    scope,
-    waitUntilGone
+    scope
 } = new SeleniumHelper();
 
 const uri = path.resolve(__dirname, '../../build/index.html');
@@ -78,7 +77,6 @@ describe('Menu bar settings', () => {
         await clickText('File');
         const input = await findByXpath('//input[@accept=".sb,.sb2,.sb3"]');
         await input.sendKeys(path.resolve(__dirname, '../fixtures/project1.sb3'));
-        await waitUntilGone(findByText('Loading'));
         // No replace alert since no changes were made
         await findByText('project1-sprite');
     });
@@ -95,7 +93,6 @@ describe('Menu bar settings', () => {
         await input.sendKeys(path.resolve(__dirname, '../fixtures/project1.sb3'));
         await driver.switchTo().alert()
             .accept();
-        await waitUntilGone(findByText('Loading'));
         await findByText('project1-sprite');
     });
 });

--- a/test/integration/project-loading.test.js
+++ b/test/integration/project-loading.test.js
@@ -9,8 +9,7 @@ const {
     getDriver,
     getLogs,
     loadUri,
-    scope,
-    waitUntilGone
+    scope
 } = new SeleniumHelper();
 
 const uri = path.resolve(__dirname, '../../build/index.html');
@@ -39,7 +38,6 @@ describe('Loading scratch gui', () => {
 
             const projectId = '96708228';
             await loadUri(`${uri}#${projectId}`);
-            await waitUntilGone(findByText('Loading'));
             await clickXpath('//img[@title="Go"]');
             await new Promise(resolve => setTimeout(resolve, 2000));
             await clickXpath('//img[@title="Stop"]');
@@ -60,7 +58,6 @@ describe('Loading scratch gui', () => {
                 .setSize(1920, 1080);
             const projectId = '96708228';
             await loadUri(`${uri}#${projectId}`);
-            await waitUntilGone(findByText('Loading'));
             await clickXpath('//img[@title="Full Screen Control"]');
             await new Promise(resolve => setTimeout(resolve, 500));
             await clickXpath('//img[@title="Go"]');

--- a/test/integration/project-loading.test.js
+++ b/test/integration/project-loading.test.js
@@ -4,7 +4,6 @@ import SeleniumHelper from '../helpers/selenium-helper';
 const {
     clickText,
     clickXpath,
-    findByText,
     findByXpath,
     getDriver,
     getLogs,


### PR DESCRIPTION
### Resolves

This should make the integration tests more stable.  This makes sure elements are visible on the page during integration tests before moving on in the tests.

### Proposed Changes

Makes the FindByXpath function in Selenium helpers wait until element is visible before returning.  This replaces the WaitUntilGone method that was used in some tests. 

### Reason for Changes

FindByXpath is ultimately used by all of the other ways of finding elements in Selenium helpers so this should effect most of the tests.  This should specifically make it so elements that tare hidden by the loading screen are revealed before they are clicked in tests.

After the changes the WaitUntilGone function was causing tests to fail.  Since it was supposed to solve the same problem, I removed that function from the rest of the tests.  All the tests passed locally after that.

### Browser Coverage
Mac Chrome
