### PR TITLE
Make the hide option on monitors a bordered menu item

### DIFF
--- a/src/components/monitor/monitor.jsx
+++ b/src/components/monitor/monitor.jsx
@@ -109,13 +109,13 @@ const MonitorComponent = props => (
                         />
                     </MenuItem>}
                 {props.onHide &&
-                    <MenuItem onClick={props.onHide}>
+                    <BorderedMenuItem onClick={props.onHide}>
                         <FormattedMessage
                             defaultMessage="hide"
                             description="Menu item to hide the monitor"
                             id="gui.monitor.contextMenu.hide"
                         />
-                    </MenuItem>}
+                    </BorderedMenuItem>}
             </ContextMenu>
         ), document.body)}
     </ContextMenuTrigger>


### PR DESCRIPTION
This adds a border to the hide option on variable monitors. It does the same thing as #4154 but uses a component that was created since that PR. We need to confirm with the design team before merging.

![image](https://user-images.githubusercontent.com/4612592/152049890-4e092d50-1eaf-430c-a73d-c85865653690.png)


