### PR TITLE
Use direction: ltr to prevent RTL languages from mirroring the variable slider

### DIFF
--- a/src/components/monitor/monitor.css
+++ b/src/components/monitor/monitor.css
@@ -66,6 +66,7 @@
 .slider {
     width: 100%;
     transform: translateZ(0); /* Fixes flickering in Safari */
+    direction: ltr;
 }
 
 .list-monitor {


### PR DESCRIPTION
### Resolves

Resolves #5545

### Proposed Changes

Adds a CSS rule so the RTL languages do not mirror the slider.

### Reason for Changes

The reason is at proposed changes above.

### Test Coverage

Manually tested with a local clone of the GUI.

### Browser Coverage

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [x] Chrome 
 * [ ] Firefox 
 * [x] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
