### PR TITLE
Resolve symlinks in Webpack

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,9 +31,6 @@ const base = {
         React: 'react',
         ReactDOM: 'react-dom'
     },
-    resolve: {
-        symlinks: false
-    },
     module: {
         rules: [{
             test: /\.jsx?$/,


### PR DESCRIPTION
### Resolves

Resolves #4965 

### Proposed Changes

This removes `resolve {symlinks: false}` from the Webpack configuration.

### Reason for Changes

This allows Webpack to pick up on changes to `npm link`ed Scratch modules and live-recompile + reload them. While [the documentation says the "resolve symlinks" option "may cause module resolution to fail when using tools that symlink packages (like npm link)"](https://webpack.js.org/configuration/resolve/#resolvesymlinks), it is unclear whether enabling or disabling it causes the failure, and in my case it only worked properly when set to `true`.

My development environment is Linux-based, so I'm not sure how this affects other OSes.