### PR TITLE
Revert "Fix duplicate running blocks by removing pointer-events: none"

### DIFF
--- a/src/components/blocks/blocks.css
+++ b/src/components/blocks/blocks.css
@@ -79,13 +79,8 @@
     /*
         Fix an issue where the drag surface was preventing hover events for sharing blocks.
         This does not prevent user interaction on the blocks themselves.
-        This was previously pointer-events: none, but that allowed clicks to fall through
-        causing incorrect stack clicks on duplicate, and prevented the correct
-        cursor from showing when dragging over the toolbox to delete.
     */
-    width: 1px;
-    height: 1px;
-    overflow: visible;
+    pointer-events: none;
     z-index: $z-index-drag-layer; /* make blocks match gui drag layer */
 }
 


### PR DESCRIPTION
Reverts LLK/scratch-gui#5078

This breaks dragging blocks on chrome on windows :( :( :( 