### PR TITLE
Variables Extension Monitors

### DIFF
--- a/src/components/monitor/monitor.jsx
+++ b/src/components/monitor/monitor.jsx
@@ -13,15 +13,8 @@ import ListMonitor from '../../containers/list-monitor.jsx';
 
 import styles from './monitor.css';
 
-const categories = {
-    data: '#FF8C1A',
-    sensing: '#5CB1D6',
-    sound: '#CF63CF',
-    looks: '#9966FF',
-    motion: '#4C97FF',
-    list: '#FC662C',
-    extension: '#0FBD8C'
-};
+
+const extensionColor = '#0FBD8C';
 
 const modes = {
     default: DefaultMonitor,
@@ -49,7 +42,7 @@ const MonitorComponent = props => (
                 onDoubleClick={props.mode === 'list' || !props.draggable ? null : props.onNextMode}
             >
                 {React.createElement(modes[props.mode], {
-                    categoryColor: categories[props.category],
+                    categoryColor: props.color,
                     ...props
                 })}
             </Box>
@@ -114,12 +107,11 @@ const MonitorComponent = props => (
 
 );
 
-MonitorComponent.categories = categories;
 
 const monitorModes = Object.keys(modes);
 
 MonitorComponent.propTypes = {
-    category: PropTypes.oneOf(Object.keys(categories)),
+    color: PropTypes.string,
     componentRef: PropTypes.func.isRequired,
     draggable: PropTypes.bool.isRequired,
     label: PropTypes.string.isRequired,
@@ -135,7 +127,7 @@ MonitorComponent.propTypes = {
 };
 
 MonitorComponent.defaultProps = {
-    category: 'extension',
+    color: extensionColor,
     mode: 'default'
 };
 

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -305,6 +305,13 @@ export default function (vm) {
     };
 
     ScratchBlocks.VerticalFlyout.getCheckboxState = function (blockId) {
+        if (vm.runtime.getPendingMonitor(blockId)) {
+            // If this block id is associated with a pending monitor,
+            // this block should have it's checkbox state set to true.
+            // The block will have the associated pending monitor removed
+            // inside the VM (when the block is created).
+            return true;
+        }
         const monitoredBlock = vm.runtime.monitorBlocks._blocks[blockId];
         return monitoredBlock ? monitoredBlock.isMonitored : false;
     };

--- a/src/lib/define-dynamic-block.js
+++ b/src/lib/define-dynamic-block.js
@@ -99,6 +99,32 @@ const setupCustomContextMenu = (guiContext, ScratchBlocks, contextMenuInfo, exte
 };
 
 /**
+ * Create a field validator function for dynamic block field dropdowns.
+ * This validator function is responsible for keeping the selected field
+ * value and the block mutation stay in sync. This validator function also
+ * emits a mutation change event so that the VM can stay
+ * in sync with these changes.
+ * @param {object} ScratchBlocks - The ScratchBlocks name space.
+ * @param {string} argName - The name of the field dropdown getting the validator function
+ * @returns {function} The validator function for the field
+ */
+const makeFieldValidator = (ScratchBlocks, argName) => function (selectedItem) {
+    // Disabling this lint rule since this function will get attached
+    // to the field_dropdown prototype appropriately.
+    /* eslint-disable no-invalid-this */
+    const oldMutation = ScratchBlocks.Xml.domToText(this.sourceBlock_.mutationToDom());
+    const currBlockInfo = JSON.parse(this.sourceBlock_.blockInfoText);
+    currBlockInfo.arguments[argName].selectedValue = selectedItem;
+    this.sourceBlock_.blockInfoText = JSON.stringify(currBlockInfo);
+    const newMutation = ScratchBlocks.Xml.domToText(this.sourceBlock_.mutationToDom());
+    ScratchBlocks.Events.fire(new ScratchBlocks.Events.BlockChange(this.sourceBlock_,
+        'mutation', null, oldMutation, newMutation));
+    this.setValue(selectedItem);
+    return null;
+    /* eslint-enable no-invalid-this */
+};
+
+/**
  * Define a block using extension info which has the ability to dynamically determine (and update) its layout.
  * This functionality is used for extension blocks which can change its properties based on different state
  * information. For example, the `control_stop` block changes its shape based on which menu item is selected
@@ -246,38 +272,24 @@ const defineDynamicBlock = (guiContext, ScratchBlocks, categoryInfo, staticBlock
                 }
             });
 
-            // Add a validator function to each field_dropdown which is responsible
-            // for keeping the mutation and the field value in sync. Emit a change
-            // event for the mutation so that the VM can also stay in sync with
-            // these changes.
-            const fieldValidator = argName => (function (selectedItem) {
-                // Disabling this lint rule since this function will get attached to the
-                // field_dropdown prototype appropriately.
-                /* eslint-disable no-invalid-this */
-                const oldMutation = ScratchBlocks.Xml.domToText(this.sourceBlock_.mutationToDom());
-                const currBlockInfo = JSON.parse(this.sourceBlock_.blockInfoText);
-                currBlockInfo.arguments[argName].selectedValue = selectedItem;
-                this.sourceBlock_.blockInfoText = JSON.stringify(currBlockInfo);
-                const newMutation = ScratchBlocks.Xml.domToText(this.sourceBlock_.mutationToDom());
-                ScratchBlocks.Events.fire(new ScratchBlocks.Events.BlockChange(this.sourceBlock_,
-                    'mutation', null, oldMutation, newMutation));
-                this.setValue(selectedItem);
-                return null;
-                /* eslint-enable no-invalid-this */
-            });
+            const fieldValidator = makeFieldValidator.bind(null, ScratchBlocks);
 
             // Set values on any args that have selectedValue specified
             args.forEach(arg => {
                 if (arg.type === 'field_dropdown') {
                     const field = this.getField(arg.name);
                     if (!field) return;
+                    // Add a validator function to each field_dropdown which is responsible
+                    // for keeping the mutation and the field value in sync. Emit a change
+                    // event for the mutation so that the VM can also stay in sync with
+                    // these changes.
                     field.setValidator(fieldValidator(arg.name));
                     if (blockInfo.arguments[arg.name].selectedValue) {
                         field.setValue(blockInfo.arguments[arg.name].selectedValue);
                     } else {
                         // Update the block info to keep track of the selected value for the
                         // next time this block gets rendered without any external forces
-                        // changing it
+                        // changing it (e.g. switching sprites or switching between editor tabs)
                         // See generic blockInfoText update below.
                         // This prevents block arguments accidentally getting updated because
                         // they don't have a selectedValue in their block info, and the

--- a/src/lib/monitor-adapter.js
+++ b/src/lib/monitor-adapter.js
@@ -4,7 +4,7 @@ const isUndefined = a => typeof a === 'undefined';
 
 /**
  * Convert monitors from VM format to what the GUI needs to render.
- * - Convert opcode to a label and a category
+ * - Convert opcode to a label and monitor color
  * @param {string} block.id - The id of the monitor block
  * @param {string} block.spriteName - Present only if the monitor applies only to the sprite
  *     with given target ID. The name of the target sprite when the monitor was created
@@ -12,12 +12,12 @@ const isUndefined = a => typeof a === 'undefined';
  * @param {object} block.params - Extra params to the monitor block
  * @param {string|number|Array} block.value - The monitor value
  * @param {VirtualMachine} block.vm - the VM instance which owns the block
- * @return {object} The adapted monitor with label and category
+ * @return {object} The adapted monitor with label and color
  */
 export default function ({id, spriteName, opcode, params, value, vm}) {
     // Extension monitors get their labels from the Runtime through `getLabelForOpcode`.
     // Other monitors' labels are hard-coded in `OpcodeLabels`.
-    let {label, category, labelFn} = (vm && vm.runtime.getLabelForOpcode(opcode)) || OpcodeLabels.getLabel(opcode);
+    let {label, color, labelFn} = (vm && vm.runtime.getMonitorLabelForBlock(id)) || OpcodeLabels.getLabel(opcode);
 
     // Use labelFn if provided for dynamic labelling (e.g. variables)
     if (!isUndefined(labelFn)) label = labelFn(params);
@@ -42,5 +42,5 @@ export default function ({id, spriteName, opcode, params, value, vm}) {
         value = value.map(item => item.toString());
     }
 
-    return {id, label, category, value};
+    return {id, label, color, value};
 }

--- a/src/lib/monitor-adapter.js
+++ b/src/lib/monitor-adapter.js
@@ -15,7 +15,7 @@ const isUndefined = a => typeof a === 'undefined';
  * @return {object} The adapted monitor with label and color
  */
 export default function ({id, spriteName, opcode, params, value, vm}) {
-    // Extension monitors get their labels from the Runtime through `getLabelForOpcode`.
+    // Extension monitors get their labels from the Runtime through `getMonitorLabelForBlock`.
     // Other monitors' labels are hard-coded in `OpcodeLabels`.
     let {label, color, labelFn} = (vm && vm.runtime.getMonitorLabelForBlock(id)) || OpcodeLabels.getLabel(opcode);
 

--- a/src/lib/opcode-labels.js
+++ b/src/lib/opcode-labels.js
@@ -115,6 +115,19 @@ const messages = defineMessages({
     }
 });
 
+// Moved from monitor component. Post-extensionification,
+// these values can just come from the block itself, and
+// this can be removed.
+const categoryColors = {
+    data: '#FF8C1A',
+    sensing: '#5CB1D6',
+    sound: '#CF63CF',
+    looks: '#9966FF',
+    motion: '#4C97FF',
+    list: '#FC662C',
+    extension: '#0FBD8C'
+};
+
 class OpcodeLabels {
     constructor () {
         /**
@@ -131,30 +144,30 @@ class OpcodeLabels {
          */
         this._opcodeMap = {
             // Motion
-            motion_direction: {category: 'motion'},
-            motion_xposition: {category: 'motion'},
-            motion_yposition: {category: 'motion'},
+            motion_direction: {color: categoryColors.motion},
+            motion_xposition: {color: categoryColors.motion},
+            motion_yposition: {color: categoryColors.motion},
 
             // Looks
-            looks_size: {category: 'looks'},
-            looks_costumenumbername: {category: 'looks'},
-            looks_backdropnumbername: {category: 'looks'},
-            looks_backdropname: {category: 'looks'},
+            looks_size: {color: categoryColors.looks},
+            looks_costumenumbername: {color: categoryColors.looks},
+            looks_backdropnumbername: {color: categoryColors.looks},
+            looks_backdropname: {color: categoryColors.looks},
 
             // Data
-            data_variable: {category: 'data'},
-            data_listcontents: {category: 'list'},
+            data_variable: {color: categoryColors.data},
+            data_listcontents: {color: categoryColors.list},
 
             // Sound
-            sound_volume: {category: 'sound'},
-            sound_tempo: {category: 'sound'},
+            sound_volume: {color: categoryColors.sound},
+            sound_tempo: {color: categoryColors.sound},
 
             // Sensing
-            sensing_answer: {category: 'sensing'},
-            sensing_loudness: {category: 'sensing'},
-            sensing_username: {category: 'sensing'},
-            sensing_current: {category: 'sensing'},
-            sensing_timer: {category: 'sensing'}
+            sensing_answer: {color: categoryColors.sensing},
+            sensing_loudness: {color: categoryColors.sensing},
+            sensing_username: {color: categoryColors.sensing},
+            sensing_current: {color: categoryColors.sensing},
+            sensing_timer: {color: categoryColors.sensing}
         };
 
         // Initialize opcodeMap with default strings
@@ -233,12 +246,12 @@ class OpcodeLabels {
     /**
      * Return the label for an opcode
      * @param {string} opcode the opcode you want a label for
-     * @return {object} object with  label and category
+     * @return {object} object with  label and color
      */
     getLabel (opcode) {
         if (opcode in this._opcodeMap) return this._opcodeMap[opcode];
         return {
-            category: 'extension',
+            color: categoryColors.extension,
             label: opcode
         };
     }

--- a/test/unit/components/monitor-list.test.jsx
+++ b/test/unit/components/monitor-list.test.jsx
@@ -14,7 +14,7 @@ describe('MonitorListComponent', () => {
         vm: {
             runtime: {
                 requestUpdateMonitor: () => {},
-                getLabelForOpcode: () => ''
+                getMonitorLabelForBlock: () => ''
             }
         }
     }});

--- a/test/unit/util/define-dynamic-block.test.js
+++ b/test/unit/util/define-dynamic-block.test.js
@@ -14,6 +14,16 @@ const MockScratchBlocks = {
             contextMenuName = name;
             contextMenuDesc = desc;
         }
+    },
+    ScratchBlocks: {
+        ProcedureUtils: {
+            removeAllInputs_: () => {},
+            disconnectOldBlocks_: () => {},
+            deleteShadows_: () => {},
+            populateArgument_: () => {},
+            attachShadow_: () => {},
+            buildShadowDom_: () => {}
+        }
     }
 };
 

--- a/test/unit/util/opcode-labels.test.js
+++ b/test/unit/util/opcode-labels.test.js
@@ -1,5 +1,7 @@
 import opcodeLabels from '../../../src/lib/opcode-labels';
 
+const extensionColor = '#0FBD8C';
+
 describe('Opcode Labels', () => {
     test('day of week label', () => {
         const labelFun = opcodeLabels.getLabel('sensing_current').labelFn;
@@ -7,9 +9,10 @@ describe('Opcode Labels', () => {
         expect(labelFun({CURRENTMENU: 'DAYOFWEEK'})).toBe('day of week');
     });
 
-    test('unspecified opcodes default to extension category and opcode as label', () => {
+    test('unspecified opcodes default to opcode as label and use default extension color as color', () => {
         const labelInfo = opcodeLabels.getLabel('music_getTempo');
         expect(labelInfo.label).toBe('music_getTempo');
-        expect(labelInfo.category).toBe('extension');
+        expect(typeof labelInfo.color).toBe('string');
+        expect(labelInfo.color).toBe(extensionColor);
     });
 });


### PR DESCRIPTION
### Proposed Changes

Add support for monitors in variables extension. Monitor info now uses color directly instead of using a category string to look up the appropriate color. This also means that the VM can then use the block instance color for the monitor color. Additionally add support for enabling a monitor for a variable/list that was just created using the modal.

### Test Coverage

Update tests that were previously broken. Update monitor related tests to account for new changes.

### Related PRs
- This PR depends on LLK/scratch-vm#2262