### PR TITLE
Fix PropType on Loupe component

### DIFF
--- a/src/components/loupe/loupe.jsx
+++ b/src/components/loupe/loupe.jsx
@@ -91,7 +91,8 @@ LoupeComponent.propTypes = {
         color: PropTypes.shape({
             r: PropTypes.number,
             g: PropTypes.number,
-            b: PropTypes.number
+            b: PropTypes.number,
+            a: PropTypes.number
         }),
         data: PropTypes.instanceOf(Uint8Array),
         width: PropTypes.number,

--- a/src/components/sprite-selector/sprite-list.jsx
+++ b/src/components/sprite-selector/sprite-list.jsx
@@ -110,7 +110,8 @@ SpriteList.propTypes = {
     editingTarget: PropTypes.string,
     hoveredTarget: PropTypes.shape({
         hoveredSprite: PropTypes.string,
-        receivedBlocks: PropTypes.bool
+        receivedBlocks: PropTypes.bool,
+        sprite: PropTypes.string
     }),
     items: PropTypes.arrayOf(PropTypes.shape({
         costume: PropTypes.shape({


### PR DESCRIPTION
Updated linter caught this missing prop type! Hooray!

This was the goal of unpinning the linter deps, so yay it worked! See https://github.com/LLK/scratch-gui/pull/4786 for the history of that issue.