### PR TITLE
Have circle deploy to the standard npm tags instead of travis.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,12 +137,12 @@ jobs:
       - checkout
       - run: |
           echo export RELEASE_VERSION="0.1.0-prerelease.$(date +'%Y%m%d%H%M%S')" >> $BASH_ENV
-          echo export NPM_TAG=circlelatest >> $BASH_ENV
+          echo export NPM_TAG=latest >> $BASH_ENV
           if [ "$CIRCLE_BRANCH" == "master" ]
-            then echo export NPM_TAG=circlestable >> $BASH_ENV
+            then echo export NPM_TAG=stable >> $BASH_ENV
           fi
           if [[ "$CIRCLE_BRANCH" == hotfix/* ]] # double brackets are important for matching the wildcard
-            then echo export NPM_TAG=circlehotfix >> $BASH_ENV
+            then echo export NPM_TAG=hotfix >> $BASH_ENV
           fi
       - run: npm version --no-git-tag-version $RELEASE_VERSION
       - run: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,28 +29,29 @@ before_deploy:
     git config --global user.name $(git log --pretty=format:"%an" -n1)
     export BEFORE_DEPLOY_RAN=true
   fi
-deploy:
-- provider: npm
-  on:
-    branch:
-    - master
-    - develop
-    - hotfix/*
-    condition: $TRAVIS_EVENT_TYPE != cron
-  skip_cleanup: true
-  email: $NPM_EMAIL
-  api_key: $NPM_TOKEN
-  tag: $NPM_TAG
-- provider: script
-  on:
-    branch:
-    - master
-    - develop
-    - smoke
-    - hotfix/*
-    condition: $TRAVIS_EVENT_TYPE != cron
-  skip_cleanup: true
-  script: if npm info scratch-gui | grep -q $RELEASE_VERSION; then git tag $RELEASE_VERSION && git push https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git $RELEASE_VERSION; fi
+# Skip the deploy to npm-- Circle should be doing it.
+# deploy:
+# - provider: npm
+#   on:
+#     branch:
+#     - master
+#     - develop
+#     - hotfix/*
+#     condition: $TRAVIS_EVENT_TYPE != cron
+#   skip_cleanup: true
+#   email: $NPM_EMAIL
+#   api_key: $NPM_TOKEN
+#   tag: $NPM_TAG
+# - provider: script
+#   on:
+#     branch:
+#     - master
+#     - develop
+#     - smoke
+#     - hotfix/*
+#     condition: $TRAVIS_EVENT_TYPE != cron
+#   skip_cleanup: true
+#   script: if npm info scratch-gui | grep -q $RELEASE_VERSION; then git tag $RELEASE_VERSION && git push https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git $RELEASE_VERSION; fi
 # Skip deploy to gh pages. Circle will do it instead.
 # - provider: script
 #   on:


### PR DESCRIPTION
Deploy to latest, stable (although we don't use gui's master branch), and hotfix.