### PR TITLE
Reupdate watermelon a and basketball background with asset exported from sketch

### DIFF
--- a/src/lib/libraries/backdrops.json
+++ b/src/lib/libraries/backdrops.json
@@ -52,7 +52,7 @@
     },
     {
         "name": "Basketball 1",
-        "md5": "dc60785adb25ef4c700e3874d7d0100c.svg",
+        "md5": "ae21eac3d1814aee1d37ae82ea287816.svg",
         "type": "backdrop",
         "tags": [
             "sports",

--- a/src/lib/libraries/costumes.json
+++ b/src/lib/libraries/costumes.json
@@ -10493,7 +10493,7 @@
     },
     {
         "name": "Watermelon-a",
-        "md5": "21d1340478e32a942914a7afd12b9f1a.svg",
+        "md5": "8736ecc2524895733534c888cd91fa1f.svg",
         "type": "costume",
         "tags": [
             "food",

--- a/src/lib/libraries/sprites.json
+++ b/src/lib/libraries/sprites.json
@@ -15612,7 +15612,7 @@
     },
     {
         "name": "Watermelon",
-        "md5": "21d1340478e32a942914a7afd12b9f1a.svg",
+        "md5": "8736ecc2524895733534c888cd91fa1f.svg",
         "type": "sprite",
         "tags": [
             "food",
@@ -15643,7 +15643,7 @@
                 {
                     "costumeName": "watermelon-a",
                     "baseLayerID": -1,
-                    "baseLayerMD5": "21d1340478e32a942914a7afd12b9f1a.svg",
+                    "baseLayerMD5": "8736ecc2524895733534c888cd91fa1f.svg",
                     "bitmapResolution": 1,
                     "rotationCenterX": 40,
                     "rotationCenterY": 27


### PR DESCRIPTION
The Android Studio svg to xml code can't interpret the svgs exported by our paint editor. This should fix the watermelon-a and basketball-1 costumes on android.