### PR TITLE
Omit componentRef from DropAreaHOC's passed props

### DIFF
--- a/src/lib/drop-area-hoc.jsx
+++ b/src/lib/drop-area-hoc.jsx
@@ -78,7 +78,7 @@ const DropAreaHOC = function (dragTypes) {
                 }
             }
             render () {
-                const componentProps = omit(this.props, ['onDrop', 'dragInfo']);
+                const componentProps = omit(this.props, ['onDrop', 'dragInfo', 'componentRef']);
                 return (
                     <WrappedComponent
                         containerRef={this.setRef}


### PR DESCRIPTION
### Resolves

Resolves #5642

### Proposed Changes

This PR omits `componentRef` from the props that `DropAreaHOC` passes into its wrapped component.

### Reason for Changes

If `DropAreaHOC` passes the `componentRef` prop into its wrapped component, this could potentially "clobber" alternative values of `componentRef` if the wrapped component is not expected to have a `componentRef` property.

This happened in the `StageSelector` component, [which sets the `componentRef` of its child `Box` component and *then* sets all of the `Box`'s remaining props to its own props](https://github.com/LLK/scratch-gui/blob/f7853a935400464f8097d8c9815108cfc6a41510/src/components/stage-selector/stage-selector.jsx#L72). Because the wrapped `StageSelector` gained a `componentRef` prop out of nowhere, it was overwriting the `Box`'s `componentRef`, breaking the `DropAreaHOC`'s functionality and making it impossible to drag and drop anything onto the stage selector.

### Test Coverage

Not sure what the best way to test dragging is.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Linux
* [x] Firefox
* [x] Chrome

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [x] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome

### Test Plan
  - Description: Omit the `componentRef` React prop from the props passed into the component that the DropAreaHOC wraps
  - Ensure that all existing uses of the DropAreaHOC are not broken
    - Test dragging and dropping into the backpack
      - Scripts
      - Costumes
      - Sounds
      - Sprites
    - Test dragging scripts from the backpack onto the scripts area
  - Ensure that items can now be dragged and dropped onto the stage selector (to the right of the sprite pane)
    - Scripts
      - From backpack and the scripts area
    - Costumes
      - From backpack and the costumes tab of another sprite
    - Sounds
      - From backpack and the sounds tab of another sprites
  - Be aware of existing behavior
    - You can drag a costume or sound from a target onto that same target, and it will duplicate it. Based on [this comment](https://github.com/LLK/scratch-gui/blob/develop/src/containers/target-pane.jsx#L174-L179), this behavior is intentional.
    - On Legacy Edge, the hover animation when you drag something onto the stage selector is broken. That bug was exposed by this PR but, as far as I can tell, is not related.
