### PR TITLE
Support for variables extension - Variable Renaming Context Menu

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -417,7 +417,7 @@ class Blocks extends React.Component {
                     // Anything else will be picked up from the XML attached to the block instance.
                     const extendedOpcode = `${categoryInfo.id}_${blockInfo.info.opcode}`;
                     const blockDefinition =
-                        defineDynamicBlock(this.ScratchBlocks, categoryInfo, blockInfo, extendedOpcode);
+                        defineDynamicBlock(this, this.ScratchBlocks, categoryInfo, blockInfo, extendedOpcode);
                     this.ScratchBlocks.Blocks[extendedOpcode] = blockDefinition;
                 });
             }

--- a/src/lib/define-dynamic-block.js
+++ b/src/lib/define-dynamic-block.js
@@ -116,6 +116,8 @@ const defineDynamicBlock = (guiContext, ScratchBlocks, categoryInfo, staticBlock
             this.blockInfoText = '{}';
             // we need a block info update (through `domToMutation`) before we have a completely initialized block
             this.needsBlockInfoUpdate = true;
+            // Keep track of menu info for use in laying out the block and its menus
+            this.menus = categoryInfo.convertedMenuInfo;
         },
         mutationToDom: function () {
             const container = document.createElement('mutation');
@@ -172,7 +174,12 @@ const defineDynamicBlock = (guiContext, ScratchBlocks, categoryInfo, staticBlock
                 const arg = blockInfo.arguments[argName];
                 switch (arg.type) {
                 case ArgumentType.STRING:
-                    args.push({type: 'input_value', name: argName});
+                    if (arg.menu && !this.menus[arg.menu].acceptReporters) {
+                        const options = this.menus[arg.menu].items;
+                        args.push({type: 'field_dropdown', name: argName, options: options});
+                    } else {
+                        args.push({type: 'input_value', name: argName});
+                    }
                     break;
                 case ArgumentType.BOOLEAN:
                     args.push({type: 'input_value', name: argName, check: 'Boolean'});

--- a/src/lib/define-dynamic-block.js
+++ b/src/lib/define-dynamic-block.js
@@ -5,7 +5,7 @@ import BlockType from 'scratch-vm/src/extension-support/block-type';
 import ContextMenuContext from 'scratch-vm/src/extension-support/context-menu-context';
 import log from './log.js';
 
-const setupCustomContextMenu = (ScratchBlocks, contextMenuInfo, extendedOpcode) => {
+const setupCustomContextMenu = (guiContext, ScratchBlocks, contextMenuInfo, extendedOpcode) => {
     // Handle custom context menu options
     const customContextMenuForBlock = {
         /**
@@ -25,9 +25,13 @@ const setupCustomContextMenu = (ScratchBlocks, contextMenuInfo, extendedOpcode) 
                             switch (contextOption.builtInCallback) {
                             case 'EDIT_A_PROCEDURE':
                                 // TODO FILL THIS IN
+                                // E.g. make use of guiContext here to bring up
+                                // the edit custom proc modal
                                 break;
                             case 'RENAME_A_VARIABLE':
                                 // TODO FILL THIS IN
+                                // E.g. make use of guiContext here to bring up
+                                // the rename variable modal
                                 break;
                             }
                         } else if (contextOption.callback) {
@@ -77,11 +81,11 @@ const setupCustomContextMenu = (ScratchBlocks, contextMenuInfo, extendedOpcode) 
  * @param {string} extendedOpcode - The opcode for the block (including the extension ID).
  */
 // TODO: grow this until it can fully replace `_convertForScratchBlocks` in the VM runtime
-const defineDynamicBlock = (ScratchBlocks, categoryInfo, staticBlockInfo, extendedOpcode) => {
+const defineDynamicBlock = (guiContext, ScratchBlocks, categoryInfo, staticBlockInfo, extendedOpcode) => {
     // Set up context menus if any
     const contextMenuInfo = staticBlockInfo.info.customContextMenu;
     const contextMenuName = contextMenuInfo ?
-        setupCustomContextMenu(ScratchBlocks, staticBlockInfo.info.customContextMenu, extendedOpcode) : '';
+        setupCustomContextMenu(guiContext, ScratchBlocks, staticBlockInfo.info.customContextMenu, extendedOpcode) : '';
 
     return ({
         init: function () {

--- a/src/lib/define-dynamic-block.js
+++ b/src/lib/define-dynamic-block.js
@@ -131,8 +131,14 @@ const defineDynamicBlock = (guiContext, ScratchBlocks, categoryInfo, staticBlock
                 throw new Error('Attempted to update block info twice');
             }
             delete this.needsBlockInfoUpdate;
-            this.blockInfoText = blockInfoText;
+
+            // Parse blockInfoText, and add this block instance's id
+            // to the blockInfoText we save back to this block.
             const blockInfo = JSON.parse(blockInfoText);
+            blockInfo.id = this.id;
+            this.blockInfoText = JSON.stringify(blockInfo);
+
+            // Use the parsed blockInfo to layout the block
 
             switch (blockInfo.blockType) {
             case BlockType.COMMAND:

--- a/src/lib/define-dynamic-block.js
+++ b/src/lib/define-dynamic-block.js
@@ -187,6 +187,9 @@ const defineDynamicBlock = (guiContext, ScratchBlocks, categoryInfo, staticBlock
                         args.push({type: 'input_value', name: argName});
                     }
                     break;
+                case ArgumentType.NUMBER:
+                    args.push({type: 'input_value', name: argName});
+                    break;
                 case ArgumentType.BOOLEAN:
                     args.push({type: 'input_value', name: argName, check: 'Boolean'});
                     break;

--- a/test/unit/util/define-dynamic-block.test.js
+++ b/test/unit/util/define-dynamic-block.test.js
@@ -88,7 +88,13 @@ class MockBlock {
     constructor (staticBlockInfo, extendedOpcode) {
         // mimic Closure-style inheritance by mixing in `defineDynamicBlock` output as this instance's prototype
         // see also the `Blockly.Block` constructor
-        const prototype = defineDynamicBlock(MockScratchBlocks, categoryInfo, staticBlockInfo, extendedOpcode);
+        const prototype = defineDynamicBlock(
+            null /* guiContext */,
+            MockScratchBlocks,
+            categoryInfo,
+            staticBlockInfo,
+            extendedOpcode
+        );
         mixin(this, prototype);
         this.init();
 


### PR DESCRIPTION
### Resolves

Towards LLK/scratch-vm#2120

### Proposed Changes

Adds support for the variable renaming context menu on a variable reporter block.
- fills in `RENAME_A_VARIABLE` built-in context menu callback, which opens the appropriate rename variable modal and passes back information to the VM extension callback for the context menu item.
- Updates the code in domToMutation which dynamically updates the layout of the block. Ensures that that shadow blocks (and any other blocks plugged into inputs) on updated dynamic blocks stay connected after layout update.
- Adds support for number arguments on dynamic extension blocks (this is for list blocks which use a `math_number` shadow block.
- Adds support for non-droppable menus in dynamic extension blocks

### Related PRs
- This PR depends on LLK/scratch-vm#2242
