### PR TITLE
Demystify non-editor mode

### DIFF
--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -77,6 +77,13 @@ class Stage extends React.Component {
         this.attachMouseEvents(this.canvas);
         this.updateRect();
         this.props.vm.runtime.addListener('QUESTION', this.questionListener);
+
+        // The GUI component seems to be recreated when entering/exiting editor mode.
+        // If we only update mystery mode in componentDidUpdate, it won't
+        // update when switching between editor and player mode.
+        if (this.props.mysteryMode !== this.renderer._mystery.modeActive) {
+            this.renderer.setMysteryMode(this.props.mysteryMode);
+        }
     }
     shouldComponentUpdate (nextProps, nextState) {
         return this.props.stageSize !== nextProps.stageSize ||
@@ -94,10 +101,8 @@ class Stage extends React.Component {
         } else if (!this.props.isColorPicking && prevProps.isColorPicking) {
             this.stopColorPickingLoop();
         }
-        if (this.props.mysteryMode && !prevProps.mysteryMode) {
-            this.renderer.setMysteryMode(true);
-        } else if (!this.props.mysteryMode && prevProps.mysteryMode) {
-            this.renderer.setMysteryMode(false);
+        if (this.props.mysteryMode !== prevProps.mysteryMode) {
+            this.renderer.setMysteryMode(this.props.mysteryMode);
         }
         this.updateRect();
         this.renderer.resize(this.rect.width, this.rect.height);
@@ -450,7 +455,8 @@ const mapStateToProps = state => ({
     micIndicator: state.scratchGui.micIndicator,
     // Do not use editor drag style in fullscreen or player mode.
     useEditorDragStyle: !(state.scratchGui.mode.isFullScreen || state.scratchGui.mode.isPlayerOnly),
-    mysteryMode: state.scratchGui.mysteryMode
+    mysteryMode: state.scratchGui.mysteryMode && !(
+        state.scratchGui.mode.isFullScreen || state.scratchGui.mode.isPlayerOnly)
 });
 
 const mapDispatchToProps = dispatch => ({


### PR DESCRIPTION
### Resolves

See [this comment](https://github.com/LLK/scratch-gui/pull/5532#issuecomment-603422282)

### Proposed Changes

This PR ensures that mystery mode is disabled when not in editor mode.

### Reason for Changes

Things were getting a bit too shadowy.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Linux
* [x] Firefox

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
