### PR TITLE
Update library-item to handle 3.0 or 2.0 library formats

### DIFF
--- a/src/containers/library-item.jsx
+++ b/src/containers/library-item.jsx
@@ -92,14 +92,16 @@ class LibraryItem extends React.PureComponent {
         this.setState({iconIndex: nextIconIndex});
     }
     curIconMd5 () {
+        const iconMd5Prop = this.props.iconMd5;
         if (this.props.icons &&
             this.state.isRotatingIcon &&
-            this.state.iconIndex < this.props.icons.length &&
-            this.props.icons[this.state.iconIndex] &&
-            this.props.icons[this.state.iconIndex].baseLayerMD5) {
-            return this.props.icons[this.state.iconIndex].baseLayerMD5;
+            this.state.iconIndex < this.props.icons.length) {
+            const icon = this.props.icons[this.state.iconIndex] || {};
+            return icon.md5ext || // 3.0 library format
+                icon.baseLayerMD5 || // 2.0 library format, TODO GH-5084
+                iconMd5Prop;
         }
-        return this.props.iconMd5;
+        return iconMd5Prop;
     }
     render () {
         const iconMd5 = this.curIconMd5();
@@ -151,7 +153,8 @@ LibraryItem.propTypes = {
     iconRawURL: PropTypes.string,
     icons: PropTypes.arrayOf(
         PropTypes.shape({
-            baseLayerMD5: PropTypes.string
+            baseLayerMD5: PropTypes.string, // 2.0 library format, TODO GH-5084
+            md5ext: PropTypes.string // 3.0 library format
         })
     ),
     id: PropTypes.number.isRequired,


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/LLK/scratch-gui/issues/5084

### Proposed Changes

_Describe what this Pull Request does_

Updates the `library-item` which was expecting library items to have the `baseLayerMD5` property to now use either `baseLayerMD5` or `md5ext`, which is what is what the libraries json will have once we start using the new library generator that works on 3.0 projects. 

This _does not_ update the library JSON files, as there are other blockers for that.

### Reason for Changes

_Explain why these changes should be made_

See https://github.com/LLK/scratch-gui/issues/5084 for more

### Test Coverage

_Please show how you have added tests to cover your changes_

Manually tested that costumes rotate correctly using the existing format, so this can be merged right away. Also tested using the new library format which is in progress, and it works for that as well. There is an automated test around costume rotation that should continue to work both here and (maybe more importantly) when the libraries themselves are updated
