### PR TITLE
Show libraries before loading their content

### DIFF
--- a/src/components/library/library.css
+++ b/src/components/library/library.css
@@ -12,6 +12,7 @@
     overflow-y: auto;
     height: auto;
     padding: 0.5rem;
+    height: calc(100% - $library-header-height);
 }
 
 .library-scroll-grid.withFilterBar {
@@ -58,4 +59,12 @@
     flex-wrap: wrap;
     height: $library-filter-bar-height;
     overflow: hidden;
+}
+
+.spinner-wrapper {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }

--- a/src/components/library/library.jsx
+++ b/src/components/library/library.jsx
@@ -9,6 +9,7 @@ import Modal from '../../containers/modal.jsx';
 import Divider from '../divider/divider.jsx';
 import Filter from '../filter/filter.jsx';
 import TagButton from '../../containers/tag-button.jsx';
+import Spinner from '../spinner/spinner.jsx';
 
 import styles from './library.css';
 
@@ -44,8 +45,15 @@ class LibraryComponent extends React.Component {
         this.state = {
             selectedItem: null,
             filterQuery: '',
-            selectedTag: ALL_TAG.tag
+            selectedTag: ALL_TAG.tag,
+            loaded: false
         };
+    }
+    componentDidMount () {
+        // Allow the spinner to display before loading the content
+        setTimeout(() => {
+            this.setState({loaded: true});
+        });
     }
     componentDidUpdate (prevProps, prevState) {
         if (prevState.filterQuery !== this.state.filterQuery ||
@@ -162,7 +170,7 @@ class LibraryComponent extends React.Component {
                     })}
                     ref={this.setFilteredDataRef}
                 >
-                    {this.getFilteredData().map((dataItem, index) => (
+                    {this.state.loaded ? this.getFilteredData().map((dataItem, index) => (
                         <LibraryItem
                             bluetoothRequired={dataItem.bluetoothRequired}
                             collaborator={dataItem.collaborator}
@@ -183,7 +191,14 @@ class LibraryComponent extends React.Component {
                             onMouseLeave={this.handleMouseLeave}
                             onSelect={this.handleSelect}
                         />
-                    ))}
+                    )) : (
+                        <div className={styles.spinnerWrapper}>
+                            <Spinner
+                                large
+                                level="primary"
+                            />
+                        </div>
+                    )}
                 </div>
             </Modal>
         );

--- a/src/components/spinner/spinner.css
+++ b/src/components/spinner/spinner.css
@@ -39,6 +39,16 @@
     height: .5rem;
 }
 
+.large {
+    width: 2.5rem;
+    height: 2.5rem;
+}
+
+.large::before, .large::after {
+    width: 2.5rem;
+    height: 2.5rem;
+}
+
 @keyframes spin {
   0% {
     transform: rotate(0deg);
@@ -70,4 +80,11 @@
 }
 .spinner.info::after {
     border-top-color: $ui-white;
+}
+
+.spinner.primary {
+    border-color: $motion-transparent;
+}
+.spinner.primary::after {
+    border-top-color: $motion-primary;
 }

--- a/src/components/spinner/spinner.jsx
+++ b/src/components/spinner/spinner.jsx
@@ -8,7 +8,8 @@ const SpinnerComponent = function (props) {
     const {
         className,
         level,
-        small
+        small,
+        large
     } = props;
     return (
         <div
@@ -16,7 +17,10 @@ const SpinnerComponent = function (props) {
                 className,
                 styles.spinner,
                 styles[level],
-                {[styles.small]: small}
+                {
+                    [styles.small]: small,
+                    [styles.large]: large
+                }
             )}
         />
     );
@@ -24,10 +28,13 @@ const SpinnerComponent = function (props) {
 SpinnerComponent.propTypes = {
     className: PropTypes.string,
     level: PropTypes.string,
-    small: PropTypes.bool
+    small: PropTypes.bool,
+    large: PropTypes.bool
 };
 SpinnerComponent.defaultProps = {
     className: '',
-    level: 'info'
+    level: 'info',
+    small: false,
+    large: false
 };
 export default SpinnerComponent;

--- a/src/components/spinner/spinner.jsx
+++ b/src/components/spinner/spinner.jsx
@@ -27,14 +27,14 @@ const SpinnerComponent = function (props) {
 };
 SpinnerComponent.propTypes = {
     className: PropTypes.string,
+    large: PropTypes.bool,
     level: PropTypes.string,
-    small: PropTypes.bool,
-    large: PropTypes.bool
+    small: PropTypes.bool
 };
 SpinnerComponent.defaultProps = {
     className: '',
+    large: false,
     level: 'info',
-    small: false,
-    large: false
+    small: false
 };
 export default SpinnerComponent;


### PR DESCRIPTION
Resolves an issue where there was no feedback when clicking the "add a sprite/costume/sound/backdrop" buttons because the libraries are waiting to render all their content before showing up. Instead of that, show a spinner and then load the data. 

This is particularly noticeable on the costumes library, and particularly particularly noticeable on low-power devices. 

This also sets up future improvements where the library content (json, etc.) could be loaded async instead of bundled with the app, saving on package size.

![library-spinner](https://user-images.githubusercontent.com/654102/59107125-ee750900-8905-11e9-9c6f-18563ea5bd60.gif)
