### PR TITLE
Check if menu can be closed before doing

### DIFF
--- a/src/components/menu-bar/menu-bar-menu.jsx
+++ b/src/components/menu-bar/menu-bar-menu.jsx
@@ -5,12 +5,14 @@ import Menu from '../../containers/menu.jsx';
 const MenuBarMenu = ({
     children,
     className,
+    ignoreClickEvent,
     onRequestClose,
     open,
     place = 'right'
 }) => (
     <div className={className}>
         <Menu
+            ignoreClickEvent={ignoreClickEvent}
             open={open}
             place={place}
             onRequestClose={onRequestClose}
@@ -23,6 +25,7 @@ const MenuBarMenu = ({
 MenuBarMenu.propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
+    ignoreClickEvent: PropTypes.bool,
     onRequestClose: PropTypes.func,
     open: PropTypes.bool,
     place: PropTypes.oneOf(['left', 'right'])

--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -56,7 +56,9 @@ import {
     languageMenuOpen,
     openLoginMenu,
     closeLoginMenu,
-    loginMenuOpen
+    loginMenuOpen,
+    fileInputOpen,
+    closeFileInput
 } from '../../reducers/menus';
 
 import collectMetadata from '../../lib/collect-metadata';
@@ -155,7 +157,8 @@ class MenuBar extends React.Component {
             'handleLanguageMouseUp',
             'handleRestoreOption',
             'getSaveToComputerHandler',
-            'restoreOptionMessage'
+            'restoreOptionMessage',
+            'handleClickMenuItem'
         ]);
     }
     componentDidMount () {
@@ -269,6 +272,10 @@ class MenuBar extends React.Component {
         }
         }
     }
