### PR TITLE
Fix library images lagging behind filter changes

### DIFF
--- a/src/components/library/library.jsx
+++ b/src/components/library/library.jsx
@@ -185,7 +185,7 @@ class LibraryComponent extends React.Component {
                             id={index}
                             insetIconURL={dataItem.insetIconURL}
                             internetConnectionRequired={dataItem.internetConnectionRequired}
-                            key={`item_${index}`}
+                            key={typeof dataItem.name === 'string' ? dataItem.name :  dataItem.rawURL}
                             name={dataItem.name}
                             onMouseEnter={this.handleMouseEnter}
                             onMouseLeave={this.handleMouseLeave}

--- a/src/components/library/library.jsx
+++ b/src/components/library/library.jsx
@@ -185,7 +185,7 @@ class LibraryComponent extends React.Component {
                             id={index}
                             insetIconURL={dataItem.insetIconURL}
                             internetConnectionRequired={dataItem.internetConnectionRequired}
-                            key={typeof dataItem.name === 'string' ? dataItem.name :  dataItem.rawURL}
+                            key={typeof dataItem.name === 'string' ? dataItem.name : dataItem.rawURL}
                             name={dataItem.name}
                             onMouseEnter={this.handleMouseEnter}
                             onMouseLeave={this.handleMouseLeave}


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/LLK/scratch-gui/issues/4939

### Proposed Changes

_Describe what this Pull Request does_

Use a unique property of the data, either name (if a string) or rawUrl, as the `key` property of the array of library items. We are using `index` right now, which forces react to re-write the `src` property of images instead of just re-arranging the already rendered images. This causes the lag-behind issue of #4939 and also just makes it slower to show in general. 

### Test Coverage

_Please show how you have added tests to cover your changes_

Can no longer reproduce 4939, which is most easily reproduced by:
1. Open the costumes library and allow it to load.
2. Click the "Letters" tag on the right. 
3. You should see the names of the tiles change, but the images lag behind. This is even easier to see if you slow your network connection. This PR fixes that