### PR TITLE
disable flaky test 'Creating new project resets active tab to Code tab'

### DIFF
--- a/test/integration/project-loading.test.js
+++ b/test/integration/project-loading.test.js
@@ -76,7 +76,9 @@ describe('Loading scratch gui', () => {
             await expect(logs).toEqual([]);
         });
 
-        test('Creating new project resets active tab to Code tab', async () => {
+        // skipping because this test fails frequently on CI; might need "wait(until.elementLocated" or similar
+        // error message is "stale element reference: element is not attached to the page document"
+        test.skip('Creating new project resets active tab to Code tab', async () => {
             await loadUri(uri);
             await findByXpath('//*[span[text()="Costumes"]]');
             await clickText('Costumes');


### PR DESCRIPTION
### Proposed Changes

Disable the "Creating new project resets active tab to Code tab" test

### Reason for Changes

This test fails frequently, but not always. Repeatedly restarting the same build will eventually lead to this test passing.

Example failure:
```
 FAIL  test/integration/project-loading.test.js (7.256s)
  ● Loading scratch gui › Loading projects by ID › Creating new project resets active tab to Code tab

    StaleElementReferenceError: stale element reference: element is not attached to the page document
      (Session info: headless chrome=90.0.4430.72)
      (Driver info: chromedriver=90.0.4430.24 (4c6d850f087da467d926e8eddb76550aed655991-refs/branch-heads/4430@{#429}),platform=Linux 4.15.0-1106-aws x86_64)
      
      at Object.checkLegacyResponse (node_modules/selenium-webdriver/lib/error.js:546:15)
      at parseHttpResponse (node_modules/selenium-webdriver/lib/http.js:509:13)
      at doSend.then.response (node_modules/selenium-webdriver/lib/http.js:441:30)
      at process._tickCallback (internal/process/next_tick.js:68:7)
      From: Task: WebElement.isDisplayed()
      at thenableWebDriverProxy.schedule (node_modules/selenium-webdriver/lib/webdriver.js:807:17)
      at WebElement.schedule_ (node_modules/selenium-webdriver/lib/webdriver.js:2010:25)
      at WebElement.isDisplayed (node_modules/selenium-webdriver/lib/webdriver.js:2362:17)
      at test/helpers/selenium-helper.js:96:32
      at ManagedPromise.invokeCallback_ (node_modules/selenium-webdriver/lib/promise.js:1376:14)
      at TaskQueue.execute_ (node_modules/selenium-webdriver/lib/promise.js:3084:14)
      at TaskQueue.executeNext_ (node_modules/selenium-webdriver/lib/promise.js:3067:27)
      at asyncRun (node_modules/selenium-webdriver/lib/promise.js:2927:27)
      at node_modules/selenium-webdriver/lib/promise.js:668:7
      at process._tickCallback (internal/process/next_tick.js:68:7)
```