### PR TITLE
Allow Node to use more memory for old space

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,12 @@ node_js:
 - 8
 env:
   global:
+  - CHROMEDRIVER_VERSION=LATEST
   - NODE_ENV=production
-  - SMOKE_URL=https://llk.github.io/scratch-gui/$TRAVIS_PULL_REQUEST_BRANCH
+  - NODE_OPTIONS=--max-old-space-size=7250
   - NPM_TAG=latest
   - RELEASE_VERSION="0.1.0-prerelease.$(date +'%Y%m%d%H%M%S')"
-  - CHROMEDRIVER_VERSION=LATEST
+  - SMOKE_URL=https://llk.github.io/scratch-gui/$TRAVIS_PULL_REQUEST_BRANCH
 cache:
   directories:
   - node_modules


### PR DESCRIPTION
This flag essentially configures how much memory Node can use. If it’s too low, then Node processes may hang as Node spends time garbage collecting. Increasing it allows more memory to be used before garbage collection is necessary.  Travis VMs have 7.5GB of memory, so set the limit to just below that to avoid running out of memory completely.

Resolves #5186. @fsih saw a webpack build hang until increasing this limit there. So increase it now to avoid this failure in the future.

Also I reordered the variables to be alphabetical just so there was some system there.
