### PR TITLE
Prevent crash when wistia API takes a while to load

### DIFF
--- a/src/components/cards/cards.jsx
+++ b/src/components/cards/cards.jsx
@@ -104,6 +104,9 @@ class VideoStep extends React.Component {
     // We use the Wistia API here to update or pause the video dynamically:
     // https://wistia.com/support/developers/player-api
     componentDidUpdate (prevProps) {
+        // Ensure the wistia API is loaded and available
+        if (!(window.Wistia && window.Wistia.api)) return;
+
         // Get a handle on the currently loaded video
         const video = window.Wistia.api(prevProps.video);
 


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/llk/scratch-gui/issues

### Proposed Changes

_Describe what this Pull Request does_

Be defensive about nested property access on the wistia API object. It may not have been loaded yet.

### Reason for Changes

_Explain why these changes should be made_

You could cause the editor to crash if you have a slow connection and click the "next" button before the wistia api has loaded

### Test Coverage

_Please show how you have added tests to cover your changes_

Tested manually by using the "fast 3g" network setting, opening a tutorial with a video, and clicking next before the video has loaded.

/cc @evhan55 