### PR TITLE
Don't let user exit full screen when branding shows

### DIFF
--- a/src/containers/stage-header.jsx
+++ b/src/containers/stage-header.jsx
@@ -25,7 +25,7 @@ class StageHeader extends React.Component {
         document.removeEventListener('keydown', this.handleKeyPress);
     }
     handleKeyPress (event) {
-        if (event.key === 'Escape' && this.props.isFullScreen) {
+        if (event.key === 'Escape' && this.props.isFullScreen && !this.props.showBranding) {
             this.props.onSetStageUnFull(false);
         }
     }


### PR DESCRIPTION
### Resolves

Resolves LLK/scratch-www#4102

### Proposed Changes

Adds `&& !this.props.showBranding` (`!this.props.showBranding` will return false when branding shows), so escape won't do anything when the project is embedded. (Because embedded projects are full screen)

### Reason for Changes

As I said above: so escape won't do anything when the project is embedded.
\
\
\
\
@benjiwheeler