### PR TITLE
Check for null child before cloning menu item

### DIFF
--- a/src/components/menu/menu.jsx
+++ b/src/components/menu/menu.jsx
@@ -58,7 +58,7 @@ MenuItem.propTypes = {
 
 
 const addDividerClassToFirstChild = (child, id) => (
-    React.cloneElement(child, {
+    child && React.cloneElement(child, {
         className: classNames(
             child.className,
             {[styles.menuSection]: id === 0}


### PR DESCRIPTION
### Resolves

File menu issue that only appears when running gui in www with a logged in users
### Proposed Changes

_Describe what this Pull Request does_
Check for null child before adding it to a menu section
