### PR TITLE
Redraw stage on fullscreen

### DIFF
--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -95,9 +95,7 @@ class Stage extends React.Component {
         }
         this.updateRect();
         this.renderer.resize(this.rect.width, this.rect.height);
-        if (this.props.isFullScreen !== prevProps.isFullScreen ||
-            this.props.stageSize !== prevProps.stageSize ||
-            this.props.isPlayerOnly !== prevProps.isPlayerOnly) {
+        if (this.props.isFullScreen !== prevProps.isFullScreen) {
             // Re-draw the stage so that it fits the screen LLK/scratch-www#2721
             this.renderer.draw();
         }
@@ -429,7 +427,6 @@ class Stage extends React.Component {
 Stage.propTypes = {
     isColorPicking: PropTypes.bool,
     isFullScreen: PropTypes.bool.isRequired,
-    isPlayerOnly: PropTypes.bool,
     isStarted: PropTypes.bool,
     micIndicator: PropTypes.bool,
     onActivateColorPicker: PropTypes.func,
@@ -446,7 +443,6 @@ Stage.defaultProps = {
 const mapStateToProps = state => ({
     isColorPicking: state.scratchGui.colorPicker.active,
     isFullScreen: state.scratchGui.mode.isFullScreen,
-    isPlayerOnly: state.scratchGui.mode.isPlayerOnly,
     isStarted: state.scratchGui.vmStatus.started,
     micIndicator: state.scratchGui.micIndicator,
     // Do not use editor drag style in fullscreen or player mode.

--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -95,6 +95,10 @@ class Stage extends React.Component {
         }
         this.updateRect();
         this.renderer.resize(this.rect.width, this.rect.height);
+        if (this.props.isFullScreen !== prevProps.isFullScreen) {
+            // Re-draw the stage so that it fits the screen LLK/scratch-www#2721
+            this.props.vm.renderer.draw();
+        }
     }
     componentWillUnmount () {
         this.detachMouseEvents(this.canvas);

--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -95,9 +95,11 @@ class Stage extends React.Component {
         }
         this.updateRect();
         this.renderer.resize(this.rect.width, this.rect.height);
-        if (this.props.isFullScreen !== prevProps.isFullScreen) {
+        if (this.props.isFullScreen !== prevProps.isFullScreen ||
+            this.props.stageSize !== prevProps.stageSize ||
+            this.props.isPlayerOnly !== prevProps.isPlayerOnly) {
             // Re-draw the stage so that it fits the screen LLK/scratch-www#2721
-            this.props.vm.renderer.draw();
+            this.renderer.draw();
         }
     }
     componentWillUnmount () {
@@ -427,6 +429,7 @@ class Stage extends React.Component {
 Stage.propTypes = {
     isColorPicking: PropTypes.bool,
     isFullScreen: PropTypes.bool.isRequired,
+    isPlayerOnly: PropTypes.bool,
     isStarted: PropTypes.bool,
     micIndicator: PropTypes.bool,
     onActivateColorPicker: PropTypes.func,
@@ -443,6 +446,7 @@ Stage.defaultProps = {
 const mapStateToProps = state => ({
     isColorPicking: state.scratchGui.colorPicker.active,
     isFullScreen: state.scratchGui.mode.isFullScreen,
+    isPlayerOnly: state.scratchGui.mode.isPlayerOnly,
     isStarted: state.scratchGui.vmStatus.started,
     micIndicator: state.scratchGui.micIndicator,
     // Do not use editor drag style in fullscreen or player mode.


### PR DESCRIPTION
### Resolves
Resolves LLK/scratch-www#2721

### Proposed Changes
Re-draws the stage when fullscreen state is changed

### Reason for Changes
Without redrawing, it seemed like the canvas was still in the old size, and other area was transparent.

### Test Coverage
Manual testing: https://scratch.mit.edu/projects/357736772/fullscreen/
![image](https://user-images.githubusercontent.com/33279053/77934779-89066480-72eb-11ea-9e60-06b8559f0154.png)
