### PR TITLE
Fix issue where context menu wouldn't come back after dragging

### DIFF
--- a/src/lib/drag-recognizer.js
+++ b/src/lib/drag-recognizer.js
@@ -109,8 +109,10 @@ class DragRecognizer {
     }
 
     _handleEnd () {
-        this._onDragEnd();
         this.reset();
+        // Call the callback after reset to make sure if gestureInProgress()
+        // is used in response, it get the correct value (i.e. no gesture in progress)
+        this._onDragEnd();
     }
 
     _isDrag () {

--- a/test/unit/util/drag-recognizer.test.js
+++ b/test/unit/util/drag-recognizer.test.js
@@ -56,6 +56,17 @@ describe('DragRecognizer', () => {
         expect(onDrag).toHaveBeenCalledTimes(1); // Still 1
     });
 
+    test('start -> end calls dragEnd callback after resetting internal state', done => {
+        onDragEnd = () => {
+            expect(dragRecognizer.gestureInProgress()).toBe(false);
+            done();
+        };
+        dragRecognizer = new DragRecognizer({onDrag, onDragEnd});
+        dragRecognizer.start({clientX: 100, clientY: 100});
+        window.dispatchEvent(new MouseEvent('touchmove', {clientX: 150, clientY: 106}));
+        window.dispatchEvent(new MouseEvent('touchend', {clientX: 150, clientY: 106}));
+    });
+
     test('start -> reset unbinds', () => {
         dragRecognizer.start({clientX: 100, clientY: 100});
         window.dispatchEvent(new MouseEvent('touchmove', {clientX: 150, clientY: 106}));


### PR DESCRIPTION
Fixes #5031, which is happening because the gestureInProgress call is still returning true after a drag ends.

### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/LLK/scratch-gui/issues/5031

### Proposed Changes

_Describe what this Pull Request does_

Make sure not to call the dragEnd callback until the drag recognizer is reset. This was causing the `preventContextMenu` to remain true longer than it should, causing the linked issue.
