### PR TITLE
ENA-121 Return early if column is null in CSV import

### DIFF
--- a/src/containers/monitor.jsx
+++ b/src/containers/monitor.jsx
@@ -168,7 +168,9 @@ class Monitor extends React.Component {
             let columnNumber = 1;
             if (numberOfColumns > 1) {
                 const msg = this.props.intl.formatMessage(messages.columnPrompt, {numberOfColumns});
-                columnNumber = parseInt(prompt(msg), 10); // eslint-disable-line no-alert
+                const column = prompt(msg); // eslint-disable-line no-alert
+                if (!column) return;
+                columnNumber = parseInt(column, 10);
             }
             const newListValue = rows.map(row => row[columnNumber - 1])
                 .filter(item => typeof item === 'string'); // CSV importer can leave undefineds


### PR DESCRIPTION
### Resolves
Resolves #7313

### Proposed Changes
Return early if column is null in CSV import. This can happen when a user cancels the prompt to enter the column.

### Reason for Changes
Previously it was impossible to actually cancel; pressing Cancel button, which causes `prompt` to return `null`, caused all of the list's data to be removed.

### Test Coverage
Manually tested by importing a CSV file with multiple columns, then canceling when asked the column. The list contents should be intact.