### PR TITLE
initialize Google Analytics only if GA_ID is set

### DIFF
--- a/src/lib/analytics.js
+++ b/src/lib/analytics.js
@@ -1,10 +1,13 @@
 import GoogleAnalytics from 'react-ga';
 
-GoogleAnalytics.initialize(process.env.GA_ID || window.GA_ID, {
-    debug: (process.env.NODE_ENV !== 'production'),
-    titleCase: true,
-    sampleRate: (process.env.NODE_ENV === 'production') ? 100 : 0,
-    forceSSL: true
-});
+const GA_ID = (process.env.GA_ID || window.GA_ID);
+if (GA_ID) {
+    GoogleAnalytics.initialize(GA_ID, {
+        debug: (process.env.NODE_ENV !== 'production'),
+        titleCase: true,
+        sampleRate: (process.env.NODE_ENV === 'production') ? 100 : 0,
+        forceSSL: true
+    });
+}
 
 export default GoogleAnalytics;

--- a/src/lib/analytics.js
+++ b/src/lib/analytics.js
@@ -8,6 +8,13 @@ if (GA_ID) {
         sampleRate: (process.env.NODE_ENV === 'production') ? 100 : 0,
         forceSSL: true
     });
+} else {
+    window.ga = () => {
+        // The `react-ga` module calls this function to implement all Google Analytics calls. Providing an empty
+        // function effectively disables `react-ga`. This is similar to the `testModeAPI` feature of `react-ga` except
+        // that `testModeAPI` logs the arguments of every call into an array. That's nice for testing purposes but
+        // would look like a memory leak in a live program.
+    };
 }
 
 export default GoogleAnalytics;

--- a/src/lib/analytics.js
+++ b/src/lib/analytics.js
@@ -1,5 +1,7 @@
 import GoogleAnalytics from 'react-ga';
 
+import log from './log';
+
 const GA_ID = (process.env.GA_ID || window.GA_ID);
 if (GA_ID) {
     GoogleAnalytics.initialize(GA_ID, {
@@ -9,6 +11,7 @@ if (GA_ID) {
         forceSSL: true
     });
 } else {
+    log.info('Disabling GA because GA_ID is not set.');
     window.ga = () => {
         // The `react-ga` module calls this function to implement all Google Analytics calls. Providing an empty
         // function effectively disables `react-ga`. This is similar to the `testModeAPI` feature of `react-ga` except


### PR DESCRIPTION
Resolves https://github.com/LLK/scratch-gui/issues/5775

### Proposed Changes

Call `GoogleAnalytics.initialize(...)` only if either `process.env.GA_ID` or `window.GA_ID` is set.

### Reason for Changes

It turns out that `GoogleAnalytics.initialize(...)` causes the download of `https://www.google-analytics.com/analytics.js` even if passed a null or undefined GA_ID. Skipping the call means we don't download that file in cases where we don't need it. In particular, we shouldn't try to download that file in Scratch Desktop since a) we should assume that the Internet is not available and b) we don't intend to use Google Analytics in Scratch Desktop.

### Test Coverage

We don't have automated tests for our usage of GA, but I've tested this locally in the context of Scratch Desktop. I'm unsure of how best to test this in the context of scratch-www or scratch-gui standalone. Any advice is welcome.

### Notes for Code Review

This diff is easier to read with "Hide whitespace changes" turned on.