### PR TITLE
reset title on transitioning to isShowingWithoutId

### DIFF
--- a/src/lib/titled-hoc.jsx
+++ b/src/lib/titled-hoc.jsx
@@ -27,6 +27,10 @@ const TitledHOC = function (WrappedComponent) {
             if (this.props.projectTitle !== prevProps.projectTitle) {
                 this.handleReceivedProjectTitle(this.props.projectTitle);
             }
+            if (this.props.isShowingWithoutId && !prevProps.isShowingWithoutId) {
+                const defaultProjectTitle = this.handleReceivedProjectTitle();
+                this.props.onUpdateProjectTitle(defaultProjectTitle);
+            }
             // if the projectTitle hasn't changed, but the reduxProjectTitle
             // HAS changed, we need to report that change to the projectTitle's owner
             if (this.props.reduxProjectTitle !== prevProps.reduxProjectTitle &&
@@ -40,6 +44,7 @@ const TitledHOC = function (WrappedComponent) {
                 newTitle = this.props.intl.formatMessage(messages.defaultProjectTitle);
             }
             this.props.onChangedProjectTitle(newTitle);
+            return newTitle;
         }
         render () {
             const {

--- a/src/lib/titled-hoc.jsx
+++ b/src/lib/titled-hoc.jsx
@@ -3,7 +3,10 @@ import React from 'react';
 import {connect} from 'react-redux';
 import {defineMessages, injectIntl, intlShape} from 'react-intl';
 
-import {getIsShowingWithoutId} from '../reducers/project-state';
+import {
+    getIsAnyCreatingNewState,
+    getIsShowingWithoutId
+} from '../reducers/project-state';
 import {setProjectTitle} from '../reducers/project-title';
 
 const messages = defineMessages({
@@ -27,7 +30,7 @@ const TitledHOC = function (WrappedComponent) {
             if (this.props.projectTitle !== prevProps.projectTitle) {
                 this.handleReceivedProjectTitle(this.props.projectTitle);
             }
-            if (this.props.isShowingWithoutId && !prevProps.isShowingWithoutId) {
+            if (this.props.isShowingWithoutId && prevProps.isAnyCreatingNewState) {
                 const defaultProjectTitle = this.handleReceivedProjectTitle();
                 this.props.onUpdateProjectTitle(defaultProjectTitle);
             }
@@ -50,6 +53,7 @@ const TitledHOC = function (WrappedComponent) {
             const {
                 /* eslint-disable no-unused-vars */
                 intl,
+                isAnyCreatingNewState,
                 isShowingWithoutId,
                 onChangedProjectTitle,
                 // for children, we replace onUpdateProjectTitle with our own
@@ -71,6 +75,7 @@ const TitledHOC = function (WrappedComponent) {
 
     TitledComponent.propTypes = {
         intl: intlShape,
+        isAnyCreatingNewState: PropTypes.bool,
         isShowingWithoutId: PropTypes.bool,
         onChangedProjectTitle: PropTypes.func,
         onUpdateProjectTitle: PropTypes.func,
@@ -85,6 +90,7 @@ const TitledHOC = function (WrappedComponent) {
     const mapStateToProps = state => {
         const loadingState = state.scratchGui.projectState.loadingState;
         return {
+            isAnyCreatingNewState: getIsAnyCreatingNewState(loadingState),
             isShowingWithoutId: getIsShowingWithoutId(loadingState),
             reduxProjectTitle: state.scratchGui.projectTitle
         };

--- a/src/lib/titled-hoc.jsx
+++ b/src/lib/titled-hoc.jsx
@@ -30,7 +30,9 @@ const TitledHOC = function (WrappedComponent) {
             if (this.props.projectTitle !== prevProps.projectTitle) {
                 this.handleReceivedProjectTitle(this.props.projectTitle);
             }
+            // if project is a new default project, and has loaded,
             if (this.props.isShowingWithoutId && prevProps.isAnyCreatingNewState) {
+                // reset title to default
                 const defaultProjectTitle = this.handleReceivedProjectTitle();
                 this.props.onUpdateProjectTitle(defaultProjectTitle);
             }

--- a/test/helpers/selenium-helper.js
+++ b/test/helpers/selenium-helper.js
@@ -28,6 +28,8 @@ class SeleniumHelper {
             'loadUri',
             'rightClickText'
         ]);
+
+        this.Key = webdriver.Key; // map Key constants, for sending special keys
     }
 
     elementIsVisible (element, timeoutMessage = 'elementIsVisible timed out') {

--- a/test/integration/project-state.test.js
+++ b/test/integration/project-state.test.js
@@ -1,0 +1,45 @@
+import path from 'path';
+import SeleniumHelper from '../helpers/selenium-helper';
+
+const {
+    clickText,
+    clickXpath,
+    findByXpath,
+    getDriver,
+    Key,
+    loadUri
+} = new SeleniumHelper();
+
+const uri = path.resolve(__dirname, '../../build/index.html');
+
+let driver;
+
+describe('Project state', () => {
+    beforeAll(() => {
+        driver = getDriver();
+    });
+
+    afterAll(async () => {
+        await driver.quit();
+    });
+
+    test('File->New resets project title', async () => {
+        const defaultProjectTitle = 'Scratch Project';
+        await loadUri(uri);
+        const inputEl = await findByXpath(`//input[@value="${defaultProjectTitle}"]`);
+        for (let i = 0; i < defaultProjectTitle.length; i++) {
+            inputEl.sendKeys(Key.BACK_SPACE);
+        }
+        inputEl.sendKeys('Changed title of project');
+        await clickText('Costumes'); // just to blur the input
+        // verify that project title has changed
+        await clickXpath('//input[@value="Changed title of project"]');
+        await clickXpath(
+            '//div[contains(@class, "menu-bar_menu-bar-item") and ' +
+            'contains(@class, "menu-bar_hoverable")][span[text()="File"]]'
+        );
+        await clickXpath('//li[span[text()="New"]]');
+        // project title should be default again
+        await clickXpath(`//input[@value="${defaultProjectTitle}"]`);
+    });
+});


### PR DESCRIPTION
https://github.com/LLK/scratch-gui/pull/5168 was originally intended to resolve https://github.com/LLK/scratch-gui/issues/3433 and https://github.com/LLK/scratch-desktop/issues/71 , but then it was narrowed in scope to a general refactor of project title handling.

This change should resolve https://github.com/LLK/scratch-gui/issues/3433 and https://github.com/LLK/scratch-desktop/issues/71 .

### Proposed Changes

When project state transitions into `isShowingWithoutId` being true, set the project title to the default title, and call GUI's owner's `onUpdateProjectTitle` function.

### Reason for Changes

In standalone and desktop modes, File->New was not resetting title.

### Test Coverage

We don't have good testing for this functionality yet. What would it look like?
