### PR TITLE
explicitly track whether we are in embed mode; block cloud vars on embed

### DIFF
--- a/src/lib/cloud-manager-hoc.jsx
+++ b/src/lib/cloud-manager-hoc.jsx
@@ -52,7 +52,10 @@ const cloudManagerHOC = function (WrappedComponent) {
             this.disconnectFromCloud();
         }
         canUseCloud (props) {
-            return !!(props.cloudHost && props.username && props.vm && props.projectId && props.hasCloudPermission);
+            return !!(
+                props.cloudHost && props.username && props.vm &&
+                props.projectId && props.hasCloudPermission && !props.isEmbed
+            );
         }
         shouldNotModifyCloudData (props) {
             return (props.hasEverEnteredEditor && !props.canSave);
@@ -107,6 +110,7 @@ const cloudManagerHOC = function (WrappedComponent) {
                 username,
                 hasCloudPermission,
                 hasEverEnteredEditor,
+                isEmbed,
                 isShowingWithId,
                 onShowCloudInfo,
                 /* eslint-enable no-unused-vars */
@@ -128,6 +132,7 @@ const cloudManagerHOC = function (WrappedComponent) {
         cloudHost: PropTypes.string,
         hasCloudPermission: PropTypes.bool,
         hasEverEnteredEditor: PropTypes.bool,
+        isEmbed: PropTypes.bool,
         isShowingWithId: PropTypes.bool,
         onShowCloudInfo: PropTypes.func,
         projectId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
@@ -139,6 +144,7 @@ const cloudManagerHOC = function (WrappedComponent) {
         const loadingState = state.scratchGui.projectState.loadingState;
         return {
             hasEverEnteredEditor: state.scratchGui.mode.hasEverEnteredEditor,
+            isEmbed: state.scratchGui.mode.isEmbed,
             isShowingWithId: getIsShowingWithId(loadingState),
             projectId: state.scratchGui.projectState.projectId
         };

--- a/src/reducers/gui.js
+++ b/src/reducers/gui.js
@@ -90,6 +90,7 @@ const initEmbedded = function (currentState) {
         {},
         currentState,
         {mode: {
+            isEmbed: true,
             showBranding: true,
             isFullScreen: true,
             isPlayerOnly: true,

--- a/src/reducers/mode.js
+++ b/src/reducers/mode.js
@@ -3,6 +3,7 @@ const SET_PLAYER = 'scratch-gui/mode/SET_PLAYER';
 
 const initialState = {
     showBranding: false,
+    isEmbed: false,
     isFullScreen: false,
     isPlayerOnly: false,
     hasEverEnteredEditor: true


### PR DESCRIPTION
### Resolves

With https://github.com/LLK/scratch-www/pull/3356, resolves https://github.com/LLK/scratch-www/issues/2471

Must be merged before https://github.com/LLK/scratch-www/pull/3356

### Proposed Changes

* adds `isEmbed` property to `mode` reducer
* sets `isEmbed` to true if GUI is inited as embed
* stops any cloud connection from being made if project is an embed

### Reason for Changes

Embeds make too many requests of our servers! 

### Test Coverage

None
