### PR TITLE
Don’t push tags to gh-pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,7 @@ deploy:
   on:
     all_branches: true
     condition: $TRAVIS_EVENT_TYPE != cron && ! $TRAVIS_BRANCH =~ ^greenkeeper/
+    tags: false # Don't push tags to gh-pages
   skip_cleanup: true
   script: npm run deploy -- -x -e $TRAVIS_BRANCH -r https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
 - provider: script


### PR DESCRIPTION
These builds make our gh-pages branch too large for GitHub to handle. Thanks to @fsih for deleting all those builds. This will keep them from re-populating.

@fsih I'm never sure who to assign for this type of change, so I assigned you since we talked about it. Here's the relevant part of Travis' docs. https://docs.travis-ci.com/user/deployment/#conditional-releases-with-on