### PR TITLE
Prevent default when dragging trim handles to prevent image drag

### DIFF
--- a/src/containers/audio-trimmer.jsx
+++ b/src/containers/audio-trimmer.jsx
@@ -42,11 +42,15 @@ class AudioTrimmer extends React.Component {
         this.containerSize = this.containerElement.getBoundingClientRect().width;
         this.trimStartDragRecognizer.start(e);
         this.initialTrim = this.props.trimStart;
+        e.stopPropagation();
+        e.preventDefault();
     }
     handleTrimEndMouseDown (e) {
         this.containerSize = this.containerElement.getBoundingClientRect().width;
         this.trimEndDragRecognizer.start(e);
         this.initialTrim = this.props.trimEnd;
+        e.stopPropagation();
+        e.preventDefault();
     }
     storeRef (el) {
         this.containerElement = el;


### PR DESCRIPTION
Fixes an issue where dragging the trim handles in the sound recorder would drag the image instead on Firefox. 

/cc @ericrosenbaum @BryceLTaylor 