### PR TITLE
tests: set --autoplay-policy=no-user-gesture-required

### DIFF
--- a/test/helpers/selenium-helper.js
+++ b/test/helpers/selenium-helper.js
@@ -57,6 +57,10 @@ class SeleniumHelper {
         // Stub getUserMedia to always not allow access
         args.push('--use-fake-ui-for-media-stream=deny');
 
+        // Suppress complaints about AudioContext starting before a user gesture
+        // This is especially important on Windows, where Selenium directs JS console messages to stdout
+        args.push('--autoplay-policy=no-user-gesture-required');
+
         chromeCapabilities.set('chromeOptions', {args});
         chromeCapabilities.setLoggingPrefs({
             performance: 'ALL'


### PR DESCRIPTION
### Proposed Changes

Add `--autoplay-policy=no-user-gesture-required` to the flags passed to the Chrome instance used by Selenium.

### Reason for Changes

Running integration tests currently floods the console with messages like this, at least on Windows:

```
[1030/101911.880:INFO:CONSOLE(294404)] "The AudioContext was not allowed to start. It must be resumed (or created) after a user gesture on the page. https://goo.gl/7K7WLu", source: file:///E:/GitHub/scratch-gui/build/lib.min.js (294404)
```

Any other messages printed to the console get lost in the flood.

If we adjust our AudioContext handling we may want to back out this change since this might make it more difficult to test autoplay behavior.

Note that this change will cause local tests to make noise again. If that's not desirable I can look for another way to solve this problem.

### Test Coverage

This change is covered by existing tests.

### Browser Coverage

Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [x] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
