### PR TITLE
shrink telemetry modal on smaller viewports

### DIFF
--- a/src/components/telemetry-modal/telemetry-modal.css
+++ b/src/components/telemetry-modal/telemetry-modal.css
@@ -148,3 +148,16 @@ $ui-gray: hsla(0, 0%, 95%, 1);
     box-shadow: none;
     opacity: 0.25;
 }
+
+@media screen and (max-height: 660px) {
+    .modal-content {
+        margin: 5vh auto;
+        width: 90%;
+    }
+}
+
+@media screen and (max-height: 540px) {
+    .illustration {
+        display: none;
+    }
+}


### PR DESCRIPTION
### Resolves

Resolves #6897 

### Proposed Changes

Add two media queries to the telemetry modal's CSS:

- If the viewport height is smaller than 660, shrink the vertical margin around the telemetry modal.
- If the viewport height is smaller than 540, also remove the image banner at the top of the telemetry modal.

### Reason for Changes

Prior to these changes, a viewport height below about 660 causes the bottom of the telemetry dialog to be clipped, and below about 600 the "Close" button starts to disappear. Some tablets have even lower viewport height - for example, the SM-T510's effective viewport height is 600 minus the height of any navigation and status bars, typically resulting in the "Close" button being pushed completely off the screen. Making these changes means that the telemetry modal stays usable even on devices with such low screen heights.

These screenshots demonstrate the effect of this change on an SM-T510.

Before:
![image](https://user-images.githubusercontent.com/7019101/110553722-46016380-80ee-11eb-9ae3-03e9248e55f1.jpg)

After:
![image](https://user-images.githubusercontent.com/7019101/118870603-95f16900-b89b-11eb-8f72-19de24bfa7b4.png)

### Test Coverage

Tested locally in the desktop app and Android app. The telemetry modal is not displayed by the web version of Scratch.
