### PR TITLE
Fix sprite tile highlight color on Edge

### DIFF
--- a/src/css/colors.css
+++ b/src/css/colors.css
@@ -41,4 +41,4 @@ $extensions-tertiary: hsla(163, 85%, 30%, 1); /* #0B8E69 */
 $extensions-transparent: hsla(163, 85%, 40%, 0.35); /* 35% transparent version of extensions-primary */
 $extensions-light: hsla(163, 57%, 85%, 1); /* opaque version of extensions-transparent, on white bg */
 
-$drop-highlight: hsla(215, 100%, 77%); /* lighter than motion-primary */
+$drop-highlight: hsla(215, 100%, 77%, 1); /* lighter than motion-primary */


### PR DESCRIPTION
### Resolves

- Resolves #5734

### Proposed Changes

This PR adds an alpha value of 1 to the CSS `hsla()` color used for highlighted sprite pane tiles.

### Reason for Changes

Edge can't parse `hsla()` color values without an alpha value.

### Test Coverage

Tested manually

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Linux
 * [x] Firefox

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [x] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome

### Test plan
- Add more sprites and test that when you drag assets and blocks over the sprite pane, those sprites' tiles:
  - Now turn blue on Edge
  - Still turn blue on other browsers