### PR TITLE
Updates to sprite and costume libraries

### DIFF
--- a/src/lib/libraries/costumes.json
+++ b/src/lib/libraries/costumes.json
@@ -75,7 +75,7 @@
     },
     {
         "name": "Andie-a",
-        "md5": "419ff5a76adbb4b076c072f68267fdeb.svg",
+        "md5": "d2c433e02481b10584e34ccdcf5a046a.svg",
         "type": "costume",
         "tags": [
             "sports",
@@ -87,14 +87,33 @@
             "alex eben meyer"
         ],
         "info": [
-            86,
-            81,
+            80,
+            65,
             1
         ]
     },
     {
         "name": "Andie-b",
-        "md5": "a6a766912b4e43064ee3f389c72925b4.svg",
+        "md5": "045f92ad80d72521098ede6d7c80549a.svg",
+        "type": "costume",
+        "tags": [
+            "sports",
+            "basketball",
+            "people",
+            "wheelchair",
+            "handicap",
+            "handicapable",
+            "alex eben meyer"
+        ],
+        "info": [
+            40,
+            91,
+            1
+        ]
+    },
+    {
+        "name": "Andie-c",
+        "md5": "c9bad70ad371b8d6d97daed7ab9def98.svg",
         "type": "costume",
         "tags": [
             "sports",
@@ -107,32 +126,13 @@
         ],
         "info": [
             46,
-            106,
-            1
-        ]
-    },
-    {
-        "name": "Andie-c",
-        "md5": "fac1025857d2c28391cb31f39a80df54.svg",
-        "type": "costume",
-        "tags": [
-            "sports",
-            "basketball",
-            "people",
-            "wheelchair",
-            "handicap",
-            "handicapable",
-            "alex eben meyer"
-        ],
-        "info": [
-            52,
-            65,
+            49,
             1
         ]
     },
     {
         "name": "Andie-d",
-        "md5": "7af50835e05d43e5e07cd2d641e7401e.svg",
+        "md5": "7c9db638cd671898ff07771112faff0f.svg",
         "type": "costume",
         "tags": [
             "sports",
@@ -144,8 +144,8 @@
             "alex eben meyer"
         ],
         "info": [
-            87,
-            72,
+            71,
+            57,
             1
         ]
     },
@@ -1069,7 +1069,7 @@
     },
     {
         "name": "Ben-a",
-        "md5": "4386d05d5abd6e1aa0a93b7b447d1b39.svg",
+        "md5": "322e13bd17d02acfdc048a5ef2167be8.svg",
         "type": "costume",
         "tags": [
             "sports",
@@ -1079,14 +1079,14 @@
             "alex eben meyer"
         ],
         "info": [
-            53,
+            54,
             69,
             1
         ]
     },
     {
         "name": "Ben-b",
-        "md5": "90db137cd0743204d02fdc9be1c8eb94.svg",
+        "md5": "59ba1e80ba75b1d06c37db4b9b4fde27.svg",
         "type": "costume",
         "tags": [
             "sports",
@@ -1096,14 +1096,14 @@
             "alex eben meyer"
         ],
         "info": [
-            53,
-            67,
+            54,
+            69,
             1
         ]
     },
     {
         "name": "Ben-c",
-        "md5": "5f05d41ede773b3bb379286e86a5b869.svg",
+        "md5": "940ec2fa85d666dde95a51bcbccd266e.svg",
         "type": "costume",
         "tags": [
             "sports",
@@ -1113,14 +1113,14 @@
             "alex eben meyer"
         ],
         "info": [
+            73,
             71,
-            72,
             1
         ]
     },
     {
         "name": "Ben-d",
-        "md5": "6f6e246567c0639c758ed4f6930be76f.svg",
+        "md5": "3043a50a91b9d484a8cd32eb82f2d88f.svg",
         "type": "costume",
         "tags": [
             "sports",
@@ -1130,8 +1130,8 @@
             "alex eben meyer"
         ],
         "info": [
-            42,
-            72,
+            44,
+            71,
             1
         ]
     },
