### PR TITLE
Fixed Portuguese (Brazilian) locale for tutorial videos

### DIFF
--- a/src/lib/libraries/decks/translate-video.js
+++ b/src/lib/libraries/decks/translate-video.js
@@ -9,7 +9,7 @@ const videos = {
         'en': 'rpjvs3v9gj',
         'it': '2im6c1f9kn',
         'pt': 'ngdfp8xg4x',
-        'pt-BR': 'ngdfp8xg4x',
+        'pt-br': 'ngdfp8xg4x',
         'ja': 'v2c2f3y2sc',
         'ja-Hira': 'v2c2f3y2sc'
     },
@@ -17,7 +17,7 @@ const videos = {
         'en': 'pyur30ho05',
         'it': 'c8zcrk6w09',
         'pt': 't49tfrukyf',
-        'pt-BR': 't49tfrukyf',
+        'pt-br': 't49tfrukyf',
         'ja': 'xrmgno02th',
         'ja-Hira': 'xrmgno02th'
     },
@@ -25,7 +25,7 @@ const videos = {
         'en': 'ir0j8ljsgm',
         'it': '8nm1v1m9zx',
         'pt': '9v4zl8504z',
-        'pt-BR': '9v4zl8504z',
+        'pt-br': '9v4zl8504z',
         'ja': 'iybhyobckr',
         'ja-Hira': 'iybhyobckr'
     },
@@ -33,7 +33,7 @@ const videos = {
         'en': '5rp47ys13g',
         'it': 'vrs1e38944',
         'pt': 'rjst5ng61s',
-        'pt-BR': 'rjst5ng61s',
+        'pt-br': 'rjst5ng61s',
         'ja': 'h4q2ea3ojw',
         'ja-Hira': 'h4q2ea3ojw'
     },
@@ -41,7 +41,7 @@ const videos = {
         'en': 'kusyx9thl5',
         'it': '899b2jmjlu',
         'pt': 'rw6kr9e37n',
-        'pt-BR': 'rw6kr9e37n',
+        'pt-br': 'rw6kr9e37n',
         'ja': 'wr6ysk8s6d',
         'ja-Hira': 'wr6ysk8s6d'
     },
@@ -49,7 +49,7 @@ const videos = {
         'en': 'nict6zdzlx',
         'it': 'vrrfpm5grh',
         'pt': 'wq7sm038pq',
-        'pt-BR': 'wq7sm038pq',
+        'pt-br': 'wq7sm038pq',
         'ja': 'j382ohngg7',
         'ja-Hira': 'j382ohngg7'
     },
@@ -57,7 +57,7 @@ const videos = {
         'en': 'p8va85hh61',
         'it': '1xb1jztsvr',
         'pt': '1ad1ip3ly7',
-        'pt-BR': '1ad1ip3ly7',
+        'pt-br': '1ad1ip3ly7',
         'ja': 'uzkfi9uai0',
         'ja-Hira': 'uzkfi9uai0'
     },
@@ -71,7 +71,7 @@ const videos = {
         'en': 'ulzl1fbzny',
         'it': 'ncr9lqk7bt',
         'pt': 'aavagpvh5w',
-        'pt-BR': 'aavagpvh5w',
+        'pt-br': 'aavagpvh5w',
         'ja': '5zmy6u614k',
         'ja-Hira': '5zmy6u614k'
     },
@@ -79,7 +79,7 @@ const videos = {
         'en': '07fed5hhpv',
         'it': 'obmrphhobt',
         'pt': 'jxqksu6zcw',
-        'pt-BR': 'jxqksu6zcw',
+        'pt-br': 'jxqksu6zcw',
         'ja': 'hjhc0a8r7j',
         'ja-Hira': 'hjhc0a8r7j'
     },
@@ -87,7 +87,7 @@ const videos = {
         'en': 'g479ahobo9',
         'it': 'v0vbx3l5uk',
         'pt': 'ibtmwb58y8',
-        'pt-BR': 'ibtmwb58y8',
+        'pt-br': 'ibtmwb58y8',
         'ja': 'ruynguvag5',
         'ja-Hira': 'ruynguvag5'
     },
@@ -95,7 +95,7 @@ const videos = {
         'en': '1ocp6a1ejn',
         'it': 'nty4xjtqcj',
         'pt': 'pnlmmv2hs7',
-        'pt-BR': 'pnlmmv2hs7',
+        'pt-br': 'pnlmmv2hs7',
         'ja': 'g3vluv0ms8',
         'ja-Hira': 'g3vluv0ms8'
     },
@@ -103,7 +103,7 @@ const videos = {
         'en': 'yetrmk4iuu',
         'it': 'jse0g0uddw',
         'pt': 'erv6eff78p',
-        'pt-BR': 'erv6eff78p',
+        'pt-br': 'erv6eff78p',
         'ja': 'fk34dcg5oz',
         'ja-Hira': 'fk34dcg5oz'
     },
@@ -111,7 +111,7 @@ const videos = {
         'en': '3jvl8zgjo2',
         'it': 'q3cjjyfju9',
         'pt': 'dz6jzpf7hm',
-        'pt-BR': 'dz6jzpf7hm',
+        'pt-br': 'dz6jzpf7hm',
         'ja': 'q7zq9vu0wb',
         'ja-Hira': 'q7zq9vu0wb'
     },


### PR DESCRIPTION
### Resolves

Portuguese (Brazilian) videos were not appearing when language was switched to Portuguese (Brazilian), though they were appearing for Italian and Portuguese

### Proposed Changes

Changes Portuguese (Brazilian) locale to 'pt-br', was mistakenly written as 'pt-BR'.