### PR TITLE
Pass fixupSvgString into paint editor

### DIFF
--- a/src/containers/paint-editor-wrapper.jsx
+++ b/src/containers/paint-editor-wrapper.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import bindAll from 'lodash.bindall';
 import VM from 'scratch-vm';
 import PaintEditor from 'scratch-paint';
-import {inlineSvgFonts} from 'scratch-svg-renderer';
+import {inlineSvgFonts, fixupSvgString} from 'scratch-svg-renderer';
 
 import {connect} from 'react-redux';
 
@@ -54,6 +54,7 @@ class PaintEditorWrapper extends React.Component {
                 onUpdateImage={this.handleUpdateImage}
                 onUpdateName={this.handleUpdateName}
                 fontInlineFn={inlineSvgFonts}
+                fixupSvgStringFn={fixupSvgString}
             />
         );
     }


### PR DESCRIPTION
## Depends on https://github.com/LLK/scratch-svg-renderer/pull/209 and https://github.com/LLK/scratch-svg-renderer/pull/210

### Resolves

- Resolves https://github.com/LLK/scratch-paint/issues/1269

### Proposed Changes

This PR passes the `fixupSvgString` function into the paint editor component.

### Reason for Changes

This allows us to call `fixupSvgString` from the paint editor without it depending on `scratch-svg-renderer` itself.

### Test Coverage

Tested manually

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome

Linux
* [x] Firefox