### PR TITLE
Make sprites wobbly when dragged

### DIFF
--- a/src/components/gui/gui.css
+++ b/src/components/gui/gui.css
@@ -33,6 +33,15 @@
     overflow-y: hidden;
 }
 
+.flex-wrapper.wobbly {
+    /*
+        Prevent horizontal scrollbar when drag canvas goes over the right edge of the screen
+        This is particularly apparent in "wobbly mode" because the canvas has some "slack space"
+        This may be a permanent fix, but for now gate it behind "wobbly mode" in case there are issues with it
+    */
+    overflow-x: hidden;
+}
+
 .editor-wrapper {
     flex-basis: 600px;
     flex-grow: 1;

--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -116,6 +116,7 @@ const GUIComponent = props => {
         telemetryModalVisible,
         tipsLibraryVisible,
         vm,
+        wobblyDragging,
         ...componentProps
     } = omit(props, 'dispatch');
     if (children) {
@@ -231,7 +232,7 @@ const GUIComponent = props => {
                     onToggleLoginOpen={onToggleLoginOpen}
                 />
                 <Box className={styles.bodyWrapper}>
-                    <Box className={styles.flexWrapper}>
+                    <Box className={classNames(styles.flexWrapper, {[styles.wobbly]: wobblyDragging})}>
                         <Box className={styles.editorWrapper}>
                             <Tabs
                                 forceRenderTabPanel
@@ -413,7 +414,8 @@ GUIComponent.propTypes = {
     targetIsStage: PropTypes.bool,
     telemetryModalVisible: PropTypes.bool,
     tipsLibraryVisible: PropTypes.bool,
-    vm: PropTypes.instanceOf(VM).isRequired
+    vm: PropTypes.instanceOf(VM).isRequired,
+    wobblyDragging: PropTypes.bool
 };
 GUIComponent.defaultProps = {
     backpackHost: null,
@@ -438,7 +440,8 @@ GUIComponent.defaultProps = {
 
 const mapStateToProps = state => ({
     // This is the button's mode, as opposed to the actual current state
-    stageSizeMode: state.scratchGui.stageSize.stageSize
+    stageSizeMode: state.scratchGui.stageSize.stageSize,
+    wobblyDragging: state.scratchGui.wobblyDragging
 });
 
 export default injectIntl(connect(

--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -33,6 +33,7 @@ import MenuBarHOC from '../../containers/menu-bar-hoc.jsx';
 import {openTipsLibrary} from '../../reducers/modals';
 import {setPlayer} from '../../reducers/mode';
 import {toggleMysteryMode} from '../../reducers/mystery-mode';
+import {toggleWobblyDragging} from '../../reducers/wobbly-dragging';
 import {
     autoUpdateProject,
     getIsUpdating,
@@ -485,6 +486,21 @@ class MenuBar extends React.Component {
                                             />
                                         )}
                                     </MenuItem>
+                                    <MenuItem onClick={this.props.onClickToggleWobblyDragging}>
+                                        {this.props.wobblyDragging ? (
+                                            <FormattedMessage
+                                                defaultMessage="Turn off wobbly sprite dragging"
+                                                description="Menu bar item for turning off wobbly sprite dragging"
+                                                id="gui.menuBar.wobblyDraggingOff"
+                                            />
+                                        ) : (
+                                            <FormattedMessage
+                                                defaultMessage="Turn on wobbly sprite dragging"
+                                                description="Menu bar item for turning on wobbly sprite dragging"
+                                                id="gui.menuBar.wobblyDraggingOn"
+                                            />
+                                        )}
+                                    </MenuItem>
                                 </MenuSection>
                             </MenuBarMenu>
                         </div>
@@ -750,6 +766,7 @@ MenuBar.propTypes = {
     onClickSave: PropTypes.func,
     onClickSaveAsCopy: PropTypes.func,
     onClickToggleMysteryMode: PropTypes.func,
+    onClickToggleWobblyDragging: PropTypes.func,
     onLogOut: PropTypes.func,
     onOpenRegistration: PropTypes.func,
     onOpenTipLibrary: PropTypes.func,
@@ -769,7 +786,8 @@ MenuBar.propTypes = {
     showComingSoon: PropTypes.bool,
     userOwnsProject: PropTypes.bool,
     username: PropTypes.string,
-    vm: PropTypes.instanceOf(VM).isRequired
+    vm: PropTypes.instanceOf(VM).isRequired,
+    wobblyDragging: PropTypes.bool
 };
 
 MenuBar.defaultProps = {
@@ -796,7 +814,8 @@ const mapStateToProps = (state, ownProps) => {
         username: user ? user.username : null,
         userOwnsProject: ownProps.authorUsername && user &&
             (ownProps.authorUsername === user.username),
-        vm: state.scratchGui.vm
+        vm: state.scratchGui.vm,
+        wobblyDragging: state.scratchGui.wobblyDragging
     };
 };
 
@@ -818,6 +837,7 @@ const mapDispatchToProps = dispatch => ({
     onClickSave: () => dispatch(manualUpdateProject()),
     onClickSaveAsCopy: () => dispatch(saveProjectAsCopy()),
     onClickToggleMysteryMode: () => dispatch(toggleMysteryMode()),
+    onClickToggleWobblyDragging: () => dispatch(toggleWobblyDragging()),
     onSeeCommunity: () => dispatch(setPlayer(true))
 });
 

--- a/src/components/stage/stage.jsx
+++ b/src/components/stage/stage.jsx
@@ -29,6 +29,8 @@ const StageComponent = props => {
         onDeactivateColorPicker,
         onDoubleClick,
         onQuestionAnswered,
+        wobblyDragging,
+        wobblyDragRef,
         ...boxProps
     } = props;
 
@@ -118,12 +120,23 @@ const StageComponent = props => {
                         </div>
                     )}
                 </div>
-                <canvas
-                    className={styles.draggingSprite}
-                    height={0}
-                    ref={dragRef}
-                    width={0}
-                />
+                {
+                    // Give the canvases two different keys to prevent React from recycling the same canvas
+                    // across two different context types (2D and WebGL)
+                    wobblyDragging ? <canvas
+                        className={styles.draggingSprite}
+                        height={0}
+                        ref={wobblyDragRef}
+                        width={0}
+                        key="non-wobbly"
+                    /> : <canvas
+                        className={styles.draggingSprite}
+                        height={0}
+                        ref={dragRef}
+                        width={0}
+                        key="wobbly"
+                    />
+                }
             </Box>
             {isColorPicking ? (
                 <Box
@@ -147,7 +160,9 @@ StageComponent.propTypes = {
     onQuestionAnswered: PropTypes.func,
     question: PropTypes.string,
     stageSize: PropTypes.oneOf(Object.keys(STAGE_DISPLAY_SIZES)).isRequired,
-    useEditorDragStyle: PropTypes.bool
+    useEditorDragStyle: PropTypes.bool,
+    wobblyDragging: PropTypes.bool,
+    wobblyDragRef: PropTypes.func
 };
 StageComponent.defaultProps = {
     dragRef: () => {}

--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -10,6 +10,7 @@ import {getEventXY} from '../lib/touch-utils';
 import VideoProvider from '../lib/video/video-provider';
 import {SVGRenderer as V2SVGAdapter} from 'scratch-svg-renderer';
 import {BitmapAdapter as V2BitmapAdapter} from 'scratch-svg-renderer';
+import RubberCanvas from '../lib/rubber-canvas';
 
 import StageComponent from '../components/stage/stage.jsx';
 
@@ -39,9 +40,11 @@ class Stage extends React.Component {
             'updateRect',
             'questionListener',
             'setDragCanvas',
+            'setWobblyDragCanvas',
             'clearDragCanvas',
             'drawDragCanvas',
-            'positionDragCanvas'
+            'positionDragCanvas',
+            '_updateWobblyCanvas'
         ]);
         this.state = {
             mouseDownTimeoutId: null,
@@ -93,7 +96,8 @@ class Stage extends React.Component {
             this.state.question !== nextState.question ||
             this.props.micIndicator !== nextProps.micIndicator ||
             this.props.isStarted !== nextProps.isStarted ||
-            this.props.mysteryMode !== nextProps.mysteryMode;
+            this.props.mysteryMode !== nextProps.mysteryMode ||
+            this.props.wobblyDragging !== nextProps.wobblyDragging;
     }
     componentDidUpdate (prevProps) {
         if (this.props.isColorPicking && !prevProps.isColorPicking) {
@@ -208,7 +212,11 @@ class Stage extends React.Component {
             // Editor drag style only updates the drag canvas, does full update at the end of drag
             // Non-editor drag style just updates the sprite continuously.
             if (this.props.useEditorDragStyle) {
-                this.positionDragCanvas(mousePosition[0], mousePosition[1]);
+                if (this.props.wobblyDragging) {
+                    this.wobblyDragCanvas.updateMousePosition(mousePosition);
+                } else {
+                    this.positionDragCanvas(mousePosition[0], mousePosition[1]);
+                }
             } else {
                 const spritePosition = this.getScratchCoords(mousePosition[0], mousePosition[1]);
                 this.props.vm.postSpriteInfo({
@@ -337,13 +345,18 @@ class Stage extends React.Component {
         this.dragCanvas.style.display = 'block';
     }
     clearDragCanvas () {
-        this.dragCanvas.width = this.dragCanvas.height = 0;
-        this.dragCanvas.style.display = 'none';
+        const dragCanvas = this.props.wobblyDragging ? this.wobblyDragCanvas._canvas : this.dragCanvas;
+        dragCanvas.width = dragCanvas.height = 0;
+        dragCanvas.style.display = 'none';
     }
     positionDragCanvas (mouseX, mouseY) {
         // mouseX/Y are relative to stage top/left, and dragCanvas is already
         // positioned so that the pick location is at (0,0).
         this.dragCanvas.style.transform = `translate(${mouseX}px, ${mouseY}px)`;
+    }
+    _updateWobblyCanvas (timestamp) {
+        this.wobblyDragCanvas.step(timestamp);
+        if (this.state.isDragging) window.requestAnimationFrame(this._updateWobblyCanvas);
     }
     onStartDrag (x, y) {
         if (this.state.dragId) return;
@@ -360,6 +373,8 @@ class Stage extends React.Component {
         // Dragging always brings the target to the front
         target.goToFront();
 
+        // Ensure drag canvas' bounds are tight by forcing renderer to generate tight bounds
+        this.renderer.getBounds(drawableId);
         // Extract the drawable art
         const drawableData = this.renderer.extractDrawable(drawableId, x, y);
 
@@ -368,10 +383,17 @@ class Stage extends React.Component {
             isDragging: true,
             dragId: targetId,
             dragOffset: drawableData.scratchOffset
+        }, () => {
+            if (this.props.wobblyDragging && this.props.useEditorDragStyle) this._updateWobblyCanvas(performance.now());
         });
         if (this.props.useEditorDragStyle) {
-            this.drawDragCanvas(drawableData);
-            this.positionDragCanvas(x, y);
+            if (this.props.wobblyDragging) {
+                this.wobblyDragCanvas.reinit(drawableData, x, y);
+            } else {
+                this.drawDragCanvas(drawableData);
+                this.positionDragCanvas(x, y);
+            }
+
             this.props.vm.postSpriteInfo({visible: false});
         }
     }
@@ -411,6 +433,13 @@ class Stage extends React.Component {
     setDragCanvas (canvas) {
         this.dragCanvas = canvas;
     }
+    setWobblyDragCanvas (canvas) {
+        if (this.wobblyDragCanvas) {
+            this.wobblyDragCanvas.destroy();
+            this.wobblyDragCanvas = null;
+        }
+        if (canvas) this.wobblyDragCanvas = new RubberCanvas(canvas);
+    }
     render () {
         const {
             vm, // eslint-disable-line no-unused-vars
@@ -425,6 +454,7 @@ class Stage extends React.Component {
                 question={this.state.question}
                 onDoubleClick={this.handleDoubleClick}
                 onQuestionAnswered={this.handleQuestionAnswered}
+                wobblyDragRef={this.setWobblyDragCanvas}
                 {...props}
             />
         );
@@ -441,7 +471,8 @@ Stage.propTypes = {
     stageSize: PropTypes.oneOf(Object.keys(STAGE_DISPLAY_SIZES)).isRequired,
     useEditorDragStyle: PropTypes.bool,
     vm: PropTypes.instanceOf(VM).isRequired,
-    mysteryMode: PropTypes.bool
+    mysteryMode: PropTypes.bool,
+    wobblyDragging: PropTypes.bool
 };
 
 Stage.defaultProps = {
@@ -456,7 +487,8 @@ const mapStateToProps = state => ({
     // Do not use editor drag style in fullscreen or player mode.
     useEditorDragStyle: !(state.scratchGui.mode.isFullScreen || state.scratchGui.mode.isPlayerOnly),
     mysteryMode: state.scratchGui.mysteryMode && !(
-        state.scratchGui.mode.isFullScreen || state.scratchGui.mode.isPlayerOnly)
+        state.scratchGui.mode.isFullScreen || state.scratchGui.mode.isPlayerOnly),
+    wobblyDragging: state.scratchGui.wobblyDragging
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/lib/rubber-canvas-frag.glsl
+++ b/src/lib/rubber-canvas-frag.glsl
@@ -1,0 +1,8 @@
+precision mediump float;
+
+uniform sampler2D u_image0;
+varying vec2 v_texCoord;
+
+void main () {
+	gl_FragColor = texture2D(u_image0, v_texCoord);
+}

--- a/src/lib/rubber-canvas-vert.glsl
+++ b/src/lib/rubber-canvas-vert.glsl
@@ -1,0 +1,15 @@
+precision mediump float;
+
+uniform vec4 u_bounds;
+attribute vec2 a_position;
+attribute vec2 a_texCoord;
+
+varying vec2 v_texCoord;
+
+void main () {
+	vec2 boundsSize = u_bounds.zw - u_bounds.xy;
+	vec2 adjusted = a_position - vec2(u_bounds.x, u_bounds.y);
+	vec4 pos = vec4(((adjusted / boundsSize) - 0.5) * vec2(2.0, -2.0), 0.0, 1.0);
+	v_texCoord = a_texCoord;
+	gl_Position = pos;
+}

--- a/src/lib/rubber-canvas.js
+++ b/src/lib/rubber-canvas.js
@@ -1,0 +1,354 @@
+import VERTEX_SOURCE from 'raw-loader!./rubber-canvas-vert.glsl';
+import FRAGMENT_SOURCE from 'raw-loader!./rubber-canvas-frag.glsl';
+
+const DAMPING = 20;
+class _Spring {
+    constructor (opts) {
+        this.reinit(opts);
+    }
+
+    reinit (opts) {
+        if (Object.prototype.hasOwnProperty.call(opts, 'stiffness')) this.stiffness = opts.stiffness;
+        if (Object.prototype.hasOwnProperty.call(opts, 'mass')) this.mass = opts.mass;
+        this.anchor = opts.anchor;
+        this.position = opts.anchor.slice(0);
+        this._velocity = [0, 0];
+    }
+
+    step (deltaTime) {
+        const springForceX = -this.stiffness * (this.position[0] - this.anchor[0]);
+        const springForceY = -this.stiffness * (this.position[1] - this.anchor[1]);
+
+        const dampingForceX = (DAMPING * this.mass) * this._velocity[0];
+        const dampingForceY = (DAMPING * this.mass) * this._velocity[1];
+
+        const forceX = springForceX - dampingForceX;
+        const forceY = springForceY - dampingForceY;
+
+        const accelerationX = forceX / this.mass;
+        const accelerationY = forceY / this.mass;
+
+        this._velocity[0] += accelerationX * deltaTime;
+        this._velocity[1] += accelerationY * deltaTime;
+
+        this.position[0] += this._velocity[0] * deltaTime;
+        this.position[1] += this._velocity[1] * deltaTime;
+    }
+}
+
+const createShader = (gl, source, type) => {
+    const shader = gl.createShader(type);
+    gl.shaderSource(shader, source);
+    gl.compileShader(shader);
+
+    if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+        const info = gl.getShaderInfoLog(shader);
+        throw new Error(`Could not compile WebGL program. \n${info}`);
+    }
+
+    return shader;
+};
+
+const createProgram = (gl, vertSource, fragSource) => {
+    const vertShader = createShader(gl, vertSource, gl.VERTEX_SHADER);
+    const fragShader = createShader(gl, fragSource, gl.FRAGMENT_SHADER);
+
+    const program = gl.createProgram();
+    gl.attachShader(program, vertShader);
+    gl.attachShader(program, fragShader);
+    gl.linkProgram(program);
+
+    const programInfo = {
+        uniforms: {},
+        attribs: {},
+        program
+    };
+
+    // Construct maps of uniform + attrib locations for convenience
+    const numActiveUniforms = gl.getProgramParameter(program, gl.ACTIVE_UNIFORMS);
+    for (let i = 0; i < numActiveUniforms; i++) {
+        const uniformInfo = gl.getActiveUniform(program, i);
+        programInfo.uniforms[uniformInfo.name] = gl.getUniformLocation(program, uniformInfo.name);
+    }
+
+    const numActiveAttributes = gl.getProgramParameter(program, gl.ACTIVE_ATTRIBUTES);
+    for (let i = 0; i < numActiveAttributes; i++) {
+        const attribInfo = gl.getActiveAttrib(program, i);
+        programInfo.attribs[attribInfo.name] = gl.getAttribLocation(program, attribInfo.name);
+    }
+
+    return programInfo;
+};
+
+// Resolution of the grid in terms of grid squares. In this case, that's 16 squares and 25 vertices.
+const SUBDIVISIONS = 4;
+
+class RubberCanvas {
+    constructor (canvas) {
+        this._canvas = canvas;
+        this._gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
+        this._size = [0, 0];
+        this._mousePosition = [0, 0];
+
+        const numPoints = (SUBDIVISIONS + 1) ** 2;
+        this._springs = [];
+        for (let i = 0; i < numPoints; i++) {
+            this._springs.push(new _Spring({
+                anchor: [0, 0],
+                position: [0, 0]
+            }));
+        }
+
+        this._vertexData = new Float32Array(numPoints * 2);
+        this._texCoordData = new Float32Array(numPoints * 2);
+        this._vertexIndices = new Uint16Array(numPoints * 6);
+
+        // Initialize texture coordinates for all grid points
+        for (let x = 0; x <= SUBDIVISIONS; x++) {
+            for (let y = 0; y <= SUBDIVISIONS; y++) {
+                const index = (y * (SUBDIVISIONS + 1)) + x;
+                this._texCoordData[index * 2] = x / SUBDIVISIONS;
+                this._texCoordData[(index * 2) + 1] = y / SUBDIVISIONS;
+            }
+        }
+
+        // Initialize vertex indices
+        for (let x = 0; x < SUBDIVISIONS; x++) {
+            for (let y = 0; y < SUBDIVISIONS; y++) {
+                const topLeftIndex = (y * (SUBDIVISIONS + 1)) + x;
+                const topRightIndex = (y * (SUBDIVISIONS + 1)) + x + 1;
+                const bottomLeftIndex = ((y + 1) * (SUBDIVISIONS + 1)) + x;
+                const bottomRightIndex = ((y + 1) * (SUBDIVISIONS + 1)) + x + 1;
+
+                this._vertexIndices[topLeftIndex * 6] = topLeftIndex;
+                this._vertexIndices[(topLeftIndex * 6) + 1] = topRightIndex;
+                this._vertexIndices[(topLeftIndex * 6) + 2] = bottomLeftIndex;
+
+                this._vertexIndices[(topLeftIndex * 6) + 3] = bottomLeftIndex;
+                this._vertexIndices[(topLeftIndex * 6) + 4] = topRightIndex;
+                this._vertexIndices[(topLeftIndex * 6) + 5] = bottomRightIndex;
+            }
+        }
+
+        // Used for delta-time calculation
+        this._lastTimestamp = 0;
+
+        const gl = this._gl;
+        this._shader = createProgram(gl, VERTEX_SOURCE, FRAGMENT_SOURCE);
+
+        this._vertexBuffer = gl.createBuffer();
+        this._indexBuffer = gl.createBuffer();
+        this._texCoordBuffer = gl.createBuffer();
+        gl.enableVertexAttribArray(this._shader.attribs.a_position);
+        gl.enableVertexAttribArray(this._shader.attribs.a_texCoord);
+
+        // The texture coordinates and vertex indices will never change, so send them over to the GPU here
+        gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this._indexBuffer);
+        gl.bufferData(
+            gl.ELEMENT_ARRAY_BUFFER,
+            this._vertexIndices,
+            gl.STATIC_DRAW
+        );
+
+        gl.bindBuffer(gl.ARRAY_BUFFER, this._texCoordBuffer);
+        gl.vertexAttribPointer(
+            this._shader.attribs.a_texCoord,
+            2, // vec2
+            gl.FLOAT,
+            false,
+            0,
+            0
+        );
+        gl.bufferData(
+            gl.ARRAY_BUFFER,
+            this._texCoordData,
+            gl.STATIC_DRAW
+        );
+
+        gl.activeTexture(gl.TEXTURE0);
+        this._texture = gl.createTexture();
+
+        // This will be correct if https://github.com/LLK/scratch-render/pull/556 goes in in time
+        gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, true);
+    }
+
+    reinit (drawableData, x, y) {
+        const {
+            width,
+            height,
+            x: grabX,
+            y: grabY
+        } = drawableData;
+
+        this._setData(drawableData);
+
+        // Reinitialize springs' mass based on their distance to the point at which the sprite was grabbed
+        for (let i = 0; i <= SUBDIVISIONS; i++) {
+            const springX = (i / SUBDIVISIONS) * width;
+
+            for (let j = 0; j <= SUBDIVISIONS; j++) {
+                const springY = (j / SUBDIVISIONS) * height;
+
+                const distance = Math.hypot(springX - grabX, springY - grabY);
+                const distanceScaled = distance / Math.hypot(width, height);
+                this._springs[(j * (SUBDIVISIONS + 1)) + i].reinit({
+                    anchor: [springX + x, springY + y],
+                    position: [springX + x, springY + y],
+                    stiffness: 15,
+                    mass: (distanceScaled * 0.05) + 0.025
+                });
+            }
+        }
+
+        this._lastTimestamp = performance.now();
+        this._canvas.style.left = `${-grabX}px`;
+        this._canvas.style.top = `${-grabY}px`;
+        this._canvas.style.display = 'block';
+        this.step();
+    }
+
+    // Calculate the bounds of the dragged sprite after being jellofied.
+    _calculateBounds () {
+        let left = Infinity;
+        let right = -Infinity;
+        let top = Infinity;
+        let bottom = -Infinity;
+
+        for (const spring of this._springs) {
+            left = Math.min(left, spring.position[0]);
+            right = Math.max(right, spring.position[0]);
+            top = Math.min(top, spring.position[1]);
+            bottom = Math.max(bottom, spring.position[1]);
+        }
+
+        left = Math.floor(left);
+        right = Math.ceil(right);
+        bottom = Math.ceil(bottom);
+        top = Math.floor(top);
+
+        return {left, right, top, bottom};
+    }
+
+    _setData (data) {
+        this._size[0] = data.width;
+        this._size[1] = data.height;
+
+        const gl = this._gl;
+
+        gl.bindTexture(gl.TEXTURE_2D, this._texture);
+        // disable automatic mipmapping
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, data.width, data.height, 0, gl.RGBA, gl.UNSIGNED_BYTE, data.data);
+    }
+
+    updateMousePosition ([x, y]) {
+        this._mousePosition[0] = x;
+        this._mousePosition[1] = y;
+
+        // update springs' destinations to match new mouse position
+        for (let i = 0; i <= SUBDIVISIONS; i++) {
+            const springX = (i / SUBDIVISIONS) * this._size[0];
+
+            for (let j = 0; j <= SUBDIVISIONS; j++) {
+                const springY = (j / SUBDIVISIONS) * this._size[1];
+
+                this._springs[(j * (SUBDIVISIONS + 1)) + i].anchor[0] = springX + x;
+                this._springs[(j * (SUBDIVISIONS + 1)) + i].anchor[1] = springY + y;
+            }
+        }
+    }
+
+    step (timestamp) {
+        // Slightly above 33.3ms (30 FPS)
+        const maxTimeStep = 35;
+
+        let deltaTime = timestamp - this._lastTimestamp;
+
+        // Take multiple steps if deltaTime is too large
+        // This prevents explodage
+        let timeSubdivisions = 1;
+        if (deltaTime > maxTimeStep) {
+            timeSubdivisions = Math.ceil(deltaTime / maxTimeStep);
+            deltaTime /= timeSubdivisions;
+        }
+        this._lastTimestamp = timestamp;
+        if (deltaTime > 0) {
+            for (let i = 0; i < timeSubdivisions; i++) {
+                for (const spring of this._springs) {
+                    // I've got a step() in my _Spring
+                    spring.step(deltaTime / 1000);
+                }
+            }
+        }
+
+        // Update vertex data to match springs' positions
+        for (let i = 0; i < this._springs.length; i++) {
+            const spring = this._springs[i];
+            this._vertexData[i * 2] = spring.position[0];
+            this._vertexData[(i * 2) + 1] = spring.position[1];
+        }
+
+        const gl = this._gl;
+        gl.bindBuffer(gl.ARRAY_BUFFER, this._vertexBuffer);
+        gl.vertexAttribPointer(
+            this._shader.attribs.a_position,
+            2, // vec2
+            gl.FLOAT,
+            false,
+            0,
+            0
+        );
+        gl.bufferData(
+            gl.ARRAY_BUFFER,
+            this._vertexData,
+            gl.DYNAMIC_DRAW
+        );
+
+        const bounds = this._calculateBounds();
+
+        // 10 pixels of slack space to avoid excessive canvas resizing
+        bounds.right += 10;
+        bounds.bottom += 10;
+
+        // Only scale the canvas up, not down-- this also avoids resizing the canvas too much
+        if (bounds.right - bounds.left < this._canvas.width) bounds.right = bounds.left + this._canvas.width;
+        if (bounds.bottom - bounds.top < this._canvas.height) bounds.bottom = bounds.top + this._canvas.height;
+
+        const width = bounds.right - bounds.left;
+        const height = bounds.bottom - bounds.top;
+
+        if (width > 2048 || height > 2048) {
+            // Avoid creating lag spikes from a huge WebGL canvas if the spring simulation blows up
+            return;
+        }
+        this._canvas.width = width;
+        this._canvas.height = height;
+
+        gl.useProgram(this._shader.program);
+        gl.uniform1i(this._shader.uniforms.u_image0, 0);
+        gl.uniform4f(this._shader.uniforms.u_bounds, bounds.left, bounds.top, bounds.right, bounds.bottom);
+
+        gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+        gl.bindTexture(gl.TEXTURE_2D, this._texture);
+
+        gl.viewport(0, 0, width, height);
+        gl.drawElements(gl.TRIANGLES, this._vertexIndices.length, gl.UNSIGNED_SHORT, 0);
+
+        this._canvas.style.transform = `translate(${bounds.left}px, ${bounds.top}px)`;
+    }
+
+    destroy () {
+        const gl = this._gl;
+
+        gl.deleteBuffer(this._texCoordBuffer);
+        gl.deleteBuffer(this._vertexBuffer);
+        gl.deleteBuffer(this._indexBuffer);
+        gl.deleteTexture(this._texture);
+        gl.deleteProgram(this._shader.program);
+    }
+}
+
+export default RubberCanvas;

--- a/src/reducers/gui.js
+++ b/src/reducers/gui.js
@@ -15,6 +15,7 @@ import modeReducer, {modeInitialState} from './mode';
 import monitorReducer, {monitorsInitialState} from './monitors';
 import monitorLayoutReducer, {monitorLayoutInitialState} from './monitor-layout';
 import mysteryModeReducer, {mysteryModeInitialState} from './mystery-mode';
+import wobblyDragReducer, {wobblyDragInitialState} from './wobbly-dragging';
 import projectChangedReducer, {projectChangedInitialState} from './project-changed';
 import projectStateReducer, {projectStateInitialState} from './project-state';
 import projectTitleReducer, {projectTitleInitialState} from './project-title';
@@ -59,7 +60,8 @@ const guiInitialState = {
     timeout: timeoutInitialState,
     toolbox: toolboxInitialState,
     vm: vmInitialState,
-    vmStatus: vmStatusInitialState
+    vmStatus: vmStatusInitialState,
+    wobblyDragging: wobblyDragInitialState
 };
 
 const initPlayer = function (currentState) {
@@ -158,7 +160,8 @@ const guiReducer = combineReducers({
     timeout: timeoutReducer,
     toolbox: toolboxReducer,
     vm: vmReducer,
-    vmStatus: vmStatusReducer
+    vmStatus: vmStatusReducer,
+    wobblyDragging: wobblyDragReducer
 });
 
 export {

--- a/src/reducers/wobbly-dragging.js
+++ b/src/reducers/wobbly-dragging.js
@@ -1,0 +1,26 @@
+const TOGGLE_WOBBLE = 'scratch-gui/mystery-mode/TOGGLE_WOBBLE';
+
+const initialState = true;
+
+const reducer = function (state, action) {
+    if (typeof state === 'undefined') state = initialState;
+
+    switch (action.type) {
+    case TOGGLE_WOBBLE:
+        return !state;
+    default:
+        return state;
+    }
+};
+
+const toggleWobblyDragging = function () {
+    return {
+        type: TOGGLE_WOBBLE
+    };
+};
+
+export {
+    reducer as default,
+    initialState as wobblyDragInitialState,
+    toggleWobblyDragging
+};


### PR DESCRIPTION
### Proposed Changes

Since 2006, Linux users have been enjoying wobbly windows through the [Compiz compositing window manager](https://www.youtube.com/watch?v=USedxVrU2Ko).

As I was once a Compiz user myself, I was surprised to find this vital\* and extremely useful\* behavior has been missing from Scratch for its entire existence!

As such, I have decided to implement this feature\* in Scratch:

![Peek 2020-03-27 09-18](https://user-images.githubusercontent.com/25993062/77759895-e197e200-700b-11ea-998e-a155af619d83.gif)

### Reason for Changes

This should greatly\* increase\* the productivity of the average Scratcher.\*

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Linux
* [x] Chrome
* [x] Firefox

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [x] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome

My Android Phone
* [x] Firefox
* [x] Chrome

\* *These statements have not been evaluated by the Food and Drug Administration.*