### PR TITLE
Close importing after failing to import

### DIFF
--- a/src/containers/target-pane.jsx
+++ b/src/containers/target-pane.jsx
@@ -141,11 +141,13 @@ class TargetPane extends React.Component {
         this.props.onShowImporting();
         handleFileUpload(e.target, (buffer, fileType, fileName, fileIndex, fileCount) => {
             spriteUpload(buffer, fileType, fileName, storage, newSprite => {
-                this.handleNewSprite(newSprite).then(() => {
-                    if (fileIndex === fileCount - 1) {
-                        this.props.onCloseImporting();
-                    }
-                });
+                this.handleNewSprite(newSprite)
+                    .then(() => {
+                        if (fileIndex === fileCount - 1) {
+                            this.props.onCloseImporting();
+                        }
+                    })
+                    .catch(this.props.onCloseImporting);
             }, this.props.onCloseImporting);
         }, this.props.onCloseImporting);
     }


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

This is a partial fix for the issue where importing non-sprite zips as sprites causes the import spinner to show up forever. I broke this out from https://github.com/LLK/scratch-gui/pull/5090 since I wanted to fix the functionality in the current system (where there is no error alert) before introducing new functionality (a dismissable error alert). 

### Proposed Changes

_Describe what this Pull Request does_

Like in other situations where file parsing fails, just close the importing alert.

Resolves #4639