### PR TITLE
Deploying to gh-pages from circle instead of Travis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,5 +206,6 @@ workflows:
             - build
           filters:
             branches:
+              only: /^(?!pull\/).*$/ # don't deploy to gh pages on PRs.
               ignore:
                 - ^dependabot/.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,13 +198,13 @@ workflows:
                 - master
                 - develop
                 - /^hotfix\/.*/
-      # - deploy-gh-pages:
-      #     requires:
-      #       - lint
-      #       - unit
-      #       - integration
-      #       - build
-      #     filters:
-      #       branches:
-      #         ignore:
-      #           - ^dependabot/.*/
+      - deploy-gh-pages:
+          requires:
+            - lint
+            - unit
+            - integration
+            - build
+          filters:
+            branches:
+              ignore:
+                - ^dependabot/.*/

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,13 +51,14 @@ deploy:
     condition: $TRAVIS_EVENT_TYPE != cron
   skip_cleanup: true
   script: if npm info scratch-gui | grep -q $RELEASE_VERSION; then git tag $RELEASE_VERSION && git push https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git $RELEASE_VERSION; fi
-- provider: script
-  on:
-    all_branches: true
-    condition: $TRAVIS_EVENT_TYPE != cron && ! $TRAVIS_BRANCH =~ ^dependabot/
-    tags: false # Don't push tags to gh-pages
-  skip_cleanup: true
-  script: npm run deploy -- -x -e $TRAVIS_BRANCH -r https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
+# Skip deploy to gh pages. Circle will do it instead.
+# - provider: script
+#   on:
+#     all_branches: true
+#     condition: $TRAVIS_EVENT_TYPE != cron && ! $TRAVIS_BRANCH =~ ^dependabot/
+#     tags: false # Don't push tags to gh-pages
+#   skip_cleanup: true
+#   script: npm run deploy -- -x -e $TRAVIS_BRANCH -r https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
 - provider: script
   on:
     branch: develop


### PR DESCRIPTION
- Turns off deploy to gh-pages in the travis config
- Turns on the deploy to gh pages from the circle config
  - Also adds a condition to only run the gh-pages build on commits, not pull requests.
  Here are the two jobs. The 1st for the PR and doesn't have a deploy-gh-pages step, the 2nd is for the commit that I pushed to the LLK branch which does have that deploy-gh-pages step.

Still TODOs:
- add i18n cron job to circle
- publish to the main npm tag instead of circlelatest & turn off travis' npm deploy.
![image](https://user-images.githubusercontent.com/15675877/91470590-e4b92780-e862-11ea-962a-7f37dfb69a95.png)
