### PR TITLE
Don't align-items: center in stage-overlay-content

### DIFF
--- a/src/components/stage/stage.css
+++ b/src/components/stage/stage.css
@@ -66,7 +66,6 @@
 
     overflow: hidden;
     display: flex;
-    align-items: center;
     justify-content: center;
 }
 


### PR DESCRIPTION
### Resolves

Resolves #5706 (also reported [in this Bugs and Glitches forum thread](https://scratch.mit.edu/discuss/topic/343753/))

### Proposed Changes

This change removes the `align-items: center` directive from the `stage-overlay-content` wrapper, as the wrapper's child element is a `DOMElementRenderer`, which is not `display: flex`, and non-flexbox elements do weird things with `align-items`.

Another solution would be to change the `DOMElementRenderer` to wrap the rendered element in a `<Box>` instead of a `<div>`, but the scope of that change seems bigger even though the `DOMElementRenderer` is only used for the stage.

### Reason for Changes

This removes the white line from the bottom of the stage:

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/25993062/68047588-22860780-fcb5-11e9-93de-7d4a419c5ff0.png) | ![image](https://user-images.githubusercontent.com/25993062/68047590-2580f800-fcb5-11e9-87d9-69cef4e56add.png) |

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [x] Edge

Linux
* [x] Firefox
* [x] Chrome
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome

### Test Plan
  - Description: Remove the `align-items: center` CSS rule from an element in the fullscreen-mode stage overlay
  - Ensure that fullscreen-mode stage layout is not altered other than now being properly centered by a few pixels
    - Use [this test project](https://scratch.mit.edu/projects/392141205/) to verify that the tops of the "o"s are no longer cut off and there is no white area between the purple rectangle and the bottom stage border
    - Use [this test project](https://scratch.mit.edu/projects/392283240/) to verify that a thin red border appears just within the stage
    - Test fullscreen stage behavior across layout engines:
      - Firefox
      - Chrome
      - Safari
      - Legacy Edge
    - Test across a variety of devices:
      - Low-DPI computer
      - High-DPI computer
      - Tablet and/or phone
    - Test across different window sizes
      - Fullscreen behavior is already somewhat broken when resizing a browser window-- on my Linux machine at least, the stage size only properly updates when maximizing and unmaximizing a window. That's an existing bug that should be tracked separately.

