### PR TITLE
Added Getting Started video in 7 languages

### DIFF
--- a/src/lib/libraries/decks/translate-video.js
+++ b/src/lib/libraries/decks/translate-video.js
@@ -11,7 +11,14 @@ const videos = {
         'pt': 'ngdfp8xg4x',
         'pt-br': 'ngdfp8xg4x',
         'ja': 'v2c2f3y2sc',
-        'ja-Hira': 'v2c2f3y2sc'
+        'ja-Hira': 'v2c2f3y2sc',
+        'es': 'htk2m9o65l',
+        'es-419': 'htk2m9o65l',
+        'sw': 'fd4bn2nli5',
+        'fr': 'dt015ouls8',
+        'am': 'e06wlsebqy',
+        'zu': 'st2x0emdx7',
+        'uk': '1ith4m4f8u'
     },
     'animate-a-name': {
         'en': 'pyur30ho05',


### PR DESCRIPTION
Adds new Getting Started video for: 
- Spanish
- Latin American Spanish (same video as Spanish)
- French
- isiZulu
- Amharic
- Ukrainian  
- Kiswahili (Swahili)

When you load the Getting Started tutorial with the language set to each of those languages, the video should appear in that language instead of English. 