### PR TITLE
Remove autofocus from question input

### DIFF
--- a/src/components/question/question.jsx
+++ b/src/components/question/question.jsx
@@ -21,7 +21,6 @@ const QuestionComponent = props => {
                 ) : null}
                 <div className={styles.questionInput}>
                     <Input
-                        autoFocus
                         value={answer}
                         onChange={onChange}
                         onKeyPress={onKeyPress}


### PR DESCRIPTION
### Resolves
Resolves #6194 

### Proposed Changes
Removes `autoFocus` from question input

### Reason for Changes
This can be easily abused to force scrolling or disturb keyboard inputs (including report options)