### PR TITLE
Revert "Update scratch-render to the latest version 🚀"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11663,9 +11663,9 @@
       }
     },
     "scratch-render": {
-      "version": "0.1.0-prerelease.20191126210304",
-      "resolved": "https://registry.npmjs.org/scratch-render/-/scratch-render-0.1.0-prerelease.20191126210304.tgz",
-      "integrity": "sha512-XGsQiTgdbw8bk+aOMC8osi5C9wkD4989on4UBUhHayx98t1rV5MmENb5vkw5EKmzxXWkSX8qNTXHJ+GjTl6S+g==",
+      "version": "0.1.0-prerelease.20191106204814",
+      "resolved": "https://registry.npmjs.org/scratch-render/-/scratch-render-0.1.0-prerelease.20191106204814.tgz",
+      "integrity": "sha512-4HSBGf9pRBc1HOsiltVGxnAlkjn1h9rgGtDAe9KdYhzZUGCUEFyNiYqgc+OEGotzckWJDeLUvH9igkroOoGz2Q==",
       "dev": true,
       "requires": {
         "grapheme-breaker": "0.3.2",
@@ -12535,12 +12535,12 @@
       "dev": true
     },
     "static-eval": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.3.tgz",
-      "integrity": "sha512-zsxDGucfAh8T339sSKgpFbvg15Fms2IVaJGC+jqp0bVsxhcpM+iMeAI8weNo8dmf4OblgifTBUoyk1vGVtYw2w==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.2.tgz",
+      "integrity": "sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==",
       "dev": true,
       "requires": {
-        "escodegen": "^1.11.1"
+        "escodegen": "^1.8.1"
       }
     },
     "static-extend": {
@@ -13276,9 +13276,9 @@
       }
     },
     "tiny-inflate": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
-      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.2.tgz",
+      "integrity": "sha1-k9nez/yIBb1X6uQxDwt0Xptvs6c=",
       "dev": true
     },
     "tmp": {

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "scratch-l10n": "3.6.20191204142956",
     "scratch-blocks": "0.1.0-prerelease.1574180945",
     "scratch-paint": "0.2.0-prerelease.20191114200704",
-    "scratch-render": "0.1.0-prerelease.20191126210304",
+    "scratch-render": "0.1.0-prerelease.20191106204814",
     "scratch-storage": "1.3.2",
     "scratch-svg-renderer": "0.2.0-prerelease.20191104164753",
     "scratch-vm": "0.2.0-prerelease.20191119203901",


### PR DESCRIPTION
Reverts LLK/scratch-gui#5319

Revert the renderer update because it includes the large mipmap change. We want to be conservative about deploys before HOC. I'll re-revert this change after we have a built version that can be released.