### PR TITLE
fix BOOST & CDM combo

### DIFF
--- a/src/containers/auto-scanning-step.jsx
+++ b/src/containers/auto-scanning-step.jsx
@@ -10,7 +10,6 @@ class AutoScanningStep extends React.Component {
         bindAll(this, [
             'handlePeripheralListUpdate',
             'handlePeripheralScanTimeout',
-            'handleUserPickedPeripheral',
             'handleStartScan',
             'handleRefresh'
         ]);
@@ -41,17 +40,22 @@ class AutoScanningStep extends React.Component {
         this.props.vm.on(
             'PERIPHERAL_LIST_UPDATE', this.handlePeripheralListUpdate);
         this.props.vm.on(
-            'USER_PICKED_PERIPHERAL', this.handlePeripheralListUpdate);
-        this.props.vm.on(
             'PERIPHERAL_SCAN_TIMEOUT', this.handlePeripheralScanTimeout);
+
+        // USER_PICKED_PERIPHERAL means the user picked the peripheral outside of this UI, say through the Android
+        // CDM, in which case it'll pass a list of exactly one peripheral which we should connect to. If the user
+        // canceled the CDM dialog, we'll get an empty list and we shouldn't connect. That already matches the
+        // behavior of handlePeripheralListUpdate, so we just reuse that handler.
+        this.props.vm.on(
+            'USER_PICKED_PERIPHERAL', this.handlePeripheralListUpdate);
     }
     unbindPeripheralUpdates () {
         this.props.vm.removeListener(
             'PERIPHERAL_LIST_UPDATE', this.handlePeripheralListUpdate);
         this.props.vm.removeListener(
-            'USER_PICKED_PERIPHERAL', this.handlePeripheralListUpdate);
-        this.props.vm.removeListener(
             'PERIPHERAL_SCAN_TIMEOUT', this.handlePeripheralScanTimeout);
+        this.props.vm.removeListener(
+            'USER_PICKED_PERIPHERAL', this.handlePeripheralListUpdate);
     }
     handleRefresh () {
         // @todo: stop the peripheral scan here, it is more important for auto scan

--- a/src/containers/auto-scanning-step.jsx
+++ b/src/containers/auto-scanning-step.jsx
@@ -10,6 +10,7 @@ class AutoScanningStep extends React.Component {
         bindAll(this, [
             'handlePeripheralListUpdate',
             'handlePeripheralScanTimeout',
+            'handleUserPickedPeripheral',
             'handleStartScan',
             'handleRefresh'
         ]);
@@ -40,11 +41,15 @@ class AutoScanningStep extends React.Component {
         this.props.vm.on(
             'PERIPHERAL_LIST_UPDATE', this.handlePeripheralListUpdate);
         this.props.vm.on(
+            'USER_PICKED_PERIPHERAL', this.handlePeripheralListUpdate);
+        this.props.vm.on(
             'PERIPHERAL_SCAN_TIMEOUT', this.handlePeripheralScanTimeout);
     }
     unbindPeripheralUpdates () {
         this.props.vm.removeListener(
             'PERIPHERAL_LIST_UPDATE', this.handlePeripheralListUpdate);
+        this.props.vm.removeListener(
+            'USER_PICKED_PERIPHERAL', this.handlePeripheralListUpdate);
         this.props.vm.removeListener(
             'PERIPHERAL_SCAN_TIMEOUT', this.handlePeripheralScanTimeout);
     }


### PR DESCRIPTION
### Proposed Changes

Add support for the `USER_PICKED_PERIPHERAL` event in `AutoScanningStep`, similar to #6273.

### Reason for Changes

When using the Android CDM, the Android system handles peripheral selection. When we find out which one the user selected, our CDM support code fires the `USER_PICKED_PERIPHERAL` event to simulate the UI event that would be generated by the user picking a peripheral in our regular, non-CDM UI. The `USER_PICKED_PERIPHERAL` event was being handled correctly in [`scanning-step.jsx`](https://github.com/LLK/scratch-gui/blob/native/src/containers/scanning-step.jsx) (used by micro:bit and others) but it was not handled here in `auto-scanning-step.jsx` at all (used by LEGO BOOST and others).

### Test Coverage

We don't currently have a way to simulate Android CDM events, so this was tested manually.

### Browser Coverage

Tested with LEGO BOOST on a Samsung Chromebook Pro running Android 9.0.