### PR TITLE
Use a "title card" instead of video if using Scratch Desktop

### DIFF
--- a/src/components/cards/card.css
+++ b/src/components/cards/card.css
@@ -162,6 +162,7 @@
 }
 
 .step-body {
+    width: 100%;
     background: $ui-white;
     display: flex;
     flex-direction: column;
@@ -177,6 +178,8 @@
 
 .step-image {
     max-width: 450px;
+    max-height: 200px;
+    object-fit: contain;
     background: #F9F9F9;
     border: 1px solid #ddd;
     border-radius: 0.5rem;

--- a/src/components/cards/cards.jsx
+++ b/src/components/cards/cards.jsx
@@ -288,6 +288,7 @@ const Cards = props => {
         onShowAll,
         onNextStep,
         onPrevStep,
+        showVideos,
         step,
         expanded,
         ...posProps
@@ -356,11 +357,18 @@ const Cards = props => {
                                 />
                             ) : (
                                 steps[step].video ? (
-                                    <VideoStep
-                                        dragging={dragging}
-                                        expanded={expanded}
-                                        video={translateVideo(steps[step].video, locale)}
-                                    />
+                                    showVideos ? (
+                                        <VideoStep
+                                            dragging={dragging}
+                                            expanded={expanded}
+                                            video={translateVideo(steps[step].video, locale)}
+                                        />
+                                    ) : ( // Else show the deck image and title
+                                        <ImageStep
+                                            image={content[activeDeckId].img}
+                                            title={content[activeDeckId].name}
+                                        />
+                                    )
                                 ) : (
                                     <ImageStep
                                         image={translateImage(steps[step].image, locale)}
@@ -410,9 +418,19 @@ Cards.propTypes = {
     onShowAll: PropTypes.func,
     onShrinkExpandCards: PropTypes.func.isRequired,
     onStartDrag: PropTypes.func,
+    showVideos: PropTypes.bool,
     step: PropTypes.number.isRequired,
     x: PropTypes.number,
     y: PropTypes.number
 };
 
-export default Cards;
+Cards.defaultProps = {
+    showVideos: true
+};
+
+export {
+    Cards as default,
+    // Others exported for testability
+    ImageStep,
+    VideoStep
+};

--- a/src/containers/cards.jsx
+++ b/src/containers/cards.jsx
@@ -19,6 +19,7 @@ import {
 
 import CardsComponent from '../components/cards/cards.jsx';
 import {loadImageData} from '../lib/libraries/decks/translate-image.js';
+import {notScratchDesktop} from '../lib/isScratchDesktop';
 
 class Cards extends React.Component {
     componentDidMount () {
@@ -52,7 +53,8 @@ const mapStateToProps = state => ({
     y: state.scratchGui.cards.y,
     isRtl: state.locales.isRtl,
     locale: state.locales.locale,
-    dragging: state.scratchGui.cards.dragging
+    dragging: state.scratchGui.cards.dragging,
+    showVideos: notScratchDesktop()
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/containers/tips-library.jsx
+++ b/src/containers/tips-library.jsx
@@ -62,10 +62,16 @@ class TipsLibrary extends React.PureComponent {
     }
     render () {
         const decksLibraryThumbnailData = Object.keys(decksLibraryContent)
-            .filter(id =>
+            .filter(id => {
+                if (notScratchDesktop()) return true; // Do not filter anything in online editor
+                const deck = decksLibraryContent[id];
                 // Scratch Desktop doesn't want tutorials with `requiredProjectId`
-                notScratchDesktop() || !decksLibraryContent[id].hasOwnProperty('requiredProjectId')
-            )
+                if (deck.hasOwnProperty('requiredProjectId')) return false;
+                // Scratch Desktop should not load tutorials that are _only_ videos
+                if (deck.steps.filter(s => s.title).length === 0) return false;
+                // Allow any other tutorials
+                return true;
+            })
             .map(id => ({
                 rawURL: decksLibraryContent[id].img,
                 id: id,

--- a/test/unit/components/cards.test.jsx
+++ b/test/unit/components/cards.test.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import {mountWithIntl} from '../../helpers/intl-helpers.jsx';
+
+// Mock this utility because it uses dynamic imports that do not work with jest
+jest.mock('../../../src/lib/libraries/decks/translate-image.js', () => {});
+
+import Cards, {ImageStep, VideoStep} from '../../../src/components/cards/cards.jsx';
+
+describe('Cards component', () => {
+    const defaultProps = () => ({
+        activeDeckId: 'id1',
+        content: {
+            id1: {
+                name: 'id1 - name',
+                img: 'id1 - img',
+                steps: [{video: 'videoUrl'}]
+            }
+        },
+        dragging: false,
+        expanded: true,
+        isRtl: false,
+        locale: 'en',
+        onActivateDeckFactory: jest.fn(),
+        onCloseCards: jest.fn(),
+        onDrag: jest.fn(),
+        onEndDrag: jest.fn(),
+        onNextStep: jest.fn(),
+        onPrevStep: jest.fn(),
+        onShowAll: jest.fn(),
+        onShrinkExpandCards: jest.fn(),
+        onStartDrag: jest.fn(),
+        showVideos: true,
+        step: 0,
+        x: 0,
+        y: 0
+    });
+
+    test('showVideos=true shows the video step', () => {
+        const component = mountWithIntl(
+            <Cards
+                {...defaultProps()}
+                showVideos
+            />
+        );
+        expect(component.find(ImageStep).exists()).toEqual(false);
+        expect(component.find(VideoStep).exists()).toEqual(true);
+    });
+
+    test('showVideos=false shows the title image/name instead of video step', () => {
+        const component = mountWithIntl(
+            <Cards
+                {...defaultProps()}
+                showVideos={false}
+            />
+        );
+        expect(component.find(VideoStep).exists()).toEqual(false);
+
+        const imageStep = component.find(ImageStep);
+        expect(imageStep.props().image).toEqual('id1 - img');
+        expect(imageStep.props().title).toEqual('id1 - name');
+    });
+});


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/LLK/scratch-gui/issues/4895

### Proposed Changes

_Describe what this Pull Request does_

Pass in a `showVideos` flag that controls whether to show videos steps or instead show a "title card" consisting of the deck image and name. This is controlled by the `notScratchDesktop()` utility function from the container.

### Test Coverage

_Please show how you have added tests to cover your changes_

Added a `cards` unit test to test whether Video or Image steps are shown based on varying that flag.

Tested the scratchDesktop flag compatibility manually, by using the `isScratchDesktop=true` url param.