### PR TITLE
Randomize empty sprite position

### DIFF
--- a/src/containers/costume-tab.jsx
+++ b/src/containers/costume-tab.jsx
@@ -163,9 +163,9 @@ class CostumeTab extends React.Component {
 
         return Promise.all(costumes.map(c => {
             if (fromCostumeLibrary) {
-                return this.props.vm.addCostumeFromLibrary(c.md5, c);
+                return this.props.vm.addCostumeFromLibrary(c.md5 || c.md5ext, c);
             }
-            return this.props.vm.addCostume(c.md5, c);
+            return this.props.vm.addCostume(c.md5 || c.md5ext, c);
         }));
     }
     handleNewBlankCostume () {

--- a/src/containers/stage-selector.jsx
+++ b/src/containers/stage-selector.jsx
@@ -83,7 +83,7 @@ class StageSelector extends React.Component {
     handleNewBackdrop (backdrops_, shouldActivateTab = true) {
         const backdrops = Array.isArray(backdrops_) ? backdrops_ : [backdrops_];
         return Promise.all(backdrops.map(backdrop =>
-            this.props.vm.addBackdrop(backdrop.md5, backdrop)
+            this.props.vm.addBackdrop(backdrop.md5 || backdrop.md5ext, backdrop)
         )).then(() => {
             if (shouldActivateTab) {
                 return this.props.onActivateTab(COSTUMES_TAB_INDEX);

--- a/src/containers/target-pane.jsx
+++ b/src/containers/target-pane.jsx
@@ -120,6 +120,7 @@ class TargetPane extends React.Component {
             formatMessage(sharedMessages.pop),
             formatMessage(sharedMessages.costume, {index: 1})
         );
+        randomizeSpritePosition(emptyItem);
         this.props.vm.addSprite(JSON.stringify(emptyItem)).then(() => {
             setTimeout(() => { // Wait for targets update to propagate before tab switching
                 this.props.onActivateTab(COSTUMES_TAB_INDEX);

--- a/src/lib/empty-assets.js
+++ b/src/lib/empty-assets.js
@@ -10,11 +10,13 @@
  */
 const emptyCostume = name => ({
     name: name,
-    md5: 'cd21514d0531fdffb22204e0ec5ed84a.svg',
+    assetId: 'cd21514d0531fdffb22204e0ec5ed84a',
+    md5ext: 'cd21514d0531fdffb22204e0ec5ed84a.svg',
+    md5: 'cd21514d0531fdffb22204e0ec5ed84a.svg', // @todo For some reason, md5 is required (or the serialization breaks)
+    bitmapResolution: 1,
     rotationCenterX: 0,
     rotationCenterY: 0,
-    bitmapResolution: 1,
-    skinId: null
+    dataFormat: 'svg'
 });
 
 /**
@@ -26,36 +28,42 @@ const emptyCostume = name => ({
  * @return {object} object expected by vm.addSprite
  */
 const emptySprite = (name, soundName, costumeName) => ({
-    objName: name,
+    isStage: false,
+    name: name,
+    variables: {},
+    lists: {},
+    broadcasts: {},
+    blocks: {},
     sounds: [
         {
-            soundName: soundName,
-            soundID: -1,
-            md5: '83a9787d4cb6f3b7632b4ddfebf74367.wav',
+            name: soundName,
+            assetId: '83a9787d4cb6f3b7632b4ddfebf74367',
+            md5ext: '83a9787d4cb6f3b7632b4ddfebf74367.wav',
             sampleCount: 258,
             rate: 11025,
+            dataFormat: 'wav',
             format: ''
         }
     ],
     costumes: [
         {
-            costumeName: costumeName,
-            baseLayerID: -1,
-            baseLayerMD5: 'cd21514d0531fdffb22204e0ec5ed84a.svg',
+            name: costumeName,
+            assetId: 'cd21514d0531fdffb22204e0ec5ed84a',
+            md5ext: 'cd21514d0531fdffb22204e0ec5ed84a.svg',
             bitmapResolution: 1,
+            dataFormat: 'svg',
             rotationCenterX: 0,
             rotationCenterY: 0
         }
     ],
-    currentCostumeIndex: 0,
-    scratchX: 36,
-    scratchY: 28,
-    scale: 1,
+    currentCostume: 0,
+    x: 36,
+    y: 28,
+    size: 100,
     direction: 90,
-    rotationStyle: 'normal',
-    isDraggable: false,
-    visible: true,
-    spriteInfo: {}
+    rotationStyle: 'all around',
+    draggable: false,
+    visible: true
 });
 
 export {


### PR DESCRIPTION
### Resolves
Resolves #5498 
Resolves #5499 

### Proposed Changes
Randomizes the empty sprite position. (also scratch3ify the empty assets)

### Reason for Changes
The sprite position is always the same.

### Test Coverage
Manually tested:
1) Adding empty costume/sprite should not fail
2) Empty costume can be serialized correctly: add empty costume, export project, see projects.json and check `md5ext` exists