### PR TITLE
Revert "build(deps): bump scratch-render from 0.1.0-prerelease.20210325231800 to 0.1.0-prerelease.20210629213715"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6552,6 +6552,11 @@
         "domelementtype": "1"
       }
     },
+    "dompurify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.1.1.tgz",
+      "integrity": "sha512-NijiNVkS/OL8mdQL1hUbCD6uty/cgFpmNiuFxrmJ5YPH2cXrPKIewoixoji56rbZ6XBPmtM8GA8/sf9unlSuwg=="
+    },
     "domutils": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
@@ -14859,9 +14864,9 @@
       }
     },
     "scratch-render": {
-      "version": "0.1.0-prerelease.20210629213715",
-      "resolved": "https://registry.npmjs.org/scratch-render/-/scratch-render-0.1.0-prerelease.20210629213715.tgz",
-      "integrity": "sha512-5JnN0/UERQhgqu2kOXEU57eyQ8U5ygPqOYszLxK5/lSQxpgMPvSSrArvmsp+F9FGLS0IzOPjeG3ja3R3/M2r1g==",
+      "version": "0.1.0-prerelease.20210325231800",
+      "resolved": "https://registry.npmjs.org/scratch-render/-/scratch-render-0.1.0-prerelease.20210325231800.tgz",
+      "integrity": "sha512-hjiIHRR8SuP/8UKKZ4O+TIJaCZ2wSN6uoEM49jwNjZecAaflBvd5t/OLL3NFQp3q7Ra6ncDi+B7URy7WRdm2fg==",
       "requires": {
         "grapheme-breaker": "0.3.2",
         "hull.js": "0.2.10",
@@ -14870,8 +14875,36 @@
         "minilog": "3.1.0",
         "raw-loader": "^0.5.1",
         "scratch-storage": "^1.0.0",
-        "scratch-svg-renderer": "0.2.0-prerelease.20210511195415",
+        "scratch-svg-renderer": "0.2.0-prerelease.20210317184701",
         "twgl.js": "4.4.0"
+      },
+      "dependencies": {
+        "base64-js": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
+          "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw=="
+        },
+        "scratch-render-fonts": {
+          "version": "1.0.0-prerelease.20200507182347",
+          "resolved": "https://registry.npmjs.org/scratch-render-fonts/-/scratch-render-fonts-1.0.0-prerelease.20200507182347.tgz",
+          "integrity": "sha512-tVt2s7lxsBhme9WKIZTnluMerdJVGEc80QSrDdIIzUvHXGCIYkLh6j7ytwXcyq2UsA34d93op9+I9Bh1SPkQkA==",
+          "requires": {
+            "base64-loader": "1.0.0"
+          }
+        },
+        "scratch-svg-renderer": {
+          "version": "0.2.0-prerelease.20210317184701",
+          "resolved": "https://registry.npmjs.org/scratch-svg-renderer/-/scratch-svg-renderer-0.2.0-prerelease.20210317184701.tgz",
+          "integrity": "sha512-drHD8kRTU//Rqgs8F6oWmBIQi6TunI86Skvp7BfM+mqalds3GzaPjZHKSCFkdkXbHO4i/zAPLvkQtMDdLm4Y6g==",
+          "requires": {
+            "base64-js": "1.2.1",
+            "base64-loader": "1.0.0",
+            "dompurify": "2.1.1",
+            "minilog": "3.1.0",
+            "scratch-render-fonts": "1.0.0-prerelease.20200507182347",
+            "transformation-matrix": "1.15.0"
+          }
+        }
       }
     },
     "scratch-render-fonts": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "scratch-blocks": "0.1.0-prerelease.20210701042432",
     "scratch-l10n": "3.13.20210703031554",
     "scratch-paint": "0.2.0-prerelease.20210615011117",
-    "scratch-render": "0.1.0-prerelease.20210629213715",
+    "scratch-render": "0.1.0-prerelease.20210325231800",
     "scratch-render-fonts": "1.0.0-prerelease.20210401210003",
     "scratch-storage": "1.3.5",
     "scratch-svg-renderer": "0.2.0-prerelease.20210511195415",


### PR DESCRIPTION
Reverts LLK/scratch-gui#7307

While the PR passed tests, it seems to be causing failures now that it's merged. Reverting pending investigation.