### PR TITLE
fix costume animation in sprite library

### DIFF
--- a/src/components/library/library.jsx
+++ b/src/components/library/library.jsx
@@ -60,8 +60,15 @@ const getItemImageSource = function (item) {
         };
     }
 
-    // TODO: adjust libraries to be more storage-friendly; don't use split() here.
-    const md5ext = item.md5 || item.baseLayerMD5;
+    if (item.assetId && item.dataFormat) {
+        return {
+            assetId: item.assetId,
+            assetType: getAssetTypeForFileExtension(item.dataFormat)
+        };
+    }
+
+    // legacy
+    const md5ext = item.md5ext || item.md5 || item.baseLayerMD5;
     if (md5ext) {
         const [assetId, fileExtension] = md5ext.split('.');
         return {

--- a/src/components/scratch-image/scratch-image.jsx
+++ b/src/components/scratch-image/scratch-image.jsx
@@ -94,7 +94,6 @@ class ScratchImage extends React.PureComponent {
     }
     render () {
         const {
-            src: _src,
             imageSource: _imageSource,
             ...imgProps
         } = this.props;
@@ -109,8 +108,8 @@ class ScratchImage extends React.PureComponent {
                         ScratchImage.loadPendingImages();
                         return (
                             <img
-                                src={this.state.imageURI}
-                                {...imgProps}
+                                {...imgProps} // do this first in case it contains `src`
+                                src={this.state.imageURI} // overrides imgProps.src if present
                             />
                         );
                     }

--- a/src/containers/library-item.jsx
+++ b/src/containers/library-item.jsx
@@ -21,7 +21,6 @@ class LibraryItem extends React.PureComponent {
             'startRotatingIcons',
             'stopRotatingIcons'
         ]);
-        // TODO: is there a better "is it an array?" check to use here?
         this.hasIconsArray = Array.isArray(props.icons);
         this.state = {
             iconIndex: 0,

--- a/src/containers/library-item.jsx
+++ b/src/containers/library-item.jsx
@@ -21,6 +21,8 @@ class LibraryItem extends React.PureComponent {
             'startRotatingIcons',
             'stopRotatingIcons'
         ]);
+        // TODO: is there a better "is it an array?" check to use here?
+        this.hasIconsArray = props.icons.hasOwnProperty('length');
         this.state = {
             iconIndex: 0,
             isRotatingIcon: false
@@ -53,7 +55,7 @@ class LibraryItem extends React.PureComponent {
         // only show hover effects on the item if not showing a play button
         if (!this.props.showPlayButton) {
             this.props.onMouseEnter(this.props.id);
-            if (this.props.icons && this.props.icons.length) {
+            if (this.hasIconsArray) {
                 this.stopRotatingIcons();
                 this.setState({
                     isRotatingIcon: true
@@ -65,7 +67,7 @@ class LibraryItem extends React.PureComponent {
         // only show hover effects on the item if not showing a play button
         if (!this.props.showPlayButton) {
             this.props.onMouseLeave(this.props.id);
-            if (this.props.icons && this.props.icons.length) {
+            if (this.hasIconsArray) {
                 this.setState({
                     isRotatingIcon: false
                 }, this.stopRotatingIcons);
@@ -92,13 +94,18 @@ class LibraryItem extends React.PureComponent {
         this.setState({iconIndex: nextIconIndex});
     }
     curIconSource () {
-        if (this.props.icons &&
-            this.state.isRotatingIcon &&
-            this.state.iconIndex < this.props.icons.length &&
-            this.props.icons[this.state.iconIndex]) {
-            return this.props.icons[this.state.iconIndex];
+        if (this.hasIconsArray) {
+            if (this.state.isRotatingIcon &&
+                this.state.iconIndex < this.props.icons.length &&
+                this.props.icons[this.state.iconIndex]) {
+                // multiple icons, currently animating: show current frame
+                return this.props.icons[this.state.iconIndex];
+            }
+            // multiple icons, not currently animating: show first frame
+            return this.props.icons[0];
         }
-        return this.props.iconSource;
+        // single icon
+        return this.props.icons;
     }
     render () {
         const iconSource = this.curIconSource();
@@ -142,8 +149,10 @@ LibraryItem.propTypes = {
     extensionId: PropTypes.string,
     featured: PropTypes.bool,
     hidden: PropTypes.bool,
-    iconSource: LibraryItemComponent.propTypes.iconSource, // single icon
-    icons: PropTypes.arrayOf(LibraryItemComponent.propTypes.iconSource), // rotating icons
+    icons: PropTypes.oneOfType([
+        LibraryItemComponent.propTypes.iconSource, // single icon
+        PropTypes.arrayOf(LibraryItemComponent.propTypes.iconSource) // rotating icons
+    ]),
     id: PropTypes.number.isRequired,
     insetIconURL: PropTypes.string,
     internetConnectionRequired: PropTypes.bool,

--- a/src/containers/library-item.jsx
+++ b/src/containers/library-item.jsx
@@ -22,7 +22,7 @@ class LibraryItem extends React.PureComponent {
             'stopRotatingIcons'
         ]);
         // TODO: is there a better "is it an array?" check to use here?
-        this.hasIconsArray = props.icons.hasOwnProperty('length');
+        this.hasIconsArray = Array.isArray(props.icons);
         this.state = {
             iconIndex: 0,
             isRotatingIcon: false


### PR DESCRIPTION
### Resolves

Resolves a problem specific to the scratch-desktop branch in which the library icons for sprites would not correctly animate even in the presence of multiple costumes.

### Proposed Changes

Two changes:
- if a library item (or sub-item) contains both `assetId` and `dataFormat` properties, use those to determine the icon. Prefer that over options which require splitting on `.`
- if a library item (or sub-item) has a property called `md5ext` use that (higher priority than existing code which used `md5` or `baseLayerMD5`).

### Reason for Changes

An animated library item may now have `assetId` and `dataFormat` properties. The new library generation code provides these properties and they align better to the way `scratch-storage` works.

Also, a library item may now contain a property called `md5ext`, which is just a renamed version of the old `md5` property. We are trying to encourage `md5ext` rather than just `md5` to describe a property or variable which contains both the MD5 hash and the file extension, just so that the code is more self-documenting.

### Test Coverage

Tested by hand:
1. Open Scratch Desktop
2. Click "Choose a Sprite"
3. Hover over "Bear-walking"

Expected: the "Bear-walking" library item shows the bear's walking animation.

Also tested:
- Loading a sprite, costume, or sound still works as intended.
- Playing sounds in the sound library works as intended.