### PR TITLE
Update babel/runtime to avoid error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -397,15 +397,15 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001187",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001187.tgz",
-          "integrity": "sha512-w7/EP1JRZ9552CyrThUnay2RkZ1DXxKe/Q2swTC4+LElLh9RRYrL1Z+27LlakB8kzY0fSmHw9mc7XYDUKAKWMA==",
+          "version": "1.0.30001189",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001189.tgz",
+          "integrity": "sha512-BSfxClP/UWCD0RX1h1L+vLDexNSJY7SfOtbJtW10bcnatfj3BcoietUFYNwWreOCk+SNvGUaNapGqUNPiGAiSA==",
           "dev": true
         },
         "electron-to-chromium": {
-          "version": "1.3.667",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.667.tgz",
-          "integrity": "sha512-Ot1pPtAVb5nd7jeVF651zmfLFilRVFomlDzwXmdlWe5jyzOGa6mVsQ06XnAurT7wWfg5VEIY+LopbAdD/bpo5w==",
+          "version": "1.3.669",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.669.tgz",
+          "integrity": "sha512-VNj10fmGC6SbE7s4tKG7y2OopVXYoTIfjE1MetflPd77KmeRuHtkl+HYsfF00BGg5hyaorTUn6lTToEHaciOSw==",
           "dev": true
         },
         "node-releases": {
@@ -688,9 +688,9 @@
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.13.tgz",
-      "integrity": "sha512-acKF7EjqOR67ASIlDTupwkKM1eUisNAjaSduo5Cz+793ikfnpe7p4Q7B7EWU2PCoSTPWsQkR7hRUWEIZPiVLGA==",
+      "version": "7.12.17",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.17.tgz",
+      "integrity": "sha512-sFL+p6zOCQMm9vilo06M4VHuTxUAwa6IxgL56Tq1DVtA0ziAGTH1ThmJq7xwPqdQlgAbKX3fb0oZNbtRIyA5KQ==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.12.13",
@@ -699,8 +699,8 @@
         "@babel/helper-split-export-declaration": "^7.12.13",
         "@babel/helper-validator-identifier": "^7.12.11",
         "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.12.13",
-        "@babel/types": "^7.12.13",
+        "@babel/traverse": "^7.12.17",
+        "@babel/types": "^7.12.17",
         "lodash": "^4.17.19"
       },
       "dependencies": {
@@ -714,12 +714,12 @@
           }
         },
         "@babel/generator": {
-          "version": "7.12.15",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.15.tgz",
-          "integrity": "sha512-6F2xHxBiFXWNSGb7vyCUTBF8RCLY66rS0zEPcP8t/nQyXjha5EuK4z7H5o7fWG8B4M7y6mqVWq1J+1PuwRhecQ==",
+          "version": "7.12.17",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.17.tgz",
+          "integrity": "sha512-DSA7ruZrY4WI8VxuS1jWSRezFnghEoYEFrZcw9BizQRmOZiUsiHl59+qEARGPqPikwA/GPTyRCi7isuCK/oyqg==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.12.13",
+            "@babel/types": "^7.12.17",
             "jsesc": "^2.5.1",
             "source-map": "^0.5.0"
           }
@@ -771,9 +771,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.12.16",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.16.tgz",
-          "integrity": "sha512-c/+u9cqV6F0+4Hpq01jnJO+GLp2DdT63ppz9Xa+6cHaajM9VFzK/iDXiKK65YtpeVwu+ctfS6iqlMqRgQRzeCw==",
+          "version": "7.12.17",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.17.tgz",
+          "integrity": "sha512-r1yKkiUTYMQ8LiEI0UcQx5ETw5dpTLn9wijn9hk6KkTtOK95FndDN10M+8/s6k/Ymlbivw0Av9q4SlgF80PtHg==",
           "dev": true
         },
         "@babel/template": {
@@ -788,26 +788,26 @@
           }
         },
         "@babel/traverse": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.13.tgz",
-          "integrity": "sha512-3Zb4w7eE/OslI0fTp8c7b286/cQps3+vdLW3UcwC8VSJC6GbKn55aeVVu2QJNuCDoeKyptLOFrPq8WqZZBodyA==",
+          "version": "7.12.17",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.17.tgz",
+          "integrity": "sha512-LGkTqDqdiwC6Q7fWSwQoas/oyiEYw6Hqjve5KOSykXkmFJFqzvGMb9niaUEag3Rlve492Mkye3gLw9FTv94fdQ==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.12.13",
-            "@babel/generator": "^7.12.13",
+            "@babel/generator": "^7.12.17",
             "@babel/helper-function-name": "^7.12.13",
             "@babel/helper-split-export-declaration": "^7.12.13",
