### PR TITLE
Move browsers options to .browserslistrc

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,3 @@
+last 3 versions
+Safari >= 8
+iOS >= 8

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -55,10 +55,7 @@ const base = {
                     ['react-intl', {
                         messagesDir: './translations/messages/'
                     }]],
-                presets: [
-                    ['@babel/preset-env', {targets: {browsers: ['last 3 versions', 'Safari >= 8', 'iOS >= 8']}}],
-                    '@babel/preset-react'
-                ]
+                presets: ['@babel/preset-env', '@babel/preset-react']
             }
         },
         {
@@ -81,9 +78,7 @@ const base = {
                         return [
                             postcssImport,
                             postcssVars,
-                            autoprefixer({
-                                browsers: ['last 3 versions', 'Safari >= 8', 'iOS >= 8']
-                            })
+                            autoprefixer
                         ];
                     }
                 }


### PR DESCRIPTION
Apparently this is the recommendation for loaders that look at the `browsers` option.

I saw this warning while trying to re-enable Greenkeeper.