### PR TITLE
Revert "Greenkeeper/scratch paint 0.2.0 prerelease.20200129174741"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11546,9 +11546,9 @@
       }
     },
     "scratch-paint": {
-      "version": "0.2.0-prerelease.20200129174741",
-      "resolved": "https://registry.npmjs.org/scratch-paint/-/scratch-paint-0.2.0-prerelease.20200129174741.tgz",
-      "integrity": "sha512-l2AZiSbu1itLoRD8lu69BbO3VN0uSp00waK4cUUJjpLnNJSX9sBYSZnQdZXGzaMLvp/QsdfFC07AW/+1c5C4kA==",
+      "version": "0.2.0-prerelease.20200109073728",
+      "resolved": "https://registry.npmjs.org/scratch-paint/-/scratch-paint-0.2.0-prerelease.20200109073728.tgz",
+      "integrity": "sha512-PJTYShD5gl4OReRN+ZOTjSFeEuarO5YV10bbmw1BSn/pAnuEYU2dglgymNSBiGXunYaDYyaPgsJldzcnydSxHQ==",
       "dev": true,
       "requires": {
         "@scratch/paper": "0.11.20190729152410",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "scratch-audio": "0.1.0-prerelease.20190925183642",
     "scratch-l10n": "3.7.20200128224436",
     "scratch-blocks": "0.1.0-prerelease.1580309823",
-    "scratch-paint": "0.2.0-prerelease.20200129174741",
+    "scratch-paint": "0.2.0-prerelease.20200109073728",
     "scratch-render": "0.1.0-prerelease.20200128205403",
     "scratch-storage": "1.3.2",
     "scratch-svg-renderer": "0.2.0-prerelease.20200109070519",


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves https://sentry.io/organizations/scratch-foundation/issues/1334444995/?project=1357122&query=is%3Aunresolved&statsPeriod=14d
Rolling this back because it introduced a crash on ipads when opening the eyedropper tool
Rolls back a fix to stacking buttons in the paint UI

### Proposed Changes

_Describe what this Pull Request does_

### Reason for Changes

_Explain why these changes should be made_

### Test Coverage

_Please show how you have added tests to cover your changes_

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
