### PR TITLE
Fix issue where reloading the blocks stops updating monitor checkboxes

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -274,6 +274,7 @@ class Blocks extends React.Component {
         this.props.vm.removeListener('VISUAL_REPORT', this.onVisualReport);
         this.props.vm.removeListener('workspaceUpdate', this.onWorkspaceUpdate);
         this.props.vm.removeListener('targetsUpdate', this.onTargetsUpdate);
+        this.props.vm.removeListener('MONITORS_UPDATE', this.handleMonitorsUpdate);
         this.props.vm.removeListener('EXTENSION_ADDED', this.handleExtensionAdded);
         this.props.vm.removeListener('BLOCKSINFO_UPDATE', this.handleBlocksInfoUpdate);
         this.props.vm.removeListener('PERIPHERAL_CONNECTED', this.handleStatusButtonUpdate);


### PR DESCRIPTION
### Resolves

- Resolves #8106 

### Proposed Changes

Add a `removeListener` call for the MONITOR_UPDATE listener when detaching the vm corresponding to [this addListener call](https://github.com/LLK/scratch-gui/pull/4147/files#diff-f391f9b9f2bc62fcad9038e12cd9d0d6adb0007dd6f5a176bfa7847ca2e5b512R263).

### Reason for Changes

The changes in #4147 introduced the ability to update the flyout checkbox when a monitor visible state was updated (e.g. via show/hide variable blocks). There was a small piece missing from that PR which removes the listener for the `MONITOR_UPDATE` event when detaching the VM (this happens when reloading languages for example).

### Test Coverage

Tested locally with switching languages and adding a new variable or showing/hiding an existing variable via the show/hide blocks.

Without this change there are lots of errors in the console and eventually a crash.
