### PR TITLE
Prevent previous tutorial images from hanging around on next/prev

### DIFF
--- a/src/components/cards/card.css
+++ b/src/components/cards/card.css
@@ -170,6 +170,9 @@
     align-items: center;
     position: relative;
     text-align: center;
+
+    /* Min height prevents layout changing when images change */
+    min-height: 256px;
 }
 
 .step-video {

--- a/src/components/cards/cards.jsx
+++ b/src/components/cards/cards.jsx
@@ -155,6 +155,7 @@ const ImageStep = ({title, image}) => (
             <img
                 className={styles.stepImage}
                 draggable={false}
+                key={image} /* Use src as key to prevent hanging around on slow connections */
                 src={image}
             />
         </div>


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/LLK/scratch-gui/issues/4927

### Proposed Changes

_Describe what this Pull Request does_

Use the react `key` property on the image to make sure it does not recycle the image DOM node, instead creating a new one. 

### Reason for Changes

_Explain why these changes should be made_

If we allow react to recycle the img node and just change its `src` property, the previous image will show until the new image is loaded. This makes it look like the image "lags behind" the tutorial step.

I needed to ensure a consistent min-height in order to prevent the card from collapsing each time the image is replaced.

### Test Coverage

_Please show how you have added tests to cover your changes_

Tested manually by using a slow connection and stepping through the cards. 
