### PR TITLE
Remove top border from first menu items

### DIFF
--- a/src/components/menu/menu.css
+++ b/src/components/menu/menu.css
@@ -41,6 +41,6 @@
     cursor: pointer;
 }
 
-.menu-section {
+.menu-section:not(.menu-item:first-child) {
     border-top: 1px solid $ui-black-transparent;
 }


### PR DESCRIPTION
### Resolves

 - Resolves #7196 

### Proposed Changes

Removes the top border from first elements in menus.

### Reason for Changes

Menus already have a border around them, so adding a top border on the first item in a menu causes there two be 2px of border instead of one.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
