### PR TITLE
ENA-119 Place z-index direction picker above other stage elements, so it displays correctly

### DIFF
--- a/src/components/direction-picker/direction-picker.css
+++ b/src/components/direction-picker/direction-picker.css
@@ -1,4 +1,9 @@
 @import "../../css/colors.css";
+@import "../../css/z-index.css";
+
+.popover {
+    z-index: $z-index-direction-picker;
+}
 
 .button-row {
     display: flex;

--- a/src/components/direction-picker/direction-picker.jsx
+++ b/src/components/direction-picker/direction-picker.jsx
@@ -56,6 +56,7 @@ const DirectionPicker = props => (
         text={directionLabel}
     >
         <Popover
+            className={styles.popover}
             body={
                 <div>
                     <Dial

--- a/src/css/z-index.css
+++ b/src/css/z-index.css
@@ -11,6 +11,7 @@ $z-index-add-button: 46;
 $z-index-tooltip: 47; /* tooltips should go over add buttons if they overlap */
 $z-index-monitor: 48; /* monitors go over add buttons */
 $z-index-stage-question: 49; /* "ask" block text input goes above monitors */
+$z-index-direction-picker: 50; /* sprite direction picker goes above other stage elements */
 
 $z-index-card: 480;
 $z-index-alerts: 490;


### PR DESCRIPTION
### Resolves

- Resolves #7467

### Proposed Changes

Adds a z-index for the direction picker above other stage element z-indices.

### Reason for Changes

The direction picker isn't part of the stage so it's unexpected to have stage elements z-indexed behind it.

### Test Coverage

I suspect z-indices aren't tested, but let me know if they are and I can add something.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [x] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
