### PR TITLE
CE-142 Fix to hold jpg on the backpack

### DIFF
--- a/src/lib/backpack/costume-payload.js
+++ b/src/lib/backpack/costume-payload.js
@@ -23,6 +23,10 @@ const costumePayload = costume => {
         payload.mime = 'image/png';
         payload.body = assetDataUrl.replace('data:image/png;base64,', '');
         break;
+    case 'jpg':
+        payload.mime = 'image/jpg';
+        payload.body = assetDataUrl.replace('data:image/png;base64,', '');
+        break;
     default:
         alert(`Cannot serialize for format: ${assetDataFormat}`); // eslint-disable-line
     }


### PR DESCRIPTION
### Resolves

- Resolves #6153

### Proposed Changes

This patch adds switch-case selection for 'image/jpg' in the backpack payload function.

### Reason for Changes

If the "image/jpg" case is missing, mime and body of the payload will not be set.

### Test Coverage

It's tested by hand.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [x] Safari
 
Windows
 * [x] Chrome 
 * [x] Firefox 
 * [x] Edge
 
Chromebook
 * [x] Chrome
 
iPad
* [x] Safari

Android Tablet
* [ ] Chrome
