### PR TITLE
Add pointer-events to alert container CSS

### DIFF
--- a/src/components/alerts/alert.css
+++ b/src/components/alerts/alert.css
@@ -15,6 +15,7 @@
     padding-right: 1rem;
     margin-bottom: 7px;
     min-height: 1.5rem;
+    pointer-events: all;
 }
 
 .alert.warn {

--- a/src/components/gui/gui.css
+++ b/src/components/gui/gui.css
@@ -309,6 +309,7 @@ $fade-out-distance: 15px;
     z-index: $z-index-alerts;
     position: absolute;
     margin-top: 53px;
+    pointer-events: none;
 }
 
 /*


### PR DESCRIPTION
### Resolves
Resolves #4428 

### Proposed Changes
Add pointer-events to alert container CSS

### Reason for Changes
Container caught the onclick event and didn't pass to things under it, therefore it blocked menu items.

### Test Coverage
To test this, go to Sound tab, upload a non-music file (such as text), and cause forever Importing. (this bug is documented #4639 )
Try changing tabs, selecting menu items, and else. All should work fine.

*This is one of my progress for adding "Record Project Video".*