### PR TITLE
Trying to unit test the direction picker z value

### DIFF
--- a/test/unit/components/__snapshots__/direction-picker.test.jsx.snap
+++ b/test/unit/components/__snapshots__/direction-picker.test.jsx.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DirectionPicker matches snapshot 1`] = `
+<label
+  className={undefined}
+>
+  <span
+    className={undefined}
+  >
+    <span>
+      Direction
+    </span>
+  </span>
+  <input
+    className="undefined"
+    disabled={false}
+    label={
+      <FormattedMessage
+        defaultMessage="Direction"
+        id="gui.SpriteInfo.direction"
+        values={Object {}}
+      />
+    }
+    onBlur={[Function]}
+    onChange={[Function]}
+    onFocus={[Function]}
+    onKeyPress={[Function]}
+    onSubmit={[Function]}
+    tabIndex="0"
+    type="text"
+    value={undefined}
+  />
+</label>
+`;

--- a/test/unit/components/direction-picker.test.jsx
+++ b/test/unit/components/direction-picker.test.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import {componentWithIntl} from '../../helpers/intl-helpers';
+import RotationStyles from '../../../src/components/direction-picker/direction-picker';
+import DirectionPicker from '../../../src/components/direction-picker/direction-picker';
+import PropTypes from 'prop-types';
+import {intlShape} from 'react-intl';
+
+describe('DirectionPicker', () => {
+
+    const getComponent = function (props = {}) {
+        return <DirectionPicker {...props} />;
+    };
+
+    test('matches snapshot', () => {
+        const props = {
+            // direction: PropTypes.number,
+            disabled: false,
+            // intl: intlShape,
+            // labelAbove: PropTypes.bool,
+            onChangeDirection: jest.fn(),
+            onClickAllAround: jest.fn(),
+            onClickDontRotate: jest.fn(),
+            onClickLeftRight: jest.fn(),
+            onClosePopover: jest.fn(),
+            onOpenPopover: jest.fn(),
+            popoverOpen: false
+            // rotationStyle: PropTypes.string
+        };
+
+
+        const component = componentWithIntl(getComponent(props));
+        const picker = component.root.findByType(DirectionPicker);
+        console.log(picker);
+        expect(component.toJSON()).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
### Resolves

- Rel https://github.com/LLK/scratch-gui/issues/7467

I'm thinking this is probably not the way to test the z-index values, but didn't want to lose the code. So stashing it in a draft PR while I give an integration approach a try.

### Proposed Changes

_Describe what this Pull Request does_

### Reason for Changes

_Explain why these changes should be made_

### Test Coverage

_Please show how you have added tests to cover your changes_

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
