### PR TITLE
Force LTR on drag-layer

### DIFF
--- a/src/components/drag-layer/drag-layer.css
+++ b/src/components/drag-layer/drag-layer.css
@@ -9,7 +9,8 @@
     left: 0;
     top: 0;
     width: 100%;
-    height: 100%
+    height: 100%;
+    direction: ltr;
 }
 
 .image-wrapper {


### PR DESCRIPTION
### Resolves
Resolves #6104 

### Proposed Changes
Force LTR on drag-layer, by adding `direction: ltr;`

### Reason for Changes
No matter which direction it displays, values passed to `transform()` is calculated from top-left to bottom-right.

### Test Coverage
Tested on the browser