### PR TITLE
unflakify four blocks integration tests

### DIFF
--- a/test/integration/blocks.test.js
+++ b/test/integration/blocks.test.js
@@ -9,6 +9,7 @@ const {
     findByXpath,
     getDriver,
     getLogs,
+    Key,
     loadUri,
     rightClickText,
     scope
@@ -185,6 +186,10 @@ describe('Working with the blocks', () => {
         await clickText('costume2', scope.costumesTab);
         const el = await findByXpath("//input[@value='costume2']");
         await el.sendKeys('newname');
+        await el.sendKeys(Key.ENTER);
+        // wait until the updated costume appears in costume item list panel
+        await findByXpath("//div[contains(@class,'sprite-selector-item_is-selected_')]" +
+            "//div[contains(text(), 'newname')]");
 
         // Make sure it is updated in the block menu
         await clickText('Code');
@@ -193,7 +198,7 @@ describe('Working with the blocks', () => {
         await clickText('newname', scope.blocksTab);
     });
 
-    test.skip('Renaming costume with a special character should not break toolbox', async () => {
+    test('Renaming costume with a special character should not break toolbox', async () => {
         await loadUri(uri);
 
         // Rename the costume
@@ -201,6 +206,10 @@ describe('Working with the blocks', () => {
         await clickText('costume2', scope.costumesTab);
         const el = await findByXpath("//input[@value='costume2']");
         await el.sendKeys('<NewCostume>');
+        await el.sendKeys(Key.ENTER);
+        // wait until the updated costume appears in costume item list panel
+        await findByXpath("//div[contains(@class,'sprite-selector-item_is-selected_')]" +
+            "//div[contains(text(), '<NewCostume>')]");
 
         // Make sure it is updated in the block menu
         await clickText('Code');
@@ -226,6 +235,9 @@ describe('Working with the blocks', () => {
             .perform();
         await driver.sleep(500); // Wait for thermometer menu to come up
         await clickXpath('//button[@aria-label="Paint"]');
+        // wait until the new costume appears in costume item list panel
+        await findByXpath("//div[contains(@class,'sprite-selector-item_is-selected_')]" +
+            "//div[contains(text(), 'costume3')]");
         await clickText('costume3', scope.costumesTab);
         // Check that the menu has been updated
         await clickText('Code');
@@ -233,11 +245,14 @@ describe('Working with the blocks', () => {
     });
 
     // Skipped because it was flakey on travis, but seems to run locally ok
-    test.skip('Adding a sound DOES update the default sound name in the toolbox', async () => {
+    test('Adding a sound DOES update the default sound name in the toolbox', async () => {
         await loadUri(uri);
         await clickText('Sounds');
         await clickXpath('//button[@aria-label="Choose a Sound"]');
         await clickText('A Bass', scope.modal); // Should close the modal
+        // wait until the selected sound appears in sounds item list panel
+        await findByXpath("//div[contains(@class,'sprite-selector-item_is-selected_')]" +
+            "//div[contains(text(), 'A Bass')]");
         await clickText('Code');
         await clickText('Sound', scope.blocksTab);
         await driver.sleep(500); // Wait for scroll to finish


### PR DESCRIPTION
### Resolves

* Resolves flakiness in the two tests mentioned here: https://github.com/LLK/scratch-gui/pull/5178
* Resolves flakiness in https://github.com/LLK/scratch-gui/issues/5429
* Resolves flakiness in https://github.com/LLK/scratch-gui/issues/5177

### Proposed Changes

* adds findByXpath to wait for updated or new items to appear
* adds an ENTER keypress

both are intended to allow callbacks to be called before we unmount the Costumes or Sounds tab.

