### PR TITLE
Fix `doneUpdatingProject` call signature

### DIFF
--- a/src/lib/project-saver-hoc.jsx
+++ b/src/lib/project-saver-hoc.jsx
@@ -433,7 +433,7 @@ const ProjectSaverHOC = function (WrappedComponent) {
         onShowCreatingRemixAlert: () => showAlertWithTimeout(dispatch, 'creatingRemix'),
         onShowSaveSuccessAlert: () => showAlertWithTimeout(dispatch, 'saveSuccess'),
         onShowSavingAlert: () => showAlertWithTimeout(dispatch, 'saving'),
-        onUpdatedProject: (projectId, loadingState) => dispatch(doneUpdatingProject(projectId, loadingState)),
+        onUpdatedProject: loadingState => dispatch(doneUpdatingProject(loadingState)),
         setAutoSaveTimeoutId: id => dispatch(setAutoSaveTimeoutId(id))
     });
     // Allow incoming props to override redux-provided props. Used to mock in tests.


### PR DESCRIPTION
ProjectSaverHOC has been using the wrong call signature for `doneUpdatingProject`.

### Resolves

I didn't look for an issue, since this doesn't fix any behaviour.

### Proposed Changes

The call signature for `doneUpdatingProject` expects a single argument, the `loadingState`. However in the `mapDispatchToProps` it was being called with two arguments, but in a way that was actually logically correct. This change reduces it to one argument to match the function definition and usage.

Relevant code sections:

- `project-saver-hoc.jsx:updateProjectToStorage` uses `this.props.onUpdatedProject` with just a loading state
- `project-saver-hoc.jsx:mapDispatchToProps` defines `onUpdatedProject` as a function with two arguments and passes both to `doneUpdatingProject`
- `project-state.js:doneUpdatingProject` defines `doneUpdatingProject` as a function that takes a single argument (loading state)

### Reason for Changes

This looks like a mistake.

### Test Coverage

There is no change in behaviour from this code change.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [x] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome