### PR TITLE
Get the mime-type for the file from the blob

### DIFF
--- a/src/lib/download-blob.js
+++ b/src/lib/download-blob.js
@@ -11,6 +11,7 @@ export default (filename, blob) => {
     const url = window.URL.createObjectURL(blob);
     downloadLink.href = url;
     downloadLink.download = filename;
+    downloadLink.type = blob.type;
     downloadLink.click();
     window.URL.revokeObjectURL(url);
     document.body.removeChild(downloadLink);


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Helps to resolve import issues with the Android version of Scratch

### Proposed Changes

_Describe what this Pull Request does_
Adds the mime-type to the download link.

### Test Coverage
Current tests are ok

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
