### PR TITLE
Add opcode to monitor id

### DIFF
--- a/src/components/monitor/monitor.jsx
+++ b/src/components/monitor/monitor.jsx
@@ -34,7 +34,7 @@ const MonitorComponent = props => (
     <ContextMenuTrigger
         disable={!props.draggable}
         holdToDisplay={props.mode === 'slider' ? -1 : 1000}
-        id={`monitor-${props.label}`}
+        id={`monitor-${props.label}-${props.opcode}`}
     >
         <Draggable
             bounds=".monitor-overlay" // Class for monitor container
@@ -59,7 +59,7 @@ const MonitorComponent = props => (
             // positioning conflicts between the monitors `transform: scale` and
             // the context menus `position: fixed`. For more details, see
             // http://meyerweb.com/eric/thoughts/2011/09/12/un-fixing-fixed-elements-with-css-transforms/
-            <ContextMenu id={`monitor-${props.label}`}>
+            <ContextMenu id={`monitor-${props.label}-${props.opcode}`}>
                 {props.onSetModeToDefault &&
                     <MenuItem onClick={props.onSetModeToDefault}>
                         <FormattedMessage
@@ -124,6 +124,7 @@ MonitorComponent.propTypes = {
     draggable: PropTypes.bool.isRequired,
     label: PropTypes.string.isRequired,
     mode: PropTypes.oneOf(monitorModes),
+    opcode: PropTypes.string,
     onDragEnd: PropTypes.func.isRequired,
     onExport: PropTypes.func,
     onImport: PropTypes.func,
@@ -136,7 +137,8 @@ MonitorComponent.propTypes = {
 
 MonitorComponent.defaultProps = {
     category: 'extension',
-    mode: 'default'
+    mode: 'default',
+    opcode: ''
 };
 
 export {

--- a/src/containers/monitor.jsx
+++ b/src/containers/monitor.jsx
@@ -205,6 +205,7 @@ class Monitor extends React.Component {
                     max={this.props.max}
                     min={this.props.min}
                     mode={this.props.mode}
+                    opcode={this.props.opcode}
                     targetId={this.props.targetId}
                     width={this.props.width}
                     onDragEnd={this.handleDragEnd}


### PR DESCRIPTION
### Resolves
Resolves #5636 

### Proposed Changes
Adds opcode to the monitor id
- there is currently one situation where there are same opcodes; variables, lists and sprite attrs.
- variables cant share names with themselves, so it's fine
- for sprite attrs, label should include sprite name
### Reason for Changes
Previously, if the label was same, the monitor had same ID, which caused some weird context menu.

### Test Coverage
manually tested