### PR TITLE
Resync package-lock for scratch-paint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11730,9 +11730,9 @@
       }
     },
     "scratch-paint": {
-      "version": "0.2.0-prerelease.20200204155336",
-      "resolved": "https://registry.npmjs.org/scratch-paint/-/scratch-paint-0.2.0-prerelease.20200204155336.tgz",
-      "integrity": "sha512-jCOkvpPXMg4OTz/NGwB/rZT88lge+NfjLNXYbGiWiTSHAnCL02tI+N6fP9XamF/SePKOEdKCAxPZvsOXCypqHw==",
+      "version": "0.2.0-prerelease.20200204235639",
+      "resolved": "https://registry.npmjs.org/scratch-paint/-/scratch-paint-0.2.0-prerelease.20200204235639.tgz",
+      "integrity": "sha512-RMBvNrdmo/xgDuP3speGx0WfsYEttmeKI4zu9HiAYHPwRDtKOtRghnNxxFCrcpzG/qOEIV9m2eshVyGj8W9d0g==",
       "dev": true,
       "requires": {
         "@scratch/paper": "0.11.20190729152410",


### PR DESCRIPTION
Fixes https://github.com/LLK/scratch-gui/pull/5433 which didn't include package-lock update