### PR TITLE
set DETECT_CHROMEDRIVER_VERSION for integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,6 +112,7 @@ jobs:
     parallelism: 2
     environment:
       JEST_JUNIT_OUTPUT_NAME: results.txt
+      DETECT_CHROMEDRIVER_VERSION: true
     steps:
       - *restore_git_cache
       - checkout


### PR DESCRIPTION
### Resolves

Resolves #5790

### Proposed Changes

Sets the environment variable `DETECT_CHROMEDRIVER_VERSION` to `true` during integration tests

### Reason for Changes

We use `node-chromedriver` to download the `chromedriver` tool used by our integration tests. By default, `node-chromedriver` downloads the version of `chromedriver` which matches the `node-chromedriver` version. If the version of `chromedriver` mismatches the version of Chrome, though, integration tests fail as described in #5790.

Setting the environment variable `DETECT_CHROMEDRIVER_VERSION` to `true` causes `node-chromedriver` to instead download a version of `chromedriver` which matches the detected version of Chrome. This could cause `node-chromedriver` version 87 to download `chromedriver` version 88, for example, allowing integration tests to pass.

### Test Coverage

As of this writing, out `node-chromedriver` version is out of date and integration tests are failing in the `develop` branch. If the integration tests on this PR pass, it means the environment variable is working :)
