### PR TITLE
try to help debug null/undef'd Redux action errors

### DIFF
--- a/src/reducers/gui.js
+++ b/src/reducers/gui.js
@@ -30,7 +30,24 @@ import throttle from 'redux-throttle';
 
 import decks from '../lib/libraries/decks/index.jsx';
 
-const guiMiddleware = compose(applyMiddleware(throttle(300, {leading: true, trailing: true})));
+const checkActionMiddleware = (/* store */) => (
+    next => (
+        action => {
+            if (action === null || typeof action === 'undefined') {
+                // something like this might help with debugging:
+                // console.log('Redux state at time of missing action:', store.getState());
+                throw new Error('Missing action in middleware. Invalid state transition?');
+            }
+            // if action is null or undefined then this call probably would have thrown anyway
+            return next(action);
+        }
+    )
+);
+
+const guiMiddleware = compose(applyMiddleware(
+    checkActionMiddleware,
+    throttle(300, {leading: true, trailing: true})
+));
 
 const guiInitialState = {
     alerts: alertsInitialState,


### PR DESCRIPTION
### Proposed Changes

This change introduces a new Redux middleware which checks the `action` and, if it's `null` or `undefined`, throws an `Error` suggesting that this might be due to an invalid state transition.

### Reason for Changes

Our current convention for Redux state transitions in GUI involves calls of the form `dispatch(createTransitionAction(state))`. The `createTransitionAction` function is expected to check the `state` to determine whether the transition is allowed, and if not, the function returns `undefined`.

Unfortunately, the high-level expression of this is difficult for a newcomer to interpret. The output looks similar to this:
```
Uncaught (in promise) TypeError: Cannot read property 'type' of undefined
    at Object.eval [as dispatch] (webpack-internal:///./node_modules/scratch-gui/node_modules/redux-throttle/build/index.js:56)
    at dispatch (<anonymous>:1:28545)
```

This error happens inside of `redux-throttle` because of the way it inspects the action to do its job. With different middleware this error might be expressed differently. Redux itself would probably detect the error and provide more meaningful debugging information, but that would only happen if the empty action made it through all middleware.

After this change, the output looks more like this:
```
Uncaught (in promise) Error: Missing action in middleware. Invalid state transition?
    at Object.eval [as dispatch] (webpack-internal:///./node_modules/scratch-gui/src/reducers/gui.js:78)
    at dispatch (<anonymous>:1:28545)
```

In both cases, the stack trace for the exception includes the offending `dispatch` call, which should help find the failing transition function.

### Test Coverage

Tested locally by causing invalid state transitions. Without those, GUI works as expected.
