### PR TITLE
Add config for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,18 +92,22 @@ jobs:
           keys:
             - v1-dist-{{ .Revision }}
       - run: npm publish --dry-run
+
+deploy-requirements: &deploy-requirements
+  requires:
+    - build
+  filters:
+    branches:
+      only:
+        - master
+        - develop
+        - smoke
+        - /^hotfix\/.*/
+      
 workflows:
   version: 2
   build_and_deploy:
     jobs:
       - build
       - deploy-npm:
-          requires:
-            - build
-          filters:
-            branches:
-              only:
-                - master
-                - develop
-                - smoke
-                - /^hotfix\/.*/
+          <<: *deploy-requirements

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,43 @@
+# Javascript Node CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-javascript/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/node:8.16-browsers
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "package-lock.json" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+
+      - run:
+          name: Install greenkeeper-lockfile
+          command: sudo npm install -g greenkeeper-lockfile
+      - run:
+          name: Install dependencies
+          command: npm --production=false install
+      - run:
+          name: Run greenkeeper-lockfile-update
+          command: greenkeeper-lockfile-update
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package-lock.json" }}
+
+      - run:
+          name: Run tests
+          command: npm test
+      - run:
+          name: Run greenkeeper-lockfile-upload
+          command: greenkeeper-lockfile-upload

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
 
       - run:
           name: Lint
-          command: npm run test:lint -- --output-file test-results/eslint/results.xml --format junit
+          command: npm run test:lint -- --quiet --output-file test-results/eslint/results.xml --format junit
 
       - store_test_results:
           path: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,15 @@ jobs:
     working_directory: ~/repo
 
     steps:
+      - restore_cache:
+          keys:
+            - v1-git-{{ .Revision }}
+            - v1-git-
       - checkout
+      - save_cache:
+          paths:
+            - .git
+          key: v1-git-{{ .Revision }}
 
       # Download and cache dependencies
       - restore_cache:
@@ -75,6 +83,10 @@ jobs:
       - image: circleci/node:8.16-browsers
     working_directory: ~/repo  
     steps:
+      - restore_cache:
+          keys:
+            - v1-git-{{ .Revision }}
+            - v1-git-
       - checkout
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,76 +1,47 @@
 version: 2.1
 aliases:
-  - &step_restore_git_cache
-    restore_cache:
-      keys:
-        - v1-git-{{ .Revision }}
-        - v1-git-
-  - &step_save_git_cache
-    save_cache:
-      paths:
-        - .git
-      key: v1-git-{{ .Revision }}
-  - &step_restore_dependency_cache
-    restore_cache:
-      keys:
-        - v1-dependencies-{{ checksum "package-lock.json" }}
-        - v1-dependencies-
-  - &step_save_dependency_cache
-    save_cache:
-      paths:
-        - node_modules
-      key: v1-dependencies-{{ checksum "package-lock.json" }}
-  - &step_save_build_cache
-    save_cache:
-      paths:
-        - build
-      key: v1-build-{{ .Revision }}
-  - &step_restore_build_cache
-    restore_cache:
-      keys:
-        - v1-build-{{ .Revision }}
-  - &step_save_dist_cache
-    save_cache:
-      paths:
-        - dist
-      key: v1-dist-{{ .Revision }}
-  - &step_restore_dist_cache
-    restore_cache:
-      keys:
-        - v1-dist-{{ .Revision }}
-  - &config_job_environment
+  - &persist
+    persist_to_workspace:
+        root: .
+        paths: .
+  - &restore
+    attach_workspace:
+        at: ~/repo
+  - &defaults
     docker:
       - image: circleci/node:8.16-browsers
     working_directory: ~/repo
 
 jobs:
   setup:
-    <<: *config_job_environment
+    <<: *defaults
     steps:
-      - *step_restore_git_cache
+      - restore_cache:
+          keys:
+            - v1-git-{{ .Revision }}
+            - v1-git-
       - checkout
-      - *step_save_git_cache
+      - save_cache:
+          paths:
+            - .git
+          key: v1-git-{{ .Revision }}
       - run: npm ci
-      - *step_save_dependency_cache
+      - *persist
   lint:
-    <<: *config_job_environment
+    <<: *defaults
     steps:
-      - *step_restore_git_cache
-      - checkout
-      - *step_restore_dependency_cache
+      - *restore
       - run:
           name: Lint
           command: npm run test:lint -- --quiet --output-file test-results/eslint/results.xml --format junit
       - store_test_results:
           path: test-results
   unit:
-    <<: *config_job_environment
+    <<: *defaults
     environment:
       JEST_JUNIT_OUTPUT_NAME: results.xml
     steps:
-      - *step_restore_git_cache
-      - checkout
-      - *step_restore_dependency_cache
+      - *restore
       - run:
           name: Unit
           environment:
@@ -81,32 +52,34 @@ jobs:
       - store_test_results:
           path: test-results
   build:
-    <<: *config_job_environment
+    <<: *defaults
     environment:
       NODE_ENV: production
       NODE_OPTIONS: --max-old-space-size=4000
     steps:
-      - *step_restore_git_cache
-      - checkout
-      - *step_restore_dependency_cache
+      - *restore
       - run:
           name: Build
           command: npm run build
+      - *persist
+  store_build:
+    <<: *defaults
+    steps:
+      - *restore
       - store_artifacts:
           path: build
