### PR TITLE
Depend on isShowingWithId for updating thumbnail

### DIFF
--- a/src/components/scratch-image/scratch-image.jsx
+++ b/src/components/scratch-image/scratch-image.jsx
@@ -136,6 +136,7 @@ ScratchImage.ImageSourcePropType = PropTypes.oneOfType([
 ]);
 
 ScratchImage.propTypes = {
+    src: PropTypes.string,
     imageSource: ScratchImage.ImageSourcePropType.isRequired
 };
 

--- a/src/containers/stage-selector.jsx
+++ b/src/containers/stage-selector.jsx
@@ -83,7 +83,6 @@ class StageSelector extends React.Component {
         this.props.onSelect(this.props.id);
     }
     handleNewBackdropClick (e) {
-        console.log('handle', this.props.onNewBackdropClick);
         e.stopPropagation();
         this.props.onNewBackdropClick(jsonStr => {
             this.handleNewBackdrop(JSON.parse(jsonStr), false);

--- a/src/lib/project-saver-hoc.jsx
+++ b/src/lib/project-saver-hoc.jsx
@@ -72,9 +72,11 @@ const ProjectSaverHOC = function (WrappedComponent) {
             }
             if (!this.props.isLoading && prevProps.isLoading) {
                 this.reportTelemetryEvent('projectDidLoad');
-                if (this.props.saveThumbnailOnLoad && this.props.reduxProjectId !== null) {
-                    this.storeProjectThumbnail(this.props.reduxProjectId);
-                }
+            }
+
+            if (this.props.isShowingWithId && !this.props.isLoading &&
+                prevProps.isLoading && this.props.saveThumbnailOnLoad) {
+                this.storeProjectThumbnail(this.props.reduxProjectId);
             }
 
             if (this.props.projectChanged && !prevProps.projectChanged) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -135,7 +135,7 @@ module.exports = [
         },
         plugins: base.plugins.concat([
             new webpack.DefinePlugin({
-                'process.env.NODE_ENV': '"' + 'production' + '"',
+                'process.env.NODE_ENV': '"production"',
                 'process.env.DEBUG': Boolean(process.env.DEBUG),
                 'process.env.GA_ID': '"' + (process.env.GA_ID || 'UA-000000-01') + '"'
             }),


### PR DESCRIPTION
In addition to being loaded, make sure the project is showing with id. I think this will prevent trying to save a thumbnail when projectId is `“0”`. Moved it out of the telemetry event condition, but it could go back if that seems like the right place for it.
