### PR TITLE
Import V2SVGAdapter instead of SVGRenderer

### DIFF
--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -8,7 +8,7 @@ import {connect} from 'react-redux';
 import {STAGE_DISPLAY_SIZES} from '../lib/layout-constants';
 import {getEventXY} from '../lib/touch-utils';
 import VideoProvider from '../lib/video/video-provider';
-import {SVGRenderer as V2SVGAdapter} from 'scratch-svg-renderer';
+import {V2SVGAdapter} from 'scratch-svg-renderer';
 import {BitmapAdapter as V2BitmapAdapter} from 'scratch-svg-renderer';
 
 import StageComponent from '../components/stage/stage.jsx';
@@ -69,7 +69,7 @@ class Stage extends React.Component {
             // default color
             this.props.vm.renderer.draw();
         }
-        this.props.vm.attachV2SVGAdapter(new V2SVGAdapter());
+        this.props.vm.attachV2SVGAdapter(V2SVGAdapter);
         this.props.vm.attachV2BitmapAdapter(new V2BitmapAdapter());
     }
     componentDidMount () {


### PR DESCRIPTION
## Depends on https://github.com/LLK/scratch-svg-renderer/pull/213 and https://github.com/LLK/scratch-vm/pull/2800

### Resolves

- Resolves https://github.com/LLK/scratch-svg-renderer/issues/211

### Proposed Changes

This PR imports the `V2SVGAdapter` API from `scratch-svg-renderer` instead of the entire `SvgRenderer` class.

### Reason for Changes

This will allow the monolithic `SvgRenderer` class to be removed.

### Test Coverage

Tested manually

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome

Linux
* [x] Firefox
* [x] Chrome