### PR TITLE
Add translation push cron job to circle.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,9 +162,31 @@ jobs:
           git config --global user.email $(git log --pretty=format:"%ae" -n1)
           git config --global user.name $(git log --pretty=format:"%an" -n1)
       - run: npm run deploy -- -e $CIRCLE_BRANCH
+  push-translations:
+    <<: *defaults
+    steps:
+      - *restore_git_cache
+      - checkout
+      - *restore_npm_cache
+      - run: npm run i18n:src
+      - run: npm run i18n:push
 
 workflows:
   version: 2
+  push-translations:
+    triggers:
+      - schedule:
+          cron: 0 0 * * * # daily at 12 UTC, 8 ET
+          filters:
+            branches:
+              only:
+                - develop
+    jobs:
+      - setup
+      - push-translations:
+          requires:
+              - setup
+
   build-test-deploy:
     jobs:
       - setup


### PR DESCRIPTION
- This will (eventually) replace the job running on Travis. For now the travis job is still running.
- It should run daily at midnight UTC

My testing of it seems to have worked: https://app.circleci.com/pipelines/github/LLK/scratch-gui/2756/workflows/a39a9cb7-6776-4dad-bd46-623f5b4191ed
I've since changed the branch and timing to be what we'd want longer term, so I'll still have to keep an eye out for it.

