### PR TITLE
Revert "Update scratch-render to the latest version 🚀"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11476,9 +11476,9 @@
       }
     },
     "scratch-render": {
-      "version": "0.1.0-prerelease.20190925202615",
-      "resolved": "https://registry.npmjs.org/scratch-render/-/scratch-render-0.1.0-prerelease.20190925202615.tgz",
-      "integrity": "sha512-Q4bnaxD9ddXXaDTgDsu5COLgd5LC59bQPYNhz/0vp/uKUJ4JXrS+KNKaXQLfDJX4ZYWna+MCVMoeAuhofAvOjg==",
+      "version": "0.1.0-prerelease.20190912174749",
+      "resolved": "https://registry.npmjs.org/scratch-render/-/scratch-render-0.1.0-prerelease.20190912174749.tgz",
+      "integrity": "sha512-GHXtprwGBFZld5wnGqw2sfySbxFZfKuQfkcEyqOZlYPgf7uQ9FEJ1MEoFhX9T6le0C9XA9f/fvh50MEWc1R3TA==",
       "dev": true,
       "requires": {
         "grapheme-breaker": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "scratch-l10n": "3.5.20190924223720",
     "scratch-blocks": "0.1.0-prerelease.1569422127",
     "scratch-paint": "0.2.0-prerelease.20190923154429",
-    "scratch-render": "0.1.0-prerelease.20190925202615",
+    "scratch-render": "0.1.0-prerelease.20190912174749",
     "scratch-storage": "1.3.2",
     "scratch-svg-renderer": "0.2.0-prerelease.20190822202608",
     "scratch-vm": "0.2.0-prerelease.20190918022946",


### PR DESCRIPTION
Reverts LLK/scratch-gui#5212

Seems to introduce an issue where bitmaps get squished

1. Start with default cat
2. Convert to bitmap
3. Draw long horizontal lines with paintbrush
4. See that the cat becomes squished on the renderer

/cc @cwillisf 