### PR TITLE
Add assets to editingTarget at the time it started uploading

### DIFF
--- a/src/containers/sound-tab.jsx
+++ b/src/containers/sound-tab.jsx
@@ -130,11 +130,12 @@ class SoundTab extends React.Component {
 
     handleSoundUpload (e) {
         const storage = this.props.vm.runtime.storage;
+        const targetId = this.props.vm.editingTarget.id;
         this.props.onShowImporting();
         handleFileUpload(e.target, (buffer, fileType, fileName, fileIndex, fileCount) => {
             soundUpload(buffer, fileType, storage, newSound => {
                 newSound.name = fileName;
-                this.props.vm.addSound(newSound).then(() => {
+                this.props.vm.addSound(newSound, targetId).then(() => {
                     this.handleNewSound();
                     if (fileIndex === fileCount - 1) {
                         this.props.onCloseImporting();


### PR DESCRIPTION
### Resolves
Resolves #5876 

### Proposed Changes
Add assets to editingTarget at the time it started uploading, not when `addCostume`/`addSound` is called. There are still some functions that use the old behavior, but I don't expect adding such assets (like adding blank costume) will be long enough for the user to switch sprites.

### Reason for Changes
Previously if you switch sprites while adding assets it would add some of the assets to the new sprite instead of the previously selected one.

### Test Coverage
Tested on Firefox 77, Windows 10

To test this,
1) Import a GIF file via costumes tab
2) Switch sprites
3) Check that all imported GIFs are still in the previous sprite
4) Import sounds (multiple preferably, to lag it a bit) via sounds tab
5) Switch sprites
6) Check that all imported sounds are still in the previous sprite