### PR TITLE
Refactor stage layout

### DIFF
--- a/src/components/gui/gui.css
+++ b/src/components/gui/gui.css
@@ -34,7 +34,17 @@
 }
 
 .editor-wrapper {
-    flex-basis: 600px;
+    /*
+        This is carefully balanced--  the minimum width at which the GUI will be displayed is 1024px.
+        At that size, the stage pane is 408px wide, with $space of padding to each side.
+        However, we must also add the border width to the stage pane. All-in-all, the stage pane's final width is
+        408px + ($space + $stage-standard-border-width * 2) (one border & padding per left/right side).
+
+        @todo This is in place to prevent "doubling up" of horizontal scrollbars in narrow windows, but there are likely
+        much better ways to solve that (e.g. undo #2124, remove this flex-basis entirely). However, they run their own
+        risks of breaking things, so let's just leave this as-is for the time being.
+    */
+    flex-basis: calc(1024px - 408px - (($space + $stage-standard-border-width) * 2));
     flex-grow: 1;
     flex-shrink: 0;
     position: relative;

--- a/src/components/gui/gui.css
+++ b/src/components/gui/gui.css
@@ -197,21 +197,9 @@
     /* pad entire wrapper to the left and right; allow children to fill width */
     padding-left: $space;
     padding-right: $space;
-}
 
