### PR TITLE
Fix duplicate running blocks by removing pointer-events: none

### DIFF
--- a/src/components/blocks/blocks.css
+++ b/src/components/blocks/blocks.css
@@ -79,8 +79,13 @@
     /*
         Fix an issue where the drag surface was preventing hover events for sharing blocks.
         This does not prevent user interaction on the blocks themselves.
+        This was previously pointer-events: none, but that allowed clicks to fall through
+        causing incorrect stack clicks on duplicate, and prevented the correct
+        cursor from showing when dragging over the toolbox to delete.
     */
-    pointer-events: none;
+    width: 1px;
+    height: 1px;
+    overflow: visible;
     z-index: $z-index-drag-layer; /* make blocks match gui drag layer */
 }
 


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/LLK/scratch-gui/issues/1307
- Fixes https://github.com/LLK/scratch-gui/issues/2755

### Proposed Changes

_Describe what this Pull Request does_

Instead of using `pointer-events: none` on the blocks drag layer, set its width/height to 1 (setting to zero makes it disappear) and allow overflow. This allows hover events to fall through (used for sharing blocks to other sprites) but keep the click behavior where the drag layer handles the click on duplicate and drag. 

### Reason for Changes

_Explain why these changes should be made_

This is hard to explain, but here goes:
- After duplicating blocks, you then need to click to drop the blocks.
- If you click on a stack to insert the duplicated blocks into a stack, it should attach the blocks but not cause the blocks to run.
- Usually this is handled by the drag surface handling the block click, which cancels the gesture and allows the blocks to be dropped.
- By setting `pointer-events: none` on the drag surface (to fix issues with hovering over sprite tiles to share them), we inadvertently changed the drop behavior so that the workspace handles the click instead of the drag surface.
- A few things are possible: your click could land on the workspace, or on a single block, in both cases nothing interesting happens, the stack is dropped/attached without running any blocks
- If you click in the middle/end of a stack, due to a strange quirk of the way block mousedown events are bound, a mousedown is triggered on _every_ block in that stack, instead of just the one you are directly over.
- Multiple block mousedowns cause a weird issue where the gesture is cancelled correctly, but then successive block mousedowns cause a new gesture to start.
- If a gesture is started, it will eventually be ended by mouseup, at which point the stackclick event is triggered and the blocks are run.

/ht to @kchadha and @picklesrus for helping to find this issue.

I'd like to follow up on a couple issues on the scratch-blocks side. I think that we may want to change the way mousedowns are bound so that the targets are not nested in a stack, this causes way to many mousedown events in large stacks that is probably a big performance problem. Additionally, we could remove the event binding from the drag layer and officially set pointer-events to none on the scratch-blocks side, which would allow us to remove this kludge.