### PR TITLE
Limit louder effect with a max RMS (w/o waveshaper)

### DIFF
--- a/src/components/sound-editor/sound-editor.jsx
+++ b/src/components/sound-editor/sound-editor.jsx
@@ -265,6 +265,7 @@ const SoundEditor = props => (
                 onClick={props.onSlower}
             />
             <IconButton
+                disabled={props.tooLoud}
                 className={classNames(styles.effectButton, styles.flipInRtl)}
                 img={louderIcon}
                 title={<FormattedMessage {...messages.louder} />}
@@ -340,6 +341,7 @@ SoundEditor.propTypes = {
     onUndo: PropTypes.func.isRequired,
     playhead: PropTypes.number,
     setRef: PropTypes.func,
+    tooLoud: PropTypes.bool.isRequired,
     trimEnd: PropTypes.number,
     trimStart: PropTypes.number
 };

--- a/src/containers/sound-editor.jsx
+++ b/src/containers/sound-editor.jsx
@@ -14,6 +14,8 @@ import log from '../lib/log.js';
 
 const UNDO_STACK_SIZE = 99;
 
+const MAX_RMS = 1.2;
+
 class SoundEditor extends React.Component {
     constructor (props) {
         super(props);
@@ -265,6 +267,15 @@ class SoundEditor extends React.Component {
             }
         });
     }
+    tooLoud () {
+        const numChunks = this.state.chunkLevels.length;
+        const startIndex = this.state.trimStart === null ?
+            0 : Math.floor(this.state.trimStart * numChunks);
+        const endIndex = this.state.trimEnd === null ?
+            numChunks - 1 : Math.ceil(this.state.trimEnd * numChunks);
+        const trimChunks = this.state.chunkLevels.slice(startIndex, endIndex);
+        return Math.max(...trimChunks) > MAX_RMS;
+    }
     getUndoItem () {
         return {
             ...this.copyCurrentBuffer(),
@@ -399,6 +410,7 @@ class SoundEditor extends React.Component {
                 name={this.props.name}
                 playhead={this.state.playhead}
                 setRef={this.setRef}
+                tooLoud={this.tooLoud()}
                 trimEnd={this.state.trimEnd}
                 trimStart={this.state.trimStart}
                 onChangeName={this.handleChangeName}

--- a/src/lib/audio/effects/volume-effect.js
+++ b/src/lib/audio/effects/volume-effect.js
@@ -14,16 +14,8 @@ class VolumeEffect {
         this.gain.gain.setValueAtTime(volume, endSeconds);
         this.gain.gain.exponentialRampToValueAtTime(1.0, endSeconds + this.rampLength);
 
-        // Use a waveshaper node to prevent sample values from exceeding -1 or 1.
-        // Without this, gain can cause samples to exceed this range, then they
-        // are clipped on save, and the sound is distorted on load.
-        this.waveShaper = this.audioContext.createWaveShaper();
-        this.waveShaper.curve = new Float32Array([-1, 1]);
-        this.waveShaper.oversample = 'none';
-
         this.input.connect(this.gain);
-        this.gain.connect(this.waveShaper);
-        this.waveShaper.connect(this.output);
+        this.gain.connect(this.output);
     }
 }
 

--- a/src/lib/audio/effects/volume-effect.js
+++ b/src/lib/audio/effects/volume-effect.js
@@ -14,8 +14,16 @@ class VolumeEffect {
         this.gain.gain.setValueAtTime(volume, endSeconds);
         this.gain.gain.exponentialRampToValueAtTime(1.0, endSeconds + this.rampLength);
 
+        // Use a waveshaper node to prevent sample values from exceeding -1 or 1.
+        // Without this, gain can cause samples to exceed this range, then they
+        // are clipped on save, and the sound is distorted on load.
+        this.waveShaper = this.audioContext.createWaveShaper();
+        this.waveShaper.curve = new Float32Array([-1, 1]);
+        this.waveShaper.oversample = 'none';
+
         this.input.connect(this.gain);
-        this.gain.connect(this.output);
+        this.gain.connect(this.waveShaper);
+        this.waveShaper.connect(this.output);
     }
 }
 


### PR DESCRIPTION
### Resolves

resolves https://github.com/LLK/scratch-gui/issues/5142

### Proposed Changes

Before applying the "louder" effect in the sound editor, measure the RMS of the sound. If any part of the selected region (or the whole sound, if nothing is selected) is above a threshold, disable the louder button.

### Reason for Changes

It's easy to press the louder button repeatedly and create badly distorted sounds. This limitation does not completely prevent the distortion, but reduces how bad you can quickly make it.

The previous attempt at this fix (https://github.com/LLK/scratch-gui/pull/5149) also included a "hard limiter" on the volume effect, but this version removes it. 

The hard limiter was meant to make the distortion caused by the louder button more consistent: without it, audio samples can get beyond their normal range of -1 to 1, and the browser will still play them, but they are clipped to the normal range after save and load, causing more severe distortion; the hard limiter does this clipping each time the effect is applied. Mac Safari has a bug in the webaudio waveshaper implementation (reported in 2014 here: https://bugs.webkit.org/show_bug.cgi?id=129333) which causes extreme distortion, so we can't use it. @paulkaplan also pointed out that the hard limiter is less important now that the RMS limit reduces extreme distortion, and a benefit of not including it is that the "louder" effect is non-destructive so that the "softer" button can bring back the undistorted sound.

 