### PR TITLE
Bump key cache version to v2 to clear out manually circle's cache.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,40 +4,40 @@ aliases:
     save_cache:
       paths:
         - .git
-      key: v1-git-{{ .Revision }}
+      key: v2-git-{{ .Revision }}
   - &restore_git_cache
     restore_cache:
       keys:
-        - v1-git-{{ .Revision }}
-        - v1-git-
+        - v2-git-{{ .Revision }}
+        - v2-git-
   - &save_build_cache
     save_cache:
       paths:
         - build
-      key: v1-build-{{ .Revision }}
+      key: v2-build-{{ .Revision }}
   - &restore_build_cache
     restore_cache:
       keys:
-        - v1-build-{{ .Revision }}
+        - v2-build-{{ .Revision }}
   - &save_dist_cache
     save_cache:
       paths:
         - dist
-      key: v1-dist-{{ .Revision }}
+      key: v2-dist-{{ .Revision }}
   - &restore_dist_cache
     restore_cache:
       keys:
-        - v1-dist-{{ .Revision }}
+        - v2-dist-{{ .Revision }}
   - &save_npm_cache
     save_cache:
       paths:
         - node_modules
-      key: v1-npm-{{ checksum "package-lock.json" }}
+      key: v2-npm-{{ checksum "package-lock.json" }}
   - &restore_npm_cache
     restore_cache:
       keys:
-        - v1-npm-{{ checksum "package-lock.json" }}
-        - v1-npm-
+        - v2-npm-{{ checksum "package-lock.json" }}
+        - v2-npm-
   - &defaults
     docker:
       - image: circleci/node:10-browsers


### PR DESCRIPTION
Link keeps failing on circle and I think it is related to having a change to package-lock cached that it shouldn't.

This is the only way I can currently see to "clear" circle's caches. 

The change that may have messed it up is https://github.com/LLK/scratch-gui/pull/6204.  It initially passed the build as a PR, but then did *not* when the branch built.  Then all subsequent builds on circle failed at the lint step.