### PR TITLE
About menu

### DIFF
--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -86,6 +86,7 @@ const GUIComponent = props => {
         isPlayerOnly,
         isRtl,
         isShared,
+        isTelemetryEnabled,
         loading,
         logo,
         renderLogin,
@@ -160,6 +161,8 @@ const GUIComponent = props => {
             >
                 {telemetryModalVisible ? (
                     <TelemetryModal
+                        isRtl={isRtl}
+                        isTelemetryEnabled={isTelemetryEnabled}
                         onCancel={onTelemetryModalCancel}
                         onOptIn={onTelemetryModalOptIn}
                         onOptOut={onTelemetryModalOptOut}

--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -393,7 +393,6 @@ GUIComponent.propTypes = {
     onActivateCostumesTab: PropTypes.func,
     onActivateSoundsTab: PropTypes.func,
     onActivateTab: PropTypes.func,
-    onClickAbout: PropTypes.func,
     onClickAccountNav: PropTypes.func,
     onClickLogo: PropTypes.func,
     onCloseAccountNav: PropTypes.func,

--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -42,6 +42,9 @@ import {
     saveProjectAsCopy
 } from '../../reducers/project-state';
 import {
+    openAboutMenu,
+    closeAboutMenu,
+    aboutMenuOpen,
     openAccountMenu,
     closeAccountMenu,
     accountMenuOpen,
@@ -283,6 +286,56 @@ class MenuBar extends React.Component {
         }
         }
     }
+    buildAboutMenu (onClickAbout) {
+        if (!onClickAbout) {
+            // hide the button
+            return null;
+        }
+        if (typeof onClickAbout === 'function') {
+            // make a button which calls a function
+            return <AboutButton onClick={onClickAbout} />;
+        }
+        // assume it's an array of objects
+        // each item must have a 'title' FormattedMessage and a 'handleClick' function
+        // generate a menu with items for each object in the array
+        return (
+            <div
+                className={classNames(styles.menuBarItem, styles.hoverable, {
+                    [styles.active]: this.props.aboutMenuOpen
+                })}
+                onMouseUp={this.props.onRequestOpenAbout}
+            >
+                <img
+                    className={styles.aboutIcon}
+                    src={aboutIcon}
+                />
+                <MenuBarMenu
+                    className={classNames(styles.menuBarMenu)}
+                    open={this.props.aboutMenuOpen}
+                    place={this.props.isRtl ? 'right' : 'left'}
+                    onRequestClose={this.props.onRequestCloseAbout}
+                >
+                    {
+                        onClickAbout.map(itemProps => (
+                            <MenuItem
+                                key={itemProps.title}
+                                isRtl={this.props.isRtl}
+                                onClick={this.wrapAboutMenuCallback(itemProps.onClick)}
+                            >
+                                {itemProps.title}
+                            </MenuItem>
+                        ))
+                    }
+                </MenuBarMenu>
+            </div>
+        );
+    }
+    wrapAboutMenuCallback (callback) {
+        return () => {
+            callback();
+            this.props.onRequestCloseAbout();
+        };
+    }
     render () {
         const saveNowMessage = (
             <FormattedMessage
@@ -326,7 +379,7 @@ class MenuBar extends React.Component {
             </Button>
         );
         // Show the About button only if we have a handler for it (like in the desktop app)
-        const aboutButton = this.props.onClickAbout ? <AboutButton onClick={this.props.onClickAbout} /> : null;
+        const aboutButton = this.buildAboutMenu(this.props.onClickAbout);
         return (
             <Box
                 className={classNames(
@@ -713,6 +766,7 @@ class MenuBar extends React.Component {
 }
 
 MenuBar.propTypes = {
+    aboutMenuOpen: PropTypes.bool,
     accountMenuOpen: PropTypes.bool,
     authorId: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
     authorThumbnailUrl: PropTypes.string,
@@ -740,7 +794,15 @@ MenuBar.propTypes = {
     locale: PropTypes.string.isRequired,
     loginMenuOpen: PropTypes.bool,
     logo: PropTypes.string,
-    onClickAbout: PropTypes.func,
+    onClickAbout: PropTypes.oneOfType([
+        PropTypes.func, // button mode: call this callback when the About button is clicked
+        PropTypes.arrayOf( // menu mode: list of items in the About menu
+            PropTypes.shape({
+                title: PropTypes.string, // text for the menu item
+                onClick: PropTypes.func // call this callback when the menu item is clicked
+            })
+        )
+    ]),
     onClickAccount: PropTypes.func,
     onClickEdit: PropTypes.func,
     onClickFile: PropTypes.func,
@@ -755,6 +817,8 @@ MenuBar.propTypes = {
     onOpenRegistration: PropTypes.func,
     onOpenTipLibrary: PropTypes.func,
     onProjectTelemetryEvent: PropTypes.func,
+    onRequestOpenAbout: PropTypes.func,
+    onRequestCloseAbout: PropTypes.func,
     onRequestCloseAccount: PropTypes.func,
     onRequestCloseEdit: PropTypes.func,
     onRequestCloseFile: PropTypes.func,
@@ -782,6 +846,7 @@ const mapStateToProps = (state, ownProps) => {
     const loadingState = state.scratchGui.projectState.loadingState;
     const user = state.session && state.session.session && state.session.session.user;
     return {
+        aboutMenuOpen: aboutMenuOpen(state),
         accountMenuOpen: accountMenuOpen(state),
         fileMenuOpen: fileMenuOpen(state),
         editMenuOpen: editMenuOpen(state),
@@ -813,6 +878,8 @@ const mapDispatchToProps = dispatch => ({
     onRequestCloseLanguage: () => dispatch(closeLanguageMenu()),
     onClickLogin: () => dispatch(openLoginMenu()),
     onRequestCloseLogin: () => dispatch(closeLoginMenu()),
+    onRequestOpenAbout: () => dispatch(openAboutMenu()),
+    onRequestCloseAbout: () => dispatch(closeAboutMenu()),
     onClickNew: needSave => dispatch(requestNewProject(needSave)),
     onClickRemix: () => dispatch(remixProject()),
     onClickSave: () => dispatch(manualUpdateProject()),

--- a/src/components/telemetry-modal/telemetry-modal.css
+++ b/src/components/telemetry-modal/telemetry-modal.css
@@ -51,7 +51,7 @@ $ui-gray: hsla(0, 0%, 95%, 1);
 }
 
 /* stack the radio buttons vertically, not horizontally */
-.radioButtons label {
+.radio-buttons label {
     display: block;
     margin: 0.5rem;
     transition: all .125s ease;
@@ -63,16 +63,16 @@ $ui-gray: hsla(0, 0%, 95%, 1);
     vertical-align: middle;
 }
 
-.radioButtons label:hover {
+.radio-buttons label:hover {
     background-color: $ui-blue-10percent;
 }
 
-.radioButtons label.labelSelected,
-.radioButtons label.labelSelected:hover {
+.radio-buttons label.label-selected,
+.radio-buttons label.label-selected:hover {
     background-color: $ui-blue-25percent;
 }
 
-.radioButtons input[type="radio"] {
+.radio-buttons input[type="radio"] {
     margin: -1px 0.75rem 1px;
     border: 1px solid $active-gray;
     border-radius: 50%;
@@ -83,19 +83,19 @@ $ui-gray: hsla(0, 0%, 95%, 1);
     vertical-align: middle;
 }
 
-.radioButtons input[type="radio"]:checked,
-.radioButtons input[type="radio"]:focus {
+.radio-buttons input[type="radio"]:checked,
+.radio-buttons input[type="radio"]:focus {
     box-shadow: 0 0 0 2px $ui-blue-25percent;
     outline: none;
 }
 
-.radioButtons input[type="radio"]:checked {
+.radio-buttons input[type="radio"]:checked {
     transition: all .25s ease;
     background-color: $ui-white;
     border: 1px solid $motion-primary;
 }
 
-.radioButtons input[type="radio"]:checked::after {
+.radio-buttons input[type="radio"]:checked::after {
     display: block;
     margin: 0.125rem;
     border-radius: 50%;
@@ -116,7 +116,7 @@ $ui-gray: hsla(0, 0%, 95%, 1);
     font-weight: bolder;
 }
 
-.settingWasUpdated {
+.setting-was-updated {
     color: $extensions-primary;
 }
 

--- a/src/components/telemetry-modal/telemetry-modal.css
+++ b/src/components/telemetry-modal/telemetry-modal.css
@@ -37,7 +37,6 @@
 .body {
     background: $ui-white;
     padding: 1.5rem 2.25rem;
-    text-align: left;
 }
 
 .privacy-policy-link {
@@ -45,38 +44,50 @@
     text-decoration: none;
 }
 
+.radioButtons {
+    justify-content: center;
+    width: fit-content;
+}
+
+/* stack the radio buttons vertically, not horizontally */
+.radioButtons label {
+    display: block;
+    margin: 0.5rem;
+}
+
 /* Confirmation buttons at the bottom of the modal */
 .button-row {
     margin: 1.5rem 0;
     font-weight: bolder;
+}
+
+[dir="ltr"] .button-row {
     text-align: right;
-    display: flex;
-    justify-content: center;
+}
+
+[dir="rtl"] .button-row {
+    text-align: left;
 }
 
 .button-row button {
     border: 1px solid $motion-primary;
     border-radius: 0.25rem;
     padding: 0.5rem 1.5rem;
-    background: white;
+    color: white;
+    background: $motion-primary;
     font-weight: bold;
     font-size: .875rem;
     cursor: pointer;
 }
 
-.button-row button.opt-in {
-    background: $motion-primary;
-    color: white;
+.button-row button:hover {
+    background: $extensions-primary;
+    box-shadow: 0 0 0 6px $motion-transparent;
 }
 
-.button-row button.opt-out {
-    color: $motion-primary;
-}
-
-[dir="ltr"] .button-row button + button {
-    margin-left: 0.5rem;
-}
-
-[dir="rtl"] .button-row button + button {
-    margin-right: 0.5rem;
+.button-row button:disabled {
+    background: $text-primary;
+    border-color: $ui-black-transparent;
+    box-shadow: none;
+    opacity: 0.25;
 }

--- a/src/components/telemetry-modal/telemetry-modal.css
+++ b/src/components/telemetry-modal/telemetry-modal.css
@@ -58,9 +58,8 @@ $ui-gray: hsla(0, 0%, 95%, 1);
     background-color: $ui-gray;
     border-radius: .5rem;
     margin: 0 auto 0.375rem;
-    padding-left: 0.8125rem;
     align-items: center;
-    padding: 1rem;
+    padding: 1rem 0;
     vertical-align: middle;
 }
 
@@ -74,7 +73,7 @@ $ui-gray: hsla(0, 0%, 95%, 1);
 }
 
 .radioButtons input[type="radio"] {
-    margin: -1px 0.75rem 1px 0;
+    margin: -1px 0.75rem 1px;
     border: 1px solid $active-gray;
     border-radius: 50%;
     width: 1rem;
@@ -98,7 +97,7 @@ $ui-gray: hsla(0, 0%, 95%, 1);
 
 .radioButtons input[type="radio"]:checked::after {
     display: block;
-    transform: translate(.125rem, .125rem);
+    margin: 0.125rem;
     border-radius: 50%;
     background-color: $motion-primary;
     width: .625rem;

--- a/src/components/telemetry-modal/telemetry-modal.css
+++ b/src/components/telemetry-modal/telemetry-modal.css
@@ -107,16 +107,17 @@ $ui-gray: hsla(0, 0%, 95%, 1);
 
 /* Confirmation buttons at the bottom of the modal */
 .button-row {
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: space-between;
+    align-items: baseline;
+
     margin: 1.5rem 0;
     font-weight: bolder;
 }
 
-[dir="ltr"] .button-row {
-    text-align: right;
-}
-
-[dir="rtl"] .button-row {
-    text-align: left;
+.settingWasUpdated {
+    color: $extensions-primary;
 }
 
 .button-row button {

--- a/src/components/telemetry-modal/telemetry-modal.css
+++ b/src/components/telemetry-modal/telemetry-modal.css
@@ -3,6 +3,12 @@
 @import "../../css/typography.css";
 @import "../../css/z-index.css";
 
+/* from scratch-www */
+$active-gray: hsla(0, 0%, 0%, .1);
+$ui-blue-10percent: hsla(215, 100%, 65%, .1);
+$ui-blue-25percent:  hsla(215, 100%, 65%, .25);
+$ui-gray: hsla(0, 0%, 95%, 1);
+
 .modal-overlay {
     position: fixed;
     top: 0;
@@ -44,15 +50,60 @@
     text-decoration: none;
 }
 
-.radioButtons {
-    justify-content: center;
-    width: fit-content;
-}
-
 /* stack the radio buttons vertically, not horizontally */
 .radioButtons label {
     display: block;
     margin: 0.5rem;
+    transition: all .125s ease;
+    background-color: $ui-gray;
+    border-radius: .5rem;
+    margin: 0 auto 0.375rem;
+    padding-left: 0.8125rem;
+    align-items: center;
+    padding: 1rem;
+    vertical-align: middle;
+}
+
+.radioButtons label:hover {
+    background-color: $ui-blue-10percent;
+}
+
+.radioButtons label.labelSelected,
+.radioButtons label.labelSelected:hover {
+    background-color: $ui-blue-25percent;
+}
+
+.radioButtons input[type="radio"] {
+    margin: -1px 0.75rem 1px 0;
+    border: 1px solid $active-gray;
+    border-radius: 50%;
+    width: 1rem;
+    height: 1rem;
+    appearance: none;
+    background-color: $ui-white;
+    vertical-align: middle;
+}
+
+.radioButtons input[type="radio"]:checked,
+.radioButtons input[type="radio"]:focus {
+    box-shadow: 0 0 0 2px $ui-blue-25percent;
+    outline: none;
+}
+
+.radioButtons input[type="radio"]:checked {
+    transition: all .25s ease;
+    background-color: $ui-white;
+    border: 1px solid $motion-primary;
+}
+
+.radioButtons input[type="radio"]:checked::after {
+    display: block;
+    transform: translate(.125rem, .125rem);
+    border-radius: 50%;
+    background-color: $motion-primary;
+    width: .625rem;
+    height: .625rem;
+    content: "";
 }
 
 /* Confirmation buttons at the bottom of the modal */

--- a/src/components/telemetry-modal/telemetry-modal.css
+++ b/src/components/telemetry-modal/telemetry-modal.css
@@ -116,7 +116,13 @@ $ui-gray: hsla(0, 0%, 95%, 1);
     font-weight: bolder;
 }
 
+@keyframes fade-out {
+    0% {opacity: 1}
+    100% {opacity: 0}
+}
+
 .setting-was-updated {
+    animation: fade-out 3s ease-out;
     color: $extensions-primary;
 }
 

--- a/src/components/telemetry-modal/telemetry-modal.jsx
+++ b/src/components/telemetry-modal/telemetry-modal.jsx
@@ -87,6 +87,8 @@ class TelemetryModal extends React.PureComponent {
     }
     render () {
         const isUndecided = (typeof this.props.isTelemetryEnabled !== 'boolean');
+        const isOff = (this.props.isTelemetryEnabled === false);
+        const isOn = (this.props.isTelemetryEnabled === true);
         return (<ReactModal
             isOpen
             className={styles.modalContent}
@@ -114,7 +116,7 @@ class TelemetryModal extends React.PureComponent {
                         }}
                     /></p>
                     <Box className={styles.radioButtons}>
-                        <label>
+                        <label className={isOn ? styles.labelSelected : null}>
                             <input
                                 name="optInOut"
                                 type="radio"
@@ -125,7 +127,7 @@ class TelemetryModal extends React.PureComponent {
                             />
                             <FormattedMessage {...messages.optInText} />
                         </label>
-                        <label>
+                        <label className={isOff ? styles.labelSelected : null}>
                             <input
                                 name="optInOut"
                                 type="radio"

--- a/src/components/telemetry-modal/telemetry-modal.jsx
+++ b/src/components/telemetry-modal/telemetry-modal.jsx
@@ -33,25 +33,30 @@ const messages = defineMessages({
         description: 'Link to the Scratch privacy policy',
         id: 'gui.telemetryOptIn.privacyPolicyLink'
     },
-    noButton: {
-        defaultMessage: 'No, thanks',
-        description: 'Text for telemetry modal opt-out button',
-        id: 'gui.telemetryOptIn.buttonTextNo'
-    },
-    noTooltip: {
-        defaultMessage: 'Disable telemetry',
-        description: 'Tooltip for telemetry modal opt-out button',
-        id: 'gui.telemetryOptIn.buttonTooltipNo'
-    },
-    yesButton: {
-        defaultMessage: "Yes, I'd like to help improve Scratch",
+    optInText: {
+        defaultMessage: 'Share my usage data with the Scratch Team',
         description: 'Text for telemetry modal opt-in button',
-        id: 'gui.telemetryOptIn.buttonTextYes'
+        id: 'gui.telemetryOptIn.optInText'
     },
-    yesTooltip: {
+    optInTooltip: {
         defaultMessage: 'Enable telemetry',
         description: 'Tooltip for telemetry modal opt-in button',
-        id: 'gui.telemetryOptIn.buttonTooltipYes'
+        id: 'gui.telemetryOptIn.optInTooltip'
+    },
+    optOutText: {
+        defaultMessage: 'Do not share my usage data with the Scratch Team',
+        description: 'Text for telemetry modal opt-in button',
+        id: 'gui.telemetryOptIn.optOutText'
+    },
+    optOutTooltip: {
+        defaultMessage: 'Disable telemetry',
+        description: 'Tooltip for telemetry modal opt-out button',
+        id: 'gui.telemetryOptIn.optOutTooltip'
+    },
+    closeButton: {
+        defaultMessage: 'Close',
+        description: 'Text for the button which closes the telemetry modal dialog',
+        id: 'gui.telemetryOptIn.buttonClose'
     }
 });
 
@@ -60,8 +65,7 @@ class TelemetryModal extends React.PureComponent {
         super(props);
         bindAll(this, [
             'handleCancel',
-            'handleOptIn',
-            'handleOptOut'
+            'handleOptInOutChanged'
         ]);
     }
     handleCancel () {
@@ -70,19 +74,19 @@ class TelemetryModal extends React.PureComponent {
             this.props.onCancel();
         }
     }
-    handleOptIn () {
-        this.props.onRequestClose();
-        if (this.props.onOptIn) {
-            this.props.onOptIn();
-        }
-    }
-    handleOptOut () {
-        this.props.onRequestClose();
-        if (this.props.onOptOut) {
-            this.props.onOptOut();
+    handleOptInOutChanged (e) {
+        if (e.target.value === 'true') {
+            if (this.props.onOptIn) {
+                this.props.onOptIn();
+            }
+        } else if (e.target.value === 'false') {
+            if (this.props.onOptOut) {
+                this.props.onOptOut();
+            }
         }
     }
     render () {
+        const isUndecided = (typeof this.props.isTelemetryEnabled !== 'boolean');
         return (<ReactModal
             isOpen
             className={styles.modalContent}
@@ -109,20 +113,37 @@ class TelemetryModal extends React.PureComponent {
                             </a>)
                         }}
                     /></p>
+                    <Box className={styles.radioButtons}>
+                        <label>
+                            <input
+                                name="optInOut"
+                                type="radio"
+                                value="true"
+                                title={this.props.intl.formatMessage(messages.optInTooltip)}
+                                checked={this.props.isTelemetryEnabled === true}
+                                onChange={this.handleOptInOutChanged}
+                            />
+                            <FormattedMessage {...messages.optInText} />
+                        </label>
+                        <label>
+                            <input
+                                name="optInOut"
+                                type="radio"
+                                value="false"
+                                title={this.props.intl.formatMessage(messages.optOutTooltip)}
+                                checked={this.props.isTelemetryEnabled === false}
+                                onChange={this.handleOptInOutChanged}
+                            />
+                            <FormattedMessage {...messages.optOutText} />
+                        </label>
+                    </Box>
                     <Box className={styles.buttonRow}>
                         <button
-                            className={styles.optOut}
-                            title={this.props.intl.formatMessage(messages.noTooltip)}
-                            onClick={this.handleOptOut}
-                        >
-                            <FormattedMessage {...messages.noButton} />
-                        </button>
-                        <button
                             className={styles.optIn}
-                            title={this.props.intl.formatMessage(messages.yesTooltip)}
-                            onClick={this.handleOptIn}
+                            onClick={this.props.onRequestClose}
+                            disabled={isUndecided}
                         >
-                            <FormattedMessage {...messages.yesButton} />
+                            <FormattedMessage {...messages.closeButton} />
                         </button>
                     </Box>
                 </Box>
@@ -134,6 +155,7 @@ class TelemetryModal extends React.PureComponent {
 TelemetryModal.propTypes = {
     intl: intlShape.isRequired,
     isRtl: PropTypes.bool,
+    isTelemetryEnabled: PropTypes.bool, // false=disabled, true=enabled, undefined=undecided
     onCancel: PropTypes.func,
     onOptIn: PropTypes.func.isRequired,
     onOptOut: PropTypes.func.isRequired,

--- a/src/components/telemetry-modal/telemetry-modal.jsx
+++ b/src/components/telemetry-modal/telemetry-modal.jsx
@@ -80,6 +80,11 @@ class TelemetryModal extends React.PureComponent {
             settingWasUpdatedTimer: null
         };
     }
+    componentWillUnmount () {
+        if (this.state.settingWasUpdatedTimer) {
+            clearTimeout(this.state.settingWasUpdatedTimer);
+        }
+    }
     handleCancel () {
         this.props.onRequestClose();
         if (this.props.onCancel) {
@@ -178,7 +183,10 @@ class TelemetryModal extends React.PureComponent {
                         </label>
                     </Box>
                     <Box className={styles.buttonRow}>
-                        <span className={styles.settingWasUpdated}>{settingWasUpdated}</span>
+                        <span
+                            className={styles.settingWasUpdated}
+                            key={this.state.settingWasUpdatedTimer} // restart CSS fade when timer changes
+                        >{settingWasUpdated}</span>
                         <button
                             className={styles.optIn}
                             onClick={this.props.onRequestClose}

--- a/src/lib/app-state-hoc.jsx
+++ b/src/lib/app-state-hoc.jsx
@@ -97,6 +97,7 @@ const AppStateHOC = function (WrappedComponent, localesOnly) {
             const {
                 isFullScreen, // eslint-disable-line no-unused-vars
                 isPlayerOnly, // eslint-disable-line no-unused-vars
+                isTelemetryEnabled, // eslint-disable-line no-unused-vars
                 showTelemetryModal, // eslint-disable-line no-unused-vars
                 ...componentProps
             } = this.props;
@@ -114,6 +115,7 @@ const AppStateHOC = function (WrappedComponent, localesOnly) {
     AppStateWrapper.propTypes = {
         isFullScreen: PropTypes.bool,
         isPlayerOnly: PropTypes.bool,
+        isTelemetryEnabled: PropTypes.bool,
         showTelemetryModal: PropTypes.bool
     };
     return AppStateWrapper;

--- a/src/reducers/menus.js
+++ b/src/reducers/menus.js
@@ -1,6 +1,7 @@
 const OPEN_MENU = 'scratch-gui/menus/OPEN_MENU';
 const CLOSE_MENU = 'scratch-gui/menus/CLOSE_MENU';
 
+const MENU_ABOUT = 'aboutMenu';
 const MENU_ACCOUNT = 'accountMenu';
 const MENU_FILE = 'fileMenu';
 const MENU_EDIT = 'editMenu';
@@ -9,6 +10,7 @@ const MENU_LOGIN = 'loginMenu';
 
 
 const initialState = {
+    [MENU_ABOUT]: false,
     [MENU_ACCOUNT]: false,
     [MENU_FILE]: false,
     [MENU_EDIT]: false,
@@ -39,6 +41,9 @@ const closeMenu = menu => ({
     type: CLOSE_MENU,
     menu: menu
 });
+const openAboutMenu = () => openMenu(MENU_ABOUT);
+const closeAboutMenu = () => closeMenu(MENU_ABOUT);
+const aboutMenuOpen = state => state.scratchGui.menus[MENU_ABOUT];
 const openAccountMenu = () => openMenu(MENU_ACCOUNT);
 const closeAccountMenu = () => closeMenu(MENU_ACCOUNT);
 const accountMenuOpen = state => state.scratchGui.menus[MENU_ACCOUNT];
@@ -58,6 +63,9 @@ const loginMenuOpen = state => state.scratchGui.menus[MENU_LOGIN];
 export {
     reducer as default,
     initialState as menuInitialState,
+    openAboutMenu,
+    closeAboutMenu,
+    aboutMenuOpen,
     openAccountMenu,
     closeAccountMenu,
     accountMenuOpen,


### PR DESCRIPTION
### Resolves

Work toward LLK/scratch-desktop#97

### Proposed Changes

* Support displaying a menu for the About button, if `onClickAbout` is a list of items instead of just one callback
* Adjust the design of the telemetry modal to better support letting the user change their mind in a later session

### Reason for Changes

Our design for LLK/scratch-desktop#97 involves adding a menu to the Scratch app for Windows & macOS. This menu will contain an entry to open the "About" window, display the privacy policy, and open the telemetry modal.

Viewing the privacy policy in-app is not only a good idea, it's also now required by Microsoft Store policy.

Re-opening the telemetry modal on demand will allow the user to change their mind at any time, which is not required by any policy but was recommended to us and seems like a good idea anyway.

The existing functionality for the "About" button, in which it calls a callback instead of opening a menu, is retained by this set of changes because it's being used by some of the Scratch Lab efforts.

### Test Coverage

Tested in context in scratch-desktop.
