### PR TITLE
Emit projectDidSave for all types of saves, not just file exports

### DIFF
--- a/src/lib/project-saver-hoc.jsx
+++ b/src/lib/project-saver-hoc.jsx
@@ -251,6 +251,7 @@ const ProjectSaverHOC = function (WrappedComponent) {
                     if (id && this.props.onUpdateProjectThumbnail) {
                         this.storeProjectThumbnail(id);
                     }
+                    this.reportTelemetryEvent('projectDidSave');
                     return response;
                 })
                 .catch(err => {
@@ -291,9 +292,15 @@ const ProjectSaverHOC = function (WrappedComponent) {
          */
         // TODO make a telemetry HOC and move this stuff there
         reportTelemetryEvent (event) {
-            if (this.props.onProjectTelemetryEvent) {
-                const metadata = collectMetadata(this.props.vm, this.props.reduxProjectTitle, this.props.locale);
-                this.props.onProjectTelemetryEvent(event, metadata);
+            try {
+                if (this.props.onProjectTelemetryEvent) {
+                    const metadata = collectMetadata(this.props.vm, this.props.reduxProjectTitle, this.props.locale);
+                    this.props.onProjectTelemetryEvent(event, metadata);
+                }
+            } catch (e) {
+                log.error('Telemetry error', event, e);
+                // This is intentionally fire/forget because a failure
+                // to report telemetry should not block saving
             }
         }
 


### PR DESCRIPTION
Make offline telemetry system record `projectDidSave` for autosaves/manual "Save Now" button pushes. Right now `projectDidSave` is only emitted for file export, because that is currently the only way to save in the desktop editor. But as we improve the different ways "offline" apps can save projects, we want to make sure we get the relevant telemetry. 

We talked about whether to have separate events for autosaving, etc. but want to keep the event space small, and this shouldn't impact the current telemetry from scratch-desktop, which won't be using this code path for now anyway.

I also made the `reportTelemetry` function more defensive and wrapped it in a try/catch because it is not essential to the saving process, so if it fails it should not stop the promise chain that saving uses/present an error to the user. I wanted this to be defensive both because collectMetadata does not have thorough property access checking, and the `onProjectTelemetryEvent` is a function passed in from external, so we have no idea how it might fail.