+  store_dist:
+    <<: *defaults
+    steps:
+      - *restore
       - store_artifacts:
           path: dist
-      - *step_save_build_cache
-      - *step_save_dist_cache
   integration:
-    <<: *config_job_environment
+    <<: *defaults
     environment:
       JEST_JUNIT_OUTPUT_NAME: results.txt
     steps:
-      - *step_restore_git_cache
-      - checkout
-      - *step_restore_dependency_cache
-      - *step_restore_build_cache
+      - *restore
       - run:
           name: Integration
           environment:
@@ -116,10 +89,11 @@ jobs:
           path: test-results
 
   deploy-npm:
-    <<: *config_job_environment
+    <<: *defaults
     environment:
       NODE_OPTIONS: --max-old-space-size=4000
     steps:
+      - *restore
       - run: |
           echo export RELEASE_VERSION="0.1.0-prerelease.$(date +'%Y%m%d%H%M%S')" >> $BASH_ENV
           echo export NPM_TAG=circlelatest >> $BASH_ENV
@@ -129,9 +103,6 @@ jobs:
           if [[ "$CIRCLE_BRANCH" == hotfix/* ]] # double brackets are important for matching the wildcard
             then echo export NPM_TAG=circlehotfix >> $BASH_ENV
           fi
-      - *step_restore_git_cache
-      - checkout
-      - *step_restore_dist_cache
       - run: npm version --no-git-tag-version $RELEASE_VERSION
       - run: |
           npm set //registry.npmjs.org/:_authToken=$NPM_TOKEN
@@ -140,15 +111,12 @@ jobs:
       - run: git push $CIRCLE_REPOSITORY_URL $RELEASE_VERSION
 
   deploy-gh-pages:
-    <<: *config_job_environment
+    <<: *defaults
     steps:
-      - *step_restore_git_cache
-      - checkout
+      - *restore
       - run: |
           git config --global user.email $(git log --pretty=format:"%ae" -n1)
           git config --global user.name $(git log --pretty=format:"%an" -n1)
-      - *step_restore_build_cache
-      - *step_restore_dependency_cache
       - run: npm run deploy -- -e $CIRCLE_BRANCH
       
 workflows:
@@ -166,6 +134,12 @@ workflows:
           requires:
             - setup
       - integration:
+          requires:
+            - build
+      - store_build:
+          requires:
+            - build
+      - store_dist:
           requires:
             - build
       - deploy-npm:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,15 @@ jobs:
       - image: circleci/node:8.16-browsers
     working_directory: ~/repo
     steps:
-      - run: echo export RELEASE_VERSION="0.1.0-prerelease.$(date +'%Y%m%d%H%M%S')" >> $BASH_ENV
+      - run: |
+          echo export RELEASE_VERSION="0.1.0-prerelease.$(date +'%Y%m%d%H%M%S')" >> $BASH_ENV
+          echo export NPM_TAG=latest >> $BASH_ENV
+          if [ "$CIRCLE_BRANCH" == "master" ]
+            then echo export NPM_TAG=circlestable >> $BASH_ENV
+          fi
+          if [[ "$CIRCLE_BRANCH" == hotfix/* ]] # double brackets are important for matching the wildcard
+            then echo export NPM_TAG=circlehotfix >> $BASH_ENV
+          fi
       - restore_cache:
           keys:
             - v1-git-{{ .Revision }}
@@ -93,9 +101,11 @@ jobs:
           keys:
             - v1-dist-{{ .Revision }}
       - run: npm version --no-git-tag-version $RELEASE_VERSION
-      - run: npm publish --dry-run
       - run: echo git tag $RELEASE_VERSION
       - run: echo git push $CIRCLE_REPOSITORY_URL $RELEASE_VERSION
+      - run: |
+          npm set //registry.npmjs.org/:_authToken=$NPM_TOKEN
+          npm publish --dry-run
 
 deploy-requirements: &deploy-requirements
   requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,6 +82,8 @@ jobs:
     docker:
       - image: circleci/node:8.16-browsers
     working_directory: ~/repo
+    environment:
+      NODE_OPTIONS: --max-old-space-size=4000
     steps:
       - run: |
           echo export RELEASE_VERSION="0.1.0-prerelease.$(date +'%Y%m%d%H%M%S')" >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,8 +48,8 @@ jobs:
     <<: *defaults
     steps:
       - *restore_git_cache
-      - *restore_npm_cache
       - checkout
+      - *restore_npm_cache
       - run: npm install
       - *save_git_cache
       - *save_npm_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,7 @@ aliases:
     restore_cache:
       keys:
         - v1-npm-{{ checksum "package-lock.json" }}
+        - v1-npm-
   - &defaults
     docker:
       - image: circleci/node:8.16-browsers
@@ -47,9 +48,10 @@ jobs:
     <<: *defaults
     steps:
       - *restore_git_cache
+      - *restore_npm_cache
       - checkout
+      - run: npm install
       - *save_git_cache
-      - run: npm ci
       - *save_npm_cache
   lint:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,6 +109,27 @@ jobs:
       - run: git tag $RELEASE_VERSION
       - run: git push $CIRCLE_REPOSITORY_URL $RELEASE_VERSION
 
+  deploy-gh-pages:
+    docker:
+      - image: circleci/node:8.16-browsers
+    working_directory: ~/repo
+    steps:
+      - restore_cache:
+          keys:
+            - v1-git-{{ .Revision }}
+            - v1-git-
+      - checkout
+      - run: |
+          git config --global user.email $(git log --pretty=format:"%ae" -n1)
+          git config --global user.name $(git log --pretty=format:"%an" -n1)
+      - restore_cache:
+          keys:
+            - v1-build-{{ .Revision }}
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "package-lock.json" }}
+      - run: npm run deploy -- -e $CIRCLE_BRANCH
+
 deploy-requirements: &deploy-requirements
   requires:
     - build
@@ -127,4 +148,6 @@ workflows:
     jobs:
       - build
       - deploy-npm:
+          <<: *deploy-requirements
+      - deploy-gh-pages:
           <<: *deploy-requirements

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,11 +101,11 @@ jobs:
           keys:
             - v1-dist-{{ .Revision }}
       - run: npm version --no-git-tag-version $RELEASE_VERSION
-      - run: echo git tag $RELEASE_VERSION
-      - run: echo git push $CIRCLE_REPOSITORY_URL $RELEASE_VERSION
       - run: |
           npm set //registry.npmjs.org/:_authToken=$NPM_TOKEN
           npm publish --dry-run
+      - run: git tag $RELEASE_VERSION
+      - run: git push $CIRCLE_REPOSITORY_URL $RELEASE_VERSION
 
 deploy-requirements: &deploy-requirements
   requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,8 +57,8 @@ jobs:
     <<: *defaults
     steps:
       - *restore_git_cache
-      - *restore_npm_cache
       - checkout
+      - *restore_npm_cache
       - run:
           name: Lint
           command: npm run test:lint -- --quiet --output-file test-results/eslint/results.xml --format junit
@@ -70,8 +70,8 @@ jobs:
       JEST_JUNIT_OUTPUT_NAME: results.xml
     steps:
       - *restore_git_cache
-      - *restore_npm_cache
       - checkout
+      - *restore_npm_cache
       - run:
           name: Unit
           environment:
@@ -88,8 +88,8 @@ jobs:
       NODE_OPTIONS: --max-old-space-size=4000
     steps:
       - *restore_git_cache
-      - *restore_npm_cache
       - checkout
+      - *restore_npm_cache
       - run:
           name: Build
           command: npm run build
@@ -113,8 +113,8 @@ jobs:
       JEST_JUNIT_OUTPUT_NAME: results.txt
     steps:
       - *restore_git_cache
-      - *restore_npm_cache
       - checkout
+      - *restore_npm_cache
       - run:
           name: Integration
           environment:
@@ -151,8 +151,8 @@ jobs:
     <<: *defaults
     steps:
       - *restore_git_cache
-      - *restore_npm_cache
       - checkout
+      - *restore_npm_cache
       - run: |
           git config --global user.email $(git log --pretty=format:"%ae" -n1)
           git config --global user.name $(git log --pretty=format:"%an" -n1)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
     steps:
       - run: |
           echo export RELEASE_VERSION="0.1.0-prerelease.$(date +'%Y%m%d%H%M%S')" >> $BASH_ENV
-          echo export NPM_TAG=latest >> $BASH_ENV
+          echo export NPM_TAG=circlelatest >> $BASH_ENV
           if [ "$CIRCLE_BRANCH" == "master" ]
             then echo export NPM_TAG=circlestable >> $BASH_ENV
           fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,11 +62,11 @@ jobs:
       - save_cache:
           paths:
             - build
-          key: v1-build-{{ .BuildNum }}
+          key: v1-build-{{ .Revision }}
       - save_cache:
           paths:
             - dist
-          key: v1-dist-{{ .BuildNum }}
+          key: v1-dist-{{ .Revision }}
       
       
       - run:
@@ -90,7 +90,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v1-dist-{{ .BuildNum }}
+            - v1-dist-{{ .Revision }}
       - run: npm publish --dry-run
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,49 +1,77 @@
-# Javascript Node CircleCI 2.0 configuration file
-#
-# Check https://circleci.com/docs/2.0/language-javascript/ for more details
-#
 version: 2.1
-jobs:
-  build:
+aliases:
+  - &step_restore_git_cache
+    restore_cache:
+      keys:
+        - v1-git-{{ .Revision }}
+        - v1-git-
+  - &step_save_git_cache
+    save_cache:
+      paths:
+        - .git
+      key: v1-git-{{ .Revision }}
+  - &step_restore_dependency_cache
+    restore_cache:
+      keys:
+        - v1-dependencies-{{ checksum "package-lock.json" }}
+        - v1-dependencies-
+  - &step_save_dependency_cache
+    save_cache:
+      paths:
+        - node_modules
+      key: v1-dependencies-{{ checksum "package-lock.json" }}
+  - &step_save_build_cache
+    save_cache:
+      paths:
+        - build
+      key: v1-build-{{ .Revision }}
+  - &step_restore_build_cache
+    restore_cache:
+      keys:
+        - v1-build-{{ .Revision }}
+  - &step_save_dist_cache
+    save_cache:
+      paths:
+        - dist
+      key: v1-dist-{{ .Revision }}
+  - &step_restore_dist_cache
+    restore_cache:
+      keys:
+        - v1-dist-{{ .Revision }}
+  - &config_job_environment
     docker:
       - image: circleci/node:8.16-browsers
-    
+    working_directory: ~/repo
+  - &config_deploy_requirements
+    requires:
+      - build
+    filters:
+      branches:
+        only:
+          - master
+          - develop
+          - smoke
+          - circle
+          - /^hotfix\/.*/
+
+jobs:
+  build:
+    <<: *config_job_environment
     environment:
       NODE_ENV: production
       JEST_JUNIT_OUTPUT_NAME: results.xml
-    working_directory: ~/repo
-
     steps:
-      - restore_cache:
-          keys:
-            - v1-git-{{ .Revision }}
-            - v1-git-
+      - *step_restore_git_cache
       - checkout
-      - save_cache:
-          paths:
-            - .git
-          key: v1-git-{{ .Revision }}
-
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "package-lock.json" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
-
+      - *step_save_git_cache
+      - *step_restore_dependency_cache
       - run: sudo npm install -g greenkeeper-lockfile
       - run: npm --production=false install
       - run: greenkeeper-lockfile-update
-
-      - save_cache:
-          paths:
-            - node_modules
-          key: v1-dependencies-{{ checksum "package-lock.json" }}
-
+      - *step_save_dependency_cache
       - run:
           name: Lint
           command: npm run test:lint -- --quiet --output-file test-results/eslint/results.xml --format junit
-      
       - run:
           name: Unit
           environment:
@@ -51,7 +79,6 @@ jobs:
           command: npm run test:unit -- --reporters="default" --reporters="jest-junit" --coverage --coverageReporters=text --coverageReporters=lcov
       - store_artifacts:
           path: coverage
-      
       - run:
           name: Build
           command: npm run build
@@ -59,16 +86,8 @@ jobs:
           path: build
       - store_artifacts:
           path: dist
-      - save_cache:
-          paths:
-            - build
-          key: v1-build-{{ .Revision }}
-      - save_cache:
-          paths:
-            - dist
-          key: v1-dist-{{ .Revision }}
-      
-      
+      - *step_save_build_cache
+      - *step_save_dist_cache
       - run:
           name: Integration
           environment:
@@ -76,12 +95,10 @@ jobs:
           command: npm run test:integration -- --reporters="default" --reporters="jest-junit"
       - store_test_results:
           path: test-results
-
       - run: greenkeeper-lockfile-upload
+
   deploy-npm:
-    docker:
-      - image: circleci/node:8.16-browsers
-    working_directory: ~/repo
+    <<: *config_job_environment
     environment:
       NODE_OPTIONS: --max-old-space-size=4000
     steps:
@@ -94,14 +111,9 @@ jobs:
           if [[ "$CIRCLE_BRANCH" == hotfix/* ]] # double brackets are important for matching the wildcard
             then echo export NPM_TAG=circlehotfix >> $BASH_ENV
           fi
-      - restore_cache:
-          keys:
-            - v1-git-{{ .Revision }}
-            - v1-git-
+      - *step_restore_git_cache
       - checkout
-      - restore_cache:
-          keys:
-            - v1-dist-{{ .Revision }}
+      - *step_restore_dist_cache
       - run: npm version --no-git-tag-version $RELEASE_VERSION
       - run: |
           npm set //registry.npmjs.org/:_authToken=$NPM_TOKEN
@@ -110,37 +122,16 @@ jobs:
       - run: git push $CIRCLE_REPOSITORY_URL $RELEASE_VERSION
 
   deploy-gh-pages:
-    docker:
-      - image: circleci/node:8.16-browsers
-    working_directory: ~/repo
+    <<: *config_job_environment
     steps:
-      - restore_cache:
-          keys:
-            - v1-git-{{ .Revision }}
-            - v1-git-
+      - *step_restore_git_cache
       - checkout
       - run: |
           git config --global user.email $(git log --pretty=format:"%ae" -n1)
           git config --global user.name $(git log --pretty=format:"%an" -n1)
-      - restore_cache:
-          keys:
-            - v1-build-{{ .Revision }}
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "package-lock.json" }}
+      - *step_restore_build_cache
+      - *step_restore_dependency_cache
       - run: npm run deploy -- -e $CIRCLE_BRANCH
-
-deploy-requirements: &deploy-requirements
-  requires:
-    - build
-  filters:
-    branches:
-      only:
-        - master
-        - develop
-        - smoke
-        - circle
-        - /^hotfix\/.*/
       
 workflows:
   version: 2
@@ -148,6 +139,6 @@ workflows:
     jobs:
       - build
       - deploy-npm:
-          <<: *deploy-requirements
+          <<: *config_deploy_requirements
       - deploy-gh-pages:
-          <<: *deploy-requirements
+          <<: *config_deploy_requirements

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
       - run: npm version --no-git-tag-version $RELEASE_VERSION
       - run: |
           npm set //registry.npmjs.org/:_authToken=$NPM_TOKEN
-          npm publish
+          npm publish --tag $NPM_TAG
       - run: git tag $RELEASE_VERSION
       - run: git push $CIRCLE_REPOSITORY_URL $RELEASE_VERSION
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,17 +109,21 @@ jobs:
           path: dist
   integration:
     <<: *defaults
+    parallelism: 2
     environment:
       JEST_JUNIT_OUTPUT_NAME: results.txt
     steps:
       - *restore_git_cache
       - checkout
       - *restore_npm_cache
+      - *restore_build_cache
       - run:
           name: Integration
           environment:
               JEST_JUNIT_OUTPUT_DIR: test-results/integration
-          command: npm run test:integration -- --reporters="default" --reporters="jest-junit"
+          command: |
+            export TESTFILES=$(circleci tests glob "test/integration/*.test.js" | circleci tests split --split-by=timings)
+            $(npm bin)/jest ${TESTFILES} --reporters="default" --reporters="jest-junit"
       - store_test_results:
           path: test-results
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,4 +54,6 @@ jobs:
 
       - store_test_results:
           path: test-results
+      - store_artifacts:
+          path: build
       - run: greenkeeper-lockfile-upload

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,6 +157,7 @@ jobs:
       - *restore_git_cache
       - checkout
       - *restore_npm_cache
+      - *restore_build_cache
       - run: |
           git config --global user.email $(git log --pretty=format:"%ae" -n1)
           git config --global user.name $(git log --pretty=format:"%an" -n1)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,42 @@
 version: 2.1
 aliases:
-  - &persist
-    persist_to_workspace:
-        root: .
-        paths: .
-  - &restore
-    attach_workspace:
-        at: ~/repo
+  - &save_git_cache
+    save_cache:
+      paths:
+        - .git
+      key: v1-git-{{ .Revision }}
+  - &restore_git_cache
+    restore_cache:
+      keys:
+        - v1-git-{{ .Revision }}
+        - v1-git-
+  - &save_build_cache
+    save_cache:
+      paths:
+        - build
+      key: v1-build-{{ .Revision }}
+  - &restore_build_cache
+    restore_cache:
+      keys:
+        - v1-build-{{ .Revision }}
+  - &save_dist_cache
+    save_cache:
+      paths:
+        - dist
+      key: v1-dist-{{ .Revision }}
+  - &restore_dist_cache
+    restore_cache:
+      keys:
+        - v1-dist-{{ .Revision }}
+  - &save_npm_cache
+    save_cache:
+      paths:
+        - node_modules
+      key: v1-npm-{{ checksum "package-lock.json" }}
+  - &restore_npm_cache
+    restore_cache:
+      keys:
+        - v1-npm-{{ checksum "package-lock.json" }}
   - &defaults
     docker:
       - image: circleci/node:8.16-browsers
@@ -16,21 +46,17 @@ jobs:
   setup:
     <<: *defaults
     steps:
-      - restore_cache:
-          keys:
-            - v1-git-{{ .Revision }}
-            - v1-git-
+      - *restore_git_cache
       - checkout
-      - save_cache:
-          paths:
-            - .git
-          key: v1-git-{{ .Revision }}
+      - *save_git_cache
       - run: npm ci
-      - *persist
+      - *save_npm_cache
   lint:
     <<: *defaults
     steps:
-      - *restore
+      - *restore_git_cache
+      - *restore_npm_cache
+      - checkout
       - run:
           name: Lint
           command: npm run test:lint -- --quiet --output-file test-results/eslint/results.xml --format junit
@@ -41,7 +67,9 @@ jobs:
     environment:
       JEST_JUNIT_OUTPUT_NAME: results.xml
     steps:
-      - *restore
+      - *restore_git_cache
+      - *restore_npm_cache
+      - checkout
       - run:
           name: Unit
           environment:
@@ -57,21 +85,24 @@ jobs:
       NODE_ENV: production
       NODE_OPTIONS: --max-old-space-size=4000
     steps:
-      - *restore
+      - *restore_git_cache
+      - *restore_npm_cache
+      - checkout
       - run:
           name: Build
           command: npm run build
-      - *persist
+      - *save_build_cache
+      - *save_dist_cache
   store_build:
     <<: *defaults
     steps:
-      - *restore
+      - *restore_build_cache
       - store_artifacts:
           path: build
   store_dist:
     <<: *defaults
     steps:
-      - *restore
+      - *restore_dist_cache
       - store_artifacts:
           path: dist
   integration:
@@ -79,7 +110,9 @@ jobs:
     environment:
       JEST_JUNIT_OUTPUT_NAME: results.txt
     steps:
-      - *restore
+      - *restore_git_cache
+      - *restore_npm_cache
+      - checkout
       - run:
           name: Integration
           environment:
@@ -93,7 +126,9 @@ jobs:
     environment:
       NODE_OPTIONS: --max-old-space-size=4000
     steps:
-      - *restore
+      - *restore_git_cache
+      - *restore_dist_cache
+      - checkout
       - run: |
           echo export RELEASE_VERSION="0.1.0-prerelease.$(date +'%Y%m%d%H%M%S')" >> $BASH_ENV
           echo export NPM_TAG=circlelatest >> $BASH_ENV
@@ -113,7 +148,9 @@ jobs:
   deploy-gh-pages:
     <<: *defaults
     steps:
-      - *restore
+      - *restore_git_cache
+      - *restore_npm_cache
+      - checkout
       - run: |
           git config --global user.email $(git log --pretty=format:"%ae" -n1)
           git config --global user.name $(git log --pretty=format:"%an" -n1)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,20 +40,22 @@ jobs:
           name: Unit
           environment:
               JEST_JUNIT_OUTPUT_DIR: test-results/unit
-          command: npm run test:unit -- --reporters="default" --reporters="jest-junit"
+          command: npm run test:unit -- --reporters="default" --reporters="jest-junit" --coverage --coverageReporters=text --coverageReporters=lcov
+      - store_artifacts:
+          path: coverage
       
       - run:
           name: Build
           command: npm run build
+      - store_artifacts:
+          path: build
       
       - run:
           name: Integration
           environment:
               JEST_JUNIT_OUTPUT_DIR: test-results/integration
           command: npm run test:integration -- --reporters="default" --reporters="jest-junit"
-
       - store_test_results:
           path: test-results
-      - store_artifacts:
-          path: build
+
       - run: greenkeeper-lockfile-upload

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
     
     environment:
       NODE_ENV: production
-
+      JEST_JUNIT_OUTPUT_NAME: results.xml
     working_directory: ~/repo
 
     steps:
@@ -35,6 +35,22 @@ jobs:
       - run:
           name: Lint
           command: npm run test:lint -- --quiet --output-file test-results/eslint/results.xml --format junit
+      
+      - run:
+          name: Unit
+          environment:
+              JEST_JUNIT_OUTPUT_DIR: test-results/unit
+          command: npm run test:unit -- --reporters="default" --reporters="jest-junit"
+      
+      - run:
+          name: Build
+          command: npm run build
+      
+      - run:
+          name: Integration
+          environment:
+              JEST_JUNIT_OUTPUT_DIR: test-results/integration
+          command: npm run test:integration -- --reporters="default" --reporters="jest-junit"
 
       - store_test_results:
           path: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,23 +44,33 @@ aliases:
     working_directory: ~/repo
 
 jobs:
-  build:
+  setup:
     <<: *config_job_environment
-    environment:
-      NODE_ENV: production
-      JEST_JUNIT_OUTPUT_NAME: results.xml
     steps:
       - *step_restore_git_cache
       - checkout
       - *step_save_git_cache
-      - *step_restore_dependency_cache
-      - run: sudo npm install -g greenkeeper-lockfile
-      - run: npm --production=false install
-      - run: greenkeeper-lockfile-update
+      - run: npm ci
       - *step_save_dependency_cache
+  lint:
+    <<: *config_job_environment
+    steps:
+      - *step_restore_git_cache
+      - checkout
+      - *step_restore_dependency_cache
       - run:
           name: Lint
           command: npm run test:lint -- --quiet --output-file test-results/eslint/results.xml --format junit
+      - store_test_results:
+          path: test-results
+  unit:
+    <<: *config_job_environment
+    environment:
+      JEST_JUNIT_OUTPUT_NAME: results.xml
+    steps:
+      - *step_restore_git_cache
+      - checkout
+      - *step_restore_dependency_cache
       - run:
           name: Unit
           environment:
@@ -68,6 +78,17 @@ jobs:
           command: npm run test:unit -- --reporters="default" --reporters="jest-junit" --coverage --coverageReporters=text --coverageReporters=lcov
       - store_artifacts:
           path: coverage
+      - store_test_results:
+          path: test-results
+  build:
+    <<: *config_job_environment
+    environment:
+      NODE_ENV: production
+      NODE_OPTIONS: --max-old-space-size=4000
+    steps:
+      - *step_restore_git_cache
+      - checkout
+      - *step_restore_dependency_cache
       - run:
           name: Build
           command: npm run build
@@ -77,6 +98,15 @@ jobs:
           path: dist
       - *step_save_build_cache
       - *step_save_dist_cache
+  integration:
+    <<: *config_job_environment
+    environment:
+      JEST_JUNIT_OUTPUT_NAME: results.txt
+    steps:
+      - *step_restore_git_cache
+      - checkout
+      - *step_restore_dependency_cache
+      - *step_restore_build_cache
       - run:
           name: Integration
           environment:
@@ -84,7 +114,6 @@ jobs:
           command: npm run test:integration -- --reporters="default" --reporters="jest-junit"
       - store_test_results:
           path: test-results
-      - run: greenkeeper-lockfile-upload
 
   deploy-npm:
     <<: *config_job_environment
@@ -124,11 +153,26 @@ jobs:
       
 workflows:
   version: 2
-  build_and_deploy:
+  build-test-deploy:
     jobs:
-      - build
+      - setup
+      - lint:
+          requires:
+            - setup
+      - unit:
+          requires:
+            - setup
+      - build:
+          requires:
+            - setup
+      - integration:
+          requires:
+            - build
       - deploy-npm:
           requires:
+            - lint
+            - unit
+            - integration
             - build
           filters:
             branches:
@@ -139,4 +183,7 @@ workflows:
                 - /^hotfix\/.*/
       - deploy-gh-pages:
           requires:
+            - lint
+            - unit
+            - integration
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,9 @@ jobs:
           key: v1-dependencies-{{ checksum "package-lock.json" }}
 
       - run:
-          name: Run tests
-          command: npm test
+          name: Lint
+          command: npm run test:lint -- --output-file test-results/eslint/results.xml --format junit
+
+      - store_test_results:
+          path: test-results
       - run: greenkeeper-lockfile-upload

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ jobs:
       - run: npm version --no-git-tag-version $RELEASE_VERSION
       - run: |
           npm set //registry.npmjs.org/:_authToken=$NPM_TOKEN
-          npm publish --dry-run
+          npm publish
       - run: git tag $RELEASE_VERSION
       - run: git push $CIRCLE_REPOSITORY_URL $RELEASE_VERSION
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,15 +23,9 @@ jobs:
             # fallback to using the latest cache if no exact match is found
             - v1-dependencies-
 
-      - run:
-          name: Install greenkeeper-lockfile
-          command: sudo npm install -g greenkeeper-lockfile
-      - run:
-          name: Install dependencies
-          command: npm --production=false install
-      - run:
-          name: Run greenkeeper-lockfile-update
-          command: greenkeeper-lockfile-update
+      - run: sudo npm install -g greenkeeper-lockfile
+      - run: npm --production=false install
+      - run: greenkeeper-lockfile-update
 
       - save_cache:
           paths:
@@ -41,6 +35,4 @@ jobs:
       - run:
           name: Run tests
           command: npm test
-      - run:
-          name: Run greenkeeper-lockfile-upload
-          command: greenkeeper-lockfile-upload
+      - run: greenkeeper-lockfile-upload

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,17 +42,6 @@ aliases:
     docker:
       - image: circleci/node:8.16-browsers
     working_directory: ~/repo
-  - &config_deploy_requirements
-    requires:
-      - build
-    filters:
-      branches:
-        only:
-          - master
-          - develop
-          - smoke
-          - circle
-          - /^hotfix\/.*/
 
 jobs:
   build:
@@ -139,6 +128,15 @@ workflows:
     jobs:
       - build
       - deploy-npm:
-          <<: *config_deploy_requirements
+          requires:
+            - build
+          filters:
+            branches:
+              only:
+                - master
+                - develop
+                - circle
+                - /^hotfix\/.*/
       - deploy-gh-pages:
-          <<: *config_deploy_requirements
+          requires:
+            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,5 +106,4 @@ workflows:
                 - master
                 - develop
                 - smoke
-                - circle
                 - /^hotfix\/.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 #
 # Check https://circleci.com/docs/2.0/language-javascript/ for more details
 #
-version: 2
+version: 2.1
 jobs:
   build:
     docker:
@@ -49,6 +49,17 @@ jobs:
           command: npm run build
       - store_artifacts:
           path: build
+      - store_artifacts:
+          path: dist
+      - save_cache:
+          paths:
+            - build
+          key: v1-build-{{ .BuildNum }}
+      - save_cache:
+          paths:
+            - dist
+          key: v1-dist-{{ .BuildNum }}
+      
       
       - run:
           name: Integration
@@ -59,3 +70,29 @@ jobs:
           path: test-results
 
       - run: greenkeeper-lockfile-upload
+  deploy-npm:
+    docker:
+      - image: circleci/node:8.16-browsers
+    working_directory: ~/repo  
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-dist-{{ .BuildNum }}
+      - run: npm publish --dry-run
+workflows:
+  version: 2
+  build_and_deploy:
+    jobs:
+      - build
+      - deploy-npm:
+          requires:
+            - build
+          filters:
+            branches:
+              only:
+                - master
+                - develop
+                - smoke
+                - circle
+                - /^hotfix\/.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,22 +186,22 @@ workflows:
       - store_dist:
           requires:
             - build
-      - deploy-npm:
-          requires:
-            - lint
-            - unit
-            - integration
-            - build
-          filters:
-            branches:
-              only:
-                - master
-                - develop
-                - circle
-                - /^hotfix\/.*/
-      - deploy-gh-pages:
-          requires:
-            - lint
-            - unit
-            - integration
-            - build
+      # Disable deployment while running in parallel with Travis
+      # - deploy-npm:
+      #     requires:
+      #       - lint
+      #       - unit
+      #       - integration
+      #       - build
+      #     filters:
+      #       branches:
+      #         only:
+      #           - master
+      #           - develop
+      #           - /^hotfix\/.*/
+      # - deploy-gh-pages:
+      #     requires:
+      #       - lint
+      #       - unit
+      #       - integration
+      #       - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,8 +81,9 @@ jobs:
   deploy-npm:
     docker:
       - image: circleci/node:8.16-browsers
-    working_directory: ~/repo  
+    working_directory: ~/repo
     steps:
+      - run: echo export RELEASE_VERSION="0.1.0-prerelease.$(date +'%Y%m%d%H%M%S')" >> $BASH_ENV
       - restore_cache:
           keys:
             - v1-git-{{ .Revision }}
@@ -91,7 +92,10 @@ jobs:
       - restore_cache:
           keys:
             - v1-dist-{{ .Revision }}
+      - run: npm version --no-git-tag-version $RELEASE_VERSION
       - run: npm publish --dry-run
+      - run: echo git tag $RELEASE_VERSION
+      - run: echo git push $CIRCLE_REPOSITORY_URL $RELEASE_VERSION
 
 deploy-requirements: &deploy-requirements
   requires:
@@ -102,6 +106,7 @@ deploy-requirements: &deploy-requirements
         - master
         - develop
         - smoke
+        - circle
         - /^hotfix\/.*/
       
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,9 @@ jobs:
   build:
     docker:
       - image: circleci/node:8.16-browsers
+    
+    environment:
+      NODE_ENV: production
 
     working_directory: ~/repo
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -921,6 +921,17 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@jest/types": {
+      "version": "24.8.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.8.0.tgz",
+      "integrity": "sha512-g17UxVr2YfBtaMUxn9u/4+siG1ptg9IGYAYwvpwn61nBg779RXnjE/m7CxYcIzEt0AbHZZAHSEZNhkE2WxURVg==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^1.1.1",
+        "@types/yargs": "^12.0.9"
+      }
+    },
     "@scratch/paper": {
       "version": "0.11.20190729152410",
       "resolved": "https://registry.npmjs.org/@scratch/paper/-/paper-0.11.20190729152410.tgz",
@@ -985,6 +996,31 @@
         "@types/node": "*"
       }
     },
+    "@types/istanbul-lib-coverage": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
+      "integrity": "sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg==",
+      "dev": true
+    },
+    "@types/istanbul-lib-report": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
+      "integrity": "sha512-3BUTyMzbZa2DtDI2BkERNC6jJw2Mr2Y0oGI7mRxYNBPxppbtEK1F66u3bKwU2g+wxwWI7PAoRpJnOY1grJqzHg==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "@types/istanbul-reports": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
+      "integrity": "sha512-UpYjBi8xefVChsCoBpKShdxTllC9pwISirfoZsUa2AAdQg/Jd2KQGtSbw+ya7GPo7x/wAPlH6JBhKhAsXUEZNA==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "*",
+        "@types/istanbul-lib-report": "*"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
@@ -1001,6 +1037,12 @@
       "version": "12.7.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.2.tgz",
       "integrity": "sha512-dyYO+f6ihZEtNPDcWNR1fkoTDf3zAK3lAABDze3mz6POyIercH0lEUawUFXlG8xaQZmm1yEBON/4TsYv/laDYg==",
