### PR TITLE
Ignore sound editor keyboard shortcut on fullscreen stage

### DIFF
--- a/src/containers/sound-editor.jsx
+++ b/src/containers/sound-editor.jsx
@@ -86,6 +86,10 @@ class SoundEditor extends React.Component {
             // Ignore keyboard shortcuts if a text input field is focused
             return;
         }
+        if (this.props.isFullScreen) {
+            // Ignore keyboard shortcuts if the stage is fullscreen mode
+            return;
+        }
         if (event.key === ' ') {
             event.preventDefault();
             if (this.state.playhead) {
@@ -465,6 +469,7 @@ class SoundEditor extends React.Component {
 }
 
 SoundEditor.propTypes = {
+    isFullScreen: PropTypes.bool,
     name: PropTypes.string.isRequired,
     sampleRate: PropTypes.number,
     samples: PropTypes.instanceOf(Float32Array),
@@ -483,6 +488,7 @@ const mapStateToProps = (state, {soundIndex}) => {
         soundId: sound.soundId,
         sampleRate: audioBuffer.sampleRate,
         samples: audioBuffer.getChannelData(0),
+        isFullScreen: state.scratchGui.mode.isFullScreen,
         name: sound.name,
         vm: state.scratchGui.vm
     };

--- a/test/unit/containers/sound-editor.test.jsx
+++ b/test/unit/containers/sound-editor.test.jsx
@@ -35,7 +35,7 @@ describe('Sound Editor Container', () => {
                 }
             }
         };
-        store = mockStore({scratchGui: {vm: vm}});
+        store = mockStore({scratchGui: {vm: vm, mode: {isFullScreen: false}}});
     });
 
     test('should pass the correct data to the component from the store', () => {


### PR DESCRIPTION
### Resolves
Resolves #6027 
### Proposed Changes
If the stage is fullscreen mode, sound editor now ignores all keyboard shortcut.

### Reason for Changes
It does not make sense that a hidden component catches keyboard event and plays sound, etc.
