### PR TITLE
disable webpack progress plugin on CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "GraphicaL User Interface for creating and running Scratch 3.0 projects",
   "main": "./dist/scratch-gui.js",
   "scripts": {
-    "build": "npm run clean && webpack --progress --colors --bail",
+    "build": "npm run clean && webpack --colors --bail",
     "clean": "rimraf ./build && mkdirp build && rimraf ./dist && mkdirp dist",
     "deploy": "touch build/.nojekyll && gh-pages -t -d build -m \"Build for $(git log --pretty=format:%H -n1) [skip ci]\"",
     "prune": "./prune-gh-pages.sh",
@@ -16,7 +16,7 @@
     "test:lint": "eslint . --ext .js,.jsx",
     "test:unit": "jest test[\\\\/]unit",
     "test:smoke": "jest --runInBand test[\\\\/]smoke",
-    "watch": "webpack --progress --colors --watch"
+    "watch": "webpack --colors --watch"
   },
   "author": "Massachusetts Institute of Technology",
   "license": "BSD-3-Clause",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -95,6 +95,10 @@ const base = {
     plugins: []
 };
 
+if (!process.env.CI) {
+    base.plugins.push(new webpack.ProgressPlugin());
+}
+
 module.exports = [
     // to run editor examples
     defaultsDeep({}, base, {


### PR DESCRIPTION
### Proposed Changes

Currently, webpack progress output is enabled at all times. This change enables progress output only when the "CI" environment variable is empty or unset, effectively disabling progress output on continuous integration build servers.

### Reason for Changes

The webpack progress plugin output is huge and can cause performance problems when trying to scroll through a CI build log.

CI log size:
| | Before this change | After this change |
-- | -- | --
Number of lines | About 11k | About 2k
File size | About 2 MB | About 289 KB

Local output (with the "CI" variable unset) should remain unchanged.

### Test Coverage

Tested locally by running the build with and without the "CI" environment variable set. See also the CI build attached to this PR ;)

### Browser Coverage

NA