### PR TITLE
Skip blocks “renaming costume wtih special character” test

### DIFF
--- a/test/integration/blocks.test.js
+++ b/test/integration/blocks.test.js
@@ -193,7 +193,7 @@ describe('Working with the blocks', () => {
         await clickText('newname', scope.blocksTab);
     });
 
-    test('Renaming costume with a special character should not break toolbox', async () => {
+    test.skip('Renaming costume with a special character should not break toolbox', async () => {
         await loadUri(uri);
 
         // Rename the costume


### PR DESCRIPTION
### Resolves

- Resolves  https://github.com/LLK/scratch-gui/issues/5429

### Proposed Changes

Skips the flaky test

### Reason for Changes

The test is flaky, so we're going to take it out until we can figure out how to make it pass

