### PR TITLE
Refactor monitor dragging

### DIFF
--- a/src/components/monitor-list/monitor-list.jsx
+++ b/src/components/monitor-list/monitor-list.jsx
@@ -35,6 +35,7 @@ const MonitorList = props => (
                         opcode={monitorData.opcode}
                         params={monitorData.params}
                         spriteName={monitorData.spriteName}
+                        stageSize={props.stageSize}
                         targetId={monitorData.targetId}
                         value={monitorData.value}
                         width={monitorData.width}

--- a/src/components/monitor/monitor.jsx
+++ b/src/components/monitor/monitor.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import classNames from 'classnames';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
-import Draggable from 'react-draggable';
+import {DraggableCore} from 'react-draggable';
 import {FormattedMessage} from 'react-intl';
 import {ContextMenuTrigger} from 'react-contextmenu';
 import {BorderedMenuItem, ContextMenu, MenuItem} from '../context-menu/context-menu.jsx';
@@ -36,15 +37,20 @@ const MonitorComponent = props => (
         holdToDisplay={props.mode === 'slider' ? -1 : 1000}
         id={`monitor-${props.label}`}
     >
-        <Draggable
-            bounds=".monitor-overlay" // Class for monitor container
+        <DraggableCore
             cancel=".no-drag" // Class used for slider input to prevent drag
-            defaultClassNameDragging={styles.dragging}
             disabled={!props.draggable}
+            onStart={props.onDragStart}
+            onDrag={props.onDrag}
             onStop={props.onDragEnd}
         >
             <Box
-                className={styles.monitorContainer}
+                className={classNames(styles.monitorContainer, {
+                    [styles.dragging]: props.dragging
+                })}
+                style={{
+                    transform: `translate(${props.x}px, ${props.y}px)`
+                }}
                 componentRef={props.componentRef}
                 onDoubleClick={props.mode === 'list' || !props.draggable ? null : props.onNextMode}
             >
@@ -53,7 +59,7 @@ const MonitorComponent = props => (
                     ...props
                 })}
             </Box>
-        </Draggable>
+        </DraggableCore>
         {ReactDOM.createPortal((
             // Use a portal to render the context menu outside the flow to avoid
             // positioning conflicts between the monitors `transform: scale` and
@@ -122,8 +128,11 @@ MonitorComponent.propTypes = {
     category: PropTypes.oneOf(Object.keys(categories)),
     componentRef: PropTypes.func.isRequired,
     draggable: PropTypes.bool.isRequired,
+    dragging: PropTypes.bool.isRequired,
     label: PropTypes.string.isRequired,
     mode: PropTypes.oneOf(monitorModes),
+    onDragStart: PropTypes.func.isRequired,
+    onDrag: PropTypes.func.isRequired,
     onDragEnd: PropTypes.func.isRequired,
     onExport: PropTypes.func,
     onImport: PropTypes.func,
@@ -131,7 +140,9 @@ MonitorComponent.propTypes = {
     onSetModeToDefault: PropTypes.func,
     onSetModeToLarge: PropTypes.func,
     onSetModeToSlider: PropTypes.func,
-    onSliderPromptOpen: PropTypes.func
+    onSliderPromptOpen: PropTypes.func,
+    x: PropTypes.number,
+    y: PropTypes.number
 };
 
 MonitorComponent.defaultProps = {


### PR DESCRIPTION
### Resolves

- Resolves #5782
- Resolves #2367
- Resolves #2949

### Proposed Changes

This PR reimplements the dragging behavior previously done in react-draggable, but taking stage scale into account.

It also changes the monitors to always position themselves using CSS transforms and never setting the `top` or `left` position--those will affect text wrapping while CSS transforms will not, resulting in wrapping differences between monitors positioned with `top`/`left` and monitors positioned with a CSS transform. This is what led to #5782.

### Reason for Changes

These changes resolve the bugs linked above.

### Test Coverage

Tested manually

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Linux
* [x] Chrome
* [x] Firefox

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
