### PR TITLE
Check list limit in list monitor

### DIFF
--- a/src/containers/list-monitor.jsx
+++ b/src/containers/list-monitor.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 import VM from 'scratch-vm';
 import {connect} from 'react-redux';
 import {getEventXY} from '../lib/touch-utils';
-import {getVariableValue, setVariableValue} from '../lib/variable-utils';
+import {getVariableValue, setVariableValue, canSetVariableValue} from '../lib/variable-utils';
 import ListMonitorComponent from '../components/monitor/list-monitor.jsx';
 import {Map} from 'immutable';
 
@@ -86,12 +86,14 @@ class ListMonitor extends React.Component {
             const newListValue = listValue.slice(0, previouslyActiveIndex + newValueOffset)
                 .concat([newListItemValue])
                 .concat(listValue.slice(previouslyActiveIndex + newValueOffset));
-            setVariableValue(vm, targetId, variableId, newListValue);
-            const newIndex = this.wrapListIndex(previouslyActiveIndex + newValueOffset, newListValue.length);
-            this.setState({
-                activeIndex: newIndex,
-                activeValue: newListItemValue
-            });
+            if (canSetVariableValue(vm, targetId, variableId, newListValue)) {
+                setVariableValue(vm, targetId, variableId, newListValue);
+                const newIndex = this.wrapListIndex(previouslyActiveIndex + newValueOffset, newListValue.length);
+                this.setState({
+                    activeIndex: newIndex,
+                    activeValue: newListItemValue
+                });
+            }
         }
     }
 
@@ -118,6 +120,7 @@ class ListMonitor extends React.Component {
         // Add button appends a blank value and switches to it
         const {vm, targetId, id: variableId} = this.props;
         const newListValue = getVariableValue(vm, targetId, variableId).concat(['']);
+        if (!canSetVariableValue(vm, targetId, variableId, newListValue)) return;
         setVariableValue(vm, targetId, variableId, newListValue);
         this.setState({activeIndex: newListValue.length - 1, activeValue: ''});
     }

--- a/src/containers/monitor.jsx
+++ b/src/containers/monitor.jsx
@@ -6,7 +6,7 @@ import {injectIntl, intlShape, defineMessages} from 'react-intl';
 import monitorAdapter from '../lib/monitor-adapter.js';
 import MonitorComponent, {monitorModes} from '../components/monitor/monitor.jsx';
 import {addMonitorRect, getInitialPosition, resizeMonitorRect, removeMonitorRect} from '../reducers/monitor-layout';
-import {getVariable, setVariableValue} from '../lib/variable-utils';
+import {getVariable, setVariableValue, LIST_ITEM_LIMIT} from '../lib/variable-utils';
 import importCSV from '../lib/import-csv';
 import downloadBlob from '../lib/download-blob';
 import SliderPrompt from './slider-prompt.jsx';
@@ -171,7 +171,8 @@ class Monitor extends React.Component {
                 columnNumber = parseInt(prompt(msg), 10); // eslint-disable-line no-alert
             }
             const newListValue = rows.map(row => row[columnNumber - 1])
-                .filter(item => typeof item === 'string'); // CSV importer can leave undefineds
+                .filter(item => typeof item === 'string') // CSV importer can leave undefineds
+                .splice(0, LIST_ITEM_LIMIT);
             const {vm, targetId, id: variableId} = this.props;
             setVariableValue(vm, targetId, variableId, newListValue);
         });

--- a/src/lib/variable-utils.js
+++ b/src/lib/variable-utils.js
@@ -1,5 +1,8 @@
 // Utility functions for updating variables in the VM
 // TODO (VM#1145) these should be moved to top-level VM API
+
+const LIST_ITEM_LIMIT = 200000;
+
 const getVariable = (vm, targetId, variableId) => {
     const target = targetId ?
         vm.runtime.getTargetById(targetId) :
@@ -18,8 +21,15 @@ const setVariableValue = (vm, targetId, variableId, value) => {
     getVariable(vm, targetId, variableId).value = value;
 };
 
+const canSetVariableValue = (vm, targetId, variableId, value) => {
+    const variable = getVariable(vm, targetId, variableId);
+    return !(variable.type === 'list' && value.length > LIST_ITEM_LIMIT);
+};
+
 export {
+    LIST_ITEM_LIMIT,
     getVariable,
     getVariableValue,
-    setVariableValue
+    setVariableValue,
+    canSetVariableValue
 };

--- a/test/unit/util/variable-utils.test.js
+++ b/test/unit/util/variable-utils.test.js
@@ -1,0 +1,31 @@
+import {canSetVariableValue} from '../../../src/lib/variable-utils.js';
+
+describe('variableUtils', () => {
+    const vm = {
+        runtime: {
+            getTargetForStage: () => ({
+                variables: {
+                    nonList: {
+                        type: '',
+                        value: ''
+                    },
+                    list: {
+                        type: 'list',
+                        value: ['a', 'b', 'c']
+                    }
+                }
+            })
+        }
+    };
+    test('canSetVariableValue returns true for non-lists', () => {
+        expect(canSetVariableValue(vm, '', 'nonList', '')).toBeTruthy();
+    });
+
+    test('canSetVariableValue returns true when the given value is less than 200000 items', () => {
+        expect(canSetVariableValue(vm, '', 'list', ['a'])).toBeTruthy();
+    });
+
+    test('canSetVariableValue returns false when the given value is more than 200000 items', () => {
+        expect(canSetVariableValue(vm, '', 'list', {length: 200001})).toBeFalsy();
+    });
+});


### PR DESCRIPTION
### Resolves
Resolves #4303 (partially)
Resolves #5495

### Proposed Changes
Adds a new function, `canSetVariableValue`. This returns true when the variable is not a list, or the limit is not reached. This is called inside `list-monitor.jsx` to check if the new item can be added. (if not, Enter or + button simply fail)

Also, this changes `monitor.jsx` so that only the first 200000 item is imported from text file.

### Reason for Changes
The list limit is not supposed to be bypassed.

### Test Coverage
Added a unit test for the new function. Manual test for other fixes.