### PR TITLE
Revert to last good scratch-svg-renderer

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "scratch-paint": "0.2.0-prerelease.20190715183326",
     "scratch-render": "0.1.0-prerelease.20190605151415",
     "scratch-storage": "1.3.2",
-    "scratch-svg-renderer": "0.2.0-prerelease.20190715153806",
+    "scratch-svg-renderer": "0.2.0-prerelease.20190523193400",
     "scratch-vm": "0.2.0-prerelease.20190717201758",
     "selenium-webdriver": "3.6.0",
     "startaudiocontext": "1.2.1",


### PR DESCRIPTION
### Resolves
Fixes a regression where loading project 167167477 then switching to the costume tab crashes the paint editor
