### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Here's how to link your local `scratch-gui` code to another project's `node_modu
 2. From the top level of each repository (such as `scratch-www`) that depends on `scratch-gui`:
     1. Make sure you have run `npm install`
     2. Run `npm link scratch-gui`
-    3. Build or run the repositoriy
+    3. Build or run the repository
 
 #### Using `npm run watch`
 


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves #6989

### Proposed Changes

_Describe what this Pull Request does_
This fixes a typo in the word Repository
### Reason for Changes

Typos are bad
### Test Coverage

Not neccesary
### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [x] Chrome 
 * [ ] Firefox 
 * [x] Edge
 
Chromebook
 * [x] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
