### PR TITLE
Prevent crash when saving locally on iOS 13 safari

### DIFF
--- a/src/lib/download-blob.js
+++ b/src/lib/download-blob.js
@@ -14,10 +14,13 @@ export default (filename, blob) => {
         downloadLink.download = filename;
         downloadLink.type = blob.type;
         downloadLink.click();
-        document.body.removeChild(downloadLink);
-        window.URL.revokeObjectURL(url);
+        // remove the link after a timeout to prevent a crash on iOS 13 Safari
+        window.setTimeout(() => {
+            document.body.removeChild(downloadLink);
+            window.URL.revokeObjectURL(url);
+        }, 1000);
     } else {
-        // iOS Safari, open a new page and set href to data-uri
+        // iOS 12 Safari, open a new page and set href to data-uri
         let popup = window.open('', '_blank');
         const reader = new FileReader();
         reader.onloadend = function () {


### PR DESCRIPTION
### Resolves

resolves https://github.com/LLK/scratch-gui/issues/1783

### Proposed Changes

When saving to a local file (file -> save to your computer), wait briefly before removing the download link. This prevents the crash on iOS 13, and the file downloads with a correct filename and extension.

### Reason for Changes

Not 100% sure why this works, but it probably prevents a race condition in iOS Safari.

### Test Coverage

No tests

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [x] Safari
 
Windows
 * [x] Chrome 
 * [x] Firefox 
 * [x] Edge
 
Chromebook
 * [ ] Chrome
 
iOS
* [x] iOS 13 Safari
* [x] iOS 12 Safari (via simulator)

Android Tablet
* [ ] Chrome
