### PR TITLE
Refresh workspace when dropping code from backpack onto sprite tile

### DIFF
--- a/src/containers/target-pane.jsx
+++ b/src/containers/target-pane.jsx
@@ -191,7 +191,7 @@ class TargetPane extends React.Component {
             topBlock.y = posY / scale;
         }
 
-        this.props.vm.shareBlocksToTarget(blocks, targetId, optFromTargetId);
+        return this.props.vm.shareBlocksToTarget(blocks, targetId, optFromTargetId);
     }
     handleDrop (dragInfo) {
         const {sprite: targetId} = this.props.hoveredTarget;
@@ -228,10 +228,8 @@ class TargetPane extends React.Component {
                 }, targetId);
             } else if (dragInfo.dragType === DragConstants.BACKPACK_CODE) {
                 fetchCode(dragInfo.payload.bodyUrl)
-                    .then(blocks => {
-                        this.shareBlocks(blocks, targetId);
-                        this.props.vm.refreshWorkspace();
-                    });
+                    .then(blocks => this.shareBlocks(blocks, targetId))
+                    .then(() => this.props.vm.refreshWorkspace());            
             }
         }
     }

--- a/src/containers/target-pane.jsx
+++ b/src/containers/target-pane.jsx
@@ -229,7 +229,7 @@ class TargetPane extends React.Component {
             } else if (dragInfo.dragType === DragConstants.BACKPACK_CODE) {
                 fetchCode(dragInfo.payload.bodyUrl)
                     .then(blocks => this.shareBlocks(blocks, targetId))
-                    .then(() => this.props.vm.refreshWorkspace());            
+                    .then(() => this.props.vm.refreshWorkspace());
             }
         }
     }


### PR DESCRIPTION
### Resolves
Resolves #5802 

### Proposed Changes
Run refreshWorkspace after shareBlocksToTarget

### Reason for Changes
shareBlocksToTarget returns Promise, so you need to refresh after that resolves

This is a replacement for the initial [PR](https://github.com/LLK/scratch-gui/pull/5803) from @apple502j, since I couldn't figure out how to fix the ci issues on that one. This one has identical code changes.    

### Test Coverage
tested locally on mac chrome