### PR TITLE
don’t update project title if it was undefined

### DIFF
--- a/src/lib/titled-hoc.jsx
+++ b/src/lib/titled-hoc.jsx
@@ -36,10 +36,14 @@ const TitledHOC = function (WrappedComponent) {
                 const defaultProjectTitle = this.handleReceivedProjectTitle();
                 this.props.onUpdateProjectTitle(defaultProjectTitle);
             }
-            // if the projectTitle hasn't changed, but the reduxProjectTitle
-            // HAS changed, we need to report that change to the projectTitle's owner
-            if (this.props.reduxProjectTitle !== prevProps.reduxProjectTitle &&
-                this.props.reduxProjectTitle !== this.props.projectTitle) {
+            // if the user has changed the project Title, and the projectTitle prop
+            // passed in to us is stale (defined, but old), we need to notify
+            // the source of the projectTitle that it should be updated
+            const reduxTitleHasChanged =
+                (this.props.reduxProjectTitle !== prevProps.reduxProjectTitle &&
+                this.props.reduxProjectTitle !== this.props.projectTitle);
+            const titlePropIsSet = !!this.props.projectTitle;
+            if (titlePropIsSet && reduxTitleHasChanged) {
                 this.props.onUpdateProjectTitle(this.props.reduxProjectTitle);
             }
         }

--- a/src/lib/titled-hoc.jsx
+++ b/src/lib/titled-hoc.jsx
@@ -42,7 +42,8 @@ const TitledHOC = function (WrappedComponent) {
             const reduxTitleHasChanged =
                 (this.props.reduxProjectTitle !== prevProps.reduxProjectTitle &&
                 this.props.reduxProjectTitle !== this.props.projectTitle);
-            const titlePropIsSet = !!this.props.projectTitle;
+            const titlePropIsSet = ((this.props.projectTitle !== null) &&
+                (typeof this.props.projectTitle !== 'undefined'));
             if (titlePropIsSet && reduxTitleHasChanged) {
                 this.props.onUpdateProjectTitle(this.props.reduxProjectTitle);
             }

--- a/src/lib/titled-hoc.jsx
+++ b/src/lib/titled-hoc.jsx
@@ -106,9 +106,15 @@ const TitledHOC = function (WrappedComponent) {
         onChangedProjectTitle: title => dispatch(setProjectTitle(title))
     });
 
+    // Allow incoming props to override redux-provided props. Used to mock in tests.
+    const mergeProps = (stateProps, dispatchProps, ownProps) => Object.assign(
+        {}, stateProps, dispatchProps, ownProps
+    );
+
     return injectIntl(connect(
         mapStateToProps,
         mapDispatchToProps,
+        mergeProps
     )(TitledComponent));
 };
 

--- a/test/unit/util/titled-hoc.test.jsx
+++ b/test/unit/util/titled-hoc.test.jsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import configureStore from 'redux-mock-store';
+import {mountWithIntl} from '../../helpers/intl-helpers.jsx';
+
+import TitledHOC from '../../../src/lib/titled-hoc.jsx';
+
+jest.mock('react-ga');
+
+describe('TitledHOC', () => {
+    const mockStore = configureStore();
+    let store;
+
+    beforeEach(() => {
+        store = mockStore({
+            scratchGui: {
+                projectState: {}
+            }
+        });
+    });
+
+    test('when a new title is set within GUI, it calls onUpdateProjectTitle', () => {
+        const Component = () => (<div />);
+        const WrappedComponent = TitledHOC(Component);
+        const mockOnUpdateProjectTitle = jest.fn();
+        const mounted = mountWithIntl(
+            <WrappedComponent
+                onUpdateProjectTitle={mockOnUpdateProjectTitle}
+                projectTitle="existing title"
+                store={store}
+            />
+        );
+        expect(mockOnUpdateProjectTitle).not.toHaveBeenCalled();
+        mounted.setProps({
+            reduxProjectTitle: 'new title'
+        });
+        expect(mockOnUpdateProjectTitle).toHaveBeenCalled();
+        expect(mockOnUpdateProjectTitle.mock.calls[0][0]).toBe('new title');
+    });
+
+    test('when new title is set in GUI but external title is blank, it does not call onUpdateProjectTitle', () => {
+        const Component = () => (<div />);
+        const WrappedComponent = TitledHOC(Component);
+        const mockOnUpdateProjectTitle = jest.fn();
+        const mounted = mountWithIntl(
+            <WrappedComponent
+                onUpdateProjectTitle={mockOnUpdateProjectTitle}
+                projectTitle=""
+                store={store}
+            />
+        );
+        expect(mockOnUpdateProjectTitle).not.toHaveBeenCalled();
+        mounted.setProps({
+            reduxProjectTitle: 'new title'
+        });
+        expect(mockOnUpdateProjectTitle).not.toHaveBeenCalled();
+    });
+
+    test('when new title is set in GUI but external title is unset, it does not call onUpdateProjectTitle', () => {
+        const Component = () => (<div />);
+        const WrappedComponent = TitledHOC(Component);
+        const mockOnUpdateProjectTitle = jest.fn();
+        const mounted = mountWithIntl(
+            <WrappedComponent
+                onUpdateProjectTitle={mockOnUpdateProjectTitle}
+                store={store}
+            />
+        );
+        expect(mockOnUpdateProjectTitle).not.toHaveBeenCalled();
+        mounted.setProps({
+            reduxProjectTitle: 'new title'
+        });
+        expect(mockOnUpdateProjectTitle).not.toHaveBeenCalled();
+    });
+});

