### PR TITLE
Get unittests and integration tests (consistently?) passing on circle again. 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ aliases:
         - v1-npm-
   - &defaults
     docker:
-      - image: circleci/node:8.16-browsers
+      - image: circleci/node:10-browsers
     working_directory: ~/repo
 
 jobs:
@@ -76,7 +76,7 @@ jobs:
           name: Unit
           environment:
               JEST_JUNIT_OUTPUT_DIR: test-results/unit
-          command: npm run test:unit -- --reporters="default" --reporters="jest-junit" --coverage --coverageReporters=text --coverageReporters=lcov
+          command: npm run test:unit -- --reporters="default" --reporters="jest-junit" --coverage --coverageReporters=text --coverageReporters=lcov --maxWorkers="2"
       - store_artifacts:
           path: coverage
       - store_test_results:
@@ -123,7 +123,7 @@ jobs:
               JEST_JUNIT_OUTPUT_DIR: test-results/integration
           command: |
             export TESTFILES=$(circleci tests glob "test/integration/*.test.js" | circleci tests split --split-by=timings)
-            $(npm bin)/jest ${TESTFILES} --reporters="default" --reporters="jest-junit"
+            $(npm bin)/jest ${TESTFILES} --reporters="default" --reporters="jest-junit" --runInBand
       - store_test_results:
           path: test-results
 
@@ -162,7 +162,7 @@ jobs:
           git config --global user.email $(git log --pretty=format:"%ae" -n1)
           git config --global user.name $(git log --pretty=format:"%an" -n1)
       - run: npm run deploy -- -e $CIRCLE_BRANCH
-      
+
 workflows:
   version: 2
   build-test-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,6 +162,7 @@ jobs:
           git config --global user.email $(git log --pretty=format:"%ae" -n1)
           git config --global user.name $(git log --pretty=format:"%an" -n1)
       - run: npm run deploy -- -e $CIRCLE_BRANCH
+
 workflows:
   version: 2
   build-test-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,7 +162,6 @@ jobs:
           git config --global user.email $(git log --pretty=format:"%ae" -n1)
           git config --global user.name $(git log --pretty=format:"%an" -n1)
       - run: npm run deploy -- -e $CIRCLE_BRANCH
-
 workflows:
   version: 2
   build-test-deploy:


### PR DESCRIPTION
- Update the docker image to node 10 and corresponding browsers (~chrome 83)
- Unit tests: They were running out of memory. Set --maxWorkers to 2 so they don't spawn so many that we run 
out of memory.  This value probably could be optimized.
- Integration tests: costumes test and tutorials test were routinely failing with an error claiming that a tab in chrome had crashed.  I think there is a weird interaction when running some of these tests in parallel. Setting it so each test runs in a separate docker instance also solves the problem, but that's not sustainable. Instead set --runInBand on integration tests (like we do in package.json) so they run one at a time.

Consistency Note: This passed 6 times in a row, which isn't that many... but far better than what I've gotten so far.

https://github.com/LLK/scratch-gui/issues/5828