### PR TITLE
Greenkeeper/scratch render 0.1.0 prerelease.20190830194018

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11476,9 +11476,9 @@
       }
     },
     "scratch-render": {
-      "version": "0.1.0-prerelease.20190830153254",
-      "resolved": "https://registry.npmjs.org/scratch-render/-/scratch-render-0.1.0-prerelease.20190830153254.tgz",
-      "integrity": "sha512-LDpgW8+SczheOkXtCYbcYUIR7SRhQmE44C408ai5NPdwfkx7kana3RRMVab7apEJ4VXHf/mloXKpQZ9vNZazrA==",
+      "version": "0.1.0-prerelease.20190830194018",
+      "resolved": "https://registry.npmjs.org/scratch-render/-/scratch-render-0.1.0-prerelease.20190830194018.tgz",
+      "integrity": "sha512-FlN79tudmhtU6O48klzSXH+9YAPi7Lyeh4648uEqc2Zhd1hdiKVCR23q6fTd2XcFtPEKuuGOGlJBLNf40LJNYw==",
       "dev": true,
       "requires": {
         "grapheme-breaker": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "scratch-l10n": "3.5.20190827223456",
     "scratch-blocks": "0.1.0-prerelease.1566984014",
     "scratch-paint": "0.2.0-prerelease.20190822205009",
-    "scratch-render": "0.1.0-prerelease.20190830153254",
+    "scratch-render": "0.1.0-prerelease.20190830194018",
     "scratch-storage": "1.3.2",
     "scratch-svg-renderer": "0.2.0-prerelease.20190822202608",
     "scratch-vm": "0.2.0-prerelease.20190822194548",


### PR DESCRIPTION
Closes #5139 
Update scratch-render.