### PR TITLE
Show an error when trying to import an invalid sprite file

### DIFF
--- a/src/containers/target-pane.jsx
+++ b/src/containers/target-pane.jsx
@@ -141,11 +141,13 @@ class TargetPane extends React.Component {
         this.props.onShowImporting();
         handleFileUpload(e.target, (buffer, fileType, fileName, fileIndex, fileCount) => {
             spriteUpload(buffer, fileType, fileName, storage, newSprite => {
-                this.handleNewSprite(newSprite).then(() => {
-                    if (fileIndex === fileCount - 1) {
-                        this.props.onCloseImporting();
-                    }
-                });
+                this.handleNewSprite(newSprite)
+                    .then(() => {
+                        if (fileIndex === fileCount - 1) {
+                            this.props.onCloseImporting();
+                        }
+                    })
+                    .catch(this.props.onCloseImporting);
             }, this.props.onCloseImporting);
         }, this.props.onCloseImporting);
     }

--- a/src/containers/target-pane.jsx
+++ b/src/containers/target-pane.jsx
@@ -147,9 +147,9 @@ class TargetPane extends React.Component {
                             this.props.onCloseImporting();
                         }
                     })
-                    .catch(this.props.onCloseImporting);
-            }, this.props.onCloseImporting);
-        }, this.props.onCloseImporting);
+                    .catch(this.props.onShowImportError);
+            }, this.props.onShowImportError);
+        }, this.props.onShowImportError);
     }
     setFileInput (input) {
         this.fileInput = input;
@@ -209,6 +209,7 @@ class TargetPane extends React.Component {
             onHighlightTarget, // eslint-disable-line no-unused-vars
             dispatchUpdateRestore, // eslint-disable-line no-unused-vars
             onShowImporting, // eslint-disable-line no-unused-vars
+            onShowImportError, // eslint-disable-line no-unused-vars
             onCloseImporting, // eslint-disable-line no-unused-vars
             ...componentProps
         } = this.props;
@@ -281,7 +282,8 @@ const mapDispatchToProps = dispatch => ({
         dispatch(highlightTarget(id));
     },
     onCloseImporting: () => dispatch(closeAlertWithId('importingAsset')),
-    onShowImporting: () => dispatch(showStandardAlert('importingAsset'))
+    onShowImporting: () => dispatch(showStandardAlert('importingAsset')),
+    onShowImportError: () => dispatch(showStandardAlert('importingAssetError'))
 });
 
 export default injectIntl(connect(

--- a/src/lib/alerts/index.jsx
+++ b/src/lib/alerts/index.jsx
@@ -212,6 +212,21 @@ const alerts = [
         ),
         iconSpinner: true,
         level: AlertLevels.SUCCESS
+    },
+    {
+        alertId: 'importingAssetError',
+        alertType: AlertTypes.STANDARD,
+        clearList: ['importingAsset'],
+        closeButton: true,
+        content: (
+            <FormattedMessage
+                defaultMessage="Could not import that file"
+                description="Message indicating importing a file failed"
+                id="gui.alerts.importingError"
+            />
+        ),
+        level: AlertLevels.WARN,
+        maxDisplaySecs: 5
     }
 ];
 


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/LLK/scratch-gui/issues/5089

### Proposed Changes

_Describe what this Pull Request does_

1. Add a specific "failed to import" error alert, and use it instead of just closing the importing alert.
2. Add a `.catch` to the sprite import promise. We were only catching errors from the file reading process itself before, but this way we can also catch issues from parsing the file as a sprite.

### Test Coverage

_Please show how you have added tests to cover your changes_

Tested manually using the upload steps from https://github.com/LLK/scratch-gui/issues/5089

If there is copy/useablility concerns with the new alert error, I can also resubmit this just fixing (2) and making it just close the import without any other feedback, the existing behavior for when the file reading fails.