### PR TITLE
Handle auto-scrolling and highlighting list monitor index

### DIFF
--- a/src/components/monitor-list/monitor-list.jsx
+++ b/src/components/monitor-list/monitor-list.jsx
@@ -26,6 +26,7 @@ const MonitorList = props => (
                     <Monitor
                         draggable={props.draggable}
                         height={monitorData.height}
+                        highlightItem={monitorData.highlightItem}
                         id={monitorData.id}
                         isDiscrete={monitorData.isDiscrete}
                         key={monitorData.id}

--- a/src/components/monitor/list-monitor-scroller.jsx
+++ b/src/components/monitor/list-monitor-scroller.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import bindAll from 'lodash.bindall';
 import {FormattedMessage} from 'react-intl';
-
+import {Set} from 'immutable';
 import styles from './monitor.css';
 import {List} from 'react-virtualized';
 
@@ -31,13 +31,21 @@ class ListMonitorScroller extends React.Component {
         );
     }
     rowRenderer ({index, key, style}) {
+        const isHighlighted = this.props.highlightItems.has(index);
         return (
             <div
                 className={styles.listRow}
                 key={key}
                 style={style}
             >
-                <div className={styles.listIndex}>{index + 1 /* one indexed */}</div>
+                <div
+                    className={classNames(
+                        styles.listIndex,
+                        {
+                            [styles.highlightIndex]: isHighlighted
+                        }
+                    )}
+                >{index + 1 /* one indexed */}</div>
                 <div
                     className={styles.listValue}
                     dataIndex={index}
@@ -74,14 +82,17 @@ class ListMonitorScroller extends React.Component {
         );
     }
     render () {
-        const {height, values, width, activeIndex, activeValue} = this.props;
+        const {height, values, width, activeIndex, activeValue, highlightItem} = this.props;
         // Keep the active index in view if defined, else must be undefined for List component
-        const scrollToIndex = activeIndex === null ? undefined : activeIndex; /* eslint-disable-line no-undefined */
+        const highlightIndex = highlightItem === null ? undefined : highlightItem; // eslint-disable-line no-undefined
+        const scrollToIndex = activeIndex === null ? highlightIndex : activeIndex; // eslint-disable-line no-undefined
         return (
             <List
                 activeIndex={activeIndex}
                 activeValue={activeValue}
                 height={(height) - 44 /* Header/footer size, approx */}
+                highlightItems={this.props.highlightItems.toString()
+                /* note that this is not an actual prop - it's just there to re-render whenever the list updates */}
                 noRowsRenderer={this.noRowsRenderer}
                 rowCount={values.length}
                 rowHeight={24 /* Row size is same for all rows */}
@@ -100,6 +111,8 @@ ListMonitorScroller.propTypes = {
     categoryColor: PropTypes.string,
     draggable: PropTypes.bool,
     height: PropTypes.number,
+    highlightItem: PropTypes.number,
+    highlightItems: PropTypes.instanceOf(Set),
     onActivate: PropTypes.func,
     onDeactivate: PropTypes.func,
     onFocus: PropTypes.func,

--- a/src/components/monitor/list-monitor.jsx
+++ b/src/components/monitor/list-monitor.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import {FormattedMessage} from 'react-intl';
+import {Set} from 'immutable';
 import styles from './monitor.css';
 import ListMonitorScroller from './list-monitor-scroller.jsx';
 
@@ -57,6 +58,8 @@ ListMonitor.propTypes = {
     categoryColor: PropTypes.string.isRequired,
     draggable: PropTypes.bool.isRequired,
     height: PropTypes.number,
+    highlightItem: PropTypes.number,
+    highlightItems: PropTypes.instanceOf(Set),
     label: PropTypes.string.isRequired,
     onActivate: PropTypes.func,
     onAdd: PropTypes.func,
@@ -74,7 +77,8 @@ ListMonitor.propTypes = {
 
 ListMonitor.defaultProps = {
     width: 110,
-    height: 200
+    height: 200,
+    highlightItem: null
 };
 
 export default ListMonitor;

--- a/src/components/monitor/monitor.css
+++ b/src/components/monitor/monitor.css
@@ -187,3 +187,7 @@
 .footer-length {
     text-align: center;
 }
+
+.highlight-index {
+    color: $control-primary;
+}

--- a/src/containers/monitor.jsx
+++ b/src/containers/monitor.jsx
@@ -201,6 +201,7 @@ class Monitor extends React.Component {
                     {...monitorProps}
                     draggable={this.props.draggable}
                     height={this.props.height}
+                    highlightItem={this.props.highlightItem}
                     isDiscrete={this.props.isDiscrete}
                     max={this.props.max}
                     min={this.props.min}
@@ -225,6 +226,7 @@ Monitor.propTypes = {
     addMonitorRect: PropTypes.func.isRequired,
     draggable: PropTypes.bool,
     height: PropTypes.number,
+    highlightItem: PropTypes.number,
     id: PropTypes.string.isRequired,
     intl: intlShape,
     isDiscrete: PropTypes.bool,


### PR DESCRIPTION
**LLK/scratch-vm#2507 must be merged first**

### Resolves
GUI part for these issues:
Resolves LLK/scratch-vm#1385
Resolves LLK/scratch-vm#1386

### Proposed Changes
![auto-scrolling and highlighting](https://i.gyazo.com/71fea3635ef1e2a175ce4b499598075e.gif)
Adds list index highlighting and list auto-scrolling feature (although the bugtracker says lack of auto-scrolling is a bug)

When a list monitor receives update to its `highlightItem`, it cancels the setTimeout (which i'll mention below), and does two things:
- adds the item to `highlightItems` which is a Map (not immutable) of number to setTimeout which unhighlights it after 500ms
- re-renders list monitor with new `highlightItem` and `highlightItems`, which scrolls to added item (list-monitor-scroller L87)

When highlighting $control-primary is used.

Note that we pass stringified version of highlightItems to List so that it re-renders - it's PureComponent and doesn't re-render when unhighlighting by itself.

### Reason for Changes
compatibility with Scratch 2.0

### Test Coverage
Attached a project sb3 - rename and open. click green flag, go to fullscreen, click the stage (not the stage monitor), try pressing arrow keys!
[scrollable-list.sb3.zip](https://github.com/LLK/scratch-gui/files/4898657/scrollable-list.sb3.zip)
