### PR TITLE
Fix backpacking zero-height/width costumes

### DIFF
--- a/src/lib/backpack/jpeg-thumbnail.js
+++ b/src/lib/backpack/jpeg-thumbnail.js
@@ -6,17 +6,24 @@ const jpegThumbnail = dataUrl => new Promise((resolve, reject) => {
 
         const maxDimension = 96; // 3x the maximum displayed size of 32px
 
-        if (image.height > image.width) {
-            canvas.height = maxDimension;
-            canvas.width = (maxDimension / image.height) * image.width;
+        if (image.height < 1 || image.width < 1) {
+            canvas.width = canvas.height = maxDimension;
+            // drawImage can fail if image height/width is less than 1
+            // Use blank image; the costume is too small to render anyway
+            ctx.fillStyle = 'white'; // Create white background, since jpeg doesn't have transparency
+            ctx.fillRect(0, 0, maxDimension, maxDimension);
         } else {
-            canvas.width = maxDimension;
-            canvas.height = (maxDimension / image.width) * image.height;
+            if (image.height > image.width) {
+                canvas.height = maxDimension;
+                canvas.width = (maxDimension / image.height) * image.width;
+            } else {
+                canvas.width = maxDimension;
+                canvas.height = (maxDimension / image.width) * image.height;
+            }
+            ctx.fillStyle = 'white';
+            ctx.fillRect(0, 0, canvas.width, canvas.height);
+            ctx.drawImage(image, 0, 0, canvas.width, canvas.height);
         }
-
-        ctx.fillStyle = 'white'; // Create white background, since jpeg doesn't have transparency
-        ctx.fillRect(0, 0, canvas.width, canvas.height);
-        ctx.drawImage(image, 0, 0, canvas.width, canvas.height);
         resolve(canvas.toDataURL('image/jpeg', 0.92 /* quality */)); // Default quality is 0.92
     };
     image.onerror = err => {

--- a/src/lib/backpack/jpeg-thumbnail.js
+++ b/src/lib/backpack/jpeg-thumbnail.js
@@ -11,7 +11,7 @@ const jpegThumbnail = dataUrl => new Promise((resolve, reject) => {
             // drawImage can fail if image height/width is less than 1
             // Use blank image; the costume is too small to render anyway
             ctx.fillStyle = 'white'; // Create white background, since jpeg doesn't have transparency
-            ctx.fillRect(0, 0, maxDimension, maxDimension);
+            ctx.fillRect(0, 0, canvas.width, canvas.height);
         } else {
             if (image.height > image.width) {
                 canvas.height = maxDimension;


### PR DESCRIPTION
### Resolves
Resolves #5972

### Proposed Changes
If the sprite height/width is less than one, use 96(maxDimension)x96 white square as the backpack thumbnail

### Reason for Changes
drawImage fails if the image is too small. I did not compare width===0 because it's possible that very-small-but-positive numbers (like 0.01) can cause this as well, and I heard some implementations floor instead of round.

### Test Coverage
Manually tested using http://localhost:8601/?token=X-TOKEN-HERE&backpack_host=https://backpack.scratch.mit.edu&username=apple502j

(by the way, why is it JPEG instead of PNG?)