### PR TITLE
Draw backpack thumbnails smaller

### DIFF
--- a/src/lib/backpack/jpeg-thumbnail.js
+++ b/src/lib/backpack/jpeg-thumbnail.js
@@ -3,15 +3,20 @@ const jpegThumbnail = dataUrl => new Promise((resolve, reject) => {
     image.onload = () => {
         const canvas = document.createElement('canvas');
         const ctx = canvas.getContext('2d');
-        // TODO we may want to draw to a smaller, fixed size to optimize file size
-        canvas.width = image.width;
-        canvas.height = image.height;
+
+        const maxDimension = 96; // 3x the maximum displayed size of 32px
+
+        if (image.height > image.width) {
+            canvas.height = maxDimension;
+            canvas.width = (maxDimension / image.height) * image.width;
+        } else {
+            canvas.width = maxDimension;
+            canvas.height = (maxDimension / image.width) * image.height;
+        }
 
         ctx.fillStyle = 'white'; // Create white background, since jpeg doesn't have transparency
         ctx.fillRect(0, 0, canvas.width, canvas.height);
-
-        ctx.drawImage(image, 0, 0);
-        // TODO we can play with the `quality` option here to optimize file size
+        ctx.drawImage(image, 0, 0, canvas.width, canvas.height);
         resolve(canvas.toDataURL('image/jpeg', 0.92 /* quality */)); // Default quality is 0.92
     };
     image.onerror = err => {


### PR DESCRIPTION
Note: paired with @kchadha 

### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/LLK/scratch-gui/issues/5195

### Proposed Changes

_Describe what this Pull Request does_

Instead of drawing the image at its native resolution, just as a jpeg, make the image smaller (chosen somewhat arbitrarily to be 3x the max displayed size of 32px (3x bc that is now a common pixel density for HD screens). 

So instead of causing the thumbnail to be 200% the size of the original backdrop, the thumbnail is now 5% the size of the original. :) 

### Testing

@kchadha and I made this test harness on glitch to do some prototyping, but there are no additional automated tests here.
https://glitch.com/~jpeg-thumbnail-test