### PR TITLE
Handle name being null in rename callback. 

### DIFF
--- a/src/lib/define-dynamic-block.js
+++ b/src/lib/define-dynamic-block.js
@@ -45,6 +45,7 @@ const setupCustomContextMenu = (guiContext, ScratchBlocks, contextMenuInfo, exte
                                 const varType = blockInfo.opcode === 'variable' ? '' : 'list';
 
                                 const renameCallback = newName => {
+                                    if (!newName) return;
                                     // Pass in additional information about the variable renaming to the
                                     // extension callback
                                     contextOptionCallbackData.newName = newName;


### PR DESCRIPTION
### Proposed Changes

Fixes an issue where attempting to renaming a variable to an existing name (and clicking okay in the resulting alert that pops up) throws an error.
