### PR TITLE
skip example change categories test

### DIFF
--- a/test/integration/examples.test.js
+++ b/test/integration/examples.test.js
@@ -75,7 +75,8 @@ describe('blocks example', () => {
         await expect(projectRequests).toEqual(['https://projects.scratch.mit.edu/96708228']);
     });
 
-    test('Change categories', async () => {
+    // skipping per https://github.com/LLK/scratch-gui/issues/4902 until we have better approach
+    test.skip('Change categories', async () => {
         await loadUri(`${uri}`);
         await clickText('Looks');
         await clickText('Sound');


### PR DESCRIPTION
Helps temporarily address https://github.com/LLK/scratch-gui/issues/4902 by skipping the "change categories" test in examples.test.js .
