### PR TITLE
Use not broken Travis VM distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 sudo: required
-dist: trusty
+dist: xenial
 addons:
     chrome: stable
 node_js:
@@ -11,6 +11,7 @@ env:
   - SMOKE_URL=https://llk.github.io/scratch-gui/$TRAVIS_PULL_REQUEST_BRANCH
   - NPM_TAG=latest
   - RELEASE_VERSION="0.1.0-prerelease.$(date +'%Y%m%d%H%M%S')"
+  - CHROMEDRIVER_VERSION=LATEST
 cache:
   directories:
   - node_modules

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "i18n:src": "rimraf ./translations/messages/src && babel src > tmp.js && rimraf tmp.js && build-i18n-src ./translations/messages/src ./translations/ && npm run i18n:push",
     "start": "webpack-dev-server",
     "test": "npm run test:lint && npm run test:unit && npm run build && npm run test:integration",
-    "test:integration": "jest --runInBand test[\\\\/]integration || true",
+    "test:integration": "jest --runInBand test[\\\\/]integration",
     "test:lint": "eslint . --ext .js,.jsx",
     "test:unit": "jest test[\\\\/]unit",
     "test:smoke": "jest --runInBand test[\\\\/]smoke",


### PR DESCRIPTION
Google Chrome doesn't install on Travis trusty anymore for some reason. Bump to xenial so we have Google Chrome.

Also use a method I discovered for keeping the installed version of chromedriver up to date, so whenever chrome is updated, chromedriver will also update on the VM.

Also un-hack the integration tests so that it matters when they fail again.