### PR TITLE
Use list-area:after to pad scroll area

### DIFF
--- a/src/components/asset-panel/selector.css
+++ b/src/components/asset-panel/selector.css
@@ -50,8 +50,16 @@ $fade-out-distance: 100px;
     overflow-y: scroll;
     display: flex;
     flex-direction: column;
+}
+
+.list-area:after {
     /* Make sure there is room to scroll beyond the last tile */
-    padding-bottom: 70px;
+    content: '';
+    display: block;
+    height: 70px;
+    width: 100%;
+    flex-shrink: 0;
+    order: 99999999;
 }
 
 .list-item {


### PR DESCRIPTION
### Resolves

Resolves LLK/scratch-gui#3278.

### Proposed Changes

Uses the `.list-area:after` pseudoelement to add padding to the end of the scroll area. See [this StackOverflow post](https://stackoverflow.com/a/22040425/4633828) for my reference; I had to add `flex-shrink: 0` so that the element wouldn't just get squished when it's meant to grow the scroll area.

### Reason for Changes

This makes it easy to drag and select the bottom tile in asset pickers.

I considered reusing the `$fade-out-distance` variable but decided against it because I saw there was already a `padding-bottom: 70px` property, which was meant to fix this issue itself but apparently no longer works (or never did in the first place). I used that value instead.

I tried putting a `margin-bottom` on `.list-area > :last-item` as well, but that didn't seem to have any effect. In the end, using `:after` worked on the browsers I tested.

### Test Coverage

No new tests; tested manually.

### Browser Coverage

Linux Firefox, Chromium.

---

/cc @benjiwheeler