### PR TITLE
Step toward GUI migration to circle: have circle deploy to npm 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,3 +204,7 @@ workflows:
             - unit
             - integration
             - build
+          filters:
+            branches:
+              ignore:
+                - ^dependabot/.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,22 +186,21 @@ workflows:
       - store_dist:
           requires:
             - build
-      # Disable deployment while running in parallel with Travis
-      # - deploy-npm:
-      #     requires:
-      #       - lint
-      #       - unit
-      #       - integration
-      #       - build
-      #     filters:
-      #       branches:
-      #         only:
-      #           - master
-      #           - develop
-      #           - /^hotfix\/.*/
-      # - deploy-gh-pages:
-      #     requires:
-      #       - lint
-      #       - unit
-      #       - integration
-      #       - build
+      - deploy-npm:
+          requires:
+            - lint
+            - unit
+            - integration
+            - build
+          filters:
+            branches:
+              only:
+                - master
+                - develop
+                - /^hotfix\/.*/
+      - deploy-gh-pages:
+          requires:
+            - lint
+            - unit
+            - integration
+            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,13 +198,13 @@ workflows:
                 - master
                 - develop
                 - /^hotfix\/.*/
-      - deploy-gh-pages:
-          requires:
-            - lint
-            - unit
-            - integration
-            - build
-          filters:
-            branches:
-              ignore:
-                - ^dependabot/.*/
+      # - deploy-gh-pages:
+      #     requires:
+      #       - lint
+      #       - unit
+      #       - integration
+      #       - build
+      #     filters:
+      #       branches:
+      #         ignore:
+      #           - ^dependabot/.*/

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,14 +51,13 @@ deploy:
     condition: $TRAVIS_EVENT_TYPE != cron
   skip_cleanup: true
   script: if npm info scratch-gui | grep -q $RELEASE_VERSION; then git tag $RELEASE_VERSION && git push https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git $RELEASE_VERSION; fi
-# Disable deploy to gh-pages. Circle will do it instead.
-# - provider: script
-#   on:
-#     all_branches: true
-#     condition: $TRAVIS_EVENT_TYPE != cron && ! $TRAVIS_BRANCH =~ ^dependabot/
-#     tags: false # Don't push tags to gh-pages
-#   skip_cleanup: true
-#   script: npm run deploy -- -x -e $TRAVIS_BRANCH -r https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
+- provider: script
+  on:
+    all_branches: true
+    condition: $TRAVIS_EVENT_TYPE != cron && ! $TRAVIS_BRANCH =~ ^dependabot/
+    tags: false # Don't push tags to gh-pages
+  skip_cleanup: true
+  script: npm run deploy -- -x -e $TRAVIS_BRANCH -r https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
 - provider: script
   on:
     branch: develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,13 +51,14 @@ deploy:
     condition: $TRAVIS_EVENT_TYPE != cron
   skip_cleanup: true
   script: if npm info scratch-gui | grep -q $RELEASE_VERSION; then git tag $RELEASE_VERSION && git push https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git $RELEASE_VERSION; fi
-- provider: script
-  on:
-    all_branches: true
-    condition: $TRAVIS_EVENT_TYPE != cron && ! $TRAVIS_BRANCH =~ ^dependabot/
-    tags: false # Don't push tags to gh-pages
-  skip_cleanup: true
-  script: npm run deploy -- -x -e $TRAVIS_BRANCH -r https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
+# Disable deploy to gh-pages. Circle will do it instead.
+# - provider: script
+#   on:
+#     all_branches: true
+#     condition: $TRAVIS_EVENT_TYPE != cron && ! $TRAVIS_BRANCH =~ ^dependabot/
+#     tags: false # Don't push tags to gh-pages
+#   skip_cleanup: true
+#   script: npm run deploy -- -x -e $TRAVIS_BRANCH -r https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
 - provider: script
   on:
     branch: develop


### PR DESCRIPTION
- Publishes the new version to circletest tag
- Adding a filter so we don't deploy dependabot PRs to gh-pages (though the gh-pages deploy is still off while I sort out permissions problems)