--- a/test/unit/util/titled-hoc.test.jsx
+++ b/test/unit/util/titled-hoc.test.jsx
@@ -37,24 +37,6 @@ describe('TitledHOC', () => {
         expect(mockOnUpdateProjectTitle.mock.calls[0][0]).toBe('new title');
     });
 
-    test('when new title is set in GUI but external title is blank, it does not call onUpdateProjectTitle', () => {
-        const Component = () => (<div />);
-        const WrappedComponent = TitledHOC(Component);
-        const mockOnUpdateProjectTitle = jest.fn();
-        const mounted = mountWithIntl(
-            <WrappedComponent
-                onUpdateProjectTitle={mockOnUpdateProjectTitle}
-                projectTitle=""
-                store={store}
-            />
-        );
-        expect(mockOnUpdateProjectTitle).not.toHaveBeenCalled();
-        mounted.setProps({
-            reduxProjectTitle: 'new title'
-        });
-        expect(mockOnUpdateProjectTitle).not.toHaveBeenCalled();
-    });
-
     test('when new title is set in GUI but external title is unset, it does not call onUpdateProjectTitle', () => {
         const Component = () => (<div />);
         const WrappedComponent = TitledHOC(Component);
@@ -70,5 +52,61 @@ describe('TitledHOC', () => {
             reduxProjectTitle: 'new title'
         });
         expect(mockOnUpdateProjectTitle).not.toHaveBeenCalled();
+    });
+
+    test('when new title is set in GUI but external title is null, it does not call onUpdateProjectTitle', () => {
+        const Component = () => (<div />);
+        const WrappedComponent = TitledHOC(Component);
+        const mockOnUpdateProjectTitle = jest.fn();
+        const mounted = mountWithIntl(
+            <WrappedComponent
+                onUpdateProjectTitle={mockOnUpdateProjectTitle}
+                projectTitle={null}
+                store={store}
+            />
+        );
+        expect(mockOnUpdateProjectTitle).not.toHaveBeenCalled();
+        mounted.setProps({
+            reduxProjectTitle: 'new title'
+        });
+        expect(mockOnUpdateProjectTitle).not.toHaveBeenCalled();
+    });
+
+    test('when new title is set in GUI and external title is blank, it does call onUpdateProjectTitle', () => {
+        const Component = () => (<div />);
+        const WrappedComponent = TitledHOC(Component);
+        const mockOnUpdateProjectTitle = jest.fn();
+        const mounted = mountWithIntl(
+            <WrappedComponent
+                onUpdateProjectTitle={mockOnUpdateProjectTitle}
+                projectTitle=""
+                store={store}
+            />
+        );
+        expect(mockOnUpdateProjectTitle).not.toHaveBeenCalled();
+        mounted.setProps({
+            reduxProjectTitle: 'new title'
+        });
+        expect(mockOnUpdateProjectTitle).toHaveBeenCalled();
+        expect(mockOnUpdateProjectTitle.mock.calls[0][0]).toBe('new title');
+    });
+
+    test('when title is erased in GUI and made blank, it does call onUpdateProjectTitle', () => {
+        const Component = () => (<div />);
+        const WrappedComponent = TitledHOC(Component);
+        const mockOnUpdateProjectTitle = jest.fn();
+        const mounted = mountWithIntl(
+            <WrappedComponent
+                onUpdateProjectTitle={mockOnUpdateProjectTitle}
+                projectTitle="existing title"
+                store={store}
+            />
+        );
+        expect(mockOnUpdateProjectTitle).not.toHaveBeenCalled();
+        mounted.setProps({
+            reduxProjectTitle: ''
+        });
+        expect(mockOnUpdateProjectTitle).toHaveBeenCalled();
+        expect(mockOnUpdateProjectTitle.mock.calls[0][0]).toBe('');
     });
 });


### PR DESCRIPTION
### Resolves

- Resolves https://github.com/LLK/scratch-www/issues/3673

### Proposed Changes

Instead of calling `onUpdateProjectTitle()` any time the title has changed in scratch-gui, only call `onUpdateProjectTitle()` if the title has changed *and the title prop passed in to scratch-gui is set.* 

That is, if the title passed in is undefined or null, then it's not really "stale" -- we trust the code which renders scratch-gui to determine the title and pass it in to us, so we should only correct it if it really is being passed in.

### Reason for Changes

We were seeing an invalid request to api, using an undefined project id; that's because www was trying to set the title when the project data hadn't fully loaded yet.

### Test Coverage

Added tests