### PR TITLE
fix isRtl warning

### DIFF
--- a/src/containers/target-pane.jsx
+++ b/src/containers/target-pane.jsx
@@ -243,6 +243,7 @@ class TargetPane extends React.Component {
             onReceivedBlocks,
             onShowImporting,
             workspaceMetrics,
+            isRtl,
             ...componentProps
         } = this.props;
         /* eslint-enable no-unused-vars */


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

https://github.com/LLK/scratch-gui/issues/6560

### Proposed Changes

Remove `isRtl` prop from `...rest`ing
### Reason for Changes

isRtl was passed down from parent,  it should be added to `unused vars`
