### PR TITLE
Replace the binding method of the beforeunload event

### DIFF
--- a/src/lib/project-saver-hoc.jsx
+++ b/src/lib/project-saver-hoc.jsx
@@ -57,7 +57,7 @@ const ProjectSaverHOC = function (WrappedComponent) {
             if (typeof window === 'object') {
                 // Note: it might be better to use a listener instead of assigning onbeforeunload;
                 // but then it'd be hard to turn this listening off in our tests
-                window.onbeforeunload = e => this.leavePageConfirm(e);
+                window.addEventListener('beforeunload', this.leavePageConfirm);
             }
 
             // Allow the GUI consumer to pass in a function to receive a trigger
@@ -115,10 +115,7 @@ const ProjectSaverHOC = function (WrappedComponent) {
         }
         componentWillUnmount () {
             this.clearAutoSaveTimeout();
-            // Cant unset the beforeunload because it might no longer belong to this component
-            // i.e. if another of this component has been mounted before this one gets unmounted
-            // which happens when going from project to editor view.
-            // window.onbeforeunload = undefined; // eslint-disable-line no-undefined
+            window.removeEventListener('beforeunload', this.leavePageConfirm);
             // Remove project thumbnailer function since the components are unmounting
             this.props.onSetProjectThumbnailer(null);
             this.props.onSetProjectSaver(null);


### PR DESCRIPTION
### Resolves

If projectChanged is true, there will still be a warning after uninstalling the component

- Resolves #

### Proposed Changes

_Describe what this Pull Request does_

### Reason for Changes

You should clean up your behavior after the component is uninstalled

### Test Coverage

_Please show how you have added tests to cover your changes_

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
