### PR TITLE
Do not show unsupported browser modal for googlebot

### DIFF
--- a/src/lib/supported-browser.js
+++ b/src/lib/supported-browser.js
@@ -26,7 +26,9 @@ const supportedBrowser = () => {
  *   always returns false
  */
 
-const recommendedBrowser = () => !bowser.isUnsupportedBrowser(minVersions, true);
+const recommendedBrowser = () =>
+    !bowser.isUnsupportedBrowser(minVersions, true) ||
+    window.navigator.userAgent.toLowerCase().indexOf('googlebot') !== -1;
 
 export {
     supportedBrowser as default,


### PR DESCRIPTION
This modal may be preventing the crawler from correctly indexing pages, because it takes over the whole screen.

(note: I would have used `bowser.googlebot` but it doesn't actually work consistently, since the googlebot smartphone does not appear to bowser as googlebot, and reports itself as using chrome 41, even though they changed it to being up-to-date with current chrome. But googlebot is still in the ua, so I used that)

/cc @rschamp we can chat about this when you have a moment. I noticed that even with our previous fix for correctly canonical ref google still isn't indexing project pages, and it looks from the search console tools that this full screen unsupported modal may be the answer. The reason it comes up is that the crawler has a "quota" for network requests and starts dropping asset requests if there are too many. It also is getting 404s from the asset server due to the `robots.txt` on scratch assets. So it hits an error boundary, which either shows the (contained) "oops" message or shows the (full screen takeover) browser unsupported modal, based on this function. I'd like to release this as a hotfix if possible?