### PR TITLE
Call renderer.draw immediately on drag start/stop

### DIFF
--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -362,6 +362,7 @@ class Stage extends React.Component {
             this.drawDragCanvas(drawableData);
             this.positionDragCanvas(x, y);
             this.props.vm.postSpriteInfo({visible: false});
+            this.props.vm.renderer.draw();
         }
     }
     onStopDrag (mouseX, mouseY) {
@@ -387,12 +388,9 @@ class Stage extends React.Component {
             }
             this.props.vm.postSpriteInfo(spriteInfo);
             // Then clear the dragging canvas and stop drag (potentially slow if selecting sprite)
-            setTimeout(() => {
-                this.clearDragCanvas();
-                setTimeout(() => {
-                    commonStopDragActions();
-                }, 30);
-            }, 30);
+            this.clearDragCanvas();
+            commonStopDragActions();
+            this.props.vm.renderer.draw();
         } else {
             commonStopDragActions();
         }


### PR DESCRIPTION
### Resolves

- Resolves #5509

### Proposed Changes

This PR calls `renderer.draw()` immediately after calling `postSpriteInfo` in `Stage.onStartDrag` and `Stage.onStopDrag`.

### Reason for Changes

This removes the one-frame delay between when a sprite starts/stops dragging and when the "dragged sprite" overlay appears:

Before | After
-- | -
![image](https://user-images.githubusercontent.com/25993062/76539746-897fae00-6457-11ea-9f9e-bbe27a73c054.gif) | ![Peek 2020-03-12 11-58](https://user-images.githubusercontent.com/25993062/76540707-e62f9880-6458-11ea-8c11-674b58ebfe3d.gif)


### Test Coverage

Tested manually

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Linux
* [x] Chrome
* [x] Firefox

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
