### PR TITLE
Pass current editing target to getBlocksXML

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -338,7 +338,7 @@ class Blocks extends React.Component {
             const stageCostumes = stage.getCostumes();
             const targetCostumes = target.getCostumes();
             const targetSounds = target.getSounds();
-            const dynamicBlocksXML = this.props.vm.runtime.getBlocksXML();
+            const dynamicBlocksXML = this.props.vm.runtime.getBlocksXML(target);
             return makeToolboxXML(target.isStage, target.id, dynamicBlocksXML,
                 targetCostumes[targetCostumes.length - 1].name,
                 stageCostumes[stageCostumes.length - 1].name,


### PR DESCRIPTION
## Depends on https://github.com/LLK/scratch-vm/pull/2442

### Resolves

- A step towards https://github.com/LLK/scratch-gui/issues/2174

### Proposed Changes

This PR goes along with https://github.com/LLK/scratch-vm/pull/2442, which allows a target to be passed to `getBlocksXML`.

It changes `getToolboxXML` to now pass that target in.

### Reason for Changes

This is necessary for the VM to generate a different toolbox depending on which target is selected, to e.g. show/hide certain blocks on the stage/sprites.

### Test Coverage

Tested manually

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Linux
* [x] Firefox

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
