### PR TITLE
wip: show specific alerts when saving fails

### DIFF
--- a/src/components/alerts/alerts.jsx
+++ b/src/components/alerts/alerts.jsx
@@ -18,6 +18,7 @@ const AlertsComponent = ({
         <Box className={styles.alertsInnerContainer} >
             {alertsList.map((a, index) => (
                 <Alert
+                    assetName={a.assetName}
                     closeButton={a.closeButton}
                     content={a.content}
                     extensionId={a.extensionId}

--- a/src/containers/alert.jsx
+++ b/src/containers/alert.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import bindAll from 'lodash.bindall';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
+import {intlShape, injectIntl} from 'react-intl';
 import SB3Downloader from './sb3-downloader.jsx';
 import AlertComponent from '../components/alerts/alert.jsx';
 import {openConnectionModal} from '../reducers/modals';
@@ -25,6 +26,7 @@ class Alert extends React.Component {
     }
     render () {
         const {
+            assetName,
             closeButton,
             content,
             extensionName,
@@ -38,11 +40,13 @@ class Alert extends React.Component {
             showReconnect,
             showSaveNow
         } = this.props;
+        let realContent = content;
+        if (typeof content === 'function') realContent = content(this.props.intl.formatMessage, assetName);
         return (
             <SB3Downloader>{(_, downloadProject) => (
                 <AlertComponent
                     closeButton={closeButton}
-                    content={content}
+                    content={realContent}
                     extensionName={extensionName}
                     iconSpinner={iconSpinner}
                     iconURL={iconURL}
@@ -74,13 +78,15 @@ const mapDispatchToProps = dispatch => ({
 });
 
 Alert.propTypes = {
+    assetName: PropTypes.string,
     closeButton: PropTypes.bool,
-    content: PropTypes.element,
+    content: PropTypes.oneOf(PropTypes.element, PropTypes.func),
     extensionId: PropTypes.string,
     extensionName: PropTypes.string,
     iconSpinner: PropTypes.bool,
     iconURL: PropTypes.string,
     index: PropTypes.number,
+    intl: intlShape,
     level: PropTypes.string.isRequired,
     message: PropTypes.string,
     onCloseAlert: PropTypes.func.isRequired,
@@ -91,7 +97,7 @@ Alert.propTypes = {
     showSaveNow: PropTypes.bool
 };
 
-export default connect(
+export default injectIntl(connect(
     mapStateToProps,
     mapDispatchToProps
-)(Alert);
+)(Alert));

--- a/src/lib/alerts/alert-messages.js
+++ b/src/lib/alerts/alert-messages.js
@@ -1,0 +1,21 @@
+import {defineMessages} from 'react-intl';
+
+/* eslint-disable max-len */
+export default defineMessages({
+    savingErrorCostumeTooLarge: {
+        defaultMessage: 'Project could not be saved because costume {assetName} was too large. Remove unnecessary parts and try again.',
+        description: 'Message indicating that project could not be saved due to a large costume',
+        id: 'gui.alerts.savingErrorCostumeTooLarge'
+    },
+    savingErrorBackdropTooLarge: {
+        defaultMessage: 'Project could not be saved because backdrop {assetName} was too large. Remove unnecessary parts and try again.',
+        description: 'Message indicating that project could not be saved due to a large backdrop',
+        id: 'gui.alerts.savingErrorBackdropTooLarge'
+    },
+    savingErrorSoundTooLarge: {
+        defaultMessage: 'Project could not be saved because sound {assetName} was too large. Split the sound using Copy to New button and try again.',
+        description: 'Message indicating that project could not be saved due to a large sound',
+        id: 'gui.alerts.savingErrorSoundTooLarge'
+    }
+});
+/* eslint-enable max-len */

--- a/src/lib/alerts/index.jsx
+++ b/src/lib/alerts/index.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import {FormattedMessage} from 'react-intl';
 import keyMirror from 'keymirror';
 
+import alertMessages from './alert-messages';
+
 import successImage from '../assets/icon--success.svg';
 
 const AlertTypes = keyMirror({
@@ -16,12 +18,37 @@ const AlertLevels = {
     WARN: 'warn'
 };
 
+const SAVING_INFO = [
+    'createSuccess',
+    'creating',
+    'createCopySuccess',
+    'creatingCopy',
+    'createRemixSuccess',
+    'creatingRemix',
+    'saveSuccess',
+    'saving'
+];
+
+const SAVING = [
+    'saving',
+    'saveSuccess',
+    'savingError',
+    'savingErrorCostumeTooLarge',
+    'savingErrorBackdropTooLarge',
+    'savingErrorSoundTooLarge',
+    'savingErrorJSONTooLarge',
+    'savingErrorNetworkProblems',
+    'savingErrorServerProblems',
+    'savingErrorInvalidSession'
+];
+
+/* eslint-disable max-len */
+
 const alerts = [
     {
         alertId: 'createSuccess',
         alertType: AlertTypes.STANDARD,
-        clearList: ['createSuccess', 'creating', 'createCopySuccess', 'creatingCopy',
-            'createRemixSuccess', 'creatingRemix', 'saveSuccess', 'saving'],
+        clearList: SAVING_INFO,
         content: (
             <FormattedMessage
                 defaultMessage="New project created."
@@ -36,8 +63,7 @@ const alerts = [
     {
         alertId: 'createCopySuccess',
         alertType: AlertTypes.STANDARD,
-        clearList: ['createSuccess', 'creating', 'createCopySuccess', 'creatingCopy',
-            'createRemixSuccess', 'creatingRemix', 'saveSuccess', 'saving'],
+        clearList: SAVING_INFO,
         content: (
             <FormattedMessage
                 defaultMessage="Project saved as a copy."
@@ -52,8 +78,7 @@ const alerts = [
     {
         alertId: 'createRemixSuccess',
         alertType: AlertTypes.STANDARD,
-        clearList: ['createSuccess', 'creating', 'createCopySuccess', 'creatingCopy',
-            'createRemixSuccess', 'creatingRemix', 'saveSuccess', 'saving'],
+        clearList: SAVING_INFO,
         content: (
             <FormattedMessage
                 defaultMessage="Project saved as a remix."
@@ -68,8 +93,7 @@ const alerts = [
     {
         alertId: 'creating',
         alertType: AlertTypes.STANDARD,
-        clearList: ['createSuccess', 'creating', 'createCopySuccess', 'creatingCopy',
-            'createRemixSuccess', 'creatingRemix', 'saveSuccess', 'saving'],
+        clearList: SAVING_INFO,
         content: (
             <FormattedMessage
                 defaultMessage="Creating new…"
@@ -83,8 +107,7 @@ const alerts = [
     {
         alertId: 'creatingCopy',
         alertType: AlertTypes.STANDARD,
-        clearList: ['createSuccess', 'creating', 'createCopySuccess', 'creatingCopy',
-            'createRemixSuccess', 'creatingRemix', 'saveSuccess', 'saving'],
+        clearList: SAVING_INFO,
         content: (
             <FormattedMessage
                 defaultMessage="Copying project…"
@@ -98,8 +121,7 @@ const alerts = [
     {
         alertId: 'creatingRemix',
         alertType: AlertTypes.STANDARD,
-        clearList: ['createSuccess', 'creating', 'createCopySuccess', 'creatingCopy',
-            'createRemixSuccess', 'creatingRemix', 'saveSuccess', 'saving'],
+        clearList: SAVING_INFO,
         content: (
             <FormattedMessage
                 defaultMessage="Remixing project…"
@@ -112,8 +134,7 @@ const alerts = [
     },
     {
         alertId: 'creatingError',
-        clearList: ['createSuccess', 'creating', 'createCopySuccess', 'creatingCopy',
-            'createRemixSuccess', 'creatingRemix', 'saveSuccess', 'saving'],
+        clearList: SAVING_INFO,
         closeButton: true,
         content: (
             <FormattedMessage
@@ -126,8 +147,7 @@ const alerts = [
     },
     {
         alertId: 'savingError',
-        clearList: ['createSuccess', 'creating', 'createCopySuccess', 'creatingCopy',
-            'createRemixSuccess', 'creatingRemix', 'saveSuccess', 'saving'],
+        clearList: SAVING_INFO,
         showDownload: true,
         showSaveNow: true,
         closeButton: false,
@@ -141,9 +161,92 @@ const alerts = [
         level: AlertLevels.WARN
     },
     {
+        alertId: 'savingErrorCostumeTooLarge',
+        clearList: SAVING_INFO,
+        showDownload: true,
+        closeButton: true,
+        content: (formatMessage, assetName) => formatMessage(alertMessages.savingErrorCostumeTooLarge, {assetName}),
+        level: AlertLevels.WARN
+    },
+    {
+        alertId: 'savingErrorBackdropTooLarge',
+        clearList: SAVING_INFO,
+        showDownload: true,
+        closeButton: true,
+        content: (formatMessage, assetName) => formatMessage(alertMessages.savingErrorBackdropTooLarge, {assetName}),
+        level: AlertLevels.WARN
+    },
+    {
+        alertId: 'savingErrorSoundTooLarge',
+        clearList: SAVING_INFO,
+        showDownload: true,
+        closeButton: true,
+        content: (formatMessage, assetName) => formatMessage(alertMessages.savingErrorSoundTooLarge, {assetName}),
+        level: AlertLevels.WARN
+    },
+    {
+        alertId: 'savingErrorJSONTooLarge',
+        clearList: SAVING_INFO,
+        showDownload: true,
+        closeButton: true,
+        content: (
+            <FormattedMessage
+                defaultMessage="Project could not be saved because it is too large. Remove unused code or reduce list sizes and try again."
+                description="Message indicating that project could not be saved because it is too large"
+                id="gui.alerts.savingErrorJSONTooLarge"
+            />
+        ),
+        level: AlertLevels.WARN
+    },
+    {
+        alertId: 'savingErrorNetworkProblems',
+        clearList: SAVING_INFO,
+        showDownload: true,
+        showSaveNow: true,
+        closeButton: false,
+        content: (
+            <FormattedMessage
+                defaultMessage="Project could not be saved due to network problems. Check your Internet connection. You can also download the project."
+                description="Message indicating that project could not be saved due to network problems"
+                id="gui.alerts.savingErrorNetworkProblems"
+            />
+        ),
+        level: AlertLevels.WARN
+    },
+    {
+        alertId: 'savingErrorServerProblems',
+        clearList: SAVING_INFO,
+        showDownload: true,
+        showSaveNow: true,
+        closeButton: false,
+        content: (
+            <FormattedMessage
+                defaultMessage="It looks like our server has some problems. Download the project and try again later."
+                description="Message indicating that project could not be saved due to server problems"
+                id="gui.alerts.savingErrorServerProblems"
+            />
+        ),
+        level: AlertLevels.WARN
+    },
+    {
+        alertId: 'savingErrorInvalidSession',
+        clearList: SAVING_INFO,
+        showDownload: true,
+        showSaveNow: false,
+        closeButton: false,
+        content: (
+            <FormattedMessage
+                defaultMessage="It looks like you are logged out of Scratch. Download the project, log in and try again."
+                description="Message indicating that project could not be saved because the user is logged out"
+                id="gui.alerts.savingErrorInvalidSession"
+            />
+        ),
+        level: AlertLevels.WARN
+    },
+    {
         alertId: 'saveSuccess',
         alertType: AlertTypes.INLINE,
-        clearList: ['saveSuccess', 'saving', 'savingError'],
+        clearList: SAVING,
         content: (
             <FormattedMessage
                 defaultMessage="Project saved."
@@ -158,7 +261,7 @@ const alerts = [
     {
         alertId: 'saving',
         alertType: AlertTypes.INLINE,
-        clearList: ['saveSuccess', 'saving', 'savingError'],
+        clearList: SAVING,
         content: (
             <FormattedMessage
                 defaultMessage="Saving project…"
@@ -214,6 +317,8 @@ const alerts = [
         level: AlertLevels.SUCCESS
     }
 ];
+
+/* eslint-enable max-len */
 
 export {
     alerts as default,

--- a/src/reducers/alerts.js
+++ b/src/reducers/alerts.js
@@ -67,6 +67,7 @@ const reducer = function (state, action) {
                 newAlert.level = alertData.level;
                 newAlert.showDownload = alertData.showDownload;
                 newAlert.showSaveNow = alertData.showSaveNow;
+                newAlert.assetName = alertData.assetName;
 
                 newList.push(newAlert);
                 return Object.assign({}, state, {
@@ -177,6 +178,21 @@ const showStandardAlert = function (alertId) {
 };
 
 /**
+ * Action creator to show an alert with the asset name.
+ *
+ * @param {string} alertId - id string of the alert to show
+ * @param {string} assetName - asset name associated with the alert
+ * @return {object} - an object to be passed to the reducer.
+ */
+const showAssetAlert = function (alertId, assetName) {
+    return {
+        type: SHOW_ALERT,
+        alertId,
+        assetName
+    };
+};
+
+/**
  * Action creator to show an alert with the given input data.
  *
  * @param {object} data - data for the alert
@@ -219,5 +235,6 @@ export {
     filterPopupAlerts,
     showAlertWithTimeout,
     showExtensionAlert,
-    showStandardAlert
+    showStandardAlert,
+    showAssetAlert
 };


### PR DESCRIPTION
### Resolves
Resolves #4283 
Resolves #5657 

### Proposed Changes
This *should* show specific alerts for some errors during the saving process:
- Project could not be saved because costume/backdrop {assetName} was too large. Remove unnecessary parts and try again.
- Project could not be saved because sound {assetName} was too large. Split the sound using Copy to New button and try again.

These messages are special because they cannot be put as `FormattedMessage` because it needs parameter. For this reason they're on `alert-messages.js` (like `shared-messages`). Also, `content` can now be a function that takes `formatMessage` and `assetName` as parameters.

- Project could not be saved because it is too large. Remove unused code or reduce list size and try again.
- Project could not be saved due to network problems. Check your Internet connection. You can also download the project.
- It looks like our server has some problems. Download the project and try again later.
- It looks like you are logged out of Scratch. Download the project, log in and try again.

Some FAQs:
- I don't like "Costume was too large to save" because the project may not be saved properly, not just the asset.
- We should have tips for "what to do", not just "what happened"

This adds messy code, but ~~don't blame me, Babel, I blame you for not having proper subclass for Error object.~~ I already added 2KB comment in the file and I can add more.

### Reason for Changes
explained in the issue above - frequently-suggested community suggestion.

### Test Coverage
I never tested this tbh. I'm not sure how to test because 1) I don't have scratchly access and 2) I'm not sure if I can use production API for this. Lints should pass.

This is draft for this reason - this code should work but I'm not 100% certain.