-.stage-and-target-wrapper.large {
-    /* Fix the max width to max large stage size (defined in layout_constants.js) + gutter size */
-    max-width: calc(480px + calc($space * 2));
-}
-
-.stage-and-target-wrapper.large-constrained {
-    /* Fix the max width to max largeConstrained stage size (defined in layout_constants.js) + gutter size */
-    max-width: calc(408px + calc($space * 2));
-}
-
-.stage-and-target-wrapper.small {
-    /* Fix the max width to max small stage size (defined in layout_constants.js) + gutter size */
-    max-width: calc(240px + calc($space * 2));
+    /* this will only ever be as wide as the stage */
+    flex-basis: 0;
 }
 
 .target-wrapper {

--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -336,6 +336,7 @@ const GUIComponent = props => {
 
                         <Box className={classNames(styles.stageAndTargetWrapper, styles[stageSize])}>
                             <StageWrapper
+                                isFullScreen={isFullScreen}
                                 isRendererSupported={isRendererSupported}
                                 isRtl={isRtl}
                                 stageSize={stageSize}

--- a/src/components/stage-wrapper/stage-wrapper.css
+++ b/src/components/stage-wrapper/stage-wrapper.css
@@ -1,5 +1,6 @@
 @import "../../css/units.css";
 @import "../../css/colors.css";
+@import "../../css/z-index.css";
 
 .stage-wrapper * {
     box-sizing: border-box;
@@ -8,4 +9,22 @@
 .stage-canvas-wrapper {
     /* Hides negative space between edge of rounded corners + container, when selected */
     user-select: none;
+}
+
+.stage-wrapper.full-screen {
+    position: fixed;
+    top: $stage-menu-height;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: $z-index-stage-wrapper-overlay;
+    background-color: $ui-white;
+    /* spacing between stage and control bar (on the top), or between
+    stage and window edges (on left/right/bottom) */
+    padding: $stage-full-screen-stage-padding;
+
+    /* this centers the stage */
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 }

--- a/src/components/stage-wrapper/stage-wrapper.jsx
+++ b/src/components/stage-wrapper/stage-wrapper.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import classNames from 'classnames';
 import VM from 'scratch-vm';
 
 import Box from '../box/box.jsx';
@@ -22,7 +23,10 @@ const StageWrapperComponent = function (props) {
 
     return (
         <Box
-            className={styles.stageWrapper}
+            className={classNames(
+                styles.stageWrapper,
+                {[styles.fullScreen]: isFullScreen}
+            )}
             dir={isRtl ? 'rtl' : 'ltr'}
         >
             <Box className={styles.stageMenuWrapper}>

--- a/src/components/stage/stage.css
+++ b/src/components/stage/stage.css
@@ -21,6 +21,13 @@
 
     /* Make sure border is not included in size calculation */
     box-sizing: content-box !important;
+
+    /* enforce overflow + reset position of absolutely-positioned children */
+    position: relative;
+}
+
+.stage.full-screen {
+    border: $stage-full-screen-border-width solid rgb(126, 133, 151);
 }
 
 .with-color-picker {
@@ -43,62 +50,29 @@
     position: relative;
 }
 
-.stage-wrapper-overlay {
-    position: fixed;
-    top: $stage-menu-height;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    z-index: $z-index-stage-wrapper-overlay;
-    background-color: $ui-white;
-    /* spacing between stage and control bar (on the top), or between
-    stage and window edges (on left/right/bottom) */
-    padding: $stage-full-screen-stage-padding;
-}
-
-/* wraps only main content of overlay player, not monitors */
-.stage-overlay-content {
-    outline: none;
-    margin: auto;
-    border: $stage-full-screen-border-width solid rgb(126, 133, 151);
-    padding: 0;
-    border-radius: $space;
-
-    overflow: hidden;
-    display: flex;
-    justify-content: center;
-}
-
-.stage-overlay-content-border-override {
-    border: none;
-}
-
-/* adjust monitors when stage is standard size:
-shift them down and right to compensate for the stage's border */
-.stage-wrapper .monitor-wrapper {
+/* we want stage overlays to all be positioned in the same spot as the stage, but can't put them inside the border
+because we want their overflow to be visible, and the bordered element must have overflow: hidden set so that the
+stage doesn't "spill" out from under its rounded corners. instead, shift these over by the border width. */
+.stage-overlays {
+    position: absolute;
     top: $stage-standard-border-width;
     left: $stage-standard-border-width;
+
+    /* the overlay itself should not capture pointer events; only its child elements can do that */
+    pointer-events: none;
 }
 
-/* adjust monitors when stage is full screen:
-.stage-wrapper-overlay uses position: fixed instead of relative, so we need
-to adjust for the border using a different method */
-.stage-wrapper-overlay .monitor-wrapper {
-    padding-top: calc($stage-full-screen-stage-padding + $stage-full-screen-border-width);
-    padding-bottom: calc($stage-full-screen-stage-padding + $stage-full-screen-border-width);
+.stage-overlays.full-screen {
+    top: $stage-full-screen-border-width;
+    left: $stage-full-screen-border-width;
 }
 
 .monitor-wrapper,
-.color-picker-wrapper,
-.frame-wrapper,
 .green-flag-overlay-wrapper {
     position: absolute;
     top: 0;
     left: 0;
-    width: 100%;
-    height: 100%;
     pointer-events: none;
-    overflow: hidden;
 }
 
 .dragging-sprite {
@@ -107,7 +81,7 @@ to adjust for the border using a different method */
     left: 0;
     z-index: $z-index-dragging-sprite;
     filter: drop-shadow(5px 5px 5px $ui-black-transparent);
- }
+}
 
 .stage-bottom-wrapper {
     position: absolute;
@@ -115,6 +89,7 @@ to adjust for the border using a different method */
     flex-direction: column;
     justify-content: flex-end;
     top: 0;
+    left: 0;
     overflow: hidden;
     pointer-events: none;
 }
@@ -141,6 +116,8 @@ to adjust for the border using a different method */
 }
 
 .green-flag-overlay-wrapper {
+    width: 100%;
+    height: 100%;
     display: flex;
     justify-content: center;
     align-items: center;

--- a/src/components/stage/stage.css
+++ b/src/components/stage/stage.css
@@ -68,6 +68,7 @@ stage doesn't "spill" out from under its rounded corners. instead, shift these o
 }
 
 .monitor-wrapper,
+.frame-wrapper,
 .green-flag-overlay-wrapper {
     position: absolute;
     top: 0;

--- a/src/components/stage/stage.jsx
+++ b/src/components/stage/stage.jsx
@@ -66,7 +66,13 @@ const StageComponent = props => {
                             stageSize={stageDimensions}
                         />
                     </Box>
-
+                    <Box className={styles.frameWrapper}>
+                        <TargetHighlight
+                            className={styles.frame}
+                            stageHeight={stageDimensions.height}
+                            stageWidth={stageDimensions.width}
+                        />
+                    </Box>
                     {isColorPicking && colorInfo ? (
                         <Loupe colorInfo={colorInfo} />
                     ) : null}
@@ -79,11 +85,6 @@ const StageComponent = props => {
                         {[styles.fullScreen]: isFullScreen}
                     )}
                 >
-                    <TargetHighlight
-                        className={styles.frame}
-                        stageHeight={stageDimensions.height}
-                        stageWidth={stageDimensions.width}
-                    />
                     <div
                         className={styles.stageBottomWrapper}
                         style={{

--- a/src/components/stage/stage.jsx
+++ b/src/components/stage/stage.jsx
@@ -35,7 +35,7 @@ const StageComponent = props => {
     const stageDimensions = getStageDimensions(stageSize, isFullScreen);
 
     return (
-        <div>
+        <React.Fragment>
             <Box
                 className={classNames(
                     styles.stageWrapper,
@@ -129,7 +129,7 @@ const StageComponent = props => {
                     onClick={onDeactivateColorPicker}
                 />
             ) : null}
-        </div>
+        </React.Fragment>
     );
 };
 StageComponent.propTypes = {

--- a/src/components/stage/stage.jsx
+++ b/src/components/stage/stage.jsx
@@ -37,21 +37,15 @@ const StageComponent = props => {
     return (
         <div>
             <Box
-                className={classNames({
-                    [styles.stageWrapper]: !isFullScreen,
-                    [styles.stageWrapperOverlay]: isFullScreen,
-                    [styles.withColorPicker]: !isFullScreen && isColorPicking
-                })}
-                style={{
-                    minHeight: stageDimensions.height,
-                    minWidth: stageDimensions.width
-                }}
+                className={classNames(
+                    styles.stageWrapper,
+                    {[styles.withColorPicker]: !isFullScreen && isColorPicking})}
                 onDoubleClick={onDoubleClick}
             >
                 <Box
                     className={classNames(
                         styles.stage,
-                        {[styles.stageOverlayContent]: isFullScreen}
+                        {[styles.fullScreen]: isFullScreen}
                     )}
                     style={{
                         height: stageDimensions.height,
@@ -66,18 +60,60 @@ const StageComponent = props => {
                         }}
                         {...boxProps}
                     />
+                    <Box className={styles.monitorWrapper}>
+                        <MonitorList
+                            draggable={useEditorDragStyle}
+                            stageSize={stageDimensions}
+                        />
+                    </Box>
+
+                    {isColorPicking && colorInfo ? (
+                        <Loupe colorInfo={colorInfo} />
+                    ) : null}
                 </Box>
-                <Box className={styles.monitorWrapper}>
-                    <MonitorList
-                        draggable={useEditorDragStyle}
-                        stageSize={stageDimensions}
-                    />
-                </Box>
-                <Box className={styles.frameWrapper}>
+
+                {/* `stageOverlays` is for items that should *not* have their overflow contained within the stage */}
+                <Box
+                    className={classNames(
+                        styles.stageOverlays,
+                        {[styles.fullScreen]: isFullScreen}
+                    )}
+                >
                     <TargetHighlight
                         className={styles.frame}
                         stageHeight={stageDimensions.height}
                         stageWidth={stageDimensions.width}
+                    />
+                    <div
+                        className={styles.stageBottomWrapper}
+                        style={{
+                            width: stageDimensions.width,
+                            height: stageDimensions.height
+                        }}
+                    >
+                        {micIndicator ? (
+                            <MicIndicator
+                                className={styles.micIndicator}
+                                stageSize={stageDimensions}
+                            />
+                        ) : null}
+                        {question === null ? null : (
+                            <div
+                                className={styles.questionWrapper}
+                                style={{width: stageDimensions.width}}
+                            >
+                                <Question
+                                    question={question}
+                                    onQuestionAnswered={onQuestionAnswered}
+                                />
+                            </div>
+                        )}
+                    </div>
+                    <canvas
+                        className={styles.draggingSprite}
+                        height={0}
+                        ref={dragRef}
+                        width={0}
                     />
                 </Box>
                 {isStarted ? null : (
@@ -86,44 +122,6 @@ const StageComponent = props => {
                         wrapperClass={styles.greenFlagOverlayWrapper}
                     />
                 )}
-                {isColorPicking && colorInfo ? (
-                    <Box className={styles.colorPickerWrapper}>
-                        <Loupe colorInfo={colorInfo} />
-                    </Box>
-                ) : null}
-                <div
-                    className={styles.stageBottomWrapper}
-                    style={{
-                        width: stageDimensions.width,
-                        height: stageDimensions.height,
-                        left: '50%',
-                        marginLeft: stageDimensions.width * -0.5
-                    }}
-                >
-                    {micIndicator ? (
-                        <MicIndicator
-                            className={styles.micIndicator}
-                            stageSize={stageDimensions}
-                        />
-                    ) : null}
-                    {question === null ? null : (
-                        <div
-                            className={styles.questionWrapper}
-                            style={{width: stageDimensions.width}}
-                        >
-                            <Question
-                                question={question}
-                                onQuestionAnswered={onQuestionAnswered}
-                            />
-                        </div>
-                    )}
-                </div>
-                <canvas
-                    className={styles.draggingSprite}
-                    height={0}
-                    ref={dragRef}
-                    width={0}
-                />
             </Box>
             {isColorPicking ? (
                 <Box

--- a/src/containers/green-flag-overlay.jsx
+++ b/src/containers/green-flag-overlay.jsx
@@ -21,8 +21,6 @@ class GreenFlagOverlay extends React.Component {
     }
 
     render () {
-        if (this.props.isStarted) return null;
-
         return (
             <Box
                 className={this.props.wrapperClass}
@@ -42,13 +40,11 @@ class GreenFlagOverlay extends React.Component {
 
 GreenFlagOverlay.propTypes = {
     className: PropTypes.string,
-    isStarted: PropTypes.bool,
     vm: PropTypes.instanceOf(VM),
     wrapperClass: PropTypes.string
 };
 
 const mapStateToProps = state => ({
-    isStarted: state.scratchGui.vmStatus.started,
     vm: state.scratchGui.vm
 });
 


### PR DESCRIPTION
### Resolves

- Resolves #5507

### Proposed Changes

There are a lot of changes in this PR, but I'll try to cover most:

- Replace hack introduced in https://github.com/LLK/scratch-gui/pull/2354 with proper flexbox solution
- Move full-screen wrapper duties from `Stage` to `StageWrapper`
- Properly position and size elements overlaid onto the stage
- Make the `Stage` component into a `React.Fragment` instead of a `<div>`
- Remove `left: 50%; marginLeft: stageDimensions.width * -0.5` hack (introduced in #3205) from `stageBottomWrapper`
- Remove some obsolete CSS
- Remove unnecessary `isStarted` prop from `GreenFlagOverlay`

### Reason for Changes
This fixes a lot of positioning and sizing bugs in stage overlays (for variables, the color picker, dragged sprites, etc), mostly related to the one-pixel stage border resulting in some hard-to-see layout issues. I find that turning up `$stage-standard-border-width` in `units.css` helps make these bugs easier to spot during development.

It also cleans up the code a fair bit, which should make it easier to maintain in the future.

In particular, using the same positioning system for the regular and full-screen stages should cut down on a fair number of bugs.

### Significant Changes and Questions
There are a few changes I made that I wasn't sure of:
- The green flag overlay in full-screen mode now covers the stage instead of the screen. I wasn't sure if this was intentional on your end or not.
- I'm not sure what `left: 50%; marginLeft: stageDimensions.width * -0.5` on `stageBottomWrapper` is (was?) for. It doesn't appear to affect RTL at all.
- This may break the speech-recognition microphone overlay, which will need to be fixed if the speech-recognition extension is ever re-enabled.

If this PR is too big/unwarranted for you to review, I can try to split it into multiple smaller ones, but a lot of bugs are "entangled" in the current stage layout system.

### Test Plan

- Monitors
  - Verify that monitors are correctly positioned in small stage, normal size, and fullscreen modes
  - Verify that monitors can't extend outside the stage in any stage size mode
  - Verify that the stage's rounded corners properly clip monitors
- Color picker loupe
  - Verify that the color picker loupe is properly positioned
  - Verify that the color picker loupe is clipped to the stage, incl. rounded corners
    - Currently the color picker loupe can go outside the stage's rounded corners a bit
- Other misc. overlays
  - Verify that the following elements are properly positioned in all stage sizes:
    - The ask and answer box
    - The blue box that flashes over sprites when you click their icons in the sprite selector pane
    - The currently dragged sprite
      - Currently, when you're dragging a sprite, it's positioned a bit too far down and to the right
- The green flag overlay
  - Verify that in full-screen mode, the green flag overlay is now sized to the stage
    - Currently, the green flag overlay covers the entire screen in full-screen mode
- The sprite pane
  - Verify that when you add a bunch of sprites to the sprite pane, it still doesn't grow horizontally at all

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Linux
* [x] Chrome
* [x] Firefox

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