-            "@babel/parser": "^7.12.13",
-            "@babel/types": "^7.12.13",
+            "@babel/parser": "^7.12.17",
+            "@babel/types": "^7.12.17",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
             "lodash": "^4.17.19"
           }
         },
         "@babel/types": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.13.tgz",
-          "integrity": "sha512-oKrdZTld2im1z8bDwTOQvUbxKwE+854zc16qWZQlcTqMN00pWxHQ4ZeOq0yDMnisOpRykH2/5Qqcrk/OlbAjiQ==",
+          "version": "7.12.17",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.17.tgz",
+          "integrity": "sha512-tNMDjcv/4DIcHxErTgwB9q2ZcYyN0sUfgGKUK/mm1FJK7Wz+KstoEekxrl/tBiNDgLK1HGi+sppj1An/1DR4fQ==",
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.12.11",
@@ -5759,12 +5759,12 @@
       "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
     },
     "core-js-compat": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.8.3.tgz",
-      "integrity": "sha512-1sCb0wBXnBIL16pfFG1Gkvei6UzvKyTNYpiC41yrdjEv0UoJoq9E/abTMzyYJ6JpTkAj15dLjbqifIzEBDVvog==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.9.0.tgz",
+      "integrity": "sha512-YK6fwFjCOKWwGnjFUR3c544YsnA/7DoLL0ysncuOJ4pwbriAtOpvM2bygdlcXbvQCQZ7bBU9CL4t7tGl7ETRpQ==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.16.1",
+        "browserslist": "^4.16.3",
         "semver": "7.0.0"
       },
       "dependencies": {
@@ -5782,15 +5782,15 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001187",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001187.tgz",
-          "integrity": "sha512-w7/EP1JRZ9552CyrThUnay2RkZ1DXxKe/Q2swTC4+LElLh9RRYrL1Z+27LlakB8kzY0fSmHw9mc7XYDUKAKWMA==",
+          "version": "1.0.30001189",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001189.tgz",
+          "integrity": "sha512-BSfxClP/UWCD0RX1h1L+vLDexNSJY7SfOtbJtW10bcnatfj3BcoietUFYNwWreOCk+SNvGUaNapGqUNPiGAiSA==",
           "dev": true
         },
         "electron-to-chromium": {
-          "version": "1.3.667",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.667.tgz",
-          "integrity": "sha512-Ot1pPtAVb5nd7jeVF651zmfLFilRVFomlDzwXmdlWe5jyzOGa6mVsQ06XnAurT7wWfg5VEIY+LopbAdD/bpo5w==",
+          "version": "1.3.669",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.669.tgz",
+          "integrity": "sha512-VNj10fmGC6SbE7s4tKG7y2OopVXYoTIfjE1MetflPd77KmeRuHtkl+HYsfF00BGg5hyaorTUn6lTToEHaciOSw==",
           "dev": true
         },
         "node-releases": {
@@ -13928,9 +13928,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.12.17",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.17.tgz",
-          "integrity": "sha512-nEvWif7aHm4O0lTT2p4kYCfYwsGSBiWA8XmAqovusBDKugpUy3BVggAjJL4iFWIwrFJktay2VLtAQl1/l8Xsow==",
+          "version": "7.12.18",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.18.tgz",
+          "integrity": "sha512-BogPQ7ciE6SYAUPtlm9tWbgI9+2AgqSam6QivMgXgAT+fKbgppaj4ZX15MHeLC1PVF5sNk70huBu20XxWOs8Cg==",
           "dev": true,
           "requires": {
             "regenerator-runtime": "^0.13.4"


### PR DESCRIPTION
Fix an issue where our package lock included the package @babel/runtime on version 7.12.17, updated from the `@babel/preset-env` update from earlier today. Re-install that package to get the package-lock to bump @babel/runtime from 17 to 18, avoiding this error. 

/cc @BryceLTaylor I think if our CI was using `npm ci` instead of `npm install` it would have caught this problem. I think what happened is that `npm install` skipped over the broken version (even though it is listed in the package-lock) so it didn't fail on CI. Also /cc @picklesrus since I believe we talked about making this change in eng meeting a few weeks back?