### PR TITLE
Skip “file->new resets project title” test because its flaky

### DIFF
--- a/test/integration/project-state.test.js
+++ b/test/integration/project-state.test.js
@@ -23,7 +23,7 @@ describe('Project state', () => {
         await driver.quit();
     });
 
-    test('File->New resets project title', async () => {
+    test.skip('File->New resets project title', async () => {
         const defaultProjectTitle = 'Scratch Project';
         await loadUri(uri);
         const inputEl = await findByXpath(`//input[@value="${defaultProjectTitle}"]`);


### PR DESCRIPTION
### Resolves

Skips a flaky test in project-state.test.js.  

- Resolves https://github.com/LLK/scratch-gui/issues/5438

### Proposed Changes

Skips the test until we can make it more stable.

### Reason for Changes

The test failed sometimes and passed others.  

