### PR TITLE
Use 2.0 versions of some svg backdrops

### DIFF
--- a/src/lib/libraries/backdrops.json
+++ b/src/lib/libraries/backdrops.json
@@ -164,7 +164,7 @@
     },
     {
         "name": "Blue Sky",
-        "md5": "11b62fc61d191b1bae0800f78c2f8c60.svg",
+        "md5": "e7c147730f19d284bcd7b3f00af19bb6.svg",
         "type": "backdrop",
         "tags": [
             "outdoors",
@@ -548,7 +548,7 @@
     },
     {
         "name": "Light",
-        "md5": "a7eb02ece0a521a6dfb5361ce0bdd7cc.svg",
+        "md5": "4b98c07876ed8997c3762e75790507b4.svg",
         "type": "backdrop",
         "tags": [
             "patterns"
@@ -687,7 +687,7 @@
     },
     {
         "name": "Party",
-        "md5": "d26e9e304872fccd5d84a70b94daf8e2.svg",
+        "md5": "108160d0e44d1c340182e31c9dc0758a.svg",
         "type": "backdrop",
         "tags": [
             "indoors",
@@ -995,7 +995,7 @@
     },
     {
         "name": "Stripes",
-        "md5": "c71bd957a3381eba291494a0decbf890.svg",
+        "md5": "a6a21f5c08d586e8daaebde37c97fb6f.svg",
         "type": "backdrop",
         "tags": [
             "patterns"


### PR DESCRIPTION
Some SVG backdrops display thumbnails incorrectly after being saved in the 3.0 paint editor. This change reverts these to the 2.0 SVG versions.