### PR TITLE
Include library JSON files in package distribution

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -219,6 +219,12 @@ module.exports = [
                 new CopyWebpackPlugin([{
                     from: 'extension-worker.{js,js.map}',
                     context: 'node_modules/scratch-vm/dist/web'
+                }]),
+                // Include library JSON files for scratch-desktop to use for downloading
+                new CopyWebpackPlugin([{
+                    from: 'src/lib/libraries/*.json',
+                    to: 'libraries',
+                    flatten: true
                 }])
             ])
         })) : []


### PR DESCRIPTION
Files like src/lib/libraries/sprites.json were being used by
packages like scratch-desktop in order to fetch all the library
assets for offline access. We stopped publishing src in #5263 to
stop bloating the dist with copies of src files. Explicitly
exporting the files that are needed by other repos is a better
long-term plan.

The files are now published to dist/libraries/*.json. Once this is
merged those repos that use the src/ path need to change it to e.g.
`require('scratch-gui/dist/libraries/backdrops.json')`

I did wonder whether these files should be copied into /dist vs.
copying them into the root of the package. Any thoughts @rschamp @chrisgarrity ?