### PR TITLE
fix package-lock (revert svg-renderer) version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11456,9 +11456,9 @@
       }
     },
     "scratch-svg-renderer": {
-      "version": "0.2.0-prerelease.20190715153806",
-      "resolved": "https://registry.npmjs.org/scratch-svg-renderer/-/scratch-svg-renderer-0.2.0-prerelease.20190715153806.tgz",
-      "integrity": "sha512-rS9RsEBb3w4c2/pGaiwtKo8nd3FbNtnJ9GQxjYPmVjxY2Vd3iAMZFRuGb73DZ7vbhkdt0MmW5Xyysj2u6Y+Z4g==",
+      "version": "0.2.0-prerelease.20190523193400",
+      "resolved": "https://registry.npmjs.org/scratch-svg-renderer/-/scratch-svg-renderer-0.2.0-prerelease.20190523193400.tgz",
+      "integrity": "sha512-IzvbM5X7RtEmkLbTwGrvAha/eAOCOU9TFA/BfPR7h2htd2UkkulumRHZzvQoy4gTB7W7CaQvPmz45dYWGcdvkw==",
       "dev": true,
       "requires": {
         "base64-js": "1.2.1",


### PR DESCRIPTION
PR https://github.com/LLK/scratch-gui/pull/5003 left the package lock in a bad state. Reverting to the May version of svg-renderer