### PR TITLE
[circle] only run store_build and store_dist if deploying

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,6 @@ jobs:
     steps:
       - *restore_git_cache
       - checkout
-      - *restore_npm_cache
       - run: npm ci
       - *save_git_cache
       - *save_npm_cache
@@ -205,9 +204,21 @@ workflows:
       - store_build:
           requires:
             - build
+          filters:
+            branches:
+              only:
+                - master
+                - develop
+                - /^hotfix\/.*/
       - store_dist:
           requires:
             - build
+          filters:
+            branches:
+              only:
+                - master
+                - develop
+                - /^hotfix\/.*/
       - deploy-npm:
           requires:
             - lint


### PR DESCRIPTION
### Resolves

We're using a lot of storage in circleCI.

### Proposed Changes

Only store artifacts if we are deploying the build.

### Reason for Changes

Should reduce the amount of storage used

