### PR TITLE
Revert "Remove autofocus from question input"

### DIFF
--- a/src/components/question/question.jsx
+++ b/src/components/question/question.jsx
@@ -21,6 +21,7 @@ const QuestionComponent = props => {
                 ) : null}
                 <div className={styles.questionInput}>
                     <Input
+                        autoFocus
                         value={answer}
                         onChange={onChange}
                         onKeyPress={onKeyPress}


### PR DESCRIPTION
Reverts LLK/scratch-gui#6230

There were issues with the question input flickering on edge and safari when we did additional QA.  So it's being reverted.