+      "dev": true
+    },
+    "@types/yargs": {
+      "version": "12.0.12",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-12.0.12.tgz",
+      "integrity": "sha512-SOhuU4wNBxhhTHxYaiG5NY4HBhDIDnJF60GU+2LqHAdKKer86//e4yg69aENCtQ04n0ovz+tq2YPME5t5yp4pw==",
       "dev": true
     },
     "@typescript-eslint/experimental-utils": {
@@ -7777,6 +7819,81 @@
         "jest-message-util": "^21.2.1",
         "jest-snapshot": "^21.2.1",
         "p-cancelable": "^0.3.0"
+      }
+    },
+    "jest-junit": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-7.0.0.tgz",
+      "integrity": "sha512-ljUdO0hLyu0A92xk7R2Wet3kj99fmazTo+ZFYQP6b7AGOBxJUj8ZkJWzJ632ajpXko2Y5oNoGR2kvOwiDdu6hg==",
+      "dev": true,
+      "requires": {
+        "jest-validate": "^24.0.0",
+        "mkdirp": "^0.5.1",
+        "strip-ansi": "^4.0.0",
+        "xml": "^1.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        },
+        "jest-get-type": {
+          "version": "24.8.0",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.8.0.tgz",
+          "integrity": "sha512-RR4fo8jEmMD9zSz2nLbs2j0zvPpk/KCEz3a62jJWbd2ayNo0cb+KFRxPHVhE4ZmgGJEQp0fosmNz84IfqM8cMQ==",
+          "dev": true
+        },
+        "jest-validate": {
+          "version": "24.8.0",
+          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.8.0.tgz",
+          "integrity": "sha512-+/N7VOEMW1Vzsrk3UWBDYTExTPwf68tavEPKDnJzrC6UlHtUDU/fuEdXqFoHzv9XnQ+zW6X3qMZhJ3YexfeLDA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^24.8.0",
+            "camelcase": "^5.0.0",
+            "chalk": "^2.0.1",
+            "jest-get-type": "^24.8.0",
+            "leven": "^2.1.0",
+            "pretty-format": "^24.8.0"
+          }
+        },
+        "pretty-format": {
+          "version": "24.8.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.8.0.tgz",
+          "integrity": "sha512-P952T7dkrDEplsR+TuY7q3VXDae5Sr7zmQb12JU/NDQa/3CH7/QW0yvqLcGN6jL+zQFKaoJcPc+yJxMTGmosqw==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^24.8.0",
+            "ansi-regex": "^4.0.0",
+            "ansi-styles": "^3.2.0",
+            "react-is": "^16.8.4"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+              "dev": true
+            }
+          }
+        }
       }
     },
     "jest-matcher-utils": {
@@ -14644,6 +14761,12 @@
           "dev": true
         }
       }
+    },
+    "xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
+      "dev": true
     },
     "xml-name-validator": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "immutable": "3.8.2",
     "intl": "1.2.5",
     "jest": "^21.0.0",
+    "jest-junit": "^7.0.0",
     "js-base64": "2.4.9",
     "keymirror": "0.1.1",
     "lodash.bindall": "4.4.0",


### PR DESCRIPTION
This adds a config for CircleCI. When this PR is merged, nothing special will happen until I enable CircleCI on this repo, which I will do as soon as it's merged. After that, the CircleCI config will take effect, running tests at the same time as Travis.  This will just be for trial purposes, making sure that CircleCI works at least as well as Travis, and to get a feel for the types of failures/annoyances we will face if we switch to CircleCI.