### PR TITLE
Remove box-sizing: content-box from sprite highlight box CSS

### DIFF
--- a/src/components/stage/stage.css
+++ b/src/components/stage/stage.css
@@ -133,7 +133,6 @@ to adjust for the border using a different method */
 }
 
 .frame {
-    box-sizing: content-box !important;
     background: $motion-transparent;
     border: 2px solid $motion-primary;
     border-radius: 0.5rem;


### PR DESCRIPTION
### Resolves

Resolves #5703

### Proposed Changes

This PR removes the `box-sizing: content-box !important;` CSS rule from the blue box that appears around sprites when they are clicked.

### Reason for Changes

`box-sizing: content-box` means that the `width` and `height` of an element will *not* include that element's border. The default used in scratch-gui, `box-sizing: border-box`, *does* include that element's border in the width and height.

The `target-highlight.jsx` code [already includes the blue box's border when calculating its width and height](https://github.com/LLK/scratch-gui/blob/develop/src/containers/target-highlight.jsx#L54-L55), so by setting `box-sizing` to `content-box`, we are adding the border size twice: once in `target-highlight.jsx` and once in the CSS. This makes the box appear 4 pixels too large in each dimension.

### Test Coverage

Tested manually

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Linux
* [x] Firefox
* [x] Chrome

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [x] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome

### Test Plan
  - Description: Remove the `box-sizing: content-box` CSS rule from the element for the box that flashes over a sprite when you click it in the sprite pane
  - Ensure that the sprite highlight box now fits within a pixel or two around sprites-- you can rapidly click on a sprite's icon in the sprite pane many times in succession to keep the highlight box visible for longer
  - [Test project](https://scratch.mit.edu/projects/392286926/)?
    - Test across layout engines:
      - Firefox
      - Chrome
      - Safari
      - Legacy Edge
    - Test across a variety of devices:
      - Low-DPI computer
      - High-DPI computer
      - Tablet and/or phone
    - Test in normal stage mode, small stage mode, and "smallish stage mode" (a 306x408 stage size activated when the browser window becomes small enough)
