### PR TITLE
Fix extension modal tiles' description line height

### DIFF
--- a/src/components/library-item/library-item.css
+++ b/src/components/library-item/library-item.css
@@ -139,7 +139,9 @@
 .featured-description {
     display: block;
     font-weight: normal;
-    line-height: 2;
+    line-height: 1.375rem;
+    padding-top: .3125rem;
+    padding-bottom: .25rem;
 }
 
 .featured-extension-metadata {


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-gui/issues/5240

### Proposed Changes

* alters the css of the extension modal tiles' description to have smaller line-height, and greater padding-top to compensate.
### Reason for Changes

### Screenshots

Before:

![image](https://user-images.githubusercontent.com/3431616/66619333-9186a980-ebaa-11e9-9fc9-0cba3b7379e1.png)

![image](https://user-images.githubusercontent.com/3431616/66619316-85025100-ebaa-11e9-95ba-8268e0319997.png)

After:

![image](https://user-images.githubusercontent.com/3431616/66619327-8c295f00-ebaa-11e9-9f39-5ca9d37e300f.png)
![image](https://user-images.githubusercontent.com/3431616/66619963-c85dbf00-ebac-11e9-9206-8c2627a26158.png)

### Test Coverage

n/a

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
