### PR TITLE
Fix logic for when to run deploy-gh-pages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,6 +206,6 @@ workflows:
             - build
           filters:
             branches:
-              only: /^(?!pull\/).*$/ # don't deploy to gh pages on PRs.
               ignore:
                 - ^dependabot/.*/
+                - ^pull/.*/ # don't deploy to  gh pages on PRs.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,5 +207,5 @@ workflows:
           filters:
             branches:
               ignore:
-                - ^dependabot/.*/
-                - ^pull/.*/ # don't deploy to  gh pages on PRs.
+                - /^dependabot/.*/
+                - /^pull/.*/ # don't deploy to  gh pages on PRs.


### PR DESCRIPTION
We do not want to deploy to gh pages on dependabot or PR branches. 

I noticed that circle ran a gh-pages deploy for this dependabot commit. https://app.circleci.com/pipelines/github/LLK/scratch-gui?branch=dependabot%2Fnpm_and_yarn%2Fscratch-l10n-3.10.20200902030719
I think that link is the commit, not the PR. Is that right?

We don’t want that deploy running. There are two sets of docs, the deprecated ones and the not-deprecated ones. I’m pretty sure we’re using the workflow version so the not-deprecated ones which states 

> If both only and ignore are specified the only is considered before ignore

Given our current config I thought that meant that `only` would get considered first (which a dependabot branch passes because it doesn’t start with “pull”) and then the `ignore` would kick in and say nope. not running that.

That doesn’t seem to be happening though. In this PR I deleted the `only` and added pull/ to the `ignore`. I could also change the `only` to be ` /^(?!(pull|dependabot)\/).*$/` and delete the `ignore` instead. 