### PR TITLE
refactor onLoadedProject() creator to handle success==false consistently; add tests of project state action creators

### DIFF
--- a/src/reducers/project-state.js
+++ b/src/reducers/project-state.js
@@ -17,7 +17,7 @@ const START_AUTO_UPDATING = 'scratch-gui/project-state/START_AUTO_UPDATING';
 const START_CREATING_NEW = 'scratch-gui/project-state/START_CREATING_NEW';
 const START_ERROR = 'scratch-gui/project-state/START_ERROR';
 const START_FETCHING_NEW = 'scratch-gui/project-state/START_FETCHING_NEW';
-const START_LOADING_VM_FILE_UPLOAD = 'scratch-gui/project-state/START_LOADING_FILE_UPLOAD';
+const START_LOADING_VM_FILE_UPLOAD = 'scratch-gui/project-state/START_LOADING_VM_FILE_UPLOAD';
 const START_MANUAL_UPDATING = 'scratch-gui/project-state/START_MANUAL_UPDATING';
 const START_REMIXING = 'scratch-gui/project-state/START_REMIXING';
 const START_UPDATING_BEFORE_CREATING_COPY = 'scratch-gui/project-state/START_UPDATING_BEFORE_CREATING_COPY';
@@ -435,10 +435,21 @@ const onLoadedProject = (loadingState, canSave, success) => {
         default:
             return;
         }
+    } else {
+        switch (loadingState) {
+        case LoadingState.LOADING_VM_WITH_ID:
+        case LoadingState.LOADING_VM_FILE_UPLOAD:
+            return {
+                type: RETURN_TO_SHOWING
+            };
+        case LoadingState.LOADING_VM_NEW_DEFAULT:
+            return {
+                type: START_ERROR
+            };
+        default:
+            return;
+        }
     }
