### PR TITLE
Add callback to update dynamic block on workspace.

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -261,6 +261,7 @@ class Blocks extends React.Component {
         this.props.vm.addListener('targetsUpdate', this.onTargetsUpdate);
         this.props.vm.addListener('EXTENSION_ADDED', this.handleExtensionAdded);
         this.props.vm.addListener('BLOCKSINFO_UPDATE', this.handleBlocksInfoUpdate);
+        this.props.vm.addListener('BLOCK_UPDATE', this.handleBlockUpdate);
         this.props.vm.addListener('PERIPHERAL_CONNECTED', this.handleStatusButtonUpdate);
         this.props.vm.addListener('PERIPHERAL_DISCONNECTED', this.handleStatusButtonUpdate);
     }
@@ -438,6 +439,12 @@ class Blocks extends React.Component {
     handleBlocksInfoUpdate (categoryInfo) {
         // @todo Later we should replace this to avoid all the warnings from redefining blocks.
         this.handleExtensionAdded(categoryInfo);
+    }
+    handleBlockUpdate (blockId, blockInfo) {
+        const block = this.workspace.getBlockById(blockId);
+        if (block && block.setBlockInfo) {
+            block.setBlockInfo(blockInfo);
+        }
     }
     handleCategorySelected (categoryId) {
         const extension = extensionData.find(ext => ext.extensionId === categoryId);

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -67,6 +67,7 @@ class Blocks extends React.Component {
             'onBlockGlowOff',
             'handleExtensionAdded',
             'handleBlocksInfoUpdate',
+            'handleBlockUpdate',
             'onTargetsUpdate',
             'onVisualReport',
             'onWorkspaceUpdate',

--- a/src/lib/define-dynamic-block.js
+++ b/src/lib/define-dynamic-block.js
@@ -177,6 +177,12 @@ const defineDynamicBlock = (ScratchBlocks, categoryInfo, staticBlockInfo, extend
                 return `%${++argCount}`;
             });
             this.interpolate_(scratchBlocksStyleText, args);
+        },
+        setBlockInfo: function (blockInfo) {
+            this.needsBlockInfoUpdate = true;
+            this.blockInfoText = JSON.stringify(blockInfo);
+            const mutation = this.mutationToDom();
+            this.domToMutation(mutation);
         }
     });
 };

--- a/test/unit/util/define-dynamic-block.test.js
+++ b/test/unit/util/define-dynamic-block.test.js
@@ -249,4 +249,20 @@ describe('defineDynamicBlock', () => {
         expect(options[0].text).toEqual('Context Menu Item');
         expect(typeof options[0].callback).toEqual('function');
     });
+
+    test('setBlockInfo updates block info', () => {
+        const extendedOpcode = 'test.reporter';
+        const block = new MockBlock(testBlockInfo.reporter, extendedOpcode);
+        const blockInfo = JSON.parse(block.blockInfoText);
+        expect(blockInfo.text).toEqual('reporter');
+
+        const newBlockInfo = JSON.parse(JSON.stringify(blockInfo));
+        newBlockInfo.text = 'renamedReporter';
+
+        block.setBlockInfo(newBlockInfo);
+
+        const updatedBlockInfo = JSON.parse(block.blockInfoText);
+        expect(updatedBlockInfo.text).toEqual('renamedReporter');
+
+    });
 });


### PR DESCRIPTION
### Resolves

Towards LLK/scratch-vm#2120

### Proposed Changes

Add a callback to update a dynamic extension block on the workspace. This callback gets passed into the vm so that the extension definition can control when a block gets updated (e.g. renaming a variable, editing a custom procedure, changing the shape of the control_stop block).

### Reason for Changes

This is a feature needed for #2120, especially to support the blocks mentioned above.

### Test Coverage

Added a unit test for the function which mocks scratch-blocks specific functionality.

### Related PRs
- Depends on LLK/scratch-vm#TBD