### PR TITLE
CDM connection flow updates

### DIFF
--- a/src/components/connection-modal/auto-scanning-step.jsx
+++ b/src/components/connection-modal/auto-scanning-step.jsx
@@ -21,22 +21,41 @@ const PHASES = keyMirror({
     notfound: null
 });
 
+const defaultPrescanMessage = (<FormattedMessage
+    defaultMessage="Have your device nearby, then begin searching."
+    description="Prompt for beginning the search"
+    id="gui.connection.auto-scanning.prescan"
+/>);
+
+const defaultScanBeginMessage = (<FormattedMessage
+    defaultMessage="Press the button on your device."
+    description="Prompt for pushing the button on the device"
+    id="gui.connection.auto-scanning.scanBeginMessage"
+/>);
+
 const AutoScanningStep = props => (
     <Box className={styles.body}>
         <Box className={styles.activityArea}>
             <div className={styles.activityAreaInfo}>
                 <div className={styles.centeredRow}>
                     {props.phase === PHASES.prescan && (
-                        <React.Fragment>
+                        props.connectionIconURL ? (
                             <img
                                 className={styles.radarBig}
-                                src={radarIcon}
+                                src={props.connectionIconURL}
                             />
-                            <img
-                                className={styles.bluetoothCenteredIcon}
-                                src={bluetoothIcon}
-                            />
-                        </React.Fragment>
+                        ) : (
+                            <React.Fragment>
+                                <img
+                                    className={styles.radarBig}
+                                    src={radarIcon}
+                                />
+                                <img
+                                    className={styles.bluetoothCenteredIcon}
+                                    src={bluetoothIcon}
+                                />
+                            </React.Fragment>
+                        )
                     )}
                     {props.phase === PHASES.pressbutton && (
                         <React.Fragment>
@@ -64,20 +83,8 @@ const AutoScanningStep = props => (
         </Box>
         <Box className={styles.bottomArea}>
             <Box className={classNames(styles.bottomAreaItem, styles.instructions)}>
-                {props.phase === PHASES.prescan && (
-                    <FormattedMessage
-                        defaultMessage="Have your device nearby, then begin searching."
-                        description="Prompt for beginning the search"
-                        id="gui.connection.auto-scanning.prescan"
-                    />
-                )}
-                {props.phase === PHASES.pressbutton && (
-                    <FormattedMessage
-                        defaultMessage="Press the button on your device."
-                        description="Prompt for pushing the button on the device"
-                        id="gui.connection.auto-scanning.pressbutton"
-                    />
-                )}
+                {props.phase === PHASES.prescan && props.prescanMessage}
+                {props.phase === PHASES.pressbutton && props.scanBeginMessage}
             </Box>
             <Dots
                 className={styles.bottomAreaItem}
@@ -142,14 +149,19 @@ const AutoScanningStep = props => (
 );
 
 AutoScanningStep.propTypes = {
+    connectionIconURL: PropTypes.string,
     connectionTipIconURL: PropTypes.string,
     onRefresh: PropTypes.func,
     onStartScan: PropTypes.func,
-    phase: PropTypes.oneOf(Object.keys(PHASES))
+    phase: PropTypes.oneOf(Object.keys(PHASES)),
+    prescanMessage: PropTypes.node,
+    scanBeginMessage: PropTypes.node
 };
 
 AutoScanningStep.defaultProps = {
-    phase: PHASES.prescan
+    phase: PHASES.prescan,
+    prescanMessage: defaultPrescanMessage,
+    scanBeginMessage: defaultScanBeginMessage
 };
 
 export {

--- a/src/components/connection-modal/connection-modal.jsx
+++ b/src/components/connection-modal/connection-modal.jsx
@@ -22,8 +22,23 @@ const PHASES = keyMirror({
     unavailable: null
 });
 
-const ConnectionModalComponent = props => (
-    <Modal
+const ConnectionModalComponent = props => {
+    // ScanningStep allows the user to choose a peripheral from a list.
+    // AutoScanningStep connects to the first peripheral found.
+    // Also, AutoScanningStep adds "prescan" and "pressbutton" phases before the actual scan.
+    // When useExternalPeripheralList is true, force the use of AutoScanningStep:
+    // - We want to automatically connect to the first peripheral "found" since it's actually the one selected by the
+    //   user from the external list.
+    // - We want to show the "prescan" phase to inform the user before the external list appears.
+    // - The "pressbutton" phase doesn't hurt: it might be hidden behind the external list (especially with Android
+    //   CDM) or it might help the user to keep the peripheral device awake.
+    // TODO: does forcing AutoScanningStep mean we can eliminate the `USER_PICKED_PERIPHERAL` message?
+    const ScanningStepContainer = (
+        (props.useAutoScan || props.useExternalPeripheralList) ?
+            AutoScanningStep :
+            ScanningStep
+    );
+    return (<Modal
         className={styles.modalContent}
         contentLabel={props.name}
         headerClassName={styles.header}
@@ -33,15 +48,14 @@ const ConnectionModalComponent = props => (
         onRequestClose={props.onCancel}
     >
         <Box className={styles.body}>
-            {props.phase === PHASES.scanning && !props.useAutoScan && <ScanningStep {...props} />}
-            {props.phase === PHASES.scanning && props.useAutoScan && <AutoScanningStep {...props} />}
+            {props.phase === PHASES.scanning && <ScanningStepContainer {...props} />}
             {props.phase === PHASES.connecting && <ConnectingStep {...props} />}
             {props.phase === PHASES.connected && <ConnectedStep {...props} />}
             {props.phase === PHASES.error && <ErrorStep {...props} />}
             {props.phase === PHASES.unavailable && <UnavailableStep {...props} />}
         </Box>
-    </Modal>
-);
+    </Modal>);
+};
 
 ConnectionModalComponent.propTypes = {
     connectingMessage: PropTypes.node.isRequired,
@@ -52,7 +66,8 @@ ConnectionModalComponent.propTypes = {
     onHelp: PropTypes.func.isRequired,
     phase: PropTypes.oneOf(Object.keys(PHASES)).isRequired,
     title: PropTypes.string.isRequired,
-    useAutoScan: PropTypes.bool.isRequired
+    useAutoScan: PropTypes.bool.isRequired,
+    useExternalPeripheralList: PropTypes.bool
 };
 
 ConnectionModalComponent.defaultProps = {

--- a/src/components/connection-modal/connection-modal.jsx
+++ b/src/components/connection-modal/connection-modal.jsx
@@ -59,12 +59,15 @@ const ConnectionModalComponent = props => {
 
 ConnectionModalComponent.propTypes = {
     connectingMessage: PropTypes.node.isRequired,
+    connectionIconURL: PropTypes.string,
     connectionSmallIconURL: PropTypes.string,
     connectionTipIconURL: PropTypes.string,
     name: PropTypes.node,
     onCancel: PropTypes.func.isRequired,
     onHelp: PropTypes.func.isRequired,
     phase: PropTypes.oneOf(Object.keys(PHASES)).isRequired,
+    prescanMessage: PropTypes.node,
+    scanBeginMessage: PropTypes.node,
     title: PropTypes.string.isRequired,
     useAutoScan: PropTypes.bool.isRequired,
     useExternalPeripheralList: PropTypes.bool

--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -121,6 +121,7 @@ const GUIComponent = props => {
         targetIsStage,
         telemetryModalVisible,
         tipsLibraryVisible,
+        useExternalPeripheralList,
         vm,
         ...componentProps
     } = omit(props, 'dispatch');
@@ -194,6 +195,7 @@ const GUIComponent = props => {
                 ) : null}
                 {connectionModalVisible ? (
                     <ConnectionModal
+                        useExternalPeripheralList={useExternalPeripheralList}
                         vm={vm}
                     />
                 ) : null}
@@ -433,8 +435,10 @@ GUIComponent.propTypes = {
     targetIsStage: PropTypes.bool,
     telemetryModalVisible: PropTypes.bool,
     tipsLibraryVisible: PropTypes.bool,
+    useExternalPeripheralList: PropTypes.bool, // true for CDM, false for normal Scratch Link
     vm: PropTypes.instanceOf(VM).isRequired
 };
+
 GUIComponent.defaultProps = {
     backpackHost: null,
     backpackVisible: false,
@@ -453,7 +457,8 @@ GUIComponent.defaultProps = {
     isShared: false,
     loading: false,
     showComingSoon: false,
-    stageSizeMode: STAGE_SIZE_MODES.large
+    stageSizeMode: STAGE_SIZE_MODES.large,
+    useExternalPeripheralList: false
 };
 
 const mapStateToProps = state => ({

--- a/src/containers/auto-scanning-step.jsx
+++ b/src/containers/auto-scanning-step.jsx
@@ -84,20 +84,26 @@ class AutoScanningStep extends React.Component {
     render () {
         return (
             <ScanningStepComponent
+                connectionIconURL={this.props.connectionIconURL}
                 connectionTipIconURL={this.props.connectionTipIconURL}
                 phase={this.state.phase}
                 title={this.props.extensionId}
                 onRefresh={this.handleRefresh}
                 onStartScan={this.handleStartScan}
+                prescanMessage={this.props.prescanMessage}
+                scanBeginMessage={this.props.scanBeginMessage}
             />
         );
     }
 }
 
 AutoScanningStep.propTypes = {
+    connectionIconURL: PropTypes.string,
     connectionTipIconURL: PropTypes.string,
     extensionId: PropTypes.string.isRequired,
     onConnecting: PropTypes.func.isRequired,
+    prescanMessage: PropTypes.node,
+    scanBeginMessage: PropTypes.node,
     vm: PropTypes.instanceOf(VM).isRequired
 };
 

--- a/src/containers/auto-scanning-step.jsx
+++ b/src/containers/auto-scanning-step.jsx
@@ -4,6 +4,14 @@ import bindAll from 'lodash.bindall';
 import ScanningStepComponent, {PHASES} from '../components/connection-modal/auto-scanning-step.jsx';
 import VM from 'scratch-vm';
 
+/**
+ * Scan for a peripheral and automatically connect to the first one found.
+ * Supports "prescan" and "pressbutton" phases.
+ * The "prescan" phase displays a message like "Have your device nearby, then begin searching" and waits for the user
+ * to choose to continue.
+ * The "pressbutton" phase displays a message like "Press the button on your device" until the scan finds a result,
+ * which in the case of an external peripheral list is when the user has chosen a peripheral.
+ */
 class AutoScanningStep extends React.Component {
     constructor (props) {
         super(props);

--- a/src/containers/connection-modal.jsx
+++ b/src/containers/connection-modal.jsx
@@ -114,6 +114,8 @@ class ConnectionModal extends React.Component {
                 extensionId={this.props.extensionId}
                 name={this.state.extension && this.state.extension.name}
                 phase={this.state.phase}
+                prescanMessage={this.state.extension && this.state.extension.prescanMessage}
+                scanBeginMessage={this.state.extension && this.state.extension.scanBeginMessage}
                 title={this.props.extensionId}
                 useAutoScan={this.state.extension && this.state.extension.useAutoScan}
                 useExternalPeripheralList={this.props.useExternalPeripheralList}

--- a/src/containers/connection-modal.jsx
+++ b/src/containers/connection-modal.jsx
@@ -116,6 +116,7 @@ class ConnectionModal extends React.Component {
                 phase={this.state.phase}
                 title={this.props.extensionId}
                 useAutoScan={this.state.extension && this.state.extension.useAutoScan}
+                useExternalPeripheralList={this.props.useExternalPeripheralList}
                 vm={this.props.vm}
                 onCancel={this.handleCancel}
                 onConnected={this.handleConnected}
@@ -131,6 +132,7 @@ class ConnectionModal extends React.Component {
 ConnectionModal.propTypes = {
     extensionId: PropTypes.string.isRequired,
     onCancel: PropTypes.func.isRequired,
+    useExternalPeripheralList: PropTypes.bool,
     vm: PropTypes.instanceOf(VM).isRequired
 };
 

--- a/src/containers/scanning-step.jsx
+++ b/src/containers/scanning-step.jsx
@@ -4,6 +4,10 @@ import bindAll from 'lodash.bindall';
 import ScanningStepComponent from '../components/connection-modal/scanning-step.jsx';
 import VM from 'scratch-vm';
 
+/**
+ * Scan for a peripheral and allow the user to choose from a list of those discovered.
+ * Does not support "prescan" and "pressbutton" phases.
+ */
 class ScanningStep extends React.Component {
     constructor (props) {
         super(props);

--- a/src/lib/libraries/extensions/index.jsx
+++ b/src/lib/libraries/extensions/index.jsx
@@ -276,6 +276,21 @@ export default [
         connectionIconURL: boostConnectionIconURL,
         connectionSmallIconURL: boostConnectionSmallIconURL,
         connectionTipIconURL: boostConnectionTipIconURL,
+        prescanMessage: (
+            <FormattedMessage
+                // eslint-disable-next-line max-len
+                defaultMessage="Press the button on your LEGO BOOST, then press the button below to start searching for your device."
+                description="Prompt before searching for a LEGO BOOST"
+                id="gui.extension.boost.prescanMessage"
+            />
+        ),
+        scanBeginMessage: (
+            <FormattedMessage
+                defaultMessage="Keep your LEGO BOOST awake and nearby."
+                description="Information shown while searching for a LEGO BOOST, before one is found"
+                id="gui.extension.boost.scanBeginMessage"
+            />
+        ),
         connectingMessage: (
             <FormattedMessage
                 defaultMessage="Connecting"
@@ -307,6 +322,21 @@ export default [
         connectionIconURL: wedo2ConnectionIconURL,
         connectionSmallIconURL: wedo2ConnectionSmallIconURL,
         connectionTipIconURL: wedo2ConnectionTipIconURL,
+        prescanMessage: (
+            <FormattedMessage
+                // eslint-disable-next-line max-len
+                defaultMessage="Press the button on your LEGO WeDo 2.0, then press the button below to start searching for your device."
+                description="Prompt before searching for a LEGO WeDo 2.0"
+                id="gui.extension.wedo2.prescanMessage"
+            />
+        ),
+        scanBeginMessage: (
+            <FormattedMessage
+                defaultMessage="Keep your LEGO WeDo 2.0 awake and nearby."
+                description="Information shown while searching for a LEGO WeDo 2.0, before one is found"
+                id="gui.extension.wedo2.scanBeginMessage"
+            />
+        ),
         connectingMessage: (
             <FormattedMessage
                 defaultMessage="Connecting"

--- a/src/lib/libraries/extensions/index.jsx
+++ b/src/lib/libraries/extensions/index.jsx
@@ -187,6 +187,20 @@ export default [
         useAutoScan: false,
         connectionIconURL: microbitConnectionIconURL,
         connectionSmallIconURL: microbitConnectionSmallIconURL,
+        prescanMessage: (
+            <FormattedMessage
+                defaultMessage="Turn on your micro:bit, then press the button below to start searching for your device."
+                description="Prompt before searching for a micro:bit"
+                id="gui.extension.microbit.prescanMessage"
+            />
+        ),
+        scanBeginMessage: (
+            <FormattedMessage
+                defaultMessage="Keep your micro:bit on and nearby."
+                description="Information shown while searching for a micro:bit, before one is found"
+                id="gui.extension.microbit.scanBeginMessage"
+            />
+        ),
         connectingMessage: (
             <FormattedMessage
                 defaultMessage="Connecting"
@@ -217,6 +231,20 @@ export default [
         useAutoScan: false,
         connectionIconURL: ev3ConnectionIconURL,
         connectionSmallIconURL: ev3ConnectionSmallIconURL,
+        prescanMessage: (
+            <FormattedMessage
+                defaultMessage="Turn on your LEGO EV3, then press the button below to start searching for your device."
+                description="Prompt before searching for a LEGO EV3"
+                id="gui.extension.ev3.prescanMessage"
+            />
+        ),
+        scanBeginMessage: (
+            <FormattedMessage
+                defaultMessage="Keep your LEGO EV3 on and nearby."
+                description="Information shown while searching for a LEGO EV3, before one is found"
+                id="gui.extension.ev3.scanBeginMessage"
+            />
+        ),
         connectingMessage: (
             <FormattedMessage
                 defaultMessage="Connecting. Make sure the pin on your EV3 is set to 1234."
@@ -309,6 +337,20 @@ export default [
         useAutoScan: false,
         connectionIconURL: gdxforConnectionIconURL,
         connectionSmallIconURL: gdxforConnectionSmallIconURL,
+        prescanMessage: (
+            <FormattedMessage
+                defaultMessage="Turn on your Go Direct, then press the button below to start searching for your device."
+                description="Prompt before searching for a Vernier Go Direct device"
+                id="gui.extension.gdxfor.prescanMessage"
+            />
+        ),
+        scanBeginMessage: (
+            <FormattedMessage
+                defaultMessage="Keep your Vernier Go Direct on and nearby."
+                description="Information shown while searching for a Vernier Go Direct, before one is found"
+                id="gui.extension.gdxfor.scanBeginMessage"
+            />
+        ),
         connectingMessage: (
             <FormattedMessage
                 defaultMessage="Connecting"


### PR DESCRIPTION
### Resolves

Progress on LLK/scratch-android#340

### Proposed Changes

Bonus change:

* Add comments explaining the difference between `ScanningStep` and `AutoScanningStep`
   * `AutoScanningStep` automatically chooses the first device discovered by a scan. It also supports a `prescan` phase, which displays a message to the user and waits for them to press a button, and `pressbutton` phase, which displays a message during the scan while waiting for the first scan result
   * `ScanningStep` allows the user to choose a peripheral device from a list managed by `scratch-gui` and does not support the `prescan` or `pressbutton` phases.

Real changes:

* Add a new flag `useExternalPeripheralList` which tells the extension connection flow to assume that peripheral selection will happen through an externally-managed UI, as with the Android Companion Device Manager (CDM)
* When `useExternalPeripheralList` is true, force all extensions to use `AutoScanningStep`
* Allow extensions to override the messages shown during the `prescan` and `pushbutton` phases of the connection flow
   * The message for the `prescan` phase is called `prescanMessage`.
   * The message for the `pushbutton` phase is called `scanBeginMessage` since for some devices it doesn't involve pushing any button.
* Add `prescanMessage` and `scanBeginMessage` overrides for all hardware extensions
* On the `prescan` phase, replace the big, static "radar" image with an extension-specific image (generally an illustration of the peripheral device)

### Reason for Changes

When running with the Android CDM, the CDM's list of scan results displays over the top of our GUI components for the connection flow. This makes it impossible for the user to see any help we might be giving them in the connection flow UI. Adding the `prescan` phase, and waiting to activate the CDM until the user presses the button, makes sure we can provide information and context for the list before it pops up.

Using the `AutoScanningStep` lets us have the `prescan` phase, but also means we get the `pressbutton` phase. Prior to these changes, the `pressbutton` phase would display a message asking the user to "Press the button on your device" -- a message that only fits some of our extensions. Adding an override lets extensions customize that text for each peripheral device's needs and features.

In theory the WeDo 2.0 and BOOST extensions don't need overrides since the "Press the button on your device" message works for them, but it's nice to have more detail. The generic messages are still available as fallbacks.

The icon change is a nice-to-have which helps the user be sure of which extension is trying to connect right now.

### Test Coverage

Tested on a Samsung Chromebook Pro
