### PR TITLE
use node 10 for travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: xenial
 addons:
     chrome: stable
 node_js:
-- 8
+- 10
 env:
   global:
   - CHROMEDRIVER_VERSION=LATEST


### PR DESCRIPTION
* chromedriver will no longer work on node 8
* paper.js has a problem with node 12
* node 10 is just right ;)