-    return {
-        type: RETURN_TO_SHOWING
-    };
 };
 
 const doneUpdatingProject = loadingState => {

--- a/src/reducers/project-state.js
+++ b/src/reducers/project-state.js
@@ -413,42 +413,30 @@ const onFetchedProjectData = (projectData, loadingState) => {
 };
 
 const onLoadedProject = (loadingState, canSave, success) => {
-    if (success) {
-        switch (loadingState) {
-        case LoadingState.LOADING_VM_WITH_ID:
-            return {
-                type: DONE_LOADING_VM_WITH_ID
-            };
-        case LoadingState.LOADING_VM_FILE_UPLOAD:
+    switch (loadingState) {
+    case LoadingState.LOADING_VM_WITH_ID:
+        if (success) {
+            return {type: DONE_LOADING_VM_WITH_ID};
+        }
+        // failed to load project; just keep showing current project
+        return {type: RETURN_TO_SHOWING};
+    case LoadingState.LOADING_VM_FILE_UPLOAD:
+        if (success) {
             if (canSave) {
-                return {
-                    type: DONE_LOADING_VM_TO_SAVE
-                };
+                return {type: DONE_LOADING_VM_TO_SAVE};
             }
-            return {
-                type: DONE_LOADING_VM_WITHOUT_ID
-            };
-        case LoadingState.LOADING_VM_NEW_DEFAULT:
-            return {
-                type: DONE_LOADING_VM_WITHOUT_ID
-            };
-        default:
-            return;
+            return {type: DONE_LOADING_VM_WITHOUT_ID};
         }
-    } else {
-        switch (loadingState) {
-        case LoadingState.LOADING_VM_WITH_ID:
-        case LoadingState.LOADING_VM_FILE_UPLOAD:
-            return {
-                type: RETURN_TO_SHOWING
-            };
-        case LoadingState.LOADING_VM_NEW_DEFAULT:
-            return {
-                type: START_ERROR
-            };
-        default:
-            return;
+        // failed to load project; just keep showing current project
+        return {type: RETURN_TO_SHOWING};
+    case LoadingState.LOADING_VM_NEW_DEFAULT:
+        if (success) {
+            return {type: DONE_LOADING_VM_WITHOUT_ID};
         }
+        // failed to load default project; show error
+        return {type: START_ERROR};
+    default:
+        return;
     }
 };
 

--- a/test/unit/reducers/project-state-reducer.test.js
+++ b/test/unit/reducers/project-state-reducer.test.js
@@ -96,142 +96,173 @@ test('onFetchedProjectData new loads project data into vm', () => {
 
 test('onLoadedProject(LOADING_VM_WITH_ID, true, true) results in state SHOWING_WITH_ID', () => {
     const initialState = {
+        projectId: '100',
         loadingState: LoadingState.LOADING_VM_WITH_ID
     };
     const action = onLoadedProject(initialState.loadingState, true, true);
     const resultState = projectStateReducer(initialState, action);
     expect(resultState.loadingState).toBe(LoadingState.SHOWING_WITH_ID);
+    expect(resultState.projectId).toBe('100');
 });
 
 test('onLoadedProject(LOADING_VM_WITH_ID, false, true) results in state SHOWING_WITH_ID', () => {
     const initialState = {
+        projectId: '100',
         loadingState: LoadingState.LOADING_VM_WITH_ID
     };
-    const action = onLoadedProject(initialState.loadingState, true, true);
+    const action = onLoadedProject(initialState.loadingState, false, true);
     const resultState = projectStateReducer(initialState, action);
     expect(resultState.loadingState).toBe(LoadingState.SHOWING_WITH_ID);
+    expect(resultState.projectId).toBe('100');
 });
 
+// case where we started out viewing a project with a projectId, then
+// started to load another project; but loading fails. We go back to
+// showing the original project.
 test('onLoadedProject(LOADING_VM_WITH_ID, false, false), with project id, ' +
     'results in state SHOWING_WITH_ID', () => {
     const initialState = {
-        loadingState: LoadingState.LOADING_VM_WITH_ID,
-        projectId: '12345'
+        projectId: '100',
+        loadingState: LoadingState.LOADING_VM_WITH_ID
     };
     const action = onLoadedProject(initialState.loadingState, false, false);
     const resultState = projectStateReducer(initialState, action);
     expect(resultState.loadingState).toBe(LoadingState.SHOWING_WITH_ID);
+    expect(resultState.projectId).toBe('100');
 });
 
+// case where we started out viewing a project with default projectId, then
+// started to load one with an id, such as in standalone mode when user adds
+// '#PROJECT_ID_NUMBER' to the URI; but loading fails. We go back to
+// showing the original project.
 test('onLoadedProject(LOADING_VM_WITH_ID, false, false), with no project id, ' +
     'results in state SHOWING_WITHOUT_ID', () => {
     const initialState = {
-        loadingState: LoadingState.LOADING_VM_WITH_ID,
-        projectId: null
+        projectId: '0',
+        loadingState: LoadingState.LOADING_VM_WITH_ID
     };
     const action = onLoadedProject(initialState.loadingState, false, false);
     const resultState = projectStateReducer(initialState, action);
     expect(resultState.loadingState).toBe(LoadingState.SHOWING_WITHOUT_ID);
+    expect(resultState.projectId).toBe('0');
 });
 
 // onLoadedProject: LOADING_VM_FILE_UPLOAD
 
 test('onLoadedProject(LOADING_VM_FILE_UPLOAD, true, true) prepares to save', () => {
     const initialState = {
+        projectId: '100',
         loadingState: LoadingState.LOADING_VM_FILE_UPLOAD
     };
     const action = onLoadedProject(initialState.loadingState, true, true);
     const resultState = projectStateReducer(initialState, action);
     expect(resultState.loadingState).toBe(LoadingState.AUTO_UPDATING);
+    expect(resultState.projectId).toBe('100');
 });
 
 test('onLoadedProject(LOADING_VM_FILE_UPLOAD, false, true) results in state SHOWING_WITHOUT_ID', () => {
     const initialState = {
+        projectId: '0',
         loadingState: LoadingState.LOADING_VM_FILE_UPLOAD
     };
     const action = onLoadedProject(initialState.loadingState, false, true);
     const resultState = projectStateReducer(initialState, action);
     expect(resultState.loadingState).toBe(LoadingState.SHOWING_WITHOUT_ID);
+    expect(resultState.projectId).toBe('0');
 });
 
 test('onLoadedProject(LOADING_VM_FILE_UPLOAD, false, false), when we know project id, ' +
     'results in state SHOWING_WITH_ID', () => {
     const initialState = {
-        loadingState: LoadingState.LOADING_VM_FILE_UPLOAD,
-        projectId: '12345'
+        projectId: '100',
+        loadingState: LoadingState.LOADING_VM_FILE_UPLOAD
     };
     const action = onLoadedProject(initialState.loadingState, false, false);
     const resultState = projectStateReducer(initialState, action);
     expect(resultState.loadingState).toBe(LoadingState.SHOWING_WITH_ID);
+    expect(resultState.projectId).toBe('100');
 });
 
 test('onLoadedProject(LOADING_VM_FILE_UPLOAD, false, false), when we ' +
     'don\'t know project id, results in state SHOWING_WITHOUT_ID', () => {
     const initialState = {
-        loadingState: LoadingState.LOADING_VM_FILE_UPLOAD,
-        projectId: null
+        projectId: '0',
+        loadingState: LoadingState.LOADING_VM_FILE_UPLOAD
     };
     const action = onLoadedProject(initialState.loadingState, false, false);
     const resultState = projectStateReducer(initialState, action);
     expect(resultState.loadingState).toBe(LoadingState.SHOWING_WITHOUT_ID);
+    expect(resultState.projectId).toBe('0');
 });
 
 // onLoadedProject: LOADING_VM_NEW_DEFAULT
 
 test('onLoadedProject(LOADING_VM_NEW_DEFAULT, true, true) results in state SHOWING_WITHOUT_ID', () => {
     const initialState = {
+        projectId: '0',
         loadingState: LoadingState.LOADING_VM_NEW_DEFAULT
     };
     const action = onLoadedProject(initialState.loadingState, true, true);
     const resultState = projectStateReducer(initialState, action);
     expect(resultState.loadingState).toBe(LoadingState.SHOWING_WITHOUT_ID);
+    expect(resultState.projectId).toBe('0');
 });
 
 test('onLoadedProject(LOADING_VM_NEW_DEFAULT, false, true) results in state SHOWING_WITHOUT_ID', () => {
     const initialState = {
+        projectId: '0',
         loadingState: LoadingState.LOADING_VM_NEW_DEFAULT
     };
     const action = onLoadedProject(initialState.loadingState, false, true);
     const resultState = projectStateReducer(initialState, action);
     expect(resultState.loadingState).toBe(LoadingState.SHOWING_WITHOUT_ID);
+    expect(resultState.projectId).toBe('0');
 });
 
 test('onLoadedProject(LOADING_VM_NEW_DEFAULT, false, false) results in ERROR state', () => {
     const initialState = {
+        projectId: '0',
         loadingState: LoadingState.LOADING_VM_NEW_DEFAULT
     };
     const action = onLoadedProject(initialState.loadingState, false, false);
     const resultState = projectStateReducer(initialState, action);
     expect(resultState.loadingState).toBe(LoadingState.ERROR);
+    expect(resultState.projectId).toBe('0');
 });
 
 // doneUpdatingProject
 
 test('doneUpdatingProject with id results in state SHOWING_WITH_ID', () => {
     const initialState = {
+        projectId: '100',
         loadingState: LoadingState.MANUAL_UPDATING
     };
     const action = doneUpdatingProject(initialState.loadingState);
     const resultState = projectStateReducer(initialState, action);
     expect(resultState.loadingState).toBe(LoadingState.SHOWING_WITH_ID);
+    expect(resultState.projectId).toBe('100');
 });
 
 test('doneUpdatingProject with id, before copy occurs, results in state CREATING_COPY', () => {
     const initialState = {
+        projectId: '100',
         loadingState: LoadingState.UPDATING_BEFORE_COPY
     };
     const action = doneUpdatingProject(initialState.loadingState);
     const resultState = projectStateReducer(initialState, action);
     expect(resultState.loadingState).toBe(LoadingState.CREATING_COPY);
+    expect(resultState.projectId).toBe('100');
 });
 
 test('doneUpdatingProject with id, before new, results in state FETCHING_NEW_DEFAULT', () => {
     const initialState = {
+        projectId: '100',
         loadingState: LoadingState.UPDATING_BEFORE_NEW
     };
     const action = doneUpdatingProject(initialState.loadingState);
     const resultState = projectStateReducer(initialState, action);
     expect(resultState.loadingState).toBe(LoadingState.FETCHING_NEW_DEFAULT);
+    expect(resultState.projectId).toBe('0'); // resets id
 });
 
 test('calling setProjectId, using with same id as already showing, ' +
@@ -272,84 +303,102 @@ test('setProjectId, with same id as before, but not same type, ' +
 
 test('requestNewProject, when can\'t create/save, results in FETCHING_NEW_DEFAULT', () => {
     const initialState = {
+        projectId: '0',
         loadingState: LoadingState.SHOWING_WITHOUT_ID
     };
     const action = requestNewProject(false);
     const resultState = projectStateReducer(initialState, action);
     expect(resultState.loadingState).toBe(LoadingState.FETCHING_NEW_DEFAULT);
+    expect(resultState.projectId).toBe('0');
 });
 
 test('requestNewProject, when can create/save, results in UPDATING_BEFORE_NEW ' +
     '(in order to save before fetching default project)', () => {
     const initialState = {
+        projectId: '100',
         loadingState: LoadingState.SHOWING_WITH_ID
     };
     const action = requestNewProject(true);
     const resultState = projectStateReducer(initialState, action);
     expect(resultState.loadingState).toBe(LoadingState.UPDATING_BEFORE_NEW);
+    expect(resultState.projectId).toBe('100');
 });
 
 test('requestProjectUpload when project not loaded results in state LOADING_VM_FILE_UPLOAD', () => {
     const initialState = {
+        projectId: null,
         loadingState: LoadingState.NOT_LOADED
     };
     const action = requestProjectUpload(initialState.loadingState);
     const resultState = projectStateReducer(initialState, action);
     expect(resultState.loadingState).toBe(LoadingState.LOADING_VM_FILE_UPLOAD);
+    expect(resultState.projectId).toBe(null);
 });
 
 test('requestProjectUpload when showing project with id results in state LOADING_VM_FILE_UPLOAD', () => {
     const initialState = {
+        projectId: '100',
         loadingState: LoadingState.SHOWING_WITH_ID
     };
     const action = requestProjectUpload(initialState.loadingState);
     const resultState = projectStateReducer(initialState, action);
     expect(resultState.loadingState).toBe(LoadingState.LOADING_VM_FILE_UPLOAD);
+    expect(resultState.projectId).toBe('100');
 });
 
 test('requestProjectUpload when showing project without id results in state LOADING_VM_FILE_UPLOAD', () => {
     const initialState = {
+        projectId: null,
         loadingState: LoadingState.SHOWING_WITHOUT_ID
     };
     const action = requestProjectUpload(initialState.loadingState);
     const resultState = projectStateReducer(initialState, action);
     expect(resultState.loadingState).toBe(LoadingState.LOADING_VM_FILE_UPLOAD);
+    expect(resultState.projectId).toBe(null);
 });
 
 test('manualUpdateProject should prepare to update', () => {
     const initialState = {
+        projectId: '100',
         loadingState: LoadingState.SHOWING_WITH_ID
     };
     const action = manualUpdateProject();
     const resultState = projectStateReducer(initialState, action);
     expect(resultState.loadingState).toBe(LoadingState.MANUAL_UPDATING);
+    expect(resultState.projectId).toBe('100');
 });
 
 test('autoUpdateProject should prepare to update', () => {
     const initialState = {
+        projectId: '100',
         loadingState: LoadingState.SHOWING_WITH_ID
     };
     const action = autoUpdateProject();
     const resultState = projectStateReducer(initialState, action);
     expect(resultState.loadingState).toBe(LoadingState.AUTO_UPDATING);
+    expect(resultState.projectId).toBe('100');
 });
 
 test('saveProjectAsCopy should save, before preparing to save as a copy', () => {
     const initialState = {
+        projectId: '100',
         loadingState: LoadingState.SHOWING_WITH_ID
     };
     const action = saveProjectAsCopy();
     const resultState = projectStateReducer(initialState, action);
     expect(resultState.loadingState).toBe(LoadingState.UPDATING_BEFORE_COPY);
+    expect(resultState.projectId).toBe('100');
 });
 
 test('remixProject should prepare to remix', () => {
     const initialState = {
+        projectId: '100',
         loadingState: LoadingState.SHOWING_WITH_ID
     };
     const action = remixProject();
     const resultState = projectStateReducer(initialState, action);
     expect(resultState.loadingState).toBe(LoadingState.REMIXING);
+    expect(resultState.projectId).toBe('100');
 });
 
 test('projectError from various states should show error', () => {
@@ -368,11 +417,13 @@ test('projectError from various states should show error', () => {
     for (const startState of startStates) {
         const initialState = {
             error: null,
+            projectId: '100',
             loadingState: startState
         };
         const action = projectError('Error string');
         const resultState = projectStateReducer(initialState, action);
         expect(resultState.error).toEqual('Error string');
+        expect(resultState.projectId).toBe('100');
     }
 });
 
@@ -386,11 +437,13 @@ test('fatal projectError should show error state', () => {
     for (const startState of startStates) {
         const initialState = {
             error: null,
+            projectId: '100',
             loadingState: startState
         };
         const action = projectError('Error string');
         const resultState = projectStateReducer(initialState, action);
         expect(resultState.loadingState).toBe(LoadingState.ERROR);
+        expect(resultState.projectId).toBe('100');
     }
 });
 
@@ -405,11 +458,13 @@ test('non-fatal projectError should show normal state', () => {
     for (const startState of startStates) {
         const initialState = {
             error: null,
+            projectId: '100',
             loadingState: startState
         };
         const action = projectError('Error string');
         const resultState = projectStateReducer(initialState, action);
         expect(resultState.loadingState).toBe(LoadingState.SHOWING_WITH_ID);
+        expect(resultState.projectId).toBe('100');
     }
 });
 
@@ -423,6 +478,7 @@ test('projectError when creating new while viewing project with id should ' +
     const action = projectError('Error string');
     const resultState = projectStateReducer(initialState, action);
     expect(resultState.loadingState).toBe(LoadingState.SHOWING_WITH_ID);
+    expect(resultState.projectId).toBe('12345');
 });
 
 test('projectError when creating new while logged out, looking at default project ' +
@@ -435,16 +491,19 @@ test('projectError when creating new while logged out, looking at default projec
     const action = projectError('Error string');
     const resultState = projectStateReducer(initialState, action);
     expect(resultState.loadingState).toBe(LoadingState.SHOWING_WITHOUT_ID);
+    expect(resultState.projectId).toBe('0');
 });
 
 test('projectError encountered while in state FETCHING_WITH_ID results in ' +
     'ERROR state', () => {
     const initialState = {
         error: null,
+        projectId: null,
         loadingState: LoadingState.FETCHING_WITH_ID
     };
     const action = projectError('Error string');
     const resultState = projectStateReducer(initialState, action);
     expect(resultState.loadingState).toBe(LoadingState.ERROR);
+    expect(resultState.projectId).toBe(null);
     expect(resultState.error).toEqual('Error string');
 });

--- a/test/unit/reducers/project-state-reducer.test.js
+++ b/test/unit/reducers/project-state-reducer.test.js
@@ -94,7 +94,7 @@ test('onFetchedProjectData new loads project data into vm', () => {
 
 // onLoadedProject: LOADING_VM_WITH_ID
 
-test('onLoadedProject (LOADING_VM_WITH_ID, true, true) shows with id', () => {
+test('onLoadedProject(LOADING_VM_WITH_ID, true, true) results in state SHOWING_WITH_ID', () => {
     const initialState = {
         loadingState: LoadingState.LOADING_VM_WITH_ID
     };
@@ -103,7 +103,7 @@ test('onLoadedProject (LOADING_VM_WITH_ID, true, true) shows with id', () => {
     expect(resultState.loadingState).toBe(LoadingState.SHOWING_WITH_ID);
 });
 
-test('onLoadedProject (LOADING_VM_WITH_ID, false, true) shows with id', () => {
+test('onLoadedProject(LOADING_VM_WITH_ID, false, true) results in state SHOWING_WITH_ID', () => {
     const initialState = {
         loadingState: LoadingState.LOADING_VM_WITH_ID
     };
@@ -112,7 +112,8 @@ test('onLoadedProject (LOADING_VM_WITH_ID, false, true) shows with id', () => {
     expect(resultState.loadingState).toBe(LoadingState.SHOWING_WITH_ID);
 });
 
-test('onLoadedProject (LOADING_VM_WITH_ID, false, false), with project id, shows with id', () => {
+test('onLoadedProject(LOADING_VM_WITH_ID, false, false), with project id, ' +
+    'results in state SHOWING_WITH_ID', () => {
     const initialState = {
         loadingState: LoadingState.LOADING_VM_WITH_ID,
         projectId: '12345'
@@ -122,7 +123,8 @@ test('onLoadedProject (LOADING_VM_WITH_ID, false, false), with project id, shows
     expect(resultState.loadingState).toBe(LoadingState.SHOWING_WITH_ID);
 });
 
-test('onLoadedProject (LOADING_VM_WITH_ID, false, false), with no project id, shows without id', () => {
+test('onLoadedProject(LOADING_VM_WITH_ID, false, false), with no project id, ' +
+    'results in state SHOWING_WITHOUT_ID', () => {
     const initialState = {
         loadingState: LoadingState.LOADING_VM_WITH_ID,
         projectId: null
@@ -143,7 +145,7 @@ test('onLoadedProject(LOADING_VM_FILE_UPLOAD, true, true) prepares to save', () 
     expect(resultState.loadingState).toBe(LoadingState.AUTO_UPDATING);
 });
 
-test('onLoadedProject (LOADING_VM_FILE_UPLOAD, false, true) shows without id', () => {
+test('onLoadedProject(LOADING_VM_FILE_UPLOAD, false, true) results in state SHOWING_WITHOUT_ID', () => {
     const initialState = {
         loadingState: LoadingState.LOADING_VM_FILE_UPLOAD
     };
@@ -152,7 +154,8 @@ test('onLoadedProject (LOADING_VM_FILE_UPLOAD, false, true) shows without id', (
     expect(resultState.loadingState).toBe(LoadingState.SHOWING_WITHOUT_ID);
 });
 
-test('onLoadedProject (LOADING_VM_FILE_UPLOAD, false, false), with project id, shows with id', () => {
+test('onLoadedProject(LOADING_VM_FILE_UPLOAD, false, false), when we know project id, ' +
+    'results in state SHOWING_WITH_ID', () => {
     const initialState = {
         loadingState: LoadingState.LOADING_VM_FILE_UPLOAD,
         projectId: '12345'
@@ -162,7 +165,8 @@ test('onLoadedProject (LOADING_VM_FILE_UPLOAD, false, false), with project id, s
     expect(resultState.loadingState).toBe(LoadingState.SHOWING_WITH_ID);
 });
 
-test('onLoadedProject (LOADING_VM_FILE_UPLOAD, false, false), with no project id, shows without id', () => {
+test('onLoadedProject(LOADING_VM_FILE_UPLOAD, false, false), when we ' +
+    'don\'t know project id, results in state SHOWING_WITHOUT_ID', () => {
     const initialState = {
         loadingState: LoadingState.LOADING_VM_FILE_UPLOAD,
         projectId: null
@@ -174,7 +178,7 @@ test('onLoadedProject (LOADING_VM_FILE_UPLOAD, false, false), with no project id
 
 // onLoadedProject: LOADING_VM_NEW_DEFAULT
 
-test('onLoadedProject (LOADING_VM_NEW_DEFAULT, true, true) shows without id', () => {
+test('onLoadedProject(LOADING_VM_NEW_DEFAULT, true, true) results in state SHOWING_WITHOUT_ID', () => {
     const initialState = {
         loadingState: LoadingState.LOADING_VM_NEW_DEFAULT
     };
@@ -183,7 +187,7 @@ test('onLoadedProject (LOADING_VM_NEW_DEFAULT, true, true) shows without id', ()
     expect(resultState.loadingState).toBe(LoadingState.SHOWING_WITHOUT_ID);
 });
 
-test('onLoadedProject (LOADING_VM_NEW_DEFAULT, false, true) shows without id', () => {
+test('onLoadedProject(LOADING_VM_NEW_DEFAULT, false, true) results in state SHOWING_WITHOUT_ID', () => {
     const initialState = {
         loadingState: LoadingState.LOADING_VM_NEW_DEFAULT
     };
@@ -192,7 +196,7 @@ test('onLoadedProject (LOADING_VM_NEW_DEFAULT, false, true) shows without id', (
     expect(resultState.loadingState).toBe(LoadingState.SHOWING_WITHOUT_ID);
 });
 
-test('onLoadedProject (LOADING_VM_NEW_DEFAULT, false, false) shows error', () => {
+test('onLoadedProject(LOADING_VM_NEW_DEFAULT, false, false) results in ERROR state', () => {
     const initialState = {
         loadingState: LoadingState.LOADING_VM_NEW_DEFAULT
     };
@@ -203,7 +207,7 @@ test('onLoadedProject (LOADING_VM_NEW_DEFAULT, false, false) shows error', () =>
 
 // doneUpdatingProject
 
-test('doneUpdatingProject with id shows with id', () => {
+test('doneUpdatingProject with id results in state SHOWING_WITH_ID', () => {
     const initialState = {
         loadingState: LoadingState.MANUAL_UPDATING
     };
@@ -212,7 +216,7 @@ test('doneUpdatingProject with id shows with id', () => {
     expect(resultState.loadingState).toBe(LoadingState.SHOWING_WITH_ID);
 });
 
-test('doneUpdatingProject with id, before copy, creates copy', () => {
+test('doneUpdatingProject with id, before copy occurs, results in state CREATING_COPY', () => {
     const initialState = {
         loadingState: LoadingState.UPDATING_BEFORE_COPY
     };
@@ -221,7 +225,7 @@ test('doneUpdatingProject with id, before copy, creates copy', () => {
     expect(resultState.loadingState).toBe(LoadingState.CREATING_COPY);
 });
 
-test('doneUpdatingProject with id, before new, fetches default project', () => {
+test('doneUpdatingProject with id, before new, results in state FETCHING_NEW_DEFAULT', () => {
     const initialState = {
         loadingState: LoadingState.UPDATING_BEFORE_NEW
     };
@@ -230,7 +234,8 @@ test('doneUpdatingProject with id, before new, fetches default project', () => {
     expect(resultState.loadingState).toBe(LoadingState.FETCHING_NEW_DEFAULT);
 });
 
-test('setProjectId, with same id as before, should show with id, not fetch', () => {
+test('calling setProjectId, using with same id as already showing, ' +
+    'results in state SHOWING_WITH_ID', () => {
     const initialState = {
         projectId: '100',
         loadingState: LoadingState.SHOWING_WITH_ID
@@ -241,7 +246,8 @@ test('setProjectId, with same id as before, should show with id, not fetch', () 
     expect(resultState.projectId).toBe('100');
 });
 
-test('setProjectId, with different id as before, should fetch with id, not show with id', () => {
+test('calling setProjectId, using different id from project already showing, ' +
+    'results in state FETCHING_WITH_ID', () => {
     const initialState = {
         projectId: 99,
         loadingState: LoadingState.SHOWING_WITH_ID
@@ -252,7 +258,8 @@ test('setProjectId, with different id as before, should fetch with id, not show 
     expect(resultState.projectId).toBe('100');
 });
 
-test('setProjectId, with same id as before, but not same type, should fetch because not ===', () => {
+test('setProjectId, with same id as before, but not same type, ' +
+    'results in FETCHING_WITH_ID because the two projectIds are not strictly equal', () => {
     const initialState = {
         projectId: '100',
         loadingState: LoadingState.SHOWING_WITH_ID
@@ -263,7 +270,7 @@ test('setProjectId, with same id as before, but not same type, should fetch beca
     expect(resultState.projectId).toBe(100);
 });
 
-test('requestNewProject, when can\'t create new, should fetch default project without id', () => {
+test('requestNewProject, when can\'t create/save, results in FETCHING_NEW_DEFAULT', () => {
     const initialState = {
         loadingState: LoadingState.SHOWING_WITHOUT_ID
     };
@@ -272,7 +279,8 @@ test('requestNewProject, when can\'t create new, should fetch default project wi
     expect(resultState.loadingState).toBe(LoadingState.FETCHING_NEW_DEFAULT);
 });
 
-test('requestNewProject, when can create new, should save and prepare to fetch default project', () => {
+test('requestNewProject, when can create/save, results in UPDATING_BEFORE_NEW ' +
+    '(in order to save before fetching default project)', () => {
     const initialState = {
         loadingState: LoadingState.SHOWING_WITH_ID
     };
@@ -281,7 +289,7 @@ test('requestNewProject, when can create new, should save and prepare to fetch d
     expect(resultState.loadingState).toBe(LoadingState.UPDATING_BEFORE_NEW);
 });
 
-test('requestProjectUpload when project not loaded should load', () => {
+test('requestProjectUpload when project not loaded results in state LOADING_VM_FILE_UPLOAD', () => {
     const initialState = {
         loadingState: LoadingState.NOT_LOADED
     };
@@ -290,7 +298,7 @@ test('requestProjectUpload when project not loaded should load', () => {
     expect(resultState.loadingState).toBe(LoadingState.LOADING_VM_FILE_UPLOAD);
 });
 
-test('requestProjectUpload when showing project with id should load', () => {
+test('requestProjectUpload when showing project with id results in state LOADING_VM_FILE_UPLOAD', () => {
     const initialState = {
         loadingState: LoadingState.SHOWING_WITH_ID
     };
@@ -299,7 +307,7 @@ test('requestProjectUpload when showing project with id should load', () => {
     expect(resultState.loadingState).toBe(LoadingState.LOADING_VM_FILE_UPLOAD);
 });
 
-test('requestProjectUpload when showing project without id should load', () => {
+test('requestProjectUpload when showing project without id results in state LOADING_VM_FILE_UPLOAD', () => {
     const initialState = {
         loadingState: LoadingState.SHOWING_WITHOUT_ID
     };
@@ -405,7 +413,8 @@ test('non-fatal projectError should show normal state', () => {
     }
 });
 
-test('projectError when creating new while viewing project with id should show project with id', () => {
+test('projectError when creating new while viewing project with id should ' +
+    'go back to state SHOWING_WITH_ID', () => {
     const initialState = {
         error: null,
         loadingState: LoadingState.CREATING_NEW,
@@ -416,7 +425,8 @@ test('projectError when creating new while viewing project with id should show p
     expect(resultState.loadingState).toBe(LoadingState.SHOWING_WITH_ID);
 });
 
-test('projectError when creating new while logged out, looking at default project should show default project', () => {
+test('projectError when creating new while logged out, looking at default project ' +
+    'should go back to state SHOWING_WITHOUT_ID', () => {
     const initialState = {
         error: null,
         loadingState: LoadingState.CREATING_NEW,
@@ -427,7 +437,8 @@ test('projectError when creating new while logged out, looking at default projec
     expect(resultState.loadingState).toBe(LoadingState.SHOWING_WITHOUT_ID);
 });
 
-test('projectError from showing project should show error', () => {
+test('projectError encountered while in state FETCHING_WITH_ID results in ' +
+    'ERROR state', () => {
     const initialState = {
         error: null,
         loadingState: LoadingState.FETCHING_WITH_ID

--- a/test/unit/reducers/project-state-reducer.test.js
+++ b/test/unit/reducers/project-state-reducer.test.js
@@ -92,25 +92,9 @@ test('onFetchedProjectData new loads project data into vm', () => {
     expect(resultState.projectData).toBe('1010101');
 });
 
-test('onLoadedProject upload, with canSave false, shows without id', () => {
-    const initialState = {
-        loadingState: LoadingState.LOADING_VM_FILE_UPLOAD
-    };
-    const action = onLoadedProject(initialState.loadingState, false, true);
-    const resultState = projectStateReducer(initialState, action);
-    expect(resultState.loadingState).toBe(LoadingState.SHOWING_WITHOUT_ID);
-});
+// onLoadedProject: LOADING_VM_WITH_ID
 
-test('onLoadedProject upload, with canSave true, prepares to save', () => {
-    const initialState = {
-        loadingState: LoadingState.LOADING_VM_FILE_UPLOAD
-    };
-    const action = onLoadedProject(initialState.loadingState, true, true);
-    const resultState = projectStateReducer(initialState, action);
-    expect(resultState.loadingState).toBe(LoadingState.AUTO_UPDATING);
-});
-
-test('onLoadedProject with id shows with id', () => {
+test('onLoadedProject (LOADING_VM_WITH_ID, true, true) shows with id', () => {
     const initialState = {
         loadingState: LoadingState.LOADING_VM_WITH_ID
     };
@@ -119,25 +103,26 @@ test('onLoadedProject with id shows with id', () => {
     expect(resultState.loadingState).toBe(LoadingState.SHOWING_WITH_ID);
 });
 
-test('onLoadedProject new shows without id', () => {
+test('onLoadedProject (LOADING_VM_WITH_ID, false, true) shows with id', () => {
     const initialState = {
-        loadingState: LoadingState.LOADING_VM_NEW_DEFAULT
-    };
-    const action = onLoadedProject(initialState.loadingState, false, true);
-    const resultState = projectStateReducer(initialState, action);
-    expect(resultState.loadingState).toBe(LoadingState.SHOWING_WITHOUT_ID);
-});
-
-test('onLoadedProject new, to save shows without id', () => {
-    const initialState = {
-        loadingState: LoadingState.LOADING_VM_NEW_DEFAULT
+        loadingState: LoadingState.LOADING_VM_WITH_ID
     };
     const action = onLoadedProject(initialState.loadingState, true, true);
     const resultState = projectStateReducer(initialState, action);
-    expect(resultState.loadingState).toBe(LoadingState.SHOWING_WITHOUT_ID);
+    expect(resultState.loadingState).toBe(LoadingState.SHOWING_WITH_ID);
 });
 
-test('onLoadedProject with success false, no project id, shows without id', () => {
+test('onLoadedProject (LOADING_VM_WITH_ID, false, false), with project id, shows with id', () => {
+    const initialState = {
+        loadingState: LoadingState.LOADING_VM_WITH_ID,
+        projectId: '12345'
+    };
+    const action = onLoadedProject(initialState.loadingState, false, false);
+    const resultState = projectStateReducer(initialState, action);
+    expect(resultState.loadingState).toBe(LoadingState.SHOWING_WITH_ID);
+});
+
+test('onLoadedProject (LOADING_VM_WITH_ID, false, false), with no project id, shows without id', () => {
     const initialState = {
         loadingState: LoadingState.LOADING_VM_WITH_ID,
         projectId: null
@@ -147,15 +132,76 @@ test('onLoadedProject with success false, no project id, shows without id', () =
     expect(resultState.loadingState).toBe(LoadingState.SHOWING_WITHOUT_ID);
 });
 
-test('onLoadedProject with success false, valid project id, shows with id', () => {
+// onLoadedProject: LOADING_VM_FILE_UPLOAD
+
+test('onLoadedProject(LOADING_VM_FILE_UPLOAD, true, true) prepares to save', () => {
     const initialState = {
-        loadingState: LoadingState.LOADING_VM_WITH_ID,
+        loadingState: LoadingState.LOADING_VM_FILE_UPLOAD
+    };
+    const action = onLoadedProject(initialState.loadingState, true, true);
+    const resultState = projectStateReducer(initialState, action);
+    expect(resultState.loadingState).toBe(LoadingState.AUTO_UPDATING);
+});
+
+test('onLoadedProject (LOADING_VM_FILE_UPLOAD, false, true) shows without id', () => {
+    const initialState = {
+        loadingState: LoadingState.LOADING_VM_FILE_UPLOAD
+    };
+    const action = onLoadedProject(initialState.loadingState, false, true);
+    const resultState = projectStateReducer(initialState, action);
+    expect(resultState.loadingState).toBe(LoadingState.SHOWING_WITHOUT_ID);
+});
+
+test('onLoadedProject (LOADING_VM_FILE_UPLOAD, false, false), with project id, shows with id', () => {
+    const initialState = {
+        loadingState: LoadingState.LOADING_VM_FILE_UPLOAD,
         projectId: '12345'
     };
     const action = onLoadedProject(initialState.loadingState, false, false);
     const resultState = projectStateReducer(initialState, action);
     expect(resultState.loadingState).toBe(LoadingState.SHOWING_WITH_ID);
 });
+
+test('onLoadedProject (LOADING_VM_FILE_UPLOAD, false, false), with no project id, shows without id', () => {
+    const initialState = {
+        loadingState: LoadingState.LOADING_VM_FILE_UPLOAD,
+        projectId: null
+    };
+    const action = onLoadedProject(initialState.loadingState, false, false);
+    const resultState = projectStateReducer(initialState, action);
+    expect(resultState.loadingState).toBe(LoadingState.SHOWING_WITHOUT_ID);
+});
+
+// onLoadedProject: LOADING_VM_NEW_DEFAULT
+
+test('onLoadedProject (LOADING_VM_NEW_DEFAULT, true, true) shows without id', () => {
+    const initialState = {
+        loadingState: LoadingState.LOADING_VM_NEW_DEFAULT
+    };
+    const action = onLoadedProject(initialState.loadingState, true, true);
+    const resultState = projectStateReducer(initialState, action);
+    expect(resultState.loadingState).toBe(LoadingState.SHOWING_WITHOUT_ID);
+});
+
+test('onLoadedProject (LOADING_VM_NEW_DEFAULT, false, true) shows without id', () => {
+    const initialState = {
+        loadingState: LoadingState.LOADING_VM_NEW_DEFAULT
+    };
+    const action = onLoadedProject(initialState.loadingState, false, true);
+    const resultState = projectStateReducer(initialState, action);
+    expect(resultState.loadingState).toBe(LoadingState.SHOWING_WITHOUT_ID);
+});
+
+test('onLoadedProject (LOADING_VM_NEW_DEFAULT, false, false) shows error', () => {
+    const initialState = {
+        loadingState: LoadingState.LOADING_VM_NEW_DEFAULT
+    };
+    const action = onLoadedProject(initialState.loadingState, false, false);
+    const resultState = projectStateReducer(initialState, action);
+    expect(resultState.loadingState).toBe(LoadingState.ERROR);
+});
+
+// doneUpdatingProject
 
 test('doneUpdatingProject with id shows with id', () => {
     const initialState = {

--- a/test/unit/util/project-saver-hoc.test.jsx
+++ b/test/unit/util/project-saver-hoc.test.jsx
@@ -56,7 +56,7 @@ describe('projectSaverHOC', () => {
         expect(mockedUpdateProject).toHaveBeenCalled();
     });
 
-    test('if canSave is alreatdy true and we show a project with an id, project will NOT be saved', () => {
+    test('if canSave is already true and we show a project with an id, project will NOT be saved', () => {
         const mockedSaveProject = jest.fn();
         const Component = () => <div />;
         const WrappedComponent = projectSaverHOC(Component);


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-gui/issues/5361

### Proposed Changes

Adds unit tests for many project state reducer action creator functions.

Also refactors the project state reducer's `onLoadedProject()` function to be clearer, and to specifically handle failures to load the default project by switching to an error state.

(This relates to the project state reducer's handling of success and failure in loading the default project. Since we get that project data locally, and not from the server, loading it into the VM should always succeed. If it fails, we should switch to an error state.)

This change doesn't make a change to actual behavior, only to the project state reducer's API for clarity and consistency.