@@ -3628,16 +3628,17 @@
     },
     {
         "name": "Earth",
-        "md5": "d9df2cf4f6eb2460d0de3e4f1e05f40b.svg",
+        "md5": "64220361b80d2812e9f27fc88ef39027.svg",
         "type": "costume",
         "tags": [
             "space",
             "planet",
-            "earth"
+            "earth",
+            "globe"
         ],
         "info": [
-            41,
-            40,
+            55,
+            55,
             1
         ]
     },
@@ -6178,7 +6179,7 @@
     },
     {
         "name": "Jordyn-a",
-        "md5": "8355df83cca2baa0fdf6269d1311f1ea.svg",
+        "md5": "2f59adebc2c0feb9ebfabd7ee9642f2b.svg",
         "type": "costume",
         "tags": [
             "sports",
@@ -6189,13 +6190,13 @@
         ],
         "info": [
             51,
-            63,
+            62,
             1
         ]
     },
     {
         "name": "Jordyn-b",
-        "md5": "2e2c43bbd7b18524fb132f1426ca3134.svg",
+        "md5": "075f382883e60dba8094b3dc30918f60.svg",
         "type": "costume",
         "tags": [
             "sports",
@@ -6212,7 +6213,7 @@
     },
     {
         "name": "Jordyn-c",
-        "md5": "5c0d24c53805e16358a2f6f6cc4a456e.svg",
+        "md5": "fbe81c40d4a880c8799c458359758629.svg",
         "type": "costume",
         "tags": [
             "sports",
@@ -6223,13 +6224,13 @@
         ],
         "info": [
             68,
-            61,
+            62,
             1
         ]
     },
     {
         "name": "Jordyn-d",
-        "md5": "ebe2b20b99c1e1b373fd2b02be48aab9.svg",
+        "md5": "68a784d4d0340475a6e6feff3b28b470.svg",
         "type": "costume",
         "tags": [
             "sports",
@@ -6240,7 +6241,7 @@
         ],
         "info": [
             40,
-            61,
+            62,
             1
         ]
     },
@@ -9660,7 +9661,7 @@
     },
     {
         "name": "Sun",
-        "md5": "55c931c65456822c0c56a2b30e3e550d.svg",
+        "md5": "14b0508da0dc30e83b2bede13c1be1e9.svg",
         "type": "costume",
         "tags": [
             "space",
@@ -9671,8 +9672,8 @@
             "nuclear"
         ],
         "info": [
-            72,
-            72,
+            54,
+            54,
             1
         ]
     },
@@ -10579,6 +10580,24 @@
         "info": [
             65,
             140,
+            1
+        ]
+    },
+    {
+        "name": "Wizard Girl",
+        "md5": "dd40d3a2565990bcc24d2b36cd446394.svg",
+        "type": "costume",
+        "tags": [
+            "people",
+            "female",
+            "girl",
+            "wizard",
+            "magic",
+            "fantasy"
+        ],
+        "info": [
+            80,
+            91,
             1
         ]
     },

