### PR TITLE
ENA-120 Fix block palette styling so scrollbar never appears on Firefox

### DIFF
--- a/src/components/blocks/blocks.css
+++ b/src/components/blocks/blocks.css
@@ -45,8 +45,15 @@
     border-bottom: 1px solid $ui-black-transparent;
     box-sizing: content-box;
     height: calc(100% - 3.25rem) !important;
-    scrollbar-width: none;
+    /*
+        For now, the layout cannot support scrollbars in the category menu.
+        The line below works for Edge, the `scrollbar-width˙ line below that is
+        for Firefox 64+, and the `::-webkit-scrollbar` line below that is for
+        webkit browsers. It isn't possible to do the same for older Firefox
+        versions, so a different solution may be needed for them.
+    */
     -ms-overflow-style: none;
+    scrollbar-width: none;
 }
 
 [dir="rtl"] .blocks :global(.blocklyToolboxDiv) {

--- a/src/components/blocks/blocks.css
+++ b/src/components/blocks/blocks.css
@@ -45,13 +45,7 @@
     border-bottom: 1px solid $ui-black-transparent;
     box-sizing: content-box;
     height: calc(100% - 3.25rem) !important;
-
-    /*
-        For now, the layout cannot support scrollbars in the category menu.
-        The line below works for Edge, the `::-webkit-scrollbar` line
-        below that is for webkit browsers. It isn't possible to do the
-        same for Firefox, so a different solution may be needed for them.
-    */
+    scrollbar-width: none;
     -ms-overflow-style: none;
 }
 


### PR DESCRIPTION
### Resolves

- Resolves #8063 

### Proposed Changes

Adds `scrollbar-width: none;` to the block palette's CSS.

### Reason for Changes

The scrollbar is quite annoying to me, and with such a simple fix it seems a pity not to fix it.