### PR TITLE
simpler findByXpath helper

### DIFF
--- a/test/helpers/selenium-helper.js
+++ b/test/helpers/selenium-helper.js
@@ -84,11 +84,7 @@ class SeleniumHelper {
     }
 
     findByXpath (xpath, timeoutMessage = `findByXpath timed out for path: ${xpath}`) {
-        return this.driver.wait(until.elementLocated(By.xpath(xpath)), DEFAULT_TIMEOUT_MILLISECONDS, timeoutMessage)
-            .then(el => (
-                this.driver.wait(el.isDisplayed(), DEFAULT_TIMEOUT_MILLISECONDS, `${xpath} is not visible`)
-                    .then(() => el)
-            ));
+        return this.driver.wait(until.elementLocated(By.xpath(xpath)), DEFAULT_TIMEOUT_MILLISECONDS, timeoutMessage);
     }
 
     findByText (text, scope) {


### PR DESCRIPTION
Resolves https://github.com/LLK/scratch-gui/issues/4906

The line https://github.com/LLK/scratch-gui/pull/4871/files#r290948638 may have been the cause of testing errors seen in #4902 and #4903.

Here, we remove part of the fix introduced in https://github.com/LLK/scratch-gui/pull/4871 , and use the simpler, older version of `findByXpath`.