### PR TITLE
Fix wobbly sprite dragging

### DIFF
--- a/src/components/stage/stage.jsx
+++ b/src/components/stage/stage.jsx
@@ -112,12 +112,23 @@ const StageComponent = props => {
                             </div>
                         )}
                     </div>
-                    <canvas
-                        className={styles.draggingSprite}
-                        height={0}
-                        ref={dragRef}
-                        width={0}
-                    />
+                    {
+                        // Give the canvases two different keys to prevent React from recycling the same canvas
+                        // across two different context types (2D and WebGL)
+                        wobblyDragging ? <canvas
+                            className={classNames(styles.draggingSprite, styles.wobbly)}
+                            height={0}
+                            ref={wobblyDragRef}
+                            width={0}
+                            key="non-wobbly"
+                        /> : <canvas
+                            className={styles.draggingSprite}
+                            height={0}
+                            ref={dragRef}
+                            width={0}
+                            key="wobbly"
+                        />
+                    }
                 </Box>
                 {isStarted ? null : (
                     <GreenFlagOverlay
@@ -125,55 +136,6 @@ const StageComponent = props => {
                         wrapperClass={styles.greenFlagOverlayWrapper}
                     />
                 )}
-                {isColorPicking && colorInfo ? (
-                    <Box className={styles.colorPickerWrapper}>
-                        <Loupe colorInfo={colorInfo} />
-                    </Box>
-                ) : null}
-                <div
-                    className={styles.stageBottomWrapper}
-                    style={{
-                        width: stageDimensions.width,
-                        height: stageDimensions.height,
-                        left: '50%',
-                        marginLeft: stageDimensions.width * -0.5
-                    }}
-                >
-                    {micIndicator ? (
-                        <MicIndicator
-                            className={styles.micIndicator}
-                            stageSize={stageDimensions}
-                        />
-                    ) : null}
-                    {question === null ? null : (
-                        <div
-                            className={styles.questionWrapper}
-                            style={{width: stageDimensions.width}}
-                        >
-                            <Question
-                                question={question}
-                                onQuestionAnswered={onQuestionAnswered}
-                            />
-                        </div>
-                    )}
-                </div>
-                {
-                    // Give the canvases two different keys to prevent React from recycling the same canvas
-                    // across two different context types (2D and WebGL)
-                    wobblyDragging ? <canvas
-                        className={classNames(styles.draggingSprite, styles.wobbly)}
-                        height={0}
-                        ref={wobblyDragRef}
-                        width={0}
-                        key="non-wobbly"
-                    /> : <canvas
-                        className={styles.draggingSprite}
-                        height={0}
-                        ref={dragRef}
-                        width={0}
-                        key="wobbly"
-                    />
-                }
             </Box>
             {isColorPicking ? (
                 <Box

--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -382,11 +382,6 @@ class Stage extends React.Component {
         const offsetX = target.x - scratchMouseX;
         const offsetY = -(target.y + scratchMouseY);
 
-        // Ensure drag canvas' bounds are tight by forcing renderer to generate tight bounds
-        this.renderer.getBounds(drawableId);
-        // Extract the drawable art
-        const drawableData = this.renderer.extractDrawable(drawableId, x, y);
-
         this.props.vm.startDrag(targetId);
         this.setState({
             isDragging: true,
@@ -397,11 +392,13 @@ class Stage extends React.Component {
         });
 
         if (this.props.useEditorDragStyle) {
+            // Ensure drag canvas' bounds are tight by forcing renderer to generate tight bounds
+            if (this.props.wobblyDragging) this.renderer.getBounds(drawableId);
+            // Extract the drawable art
+            const drawableData = this.renderer.extractDrawableScreenSpace(drawableId);
             if (this.props.wobblyDragging) {
                 this.wobblyDragCanvas.reinit(drawableData, x, y);
             } else {
-                // Extract the drawable art
-                const drawableData = this.renderer.extractDrawableScreenSpace(drawableId);
                 this.drawDragCanvas(drawableData, x, y);
                 this.positionDragCanvas(x, y);
             }

--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -397,7 +397,8 @@ class Stage extends React.Component {
             // Extract the drawable art
             const drawableData = this.renderer.extractDrawableScreenSpace(drawableId);
             if (this.props.wobblyDragging) {
-                this.wobblyDragCanvas.reinit(drawableData, x, y);
+                const ratio = this.canvas.getBoundingClientRect().width / this.canvas.width;
+                this.wobblyDragCanvas.reinit(drawableData, x, y, ratio);
             } else {
                 this.drawDragCanvas(drawableData, x, y);
                 this.positionDragCanvas(x, y);

--- a/src/lib/rubber-canvas.js
+++ b/src/lib/rubber-canvas.js
@@ -88,7 +88,6 @@ class RubberCanvas {
         this._canvas = canvas;
         this._gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
         this._size = [0, 0];
-        this._mousePosition = [0, 0];
 
         const numPoints = (SUBDIVISIONS + 1) ** 2;
         this._springs = [];
@@ -168,7 +167,6 @@ class RubberCanvas {
         gl.activeTexture(gl.TEXTURE0);
         this._texture = gl.createTexture();
 
-        // This will be correct if https://github.com/LLK/scratch-render/pull/556 goes in in time
         gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, true);
 
         gl.clearColor(0, 0, 0, 0);
@@ -178,11 +176,14 @@ class RubberCanvas {
         const {
             width,
             height,
-            x: grabX,
-            y: grabY
+            x: drawableX,
+            y: drawableY
         } = drawableData;
 
-        this._setData(drawableData);
+        const grabX = x - drawableX;
+        const grabY = y - drawableY;
+
+        this._setData(drawableData.imageData);
 
         // Reinitialize springs' mass based on their distance to the point at which the sprite was grabbed
         for (let i = 0; i <= SUBDIVISIONS; i++) {
@@ -204,8 +205,8 @@ class RubberCanvas {
 
         this._lastTimestamp = performance.now();
         const {x: parentX, y: parentY} = this._canvas.parentElement.getBoundingClientRect();
-        this._canvas.style.left = `${-grabX + parentX}px`;
-        this._canvas.style.top = `${-grabY + parentY}px`;
+        this._canvas.style.left = `${parentX - grabX}px`;
+        this._canvas.style.top = `${parentY - grabY}px`;
         this._canvas.style.display = 'block';
         this.step();
     }
@@ -248,9 +249,6 @@ class RubberCanvas {
     }
 
     updateMousePosition ([x, y]) {
-        this._mousePosition[0] = x;
-        this._mousePosition[1] = y;
-
         // update springs' destinations to match new mouse position
         for (let i = 0; i <= SUBDIVISIONS; i++) {
             const springX = (i / SUBDIVISIONS) * this._size[0];


### PR DESCRIPTION
### Resolves

None of these issues have hit production yet and only exist on the `hotfix/totally-normal-2021` branch--should I make issues for tracking purposes?

- #5507 has regressed, even when wobbly sprite dragging is turned off:
  ![Peek 2021-03-16 03-18](https://user-images.githubusercontent.com/25993062/111270502-52ae1c00-8606-11eb-8690-f887c8b3fb05.gif)
- Wobbly dragged sprites are improperly sized in small-stage mode and on high-DPI devices:
  ![Peek 2021-03-16 03-20](https://user-images.githubusercontent.com/25993062/111270708-93a63080-8606-11eb-8f72-b855069bed0e.gif)
- There are two `Loupe` components rendered at once when color picking, and two ask prompts displayed atop one another when "ask and wait" is used. This seems to be a result of a merge gone wrong in the `Stage` component. This also occurs even when wobbly sprite dragging is turned off.

### Proposed Changes

This PR merges in changes from #5508 and #5513, and fixes the merge in `stage.jsx`, to ensure that wobbly sprite dragging is a good experience for all Scratchers.

### Reason for Changes

_Explain why these changes should be made_

### Test Coverage

Tested manually

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge

Linux
 * [x] Firefox
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
