### PR TITLE
Fix saving after recording a sound

### DIFF
--- a/src/lib/vm-listener-hoc.jsx
+++ b/src/lib/vm-listener-hoc.jsx
@@ -60,9 +60,9 @@ const vmListenerHOC = function (WrappedComponent) {
                 this.props.vm.postIOData('userData', {username: this.props.username});
             }
 
-            // Re-request a targets update when the shouldEmitUpdate state changes to true
+            // Re-request a targets update when the shouldUpdateTargets state changes to true
             // i.e. when the editor transitions out of fullscreen/player only modes
-            if (this.props.shouldEmitUpdates && !prevProps.shouldEmitUpdates) {
+            if (this.props.shouldUpdateTargets && !prevProps.shouldUpdateTargets) {
                 this.props.vm.emitTargetsUpdate(false /* Emit the event, but do not trigger project change */);
             }
         }
@@ -74,12 +74,12 @@ const vmListenerHOC = function (WrappedComponent) {
             }
         }
         handleProjectChanged () {
-            if (this.props.shouldEmitUpdates && !this.props.projectChanged) {
+            if (this.props.shouldUpdateProjectChanged && !this.props.projectChanged) {
                 this.props.onProjectChanged();
             }
         }
         handleTargetsUpdate (data) {
-            if (this.props.shouldEmitUpdates) {
+            if (this.props.shouldUpdateTargets) {
                 this.props.onTargetsUpdate(data);
             }
         }
@@ -118,7 +118,8 @@ const vmListenerHOC = function (WrappedComponent) {
                 /* eslint-disable no-unused-vars */
                 attachKeyboardEvents,
                 projectChanged,
-                shouldEmitUpdates,
+                shouldUpdateTargets,
+                shouldUpdateProjectChanged,
                 onBlockDragUpdate,
                 onGreenFlag,
                 onKeyDown,
@@ -158,7 +159,8 @@ const vmListenerHOC = function (WrappedComponent) {
         onTurboModeOff: PropTypes.func.isRequired,
         onTurboModeOn: PropTypes.func.isRequired,
         projectChanged: PropTypes.bool,
-        shouldEmitUpdates: PropTypes.bool,
+        shouldUpdateTargets: PropTypes.bool,
+        shouldUpdateProjectChanged: PropTypes.bool,
         username: PropTypes.string,
         vm: PropTypes.instanceOf(VM).isRequired
     };
@@ -170,8 +172,10 @@ const vmListenerHOC = function (WrappedComponent) {
         projectChanged: state.scratchGui.projectChanged,
         // Do not emit target or project updates in fullscreen or player only mode
         // or when recording sounds (it leads to garbled recordings on low-power machines)
-        shouldEmitUpdates: !state.scratchGui.mode.isFullScreen && !state.scratchGui.mode.isPlayerOnly &&
+        shouldUpdateTargets: !state.scratchGui.mode.isFullScreen && !state.scratchGui.mode.isPlayerOnly &&
             !state.scratchGui.modals.soundRecorder,
+        // Do not update the projectChanged state in fullscreen or player only mode
+        shouldUpdateProjectChanged: !state.scratchGui.mode.isFullScreen && !state.scratchGui.mode.isPlayerOnly,
         vm: state.scratchGui.vm,
         username: state.session && state.session.session && state.session.session.user ?
             state.session.session.user.username : ''

--- a/test/unit/util/vm-listener-hoc.test.jsx
+++ b/test/unit/util/vm-listener-hoc.test.jsx
@@ -91,4 +91,46 @@ describe('VMListenerHOC', () => {
         const actions = store.getActions();
         expect(actions.length).toEqual(0);
     });
+
+    test('PROJECT_CHANGED does dispatch if the sound recorder is visible', () => {
+        const Component = () => (<div />);
+        const WrappedComponent = vmListenerHOC(Component);
+        store = mockStore({
+            scratchGui: {
+                mode: {},
+                modals: {soundRecorder: true},
+                vm: vm
+            }
+        });
+        mount(
+            <WrappedComponent
+                store={store}
+                vm={vm}
+            />
+        );
+        vm.emit('PROJECT_CHANGED');
+        const actions = store.getActions();
+        expect(actions.length).toEqual(1);
+    });
+
+    test('PROJECT_CHANGED does not dispatch if in fullscreen mode', () => {
+        const Component = () => (<div />);
+        const WrappedComponent = vmListenerHOC(Component);
+        store = mockStore({
+            scratchGui: {
+                mode: {isFullScreen: true},
+                modals: {soundRecorder: true},
+                vm: vm
+            }
+        });
+        mount(
+            <WrappedComponent
+                store={store}
+                vm={vm}
+            />
+        );
+        vm.emit('PROJECT_CHANGED');
+        const actions = store.getActions();
+        expect(actions.length).toEqual(0);
+    });
 });


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/LLK/scratch-gui/issues/4742

### Proposed Changes

_Describe what this Pull Request does_

Separate the flag that controls if the GUI should update its internal targets list (which shouldn't happen during sound recording for performance reasons) from the flag that controls if GUI should update its internal "does the project need saving" flag, which _should_ happen during sound recording. We were recycling the flag, but the sound editor performance optimization was added later and the implications of that were not obvious.

I made the variable name for the old flag more explicit, to make the code more understandable, and 
 added more unit tests to make the behavior more explicit