### PR TITLE
prevent duplicate selections in sensing_of

### DIFF
--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -245,13 +245,13 @@ export default function (vm) {
                     // The block was in the flyout so look up future block info there.
                     lookupBlocks = vm.runtime.flyoutBlocks;
                 }
-                const sort = function (options) {
-                    options.sort(ScratchBlocks.scratchBlocksUtils.compareStrings);
-                };
+                const sort = options => {
+                    options.sort((var1, var2) => ScratchBlocks.scratchBlocksUtils.compareStrings(var1.name, var2.name));
+                }
                 // Get all the stage variables (no lists) so we can add them to menu when the stage is selected.
-                const stageVariableOptions = vm.runtime.getTargetForStage().getAllVariableNamesInScopeByType('');
+                const stageVariableOptions = Object.values(vm.runtime.getTargetForStage().variables);
                 sort(stageVariableOptions);
-                const stageVariableMenuItems = stageVariableOptions.map(variable => [variable, variable]);
+                const stageVariableMenuItems = stageVariableOptions.map(variable => [variable.name, variable.id]);
                 if (sensingOfBlock.inputs.OBJECT.shadow !== sensingOfBlock.inputs.OBJECT.block) {
                     // There's a block dropped on top of the menu. It'd be nice to evaluate it and
                     // return the correct list, but that is tricky. Scratch2 just returns stage options
@@ -268,10 +268,10 @@ export default function (vm) {
                 let spriteVariableOptions = [];
                 // The target should exist, but there are ways for it not to (e.g. #4203).
                 if (target) {
-                    spriteVariableOptions = target.getAllVariableNamesInScopeByType('', true);
+                    spriteVariableOptions = Object.values(target.variables);
                     sort(spriteVariableOptions);
                 }
-                const spriteVariableMenuItems = spriteVariableOptions.map(variable => [variable, variable]);
+                const spriteVariableMenuItems = spriteVariableOptions.map(variable => [variable.name, variable.id]);
                 return spriteOptions.concat(spriteVariableMenuItems);
             }
             return [['', '']];


### PR DESCRIPTION
### Resolves

- Resolves #5488 

### Proposed Changes

This PR changes `sensing_of` so that instead of building a list of variables as `[variable, variable]` (which leads to there being a duplicate between a variable name and one of the pre-defined options (ex: volume) it uses `[variable.name, variable.id]` so there is no conflict. This allowed for the pre-defined value (ex: `volume`) and a user-made variable of the same name to not be checked at the same time.

### Reason for Changes

These changes allow for `sensing_of` to use variables that keep the same names as the pre-defined ones, such as `direction` and `volume`.

### Test Coverage

Manually tested, changes shown:
fixed:
![image](https://user-images.githubusercontent.com/14064434/77486798-0bcc8280-6e07-11ea-9cfe-3aa851103e30.png)
original:
![image](https://user-images.githubusercontent.com/14064434/77486860-30c0f580-6e07-11ea-8425-c52178e3700e.png)
The pre-defined `volume` returns `100` as expected, and the user-defined `volume` returns `100`, as defined.

### Browser Coverage

Mac
 * [x] Chrome 
 * [x] Firefox 

iPad
* [x] Safari