### PR TITLE
run integration tests in parallel

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "i18n:src": "rimraf ./translations/messages/src && babel src > tmp.js && rimraf tmp.js && build-i18n-src ./translations/messages/src ./translations/ && npm run i18n:push",
     "start": "webpack-dev-server",
     "test": "npm run test:lint && npm run test:unit && npm run build && npm run test:integration",
-    "test:integration": "jest --runInBand test[\\\\/]integration",
+    "test:integration": "jest --maxWorkers=4 test[\\\\/]integration",
     "test:lint": "eslint . --ext .js,.jsx",
     "test:unit": "jest test[\\\\/]unit",
     "test:smoke": "jest --runInBand test[\\\\/]smoke",


### PR DESCRIPTION
Run 4 tests at a time. 

### Proposed Changes

Replace --runInBand with --maxWorkers=4
This will run 4 test suites at a time rather than 1.
Running more at a time has historically caused errors, but using limited parallelization like this worked in WWW

### Reason for Changes

Speed up the tests 

### Test Coverage

I ran the tests locally and they dramatically sped up without causing failures.
