### PR TITLE
don't close menus on mouse click, if element clicked is modal

### DIFF
--- a/src/containers/menu.jsx
+++ b/src/containers/menu.jsx
@@ -30,8 +30,18 @@ class Menu extends React.Component {
     removeListeners () {
         document.removeEventListener('mouseup', this.handleClick);
     }
+    elementIsModal (element) {
+        const modalPortals = document.getElementsByClassName('ReactModalPortal');
+        for (let i = 0; i < modalPortals.length; i++) {
+            if (modalPortals[i].contains(element)) return true;
+        }
+        return false;
+    }
     handleClick (e) {
-        if (this.props.open && !this.menu.contains(e.target)) {
+        // request close, if menu is open, click was not inside menu, and click
+        // was not inside modal. This prevents menu from closing when it is in
+        // background.
+        if (this.props.open && !this.menu.contains(e.target) && !this.elementIsModal(e.target)) {
             this.props.onRequestClose();
         }
     }


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-gui/issues/4907

### Proposed Changes

When a menu bar menu handles mouseup, it should check if the mouse was in a modal; if so, the menu should not close itself.

### Reason for Changes

It became clear in working on https://github.com/LLK/scratch-gui/issues/4762 that this issue was a blocker for introducing a custom confirm modal for project upload.

### Test Coverage

None -- we don't yet have a modal that would be opened by a menu, so it's hard to test this with existing code.