+    handleClickMenuItem (opener) {
+        this.props.onCloseFileInput();
+        opener();
+    }
     render () {
         const saveNowMessage = (
             <FormattedMessage
@@ -351,7 +358,9 @@ class MenuBar extends React.Component {
                                 className={classNames(styles.menuBarItem, styles.hoverable, {
                                     [styles.active]: this.props.fileMenuOpen
                                 })}
-                                onMouseUp={this.props.onClickFile}
+                                /* eslint-disable react/jsx-no-bind */
+                                onMouseUp={() => this.handleClickMenuItem(this.props.onClickFile)}
+                                /* eslint-enable react/jsx-no-bind */
                             >
                                 <FormattedMessage
                                     defaultMessage="File"
@@ -360,6 +369,7 @@ class MenuBar extends React.Component {
                                 />
                                 <MenuBarMenu
                                     className={classNames(styles.menuBarMenu)}
+                                    ignoreClickEvent={this.props.isUploadingFile}
                                     open={this.props.fileMenuOpen}
                                     place={this.props.isRtl ? 'left' : 'right'}
                                     onRequestClose={this.props.onRequestCloseFile}
@@ -428,7 +438,9 @@ class MenuBar extends React.Component {
                             className={classNames(styles.menuBarItem, styles.hoverable, {
                                 [styles.active]: this.props.editMenuOpen
                             })}
-                            onMouseUp={this.props.onClickEdit}
+                            /* eslint-disable react/jsx-no-bind */
+                            onMouseUp={() => this.handleClickMenuItem(this.props.onClickEdit)}
+                            /* eslint-enable react/jsx-no-bind */
                         >
                             <div className={classNames(styles.editMenu)}>
                                 <FormattedMessage
@@ -718,10 +730,12 @@ MenuBar.propTypes = {
     isShared: PropTypes.bool,
     isShowingProject: PropTypes.bool,
     isUpdating: PropTypes.bool,
+    isUploadingFile: PropTypes.bool,
     languageMenuOpen: PropTypes.bool,
     locale: PropTypes.string.isRequired,
     loginMenuOpen: PropTypes.bool,
     logo: PropTypes.string,
+    onCloseFileInput: PropTypes.func,
     onClickAccount: PropTypes.func,
     onClickEdit: PropTypes.func,
     onClickFile: PropTypes.func,
@@ -768,6 +782,7 @@ const mapStateToProps = (state, ownProps) => {
         editMenuOpen: editMenuOpen(state),
         isRtl: state.locales.isRtl,
         isUpdating: getIsUpdating(loadingState),
+        isUploadingFile: fileInputOpen(state),
         isShowingProject: getIsShowingProject(loadingState),
         languageMenuOpen: languageMenuOpen(state),
         locale: state.locales.locale,
@@ -798,7 +813,8 @@ const mapDispatchToProps = dispatch => ({
     onClickRemix: () => dispatch(remixProject()),
     onClickSave: () => dispatch(manualUpdateProject()),
     onClickSaveAsCopy: () => dispatch(saveProjectAsCopy()),
-    onSeeCommunity: () => dispatch(setPlayer(true))
+    onSeeCommunity: () => dispatch(setPlayer(true)),
+    onCloseFileInput: () => dispatch(closeFileInput())
 });
 
 export default compose(

--- a/src/containers/menu.jsx
+++ b/src/containers/menu.jsx
@@ -31,7 +31,7 @@ class Menu extends React.Component {
         document.removeEventListener('mouseup', this.handleClick);
     }
     handleClick (e) {
-        if (this.props.open && !this.menu.contains(e.target)) {
+        if (this.props.open && !this.menu.contains(e.target) && !this.props.ignoreClickEvent) {
             this.props.onRequestClose();
         }
     }
@@ -58,6 +58,7 @@ class Menu extends React.Component {
 
 Menu.propTypes = {
     children: PropTypes.node,
+    ignoreClickEvent: PropTypes.bool,
     onRequestClose: PropTypes.func.isRequired,
     open: PropTypes.bool.isRequired
 };

--- a/src/containers/sb-file-uploader.jsx
+++ b/src/containers/sb-file-uploader.jsx
@@ -21,7 +21,9 @@ import {
     closeLoadingProject
 } from '../reducers/modals';
 import {
-    closeFileMenu
+    closeFileMenu,
+    openFileInput,
+    closeFileInput
 } from '../reducers/menus';
 
 /**
@@ -101,6 +103,7 @@ class SBFileUploader extends React.Component {
         } = this.props;
 
         const thisFileInput = e.target;
+        this.props.closeFileInput();
         if (thisFileInput.files) { // Don't attempt to load if no file was selected
             this.fileToUpload = thisFileInput.files[0];
 
@@ -146,8 +149,10 @@ class SBFileUploader extends React.Component {
                 });
         }
     }
-    handleClick () {
+    handleClick (e) {
         // open filesystem browsing window
+        e.stopPropagation();
+        this.props.openFileInput();
         this.fileInput.click();
     }
     setFileInput (input) {
@@ -174,12 +179,14 @@ SBFileUploader.propTypes = {
     children: PropTypes.func,
     className: PropTypes.string,
     closeFileMenu: PropTypes.func,
+    closeFileInput: PropTypes.func,
     intl: intlShape.isRequired,
     isLoadingUpload: PropTypes.bool,
     isShowingWithoutId: PropTypes.bool,
     loadingState: PropTypes.oneOf(LoadingStates),
     onLoadingFinished: PropTypes.func,
     onLoadingStarted: PropTypes.func,
+    openFileInput: PropTypes.func,
     projectChanged: PropTypes.bool,
     requestProjectUpload: PropTypes.func,
     onReceivedProjectTitle: PropTypes.func,
@@ -204,6 +211,8 @@ const mapStateToProps = state => {
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
     closeFileMenu: () => dispatch(closeFileMenu()),
+    closeFileInput: () => dispatch(closeFileInput()),
+    openFileInput: () => dispatch(openFileInput()),
     onLoadingFinished: (loadingState, success) => {
         dispatch(onLoadedProject(loadingState, ownProps.canSave, success));
         dispatch(closeLoadingProject());

--- a/src/reducers/menus.js
+++ b/src/reducers/menus.js
@@ -6,6 +6,7 @@ const MENU_FILE = 'fileMenu';
 const MENU_EDIT = 'editMenu';
 const MENU_LANGUAGE = 'languageMenu';
 const MENU_LOGIN = 'loginMenu';
+const INPUT_FILE = 'uploadingFile';
 
 
 const initialState = {
@@ -13,7 +14,8 @@ const initialState = {
     [MENU_FILE]: false,
     [MENU_EDIT]: false,
     [MENU_LANGUAGE]: false,
-    [MENU_LOGIN]: false
+    [MENU_LOGIN]: false,
+    [INPUT_FILE]: false
 };
 
 const reducer = function (state, action) {
@@ -54,6 +56,9 @@ const languageMenuOpen = state => state.scratchGui.menus[MENU_LANGUAGE];
 const openLoginMenu = () => openMenu(MENU_LOGIN);
 const closeLoginMenu = () => closeMenu(MENU_LOGIN);
 const loginMenuOpen = state => state.scratchGui.menus[MENU_LOGIN];
+const openFileInput = () => openMenu(INPUT_FILE);
+const closeFileInput = () => closeMenu(INPUT_FILE);
+const fileInputOpen = state => state.scratchGui.menus[INPUT_FILE];
 
 export {
     reducer as default,
@@ -72,5 +77,8 @@ export {
     languageMenuOpen,
     openLoginMenu,
     closeLoginMenu,
-    loginMenuOpen
+    loginMenuOpen,
+    openFileInput,
+    closeFileInput,
+    fileInputOpen
 };


### PR DESCRIPTION
### Resolves
Resolves #3365

This is one of the ways to handle #4907 
#### Duplicates
Resolves #4332 
Resolves #4884 
Resolves #5284 

### Proposed Changes
This adds new prop, `ignoreClickEvent`, to the Menu and MenuBarMenu component. When set to truthy value, it no longer closes when something outside the menu is clicked. (Using closeFileMenu reducer to close the menu still works) A new reducer item, `INPUT_FILE`, was added to menus reducer. (better name idea wanted)

ignoreClickEvent for File menu is set to `true` inside SBFileUploader's onclick handler, and set to `false` after the file was chosen. The problem is that, as shown in #4681, there's no oncancel event - so, the File menu won't disappear after clicking Cancel. Clicking one of the menus can make it false, thus making it closable by clicking anywhere.

### Reason for Changes
The click event was fired when doubleclicking the file on the file input, causing the menu to disappear and SBFileUploader to unmount when shouldn't.

### Test Coverage
I was not sure if I could add a test, but if you know how, let me know!

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
