### PR TITLE
Allow some kind of downloading to work on iOS Safari

### DIFF
--- a/src/lib/download-blob.js
+++ b/src/lib/download-blob.js
@@ -8,11 +8,23 @@ export default (filename, blob) => {
         return;
     }
 
-    const url = window.URL.createObjectURL(blob);
-    downloadLink.href = url;
-    downloadLink.download = filename;
-    downloadLink.type = blob.type;
-    downloadLink.click();
-    window.URL.revokeObjectURL(url);
-    document.body.removeChild(downloadLink);
+    if ('download' in HTMLAnchorElement.prototype) {
+        const url = window.URL.createObjectURL(blob);
+        downloadLink.href = url;
+        downloadLink.download = filename;
+        downloadLink.type = blob.type;
+        downloadLink.click();
+        document.body.removeChild(downloadLink);
+        window.URL.revokeObjectURL(url);
+    } else {
+        // iOS Safari, open a new page and set href to data-uri
+        let popup = window.open('', '_blank');
+        const reader = new FileReader();
+        reader.onloadend = function () {
+            popup.location.href = reader.result;
+            popup = null;
+        };
+        reader.readAsDataURL(blob);
+    }
+
 };


### PR DESCRIPTION
This allows exporting of projects/sprites/costumes/sounds in iOS Safari.

iOS safari does not support the `download` attribute on `<a>` elements, so we need to read the blob as a data-uri and assign that to a popup window. This prevents the situation where trying to export closes the project, possibly losing work. It is not a great experience on iOS, though. It opens a new tab, but the file name is always "unknown". It does allow the user to download sprite/project files to the local "Files" app. For costumes/sprites, it just shows the asset in a new tab, using the menu at the top/right allows the user to download the image/sound.

Apparently iOS13 will have support for downloading files, so we should keep an eye on this in the fall, but it looks like it will just automatically switch over to using the current download method. 

### Testing plan:
* try exporting costume, sound, sprite
* try downloading project
* make sure doing this doesn't close the project or make you lose work!