### PR TITLE
Correctly specify react and react-dom as externals

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,10 +27,6 @@ const base = {
         filename: '[name].js',
         chunkFilename: 'chunks/[name].js'
     },
-    externals: {
-        React: 'react',
-        ReactDOM: 'react-dom'
-    },
     resolve: {
         symlinks: false
     },
@@ -112,10 +108,6 @@ module.exports = [
         output: {
             path: path.resolve(__dirname, 'build'),
             filename: '[name].js'
-        },
-        externals: {
-            React: 'react',
-            ReactDOM: 'react-dom'
         },
         module: {
             rules: base.module.rules.concat([
@@ -200,8 +192,8 @@ module.exports = [
                 publicPath: `${STATIC_PATH}/`
             },
             externals: {
-                React: 'react',
-                ReactDOM: 'react-dom'
+                'react': 'react',
+                'react-dom': 'react-dom'
             },
             module: {
                 rules: base.module.rules.concat([


### PR DESCRIPTION
Previously, the syntax for `externals` in the webpack config was incorrect and was not doing anything.

Additionally, it was attempting to set react and react-dom as externals in the playground
builds, which is incorrect, they need to be included in the playground build. Luckily the syntax was wrong anyway ;)

Since the distribution only exports the GUI component, and not anything useable without react, I think it is safe to say that any consumer of the `scratch-gui` npm repo already has React/ReactDOM as a peer dependency (it is specified that way in the package.json already). So I do not think this will cause any breakage from any downstream consumers (either ours like `scratch-www`) or anyone elses.

This allows us to more freely update 3 related parts around React:
1. As a GUI consumer, know that it is safe to specify your own React version and GUI will be using it as well, ensuring their are no "double react version" errors (like what happens now if you try to update www to react17).
2. The GUI repo can update the version of React it is using in local development/deployed to the example playgrounds, without worrying about such changes being included in downstream consumers of GUI
3. The package.json can update its peerDependency section to include react > 16 when it is tested, and can also bump up its minimum required version when it starts to update to new features (new lifecycle methods, etc).

---

I've tested this in a few ways:
1. Confirm the playground files still work, and still bundle react/react-dom
2. Confirm that react/react-dom are not included in the `dist` build (did this using the `webpack-bundle-analyzer` package locally)
3. Confirm that as a consumer of this new dist I can require my own version of react and have it used by the GUI (did this by including some logging about which react version is being used by both the `www/preview.jsx` and `gui/gui.jsx` files)

---

Note for anyone building scratch-gui from src (@cwillisf with `scratch-desktop`) this should not have any impact here, since (a) the externals section wasn't doing anything anyway and (b) the gui/webpack config wouldn't have been used in that situation anyway. 
