### PR TITLE
On workspace reload, save+load pre-reload metrics

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -355,7 +355,11 @@ class Blocks extends React.Component {
             this.props.updateToolboxState(toolboxXML);
         }
 
-        if (this.props.vm.editingTarget && !this.state.workspaceMetrics[this.props.vm.editingTarget.id]) {
+        // For some reason, calling clearWorkspaceAndLoadFromXml sets this.state.workspaceMetrics... synchronously?
+        // Ensure that we're retaining the old metrics *before* reloading the workspace.
+        const oldMetrics = this.state.workspaceMetrics[this.props.vm.editingTarget.id];
+
+        if (this.props.vm.editingTarget && !oldMetrics) {
             this.onWorkspaceMetricsChange();
         }
 
@@ -381,8 +385,8 @@ class Blocks extends React.Component {
         }
         this.workspace.addChangeListener(this.props.vm.blockListener);
 
-        if (this.props.vm.editingTarget && this.state.workspaceMetrics[this.props.vm.editingTarget.id]) {
-            const {scrollX, scrollY, scale} = this.state.workspaceMetrics[this.props.vm.editingTarget.id];
+        if (this.props.vm.editingTarget && oldMetrics) {
+            const {scrollX, scrollY, scale} = oldMetrics;
             this.workspace.scrollX = scrollX;
             this.workspace.scrollY = scrollY;
             this.workspace.scale = scale;


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-gui/issues/4615

(See also [this discussion on scratch-gui#4400](https://github.com/LLK/scratch-gui/issues/4400#issuecomment-462994133))

### Proposed Changes

In `onWorkspaceUpdate`, which triggers a workspace clear + reload, save the old workspace metrics (scroll position and zoom) *before* calling `clearWorkspaceAndLoadFromXml`, and restore them afterwards.

### Reason for Changes

The previous code [restored the workspace metrics from `this.state.workspaceMetrics[this.props.vm.editingTarget.id]`](https://github.com/LLK/scratch-gui/blob/dee7462c57e5fe2cd726ef12ef7f338f2ee01868/src/containers/blocks.jsx#L384-L390). This appeared to be correct, because `setState` in React is supposedly asynchronous so `this.state.workspaceMetrics` shouldn't be changed until a tick later.

However, React was apparently setting the workspace metrics state synchronously after `clearWorkspaceAndLoadFromXml` was called, meaning that instead of restoring the *old* workspace metrics, it was restoring the metrics that scratch-blocks had just updated with.

Even if `setState` suddenly turns completely asynchronous in the future, this shouldn't cause a race condition-- restoring the workspace metrics should trigger another `onWorkspaceMetricsChange` call, always setting the proper state afterwards (as long as React guarantees that `setState` calls maintain their order, which I think it does).

### Test Coverage

Tested manually

### Testing Steps
- Add a sprite (so that there are at least 2 total sprites)
- Drag the "(attribute) of (sprite)" block into the block workspace
- Drag that block further down and to the right a lot
- Change the sprite selected in the block's dropdown
- Before: The block workspace will scroll up and to the left
- After: The block workspace should no longer change scroll position

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Linux
* [x] Firefox
* [x] Chrome

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
