### PR TITLE
Revert "Limit louder effect with a max RMS"

### DIFF
--- a/src/components/sound-editor/sound-editor.jsx
+++ b/src/components/sound-editor/sound-editor.jsx
@@ -265,7 +265,6 @@ const SoundEditor = props => (
                 onClick={props.onSlower}
             />
             <IconButton
-                disabled={props.tooLoud}
                 className={classNames(styles.effectButton, styles.flipInRtl)}
                 img={louderIcon}
                 title={<FormattedMessage {...messages.louder} />}
@@ -341,7 +340,6 @@ SoundEditor.propTypes = {
     onUndo: PropTypes.func.isRequired,
     playhead: PropTypes.number,
     setRef: PropTypes.func,
-    tooLoud: PropTypes.bool.isRequired,
     trimEnd: PropTypes.number,
     trimStart: PropTypes.number
 };

--- a/src/containers/sound-editor.jsx
+++ b/src/containers/sound-editor.jsx
@@ -14,8 +14,6 @@ import log from '../lib/log.js';
 
 const UNDO_STACK_SIZE = 99;
 
-const MAX_RMS = 1.2;
-
 class SoundEditor extends React.Component {
     constructor (props) {
         super(props);
@@ -267,15 +265,6 @@ class SoundEditor extends React.Component {
             }
         });
     }
-    tooLoud () {
-        const numChunks = this.state.chunkLevels.length;
-        const startIndex = this.state.trimStart === null ?
-            0 : Math.floor(this.state.trimStart * numChunks);
-        const endIndex = this.state.trimEnd === null ?
-            numChunks - 1 : Math.ceil(this.state.trimEnd * numChunks);
-        const trimChunks = this.state.chunkLevels.slice(startIndex, endIndex);
-        return Math.max(...trimChunks) > MAX_RMS;
-    }
     getUndoItem () {
         return {
             ...this.copyCurrentBuffer(),
@@ -410,7 +399,6 @@ class SoundEditor extends React.Component {
                 name={this.props.name}
                 playhead={this.state.playhead}
                 setRef={this.setRef}
-                tooLoud={this.tooLoud()}
                 trimEnd={this.state.trimEnd}
                 trimStart={this.state.trimStart}
                 onChangeName={this.handleChangeName}

--- a/src/lib/audio/effects/volume-effect.js
+++ b/src/lib/audio/effects/volume-effect.js
@@ -14,16 +14,8 @@ class VolumeEffect {
         this.gain.gain.setValueAtTime(volume, endSeconds);
         this.gain.gain.exponentialRampToValueAtTime(1.0, endSeconds + this.rampLength);
 
-        // Use a waveshaper node to prevent sample values from exceeding -1 or 1.
-        // Without this, gain can cause samples to exceed this range, then they
-        // are clipped on save, and the sound is distorted on load.
-        this.waveShaper = this.audioContext.createWaveShaper();
-        this.waveShaper.curve = new Float32Array([-1, 1]);
-        this.waveShaper.oversample = 'none';
-
         this.input.connect(this.gain);
-        this.gain.connect(this.waveShaper);
-        this.waveShaper.connect(this.output);
+        this.gain.connect(this.output);
     }
 }
 


### PR DESCRIPTION
Reverts LLK/scratch-gui#5149

Turns out this causes the softer button to max out the volume louder :(

