### PR TITLE
Change end-of-tutorial links for several tutorials

### DIFF
--- a/src/lib/libraries/decks/index.jsx
+++ b/src/lib/libraries/decks/index.jsx
@@ -710,7 +710,7 @@ export default {
             image: 'animateCharChangeColor'
         }, {
             deckIds: [
-                'Chase-Game',
+                'code-cartoon',
                 'Tell-A-Story'
             ]
         }
@@ -1463,7 +1463,7 @@ export default {
         }, {
             deckIds: [
                 'animate-a-name',
-                'Make-Music'
+                'talking'
             ]
         }
         ],
@@ -1899,7 +1899,7 @@ export default {
             image: 'switchCostumes'
         }, {
             deckIds: [
-                'add-a-backdrop',
+                'imagine',
                 'add-effects'
             ]
         }],
@@ -1938,7 +1938,7 @@ export default {
             image: 'moveArrowKeysUpDown'
         }, {
             deckIds: [
-                'add-a-backdrop',
+                'make-it-fly',
                 'switch-costume'
             ]
         }],
@@ -1970,7 +1970,7 @@ export default {
         }, {
             deckIds: [
                 'add-a-backdrop',
-                'switch-costume'
+                'code-cartoon'
             ]
         }],
         urlId: 'add-effects'

--- a/src/lib/libraries/decks/index.jsx
+++ b/src/lib/libraries/decks/index.jsx
@@ -1734,7 +1734,7 @@ export default {
             image: 'glideAroundPoint'
         }, {
             deckIds: [
-                'add-a-backdrop',
+                'Tell-A-Story',
                 'switch-costume'
             ]
         }],


### PR DESCRIPTION
Change end-of-tutorial links for several tutorials

Changes: 
- **Create Animations That Talk** now points to Animate a Name and Talking Tales
- **Animate a Character** now points to Code a Cartoon and Create a Story
- **Use Arrow Keys** now points to Make it Fly and Animate a Sprite
- **Animate a Sprite** now points to Imagine a World and Add Effects
- **Add Effects** now points to Add a Backdrop and Code a Cartoon
- **Glide Around** now points to Create a Story and Animate a Sprite

This was inspired by the tutorial linking visualization that @paulkaplan helped Zoë create, as well as thinking from @kosiecki17 about learning pathways through the tutorials. 