### PR TITLE
Revert "Only call Renderer.pick() on draggable targets in Stage.onStartDrag"

### DIFF
--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -342,28 +342,15 @@ class Stage extends React.Component {
     }
     onStartDrag (x, y) {
         if (this.state.dragId) return;
-
-        // Targets with no attached drawable cannot be dragged.
-        let draggableTargets = this.props.vm.runtime.targets.filter(
-            target => Number.isFinite(target.drawableID)
-        );
-
-        // Because pick queries can be expensive, only perform them for drawables that are currently draggable.
-        // If we're in the editor, we can drag all targets. Otherwise, filter.
-        if (!this.props.useEditorDragStyle) {
-            draggableTargets = draggableTargets.filter(
-                target => target.draggable
-            );
-        }
-        if (draggableTargets.length === 0) return;
-
-        const draggableIDs = draggableTargets.map(target => target.drawableID);
-        const drawableId = this.renderer.pick(x, y, 1, 1, draggableIDs);
+        const drawableId = this.renderer.pick(x, y);
         if (drawableId === null) return;
         const targetId = this.props.vm.getTargetIdForDrawableId(drawableId);
         if (targetId === null) return;
 
         const target = this.props.vm.runtime.getTargetById(targetId);
+
+        // Do not start drag unless in editor drag mode or target is draggable
+        if (!(this.props.useEditorDragStyle || target.draggable)) return;
 
         // Dragging always brings the target to the front
         target.goToFront();


### PR DESCRIPTION
Reverts LLK/scratch-gui#4982

In the bug hunt testing, we realized that #4982 does indeed let you pick up a draggable sprite that's hidden on the bottom of a stack of non-draggable sprites; contrast the "Purple cats are a drag" projects in these studios: 

* https://scratch.mit.edu/studios/28480703/
* https://scratch.ly/studios/10003668/

Reverting.
