### PR TITLE
Set monitor value to bidi/plaintext

### DIFF
--- a/src/components/monitor/monitor.css
+++ b/src/components/monitor/monitor.css
@@ -45,6 +45,7 @@
     padding: 0 2px;
     white-space: pre-wrap;
     transform: translateZ(0); /* Fixes flickering in Safari */
+    unicode-bidi: plaintext;
 }
 
 .large-value {


### PR DESCRIPTION
### Resolves

- Fixes of https://github.com/LLK/scratch-gui/issues/5483

### Proposed Changes

Set monitor value to bidi/plaintext. This displays as LTR when numeric.

<img width="1429" alt="Screen_Shot_2022-02-25_at_7_30_06" src="https://user-images.githubusercontent.com/690/155618351-949c3413-2076-47e6-a0dc-b929e406d8fd.png">

### Reason for Changes

Without it "-11" shows up as "11-" which is backwards in a bidirectional text setting (hebrew, arabic).

### Test Coverage

_Please show how you have added tests to cover your changes_

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * ~~Safari~~ (safari doesn't support this property yet)
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
