### PR TITLE
Make delete button accessible

### DIFF
--- a/src/components/delete-button/delete-button.css
+++ b/src/components/delete-button/delete-button.css
@@ -6,9 +6,15 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    border-radius: 50%;
     user-select: none;
     cursor: pointer;
     transition: all 0.15s ease-out;
+}
+
+.delete-button:focus {
+    outline: none;
+    box-shadow: 0px 0px 0px 4px $motion-transparent;
 }
 
 .delete-button-visible {

--- a/src/components/delete-button/delete-button.jsx
+++ b/src/components/delete-button/delete-button.jsx
@@ -19,6 +19,7 @@ const DeleteButton = props => (
         <div className={styles.deleteButtonVisible}>
             <img
                 className={styles.deleteIcon}
+                draggable={false}
                 src={deleteIcon}
             />
         </div>

--- a/src/components/delete-button/delete-button.jsx
+++ b/src/components/delete-button/delete-button.jsx
@@ -1,67 +1,60 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import bindAll from 'lodash.bindall';
 import classNames from 'classnames';
+import {defineMessages, injectIntl, intlShape} from 'react-intl';
 
 import styles from './delete-button.css';
 import deleteIcon from './icon--delete.svg';
 
-class DeleteButton extends React.Component {
-    constructor (props) {
-        super(props);
-        bindAll(this, [
-            'handleKeyPress',
-            'setRef'
-        ]);
+const messages = defineMessages({
+    delete: {
+        id: 'gui.deleteButton.delete',
+        description: 'Title of the button to delete a sprite, costume or sound',
+        defaultMessage: 'Delete'
     }
-    componentDidMount () {
-        document.addEventListener('keydown', this.handleKeyPress);
-    }
-    componentWillUnmount () {
-        document.removeEventListener('keydown', this.handleKeyPress);
-    }
-    setRef (ref) {
-        this.ref = ref;
-    }
-    handleKeyPress (event) {
-        if (this.ref === event.currentTarget.activeElement && (event.key === 'Enter' || event.key === ' ')) {
-            this.props.onClick(event);
-            event.preventDefault();
-        }
-    }
-    render () {
-        return (
-            <div
-                aria-label="Delete"
-                className={classNames(
-                    styles.deleteButton,
-                    this.props.className
-                )}
-                ref={this.setRef}
-                role="button"
-                tabIndex={this.props.tabIndex}
-                onClick={this.props.onClick}
-            >
-                <div className={styles.deleteButtonVisible}>
-                    <img
-                        className={styles.deleteIcon}
-                        draggable={false}
-                        src={deleteIcon}
-                    />
-                </div>
-            </div>
-        );
-    }
-}
+});
 
-DeleteButton.propTypes = {
+const DeleteButtonComponent = ({
+    className,
+    intl,
+    onClick,
+    setRef,
+    tabIndex,
+    ...props
+}) => (
+    <div
+        aria-label={intl.formatMessage(messages.delete)}
+        className={classNames(
+            styles.deleteButton,
+            className
+        )}
+        ref={setRef}
+        role="button"
+        tabIndex={tabIndex}
+        onClick={onClick}
+        {...props}
+    >
+        <div className={styles.deleteButtonVisible}>
+            <img
+                className={styles.deleteIcon}
+                draggable={false}
+                src={deleteIcon}
+            />
+        </div>
+    </div>
+);
+
+
+DeleteButtonComponent.propTypes = {
     className: PropTypes.string,
+    intl: intlShape,
     onClick: PropTypes.func.isRequired,
+    setRef: PropTypes.func.isRequired,
     tabIndex: PropTypes.number
 };
 
-DeleteButton.defaultProps = {
+DeleteButtonComponent.defaultProps = {
     tabIndex: 0
 };
 
-export default DeleteButton;
+export default injectIntl(DeleteButtonComponent);

--- a/src/components/delete-button/delete-button.jsx
+++ b/src/components/delete-button/delete-button.jsx
@@ -1,31 +1,58 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import bindAll from 'lodash.bindall';
 import classNames from 'classnames';
 
 import styles from './delete-button.css';
 import deleteIcon from './icon--delete.svg';
 
-const DeleteButton = props => (
-    <div
-        aria-label="Delete"
-        className={classNames(
-            styles.deleteButton,
-            props.className
-        )}
-        role="button"
-        tabIndex={props.tabIndex}
-        onClick={props.onClick}
-    >
-        <div className={styles.deleteButtonVisible}>
-            <img
-                className={styles.deleteIcon}
-                draggable={false}
-                src={deleteIcon}
-            />
-        </div>
-    </div>
-
-);
+class DeleteButton extends React.Component {
+    constructor (props) {
+        super(props);
+        bindAll(this, [
+            'handleKeyPress',
+            'setRef'
+        ]);
+    }
+    componentDidMount () {
+        document.addEventListener('keydown', this.handleKeyPress);
+    }
+    componentWillUnmount () {
+        document.removeEventListener('keydown', this.handleKeyPress);
+    }
+    setRef (ref) {
+        this.ref = ref;
+    }
+    handleKeyPress (event) {
+        if (this.ref === event.currentTarget.activeElement && (event.key === 'Enter' || event.key === ' ')) {
+            this.props.onClick(event);
+            event.preventDefault();
+        }
+    }
+    render () {
+        return (
+            <div
+                aria-label="Delete"
+                className={classNames(
+                    styles.deleteButton,
+                    this.props.className
+                )}
+                ref={this.setRef}
+                role="button"
+                tabIndex={this.props.tabIndex}
+                onClick={this.props.onClick}
+            >
+                <div className={styles.deleteButtonVisible}>
+                    <img
+                        className={styles.deleteIcon}
+                        draggable={false}
+                        src={deleteIcon}
+                    />
+                </div>
+            </div>
+        );
+    }
+}
 
 DeleteButton.propTypes = {
     className: PropTypes.string,

--- a/src/components/sprite-selector-item/sprite-selector-item.jsx
+++ b/src/components/sprite-selector-item/sprite-selector-item.jsx
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import DeleteButton from '../delete-button/delete-button.jsx';
+import DeleteButton from '../../containers/delete-button.jsx';
 import styles from './sprite-selector-item.css';
 import {ContextMenuTrigger} from 'react-contextmenu';
 import {DangerousMenuItem, ContextMenu, MenuItem} from '../context-menu/context-menu.jsx';

--- a/src/containers/delete-button.jsx
+++ b/src/containers/delete-button.jsx
@@ -1,0 +1,52 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import bindAll from 'lodash.bindall';
+
+import DeleteButtonComponent from '../components/delete-button/delete-button.jsx';
+
+class DeleteButton extends React.Component {
+    constructor (props) {
+        super(props);
+        bindAll(this, [
+            'handleKeyPress',
+            'setRef'
+        ]);
+    }
+    componentDidMount () {
+        document.addEventListener('keydown', this.handleKeyPress);
+    }
+    componentWillUnmount () {
+        document.removeEventListener('keydown', this.handleKeyPress);
+    }
+    setRef (ref) {
+        this.ref = ref;
+    }
+    handleKeyPress (event) {
+        if (this.ref === event.currentTarget.activeElement && (event.key === 'Enter' || event.key === ' ')) {
+            this.props.onClick(event);
+            event.preventDefault();
+        }
+    }
+    render () {
+        return (
+            <DeleteButtonComponent
+                className={this.props.className}
+                setRef={this.setRef}
+                tabIndex={this.props.tabIndex}
+                onClick={this.props.onClick}
+            />
+        );
+    }
+}
+
+DeleteButton.propTypes = {
+    className: PropTypes.string,
+    onClick: PropTypes.func.isRequired,
+    tabIndex: PropTypes.number
+};
+
+DeleteButton.defaultProps = {
+    tabIndex: 0
+};
+
+export default DeleteButton;

--- a/test/unit/components/__snapshots__/sprite-selector-item.test.jsx.snap
+++ b/test/unit/components/__snapshots__/sprite-selector-item.test.jsx.snap
@@ -57,6 +57,7 @@ exports[`SpriteSelectorItemComponent matches snapshot when given a number and de
     >
       <img
         className={undefined}
+        draggable={false}
         src="test-file-stub"
       />
     </div>
@@ -141,6 +142,7 @@ exports[`SpriteSelectorItemComponent matches snapshot when selected 1`] = `
     >
       <img
         className={undefined}
+        draggable={false}
         src="test-file-stub"
       />
     </div>

--- a/test/unit/components/sprite-selector-item.test.jsx
+++ b/test/unit/components/sprite-selector-item.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {mountWithIntl, shallowWithIntl, componentWithIntl} from '../../helpers/intl-helpers.jsx';
 import SpriteSelectorItemComponent from '../../../src/components/sprite-selector-item/sprite-selector-item';
-import DeleteButton from '../../../src/components/delete-button/delete-button';
+import DeleteButton from '../../../src/containers/delete-button.jsx';
 
 describe('SpriteSelectorItemComponent', () => {
     let className;


### PR DESCRIPTION
### Resolves
- Follow up to #4911

The default outline on focusing the button was ugly.

### Proposed Changes

Change the focus outline to a border that matches other elements. If the element is focused (e.g. through tabbing) and the user presses space or enter, the button is activated deleting the current item.

Don’t allow the image to be dragged.

### Reason for Changes

Looks better and is accessible.

### Test Coverage

No changes

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [x] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [x] Chrome (with touch)
