### PR TITLE
fix: initialize audio context only with user interaction

### DIFF
--- a/src/lib/audio/shared-audio-context.js
+++ b/src/lib/audio/shared-audio-context.js
@@ -2,10 +2,20 @@ import StartAudioContext from 'startaudiocontext';
 import bowser from 'bowser';
 
 let AUDIO_CONTEXT;
-if (!bowser.msie) {
-    AUDIO_CONTEXT = new (window.AudioContext || window.webkitAudioContext)();
 
-    StartAudioContext(AUDIO_CONTEXT);
+if (!bowser.msie) {
+    /**
+     * AudioContext can be initialized only when user interaction event happens
+     */
+    const event =
+        typeof document.ontouchend === 'undefined' ? 'mouseup' : 'touchend';
+    const initAudioContext = () => {
+        document.removeEventListener(event, initAudioContext);
+        AUDIO_CONTEXT = new (window.AudioContext ||
+            window.webkitAudioContext)();
+        StartAudioContext(AUDIO_CONTEXT);
+    };
+    document.addEventListener(event, initAudioContext);
 }
 
 /**


### PR DESCRIPTION
### Resolves

- Resolves #4514

### Proposed Changes

Add a one-dispatch event listener to trigger the shared audio context.

### Reason for Changes

To help developers to debug by removing a warning.

### Test Coverage

WIP

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [x] Chrome 
 * [x] Firefox 
 * [x] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
