### PR TITLE
Add power (exponentiation) operator

### DIFF
--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -555,6 +555,18 @@ const operators = function () {
                 </shadow>
             </value>
         </block>
+        <block type="operator_power">
+            <value name="NUM1">
+                <shadow type="math_number">
+                    <field name="NUM"/>
+                </shadow>
+            </value>
+            <value name="NUM2">
+                <shadow type="math_number">
+                    <field name="NUM"/>
+                </shadow>
+            </value>
+        </block>
         ${blockSeparator}
         <block type="operator_random">
             <value name="FROM">


### PR DESCRIPTION
### Proposed Changes

It adds power (exponentiation) operator to Scratch. It now supports an easy way to do exponentiations.

### Reason for Changes

Scratch does not support exponentiation. Although there are some ways to "simulate" it, they are very hard to do, especially for young users.

This was also requested a long time ago on [Scracth Forum](https://scratch.mit.edu/discuss/topic/70660/) and [Scratch Wiki](https://en.scratch-wiki.info/wiki/Solving_Exponents)

### Test Coverage

I didn't do any new "advanced" tests. I mostly copied things that are used for existing operator blocks to create a new block.

### Related PRs

Other PRs that are needed for this implementation are:

* LLK/scratch-vm#2296
* LLK/scratch-blocks#2007
* LLK/scratch-gui#5266
