### PR TITLE
Do not update trimmers only if both have not changed

### DIFF
--- a/src/containers/audio-selector.jsx
+++ b/src/containers/audio-selector.jsx
@@ -43,7 +43,8 @@ class AudioSelector extends React.Component {
         });
     }
     componentWillReceiveProps (newProps) {
-        if (newProps.trimStart === this.props.trimStart) return;
+        const {trimStart, trimEnd} = this.props;
+        if (newProps.trimStart === trimStart && newProps.trimEnd === trimEnd) return;
         this.setState({
             trimStart: newProps.trimStart,
             trimEnd: newProps.trimEnd


### PR DESCRIPTION
@ericrosenbaum @BryceLTaylor this fixes the issue we found where the trim handles wouldn't update if your selection started at zero. This was happening because the audio-selector was using whether or not trimstart changed to update its internal state, but it should check both start and end. 