### PR TITLE
Fix wobbly dragging in Edge

### DIFF
--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -76,8 +76,6 @@ import scratchLogo from './scratch-logo.svg';
 
 import sharedMessages from '../../lib/shared-messages';
 
-const isEdge = bowser.msedge;
-
 const ariaMessages = defineMessages({
     language: {
         id: 'gui.menuBar.LanguageSelector',
@@ -488,23 +486,21 @@ class MenuBar extends React.Component {
                                             />
                                         )}
                                     </MenuItem>
-                                    {isEdge ? null : (
-                                        <MenuItem onClick={this.props.onClickToggleWobblyDragging}>
-                                            {this.props.wobblyDragging ? (
-                                                <FormattedMessage
-                                                    defaultMessage="Turn off wobbly sprite dragging"
-                                                    description="Menu bar item for turning off wobbly sprite dragging"
-                                                    id="gui.menuBar.wobblyDraggingOff"
-                                                />
-                                            ) : (
-                                                <FormattedMessage
-                                                    defaultMessage="Turn on wobbly sprite dragging"
-                                                    description="Menu bar item for turning on wobbly sprite dragging"
-                                                    id="gui.menuBar.wobblyDraggingOn"
-                                                />
-                                            )}
-                                        </MenuItem>
-                                    )}
+                                    <MenuItem onClick={this.props.onClickToggleWobblyDragging}>
+                                        {this.props.wobblyDragging ? (
+                                            <FormattedMessage
+                                                defaultMessage="Turn off wobbly sprite dragging"
+                                                description="Menu bar item for turning off wobbly sprite dragging"
+                                                id="gui.menuBar.wobblyDraggingOff"
+                                            />
+                                        ) : (
+                                            <FormattedMessage
+                                                defaultMessage="Turn on wobbly sprite dragging"
+                                                description="Menu bar item for turning on wobbly sprite dragging"
+                                                id="gui.menuBar.wobblyDraggingOn"
+                                            />
+                                        )}
+                                    </MenuItem>
                                 </MenuSection>
                             </MenuBarMenu>
                         </div>

--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -11,6 +11,7 @@ import VideoProvider from '../lib/video/video-provider';
 import {SVGRenderer as V2SVGAdapter} from 'scratch-svg-renderer';
 import {BitmapAdapter as V2BitmapAdapter} from 'scratch-svg-renderer';
 import RubberCanvas from '../lib/rubber-canvas';
+import {toggleWobblyDragging} from '../reducers/wobbly-dragging';
 
 import StageComponent from '../components/stage/stage.jsx';
 
@@ -438,7 +439,17 @@ class Stage extends React.Component {
             this.wobblyDragCanvas.destroy();
             this.wobblyDragCanvas = null;
         }
-        if (canvas) this.wobblyDragCanvas = new RubberCanvas(canvas);
+
+        // Where could these errors come from?
+        // Where would these errors go?
+        // When will this catch block run?
+        // Nobody knows.
+        try {
+            if (canvas) this.wobblyDragCanvas = new RubberCanvas(canvas);
+        } catch (err) {
+            this.props.onToggleWobblyDragging();
+        }
+
     }
     render () {
         const {
@@ -468,6 +479,7 @@ Stage.propTypes = {
     micIndicator: PropTypes.bool,
     onActivateColorPicker: PropTypes.func,
     onDeactivateColorPicker: PropTypes.func,
+    onToggleWobblyDragging: PropTypes.func,
     stageSize: PropTypes.oneOf(Object.keys(STAGE_DISPLAY_SIZES)).isRequired,
     useEditorDragStyle: PropTypes.bool,
     vm: PropTypes.instanceOf(VM).isRequired,
@@ -493,7 +505,8 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
     onActivateColorPicker: () => dispatch(activateColorPicker()),
-    onDeactivateColorPicker: color => dispatch(deactivateColorPicker(color))
+    onDeactivateColorPicker: color => dispatch(deactivateColorPicker(color)),
+    onToggleWobblyDragging: () => dispatch(toggleWobblyDragging())
 });
 
 export default connect(

--- a/src/lib/rubber-canvas.js
+++ b/src/lib/rubber-canvas.js
@@ -203,7 +203,7 @@ class RubberCanvas {
         }
 
         this._lastTimestamp = performance.now();
-        const {x: parentX, y: parentY} = this._canvas.parentElement.getBoundingClientRect();
+        const {left: parentX, top: parentY} = this._canvas.parentElement.getBoundingClientRect();
         this._canvas.style.left = `${-grabX + parentX}px`;
         this._canvas.style.top = `${-grabY + parentY}px`;
         this._canvas.style.display = 'block';

--- a/src/reducers/wobbly-dragging.js
+++ b/src/reducers/wobbly-dragging.js
@@ -1,6 +1,6 @@
 const TOGGLE_WOBBLE = 'scratch-gui/mystery-mode/TOGGLE_WOBBLE';
 
-const initialState = false;
+const initialState = true;
 
 const reducer = function (state, action) {
     if (typeof state === 'undefined') state = initialState;


### PR DESCRIPTION
Let me know if you don't want to merge this or enable wobbles by default; I understand if this "feature" has become a bit of a chore.

Edge's `getBoundingClientRect` doesn't return a rectangle with `x` or `y`, but it does have `left` and `top`, so use those when positioning the drag canvas.