### PR TITLE
Revert "build(deps): bump query-string from 5.1.1 to 6.13.7"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13306,13 +13306,13 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "query-string": {
-      "version": "6.13.7",
-      "resolved": "http://registry.npmjs.org/query-string/-/query-string-6.13.7.tgz",
-      "integrity": "sha512-CsGs8ZYb39zu0WLkeOhe0NMePqgYdAuCqxOYKDR5LVCytDZYMGx3Bb+xypvQvPHVPijRXB0HZNFllCzHRe4gEA==",
+      "version": "5.1.1",
+      "resolved": "http://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+      "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
       "requires": {
         "decode-uri-component": "^0.2.0",
-        "split-on-first": "^1.0.0",
-        "strict-uri-encode": "^2.0.0"
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
       }
     },
     "querystring": {
@@ -15255,11 +15255,6 @@
         }
       }
     },
-    "split-on-first": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
-      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
-    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -15424,9 +15419,9 @@
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
     },
     "strict-uri-encode": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
     "string-length": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "postcss-loader": "^3.0.0",
     "postcss-simple-vars": "^5.0.1",
     "prop-types": "^15.5.10",
-    "query-string": "^6.13.7",
+    "query-string": "^5.1.1",
     "raw-loader": "^0.5.1",
     "react": "16.2.0",
     "react-contextmenu": "2.9.4",


### PR DESCRIPTION
Reverts LLK/scratch-gui#6342

The PR to update gui on www is failing with the same error that the query-string update to www is. I'm thinking this is related so reverting to see if that solves the problem. Here are the builds:

The www version of the PR to bump query string doesn’t build with this error: https://travis-ci.org/github/LLK/scratch-www/builds/742529546#L3016
And there’s a PR to update gui on www that is currently failing with this error: https://travis-ci.com/github/LLK/scratch-www/builds/199659136#L3018 (edited) 