### PR TITLE
Do not call onClickSave if canSave is false

### DIFF
--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -235,7 +235,9 @@ class MenuBar extends React.Component {
     handleKeyPress (event) {
         const modifier = bowser.mac ? event.metaKey : event.ctrlKey;
         if (modifier && event.key === 's') {
-            this.props.onClickSave();
+            if (this.props.canSave) {
+                this.props.onClickSave();
+            }
             event.preventDefault();
         }
     }


### PR DESCRIPTION
### Resolves
Resolves #5980 

### Proposed Changes
Do not call onClickSave if canSave is false. It will still preventDefault for consistency.

### Reason for Changes
It was previously possible to try to save (and fail) by pressing Ctrl+S anywhere.