### PR TITLE
Correctly fail on non-200 responses when saving

### DIFF
--- a/src/lib/project-saver-hoc.jsx
+++ b/src/lib/project-saver-hoc.jsx
@@ -234,9 +234,14 @@ const ProjectSaverHOC = function (WrappedComponent) {
                         asset.dataFormat,
                         asset.data,
                         asset.assetId
-                    ).then(
-                        () => (asset.clean = true)
-                    )
+                    ).then(response => {
+                        // Asset servers respond with {status: ok} for successful POSTs
+                        if (response.status !== 'ok') {
+                            // Errors include a `code` property, e.g. "Forbidden"
+                            return Promise.reject(response.code);
+                        }
+                        asset.clean = true;
+                    })
                 )
             )
                 .then(() => this.props.onUpdateProjectData(projectId, savedVMState, requestParams))

--- a/src/lib/save-project-to-server.js
+++ b/src/lib/save-project-to-server.js
@@ -45,6 +45,7 @@ export default function (projectId, vmState, params) {
     return new Promise((resolve, reject) => {
         xhr(opts, (err, response) => {
             if (err) return reject(err);
+            if (response.statusCode !== 200) return reject(response.statusCode);
             let body;
             try {
                 // Since we didn't set json: true, we have to parse manually


### PR DESCRIPTION
This patches an issue where we are not correctly handling non-200 (i.e. failures) when saving assets and saving projects.

The assets part of this is also https://github.com/LLK/scratch-storage/issues/100, but we are able to detect it here by inspecting the JSON response, which should have `status: 'ok'` but instead has a different JSON body. I think it is an open question how storage should handle network responses like this, but we can at least prevent further damage this way.

Incidentally, we were doing the same thing when trying to save projects – ignoring non-200 responses. It is important to note that, per the `xhr` docs (and it is the same with fetch) that error responses do not trigger an `error` in the promise chain or an `error` param in the callback, that only happens when something prevents the request from being made. All "error-y" responses are still valid responses, and you need to check the response status code to be sure the request succeeded.

I built this as a hotfix branch in case we want to hotfix into www. But because hotfix/ builds to travis, nothing special needs to be done here to support that.

/cc @kchadha @BryceLTaylor 