### PR TITLE
don't pass isRtl to TargetPaneComponent

### DIFF
--- a/src/containers/target-pane.jsx
+++ b/src/containers/target-pane.jsx
@@ -237,6 +237,7 @@ class TargetPane extends React.Component {
         /* eslint-disable no-unused-vars */
         const {
             dispatchUpdateRestore,
+            isRtl,
             onActivateTab,
             onCloseImporting,
             onHighlightTarget,


### PR DESCRIPTION
### Resolves

Resolves #6560

Closes #6630 

After I made this change, I noticed that @chungwong also proposed #6630 with a similar change. Sorry about that! The only real difference is that the `isRtl` property is listed in alphabetical order here.

### Proposed Changes

Adds `isRtl` to the list of properties NOT passed from `TargetPane` to `TargetPaneComponent`.

### Reason for Changes

I know this is a low-priority issue but I was recently doing some work that involved a lot of logging and reloading and the warning message was getting in the way, so I tracked it down and fixed it.

Prior to this change, `TargetPane` passed `isRtl` to `TargetPaneComponent` which then passed it into a `div`, causing the warning below. Since `TargetPaneComponent` doesn't currently use `isRtl` so there's no need to pass it in. If `TargetPaneComponent` starts needing `isRtl` then we should adjust it to not pass that property to any DOM elements.

The console warning in question is 57 lines long and starts with:

> Warning: React does not recognize the `isRtl` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `isrtl` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
