### PR TITLE
Default blocks to last asset instead of first

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -340,9 +340,9 @@ class Blocks extends React.Component {
             const targetSounds = target.getSounds();
             const dynamicBlocksXML = this.props.vm.runtime.getBlocksXML();
             return makeToolboxXML(target.isStage, target.id, dynamicBlocksXML,
-                targetCostumes[0].name,
-                stageCostumes[0].name,
-                targetSounds.length > 0 ? targetSounds[0].name : ''
+                targetCostumes[targetCostumes.length - 1].name,
+                stageCostumes[stageCostumes.length - 1].name,
+                targetSounds.length > 0 ? targetSounds[targetSounds.length - 1].name : ''
             );
         } catch {
             return null;

--- a/test/integration/blocks.test.js
+++ b/test/integration/blocks.test.js
@@ -182,7 +182,8 @@ describe('Working with the blocks', () => {
 
         // Rename the costume
         await clickText('Costumes');
-        const el = await findByXpath("//input[@value='costume1']");
+        await clickText('costume2', scope.costumesTab);
+        const el = await findByXpath("//input[@value='costume2']");
         await el.sendKeys('newname');
 
         // Make sure it is updated in the block menu
@@ -197,7 +198,8 @@ describe('Working with the blocks', () => {
 
         // Rename the costume
         await clickText('Costumes');
-        const el = await findByXpath("//input[@value='costume1']");
+        await clickText('costume2', scope.costumesTab);
+        const el = await findByXpath("//input[@value='costume2']");
         await el.sendKeys('<NewCostume>');
 
         // Make sure it is updated in the block menu
@@ -209,9 +211,7 @@ describe('Working with the blocks', () => {
         await clickText('Sound', scope.blocksTab);
     });
 
-    // NOTE: This test describes the current behavior so that changes are not
-    // introduced inadvertly, but I know this is not the desired behavior
-    test('Adding costumes DOES NOT update the default costume name in the toolbox', async () => {
+    test('Adding costumes DOES update the default costume name in the toolbox', async () => {
         await loadUri(uri);
 
         // By default, costume1 is in the costume tab
@@ -219,7 +219,7 @@ describe('Working with the blocks', () => {
         await driver.sleep(500); // Wait for scroll to finish
         await clickText('costume1', scope.blocksTab);
 
-        // Also check that adding a new costume does not update the list
+        // Also check that adding a new costume does update the list
         await clickText('Costumes');
         const el = await findByXpath('//button[@aria-label="Choose a Costume"]');
         await driver.actions().mouseMove(el)
@@ -227,14 +227,12 @@ describe('Working with the blocks', () => {
         await driver.sleep(500); // Wait for thermometer menu to come up
         await clickXpath('//button[@aria-label="Paint"]');
         await clickText('costume3', scope.costumesTab);
-        // Check that the menu has not been updated
+        // Check that the menu has been updated
         await clickText('Code');
-        await clickText('costume1', scope.blocksTab);
+        await clickText('costume3', scope.blocksTab);
     });
 
-    // NOTE: This test describes the current behavior so that changes are not
-    // introduced inadvertly, but I know this is not the desired behavior
-    test('Adding a sound DOES NOT update the default sound name in the toolbox', async () => {
+    test('Adding a sound DOES update the default sound name in the toolbox', async () => {
         await loadUri(uri);
         await clickText('Sounds');
         await clickXpath('//button[@aria-label="Choose a Sound"]');
@@ -242,7 +240,7 @@ describe('Working with the blocks', () => {
         await clickText('Code');
         await clickText('Sound', scope.blocksTab);
         await driver.sleep(500); // Wait for scroll to finish
-        await clickText('Meow', scope.blocksTab); // Meow, not A Bass
+        await clickText('A Bass', scope.blocksTab);
     });
 
     // Regression test for switching between editor/player causing toolbox to stop updating

--- a/test/integration/blocks.test.js
+++ b/test/integration/blocks.test.js
@@ -214,10 +214,10 @@ describe('Working with the blocks', () => {
     test('Adding costumes DOES update the default costume name in the toolbox', async () => {
         await loadUri(uri);
 
-        // By default, costume1 is in the costume tab
+        // By default, costume2 is in the costume tab
         await clickText('Looks', scope.blocksTab);
         await driver.sleep(500); // Wait for scroll to finish
-        await clickText('costume1', scope.blocksTab);
+        await clickText('costume2', scope.blocksTab);
 
         // Also check that adding a new costume does update the list
         await clickText('Costumes');

--- a/test/integration/blocks.test.js
+++ b/test/integration/blocks.test.js
@@ -240,7 +240,7 @@ describe('Working with the blocks', () => {
         await clickText('Code');
         await clickText('Sound', scope.blocksTab);
         await driver.sleep(500); // Wait for scroll to finish
-        await clickText('A Bass', scope.blocksTab);
+        await clickText('A\u00A0Bass', scope.blocksTab); // Need &nbsp; for block text
     });
 
     // Regression test for switching between editor/player causing toolbox to stop updating


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/LLK/scratch-gui/issues/1452

### Proposed Changes

_Describe what this Pull Request does_

Make the toolbox use the _last_ costume/sound/backdrop instead of the first one, so that when you add a new asset, it is automatically available in the blocks to use right away.

### Reason for Changes

_Explain why these changes should be made_

See discussion in https://github.com/LLK/scratch-gui/issues/1452

### Testing

Updated the selenium tests that were specifically introduced to document this behavior