--- a/src/lib/libraries/sprites.json
+++ b/src/lib/libraries/sprites.json
@@ -118,7 +118,7 @@
     },
     {
         "name": "Andie",
-        "md5": "419ff5a76adbb4b076c072f68267fdeb.svg",
+        "md5": "d2c433e02481b10584e34ccdcf5a046a.svg",
         "type": "sprite",
         "tags": [
             "sports",
@@ -138,7 +138,7 @@
             "objName": "Andie",
             "sounds": [
                 {
-                    "soundName": "basketball bounce",
+                    "soundName": "Basketball Bounce",
                     "soundID": -1,
                     "md5": "1727f65b5f22d151685b8e5917456a60.wav",
                     "sampleCount": 8099,
@@ -149,40 +149,40 @@
             "costumes": [
                 {
                     "costumeName": "andie-a",
-                    "baseLayerID": 0,
-                    "baseLayerMD5": "419ff5a76adbb4b076c072f68267fdeb.svg",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "d2c433e02481b10584e34ccdcf5a046a.svg",
                     "bitmapResolution": 1,
-                    "rotationCenterX": 86,
-                    "rotationCenterY": 81
+                    "rotationCenterX": 80,
+                    "rotationCenterY": 65
                 },
                 {
                     "costumeName": "andie-b",
                     "baseLayerID": -1,
-                    "baseLayerMD5": "a6a766912b4e43064ee3f389c72925b4.svg",
+                    "baseLayerMD5": "045f92ad80d72521098ede6d7c80549a.svg",
                     "bitmapResolution": 1,
-                    "rotationCenterX": 46,
-                    "rotationCenterY": 106
+                    "rotationCenterX": 40,
+                    "rotationCenterY": 91
                 },
                 {
                     "costumeName": "andie-c",
                     "baseLayerID": -1,
-                    "baseLayerMD5": "fac1025857d2c28391cb31f39a80df54.svg",
+                    "baseLayerMD5": "c9bad70ad371b8d6d97daed7ab9def98.svg",
                     "bitmapResolution": 1,
-                    "rotationCenterX": 52,
-                    "rotationCenterY": 65
+                    "rotationCenterX": 46,
+                    "rotationCenterY": 49
                 },
                 {
                     "costumeName": "andie-d",
                     "baseLayerID": -1,
-                    "baseLayerMD5": "7af50835e05d43e5e07cd2d641e7401e.svg",
+                    "baseLayerMD5": "7c9db638cd671898ff07771112faff0f.svg",
                     "bitmapResolution": 1,
-                    "rotationCenterX": 87,
-                    "rotationCenterY": 72
+                    "rotationCenterX": 71,
+                    "rotationCenterY": 57
                 }
             ],
             "currentCostumeIndex": 0,
-            "scratchX": -129,
-            "scratchY": -73,
+            "scratchX": -150,
+            "scratchY": 90,
             "scale": 1,
             "direction": 90,
             "rotationStyle": "normal",
@@ -1442,7 +1442,7 @@
     },
     {
         "name": "Ben",
-        "md5": "4386d05d5abd6e1aa0a93b7b447d1b39.svg",
+        "md5": "322e13bd17d02acfdc048a5ef2167be8.svg",
         "type": "sprite",
         "tags": [
             "sports",
@@ -1460,18 +1460,18 @@
             "objName": "Ben",
             "sounds": [
                 {
-                    "soundName": "pop",
+                    "soundName": "Goal Cheer",
                     "soundID": -1,
-                    "md5": "83a9787d4cb6f3b7632b4ddfebf74367.wav",
-                    "sampleCount": 258,
-                    "rate": 11025,
-                    "format": ""
+                    "md5": "a434069c58e79d42f5d21abb1c318919.wav",
+                    "sampleCount": 84096,
+                    "rate": 22050,
+                    "format": "adpcm"
                 },
                 {
-                    "soundName": "basketball bounce",
+                    "soundName": "Referee Whistle",
                     "soundID": -1,
-                    "md5": "1727f65b5f22d151685b8e5917456a60.wav",
-                    "sampleCount": 8099,
+                    "md5": "8468b9b3f11a665ee4d215afd8463b97.wav",
+                    "sampleCount": 14034,
                     "rate": 22050,
                     "format": "adpcm"
                 }
@@ -1480,39 +1480,39 @@
                 {
                     "costumeName": "ben-a",
                     "baseLayerID": -1,
-                    "baseLayerMD5": "4386d05d5abd6e1aa0a93b7b447d1b39.svg",
+                    "baseLayerMD5": "322e13bd17d02acfdc048a5ef2167be8.svg",
                     "bitmapResolution": 1,
-                    "rotationCenterX": 53,
+                    "rotationCenterX": 54,
                     "rotationCenterY": 69
                 },
                 {
                     "costumeName": "ben-b",
                     "baseLayerID": -1,
-                    "baseLayerMD5": "90db137cd0743204d02fdc9be1c8eb94.svg",
+                    "baseLayerMD5": "59ba1e80ba75b1d06c37db4b9b4fde27.svg",
                     "bitmapResolution": 1,
-                    "rotationCenterX": 53,
-                    "rotationCenterY": 67
+                    "rotationCenterX": 54,
+                    "rotationCenterY": 69
                 },
                 {
                     "costumeName": "ben-c",
                     "baseLayerID": -1,
-                    "baseLayerMD5": "5f05d41ede773b3bb379286e86a5b869.svg",
+                    "baseLayerMD5": "940ec2fa85d666dde95a51bcbccd266e.svg",
                     "bitmapResolution": 1,
-                    "rotationCenterX": 71,
-                    "rotationCenterY": 72
+                    "rotationCenterX": 73,
+                    "rotationCenterY": 71
                 },
                 {
                     "costumeName": "ben-d",
                     "baseLayerID": -1,
-                    "baseLayerMD5": "6f6e246567c0639c758ed4f6930be76f.svg",
+                    "baseLayerMD5": "3043a50a91b9d484a8cd32eb82f2d88f.svg",
                     "bitmapResolution": 1,
-                    "rotationCenterX": 42,
-                    "rotationCenterY": 72
+                    "rotationCenterX": 44,
+                    "rotationCenterY": 71
                 }
             ],
             "currentCostumeIndex": 0,
-            "scratchX": -63,
-            "scratchY": -94,
+            "scratchX": -15,
+            "scratchY": 93,
             "scale": 1,
             "direction": 90,
             "rotationStyle": "normal",
@@ -5434,12 +5434,13 @@
     },
     {
         "name": "Earth",
-        "md5": "d9df2cf4f6eb2460d0de3e4f1e05f40b.svg",
+        "md5": "64220361b80d2812e9f27fc88ef39027.svg",
         "type": "sprite",
         "tags": [
             "space",
             "planet",
-            "earth"
+            "earth",
+            "globe"
         ],
         "info": [
             0,
@@ -5460,17 +5461,17 @@
             ],
             "costumes": [
                 {
-                    "costumeName": "Earth",
+                    "costumeName": "earth",
                     "baseLayerID": -1,
-                    "baseLayerMD5": "d9df2cf4f6eb2460d0de3e4f1e05f40b.svg",
+                    "baseLayerMD5": "64220361b80d2812e9f27fc88ef39027.svg",
                     "bitmapResolution": 1,
-                    "rotationCenterX": 41,
-                    "rotationCenterY": 40
+                    "rotationCenterX": 55,
+                    "rotationCenterY": 55
                 }
             ],
             "currentCostumeIndex": 0,
-            "scratchX": 57,
-            "scratchY": -39,
+            "scratchX": 142,
+            "scratchY": -53,
             "scale": 1,
             "direction": 90,
             "rotationStyle": "normal",
@@ -8842,7 +8843,7 @@
     },
     {
         "name": "Jordyn",
-        "md5": "8355df83cca2baa0fdf6269d1311f1ea.svg",
+        "md5": "2f59adebc2c0feb9ebfabd7ee9642f2b.svg",
         "type": "sprite",
         "tags": [
             "sports",
@@ -8854,16 +8855,24 @@
         "info": [
             0,
             4,
-            1
+            2
         ],
         "json": {
             "objName": "Jordyn",
             "sounds": [
                 {
-                    "soundName": "basketball bounce",
+                    "soundName": "Goal Cheer",
                     "soundID": -1,
-                    "md5": "1727f65b5f22d151685b8e5917456a60.wav",
-                    "sampleCount": 8099,
+                    "md5": "199b30c8b4fe0642e849924bd1e1b463.wav",
+                    "sampleCount": 84411,
+                    "rate": 22050,
+                    "format": "adpcm"
+                },
+                {
+                    "soundName": "Referee Whistle",
+                    "soundID": -1,
+                    "md5": "7d91d95d841dc6cf1282914306a4674a.wav",
+                    "sampleCount": 14238,
                     "rate": 22050,
                     "format": "adpcm"
                 }
@@ -8872,15 +8881,15 @@
                 {
                     "costumeName": "jordyn-a",
                     "baseLayerID": -1,
-                    "baseLayerMD5": "8355df83cca2baa0fdf6269d1311f1ea.svg",
+                    "baseLayerMD5": "2f59adebc2c0feb9ebfabd7ee9642f2b.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 51,
-                    "rotationCenterY": 63
+                    "rotationCenterY": 62
                 },
                 {
                     "costumeName": "jordyn-b",
                     "baseLayerID": -1,
-                    "baseLayerMD5": "2e2c43bbd7b18524fb132f1426ca3134.svg",
+                    "baseLayerMD5": "075f382883e60dba8094b3dc30918f60.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 51,
                     "rotationCenterY": 63
@@ -8888,23 +8897,23 @@
                 {
                     "costumeName": "jordyn-c",
                     "baseLayerID": -1,
-                    "baseLayerMD5": "5c0d24c53805e16358a2f6f6cc4a456e.svg",
+                    "baseLayerMD5": "fbe81c40d4a880c8799c458359758629.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 68,
-                    "rotationCenterY": 61
+                    "rotationCenterY": 62
                 },
                 {
                     "costumeName": "jordyn-d",
                     "baseLayerID": -1,
-                    "baseLayerMD5": "ebe2b20b99c1e1b373fd2b02be48aab9.svg",
+                    "baseLayerMD5": "68a784d4d0340475a6e6feff3b28b470.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 40,
-                    "rotationCenterY": 61
+                    "rotationCenterY": 62
                 }
             ],
             "currentCostumeIndex": 0,
-            "scratchX": -164,
-            "scratchY": -41,
+            "scratchX": 61,
+            "scratchY": 93,
             "scale": 1,
             "direction": 90,
             "rotationStyle": "normal",
@@ -14372,7 +14381,7 @@
     },
     {
         "name": "Sun",
-        "md5": "55c931c65456822c0c56a2b30e3e550d.svg",
+        "md5": "14b0508da0dc30e83b2bede13c1be1e9.svg",
         "type": "sprite",
         "tags": [
             "space",
@@ -14403,15 +14412,15 @@
                 {
                     "costumeName": "sun",
                     "baseLayerID": -1,
-                    "baseLayerMD5": "55c931c65456822c0c56a2b30e3e550d.svg",
+                    "baseLayerMD5": "14b0508da0dc30e83b2bede13c1be1e9.svg",
                     "bitmapResolution": 1,
-                    "rotationCenterX": 72,
-                    "rotationCenterY": 72
+                    "rotationCenterX": 54,
+                    "rotationCenterY": 54
                 }
             ],
             "currentCostumeIndex": 0,
-            "scratchX": 16,
-            "scratchY": -28,
+            "scratchX": -3,
+            "scratchY": -42,
             "scale": 1,
             "direction": 90,
             "rotationStyle": "normal",
@@ -15770,6 +15779,56 @@
             "currentCostumeIndex": 0,
             "scratchX": -137,
             "scratchY": 2,
+            "scale": 1,
+            "direction": 90,
+            "rotationStyle": "normal",
+            "isDraggable": false,
+            "visible": true,
+            "spriteInfo": {}
+        }
+    },
+    {
+        "name": "Wizard Girl",
+        "md5": "dd40d3a2565990bcc24d2b36cd446394.svg",
+        "type": "sprite",
+        "tags": [
+            "people",
+            "female",
+            "girl",
+            "wizard",
+            "magic",
+            "fantasy"
+        ],
+        "info": [
+            0,
+            1,
+            1
+        ],
+        "json": {
+            "objName": "Wizard Girl",
+            "sounds": [
+                {
+                    "soundName": "Magic Spell",
+                    "soundID": -1,
+                    "md5": "1cb60ecdb1075c8769cb346d5c2a22c7.wav",
+                    "sampleCount": 43077,
+                    "rate": 22050,
+                    "format": "adpcm"
+                }
+            ],
+            "costumes": [
+                {
+                    "costumeName": "wizard girl",
+                    "baseLayerID": -1,
+                    "baseLayerMD5": "dd40d3a2565990bcc24d2b36cd446394.svg",
+                    "bitmapResolution": 1,
+                    "rotationCenterX": 80,
+                    "rotationCenterY": 91
+                }
+            ],
+            "currentCostumeIndex": 0,
+            "scratchX": -147,
+            "scratchY": -71,
             "scale": 1,
             "direction": 90,
             "rotationStyle": "normal",


### PR DESCRIPTION
Updates to the sprite and costume libraries, from @kosiecki17: 

Sprite library changes:

- Andie - remove extra arms from andie-d costume
- Ben - remove cleats and pads, add sounds
- Jordyn - remove cleats and pads, add sounds
- Globe - new design
- Sun - new design
- Wizard girl - bring back a 2.0 sprite, add a sound

The costume library should reflect all the costumes changed and added above.




