### PR TITLE
Make Spanish tutorial images also load for Latinamerican Spanish

### DIFF
--- a/src/lib/libraries/decks/translate-image.js
+++ b/src/lib/libraries/decks/translate-image.js
@@ -13,7 +13,8 @@ const loadSpanish = () =>
         .then(({esImages: imageData}) => imageData);
 
 const translations = {
-    es: () => loadSpanish()
+    'es': () => loadSpanish(),
+    'es-419': () => loadSpanish()
 };
 
 const loadImageData = locale => {


### PR DESCRIPTION
Changes translate-images.js file so that the Spanish tutorial images load for Latinamerican Spanish
This change would mean that Latinamerican Spanish has tutorial images for all tutorials