### PR TITLE
Use a larger buffer size for recording to prevent glitching

### DIFF
--- a/src/components/record-modal/record-modal.css
+++ b/src/components/record-modal/record-modal.css
@@ -20,8 +20,10 @@
     border: 1px solid $ui-black-transparent;
     border-radius: 5px;
     padding: 3px;
-
+    /* Force these to be on their own render layer because they update often */
+    transform: translateZ(0);
 }
+
 .meter-container {
     margin-right: 5px;
     height: 180px;

--- a/src/containers/recording-step.jsx
+++ b/src/containers/recording-step.jsx
@@ -44,10 +44,10 @@ class RecordingStep extends React.Component {
         alert(this.props.intl.formatMessage(messages.alertMsg)); // eslint-disable-line no-alert
     }
     handleLevelUpdate (level) {
-        this.setState({level});
-        if (this.props.recording) {
-            this.setState({levels: (this.state.levels || []).concat([level])});
-        }
+        this.setState({
+            level: level,
+            levels: this.props.recording ? (this.state.levels || []).concat([level]) : this.state.levels
+        });
     }
     handleRecord () {
         this.audioRecorder.startRecording();


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Helps with https://github.com/LLK/scratch-gui/issues/1735

### Proposed Changes

_Describe what this Pull Request does_

Use an 8x larger buffer size for script processor node, which allows the browser much more leeway in terms of how quickly it needs to run the script processor node before buffers start getting dropped. This does not impact the smoothness of the visualization, which is run at RAF framerate using a separate analyzer path. 

I had to change the `stop` function, which previously was relying on the buffer size being 1024 implicitly (it would submit RMS chunks depending on the script processor buffer length). Instead use the other RMS utility by switching around the order of operations.

### Reason for Changes

_Explain why these changes should be made_

By using a small buffer size, we were causing glitchiness in exchange for latency, which it turns out we do not need because we are recording!