### PR TITLE
Only call Renderer.pick() on draggable targets in Stage.onStartDrag

### DIFF
--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -342,15 +342,23 @@ class Stage extends React.Component {
     }
     onStartDrag (x, y) {
         if (this.state.dragId) return;
-        const drawableId = this.renderer.pick(x, y);
+
+        // Because pick queries are expensive, only perform them for drawables that are currently draggable.
+        let draggableTargets = this.props.vm.runtime.targets;
+        if (!this.props.useEditorDragStyle) {
+            draggableTargets = draggableTargets.filter(
+                target => Number.isFinite(target.drawableID) && target.draggable
+            );
+        }
+        if (draggableTargets.length === 0) return;
+
+        const draggableIDs = draggableTargets.map(target => target.drawableID);
+        const drawableId = this.renderer.pick(x, y, 1, 1, draggableIDs);
         if (drawableId === null) return;
         const targetId = this.props.vm.getTargetIdForDrawableId(drawableId);
         if (targetId === null) return;
 
         const target = this.props.vm.runtime.getTargetById(targetId);
-
-        // Do not start drag unless in editor drag mode or target is draggable
-        if (!(this.props.useEditorDragStyle || target.draggable)) return;
 
         // Dragging always brings the target to the front
         target.goToFront();

--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -343,11 +343,16 @@ class Stage extends React.Component {
     onStartDrag (x, y) {
         if (this.state.dragId) return;
 
-        // Because pick queries are expensive, only perform them for drawables that are currently draggable.
-        let draggableTargets = this.props.vm.runtime.targets;
+        // Targets with no attached drawable cannot be dragged.
+        let draggableTargets = this.props.vm.runtime.targets.filter(
+            target => Number.isFinite(target.drawableID)
+        );
+
+        // Because pick queries can be expensive, only perform them for drawables that are currently draggable.
+        // If we're in the editor, we can drag all targets. Otherwise, filter.
         if (!this.props.useEditorDragStyle) {
             draggableTargets = draggableTargets.filter(
-                target => Number.isFinite(target.drawableID) && target.draggable
+                target => target.draggable
             );
         }
         if (draggableTargets.length === 0) return;


### PR DESCRIPTION
Resolves https://github.com/LLK/scratch-gui/issues/5776
Resolves #5781

### Proposed Changes

This PR changes the `Stage` component's `onStartDrag` handler to only `Renderer.pick` drawables that are currently draggable, instead of `pick`ing all drawables then checking if each is draggable as it currently does.

### Reason for Changes

Currently, `Renderer.pick()` is called every time you click and drag the mouse on the stage. Projects which make use of a "dragging" action do this a lot.

`Renderer.pick()` can be expensive, especially if they trigger a silhouette update on a pen skin (which calls `gl.readPixels` and massively impacts performance), and `onStartDrag` seems to be called every frame the mouse is down. By only `pick`ing draggable targets, performance can be improved, especially for mouse-controlled projects which make use of the pen.

The last time I benchmarked this, it saved 5ms out of the 33ms frame budget, but since https://github.com/LLK/scratch-render/pull/475 went in, this may have changed. I'll try to get some better numbers now.

Note: this may *appear* to cause a performance regression on Edge (large amounts of lag appear when the mouse is being dragged), but that seems to happen in dev-server builds (and only dev-server builds) with and without this patch.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [x] Edge

Linux
* [x] Chrome
* [x] Firefox
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
