### PR TITLE
Set up audio context during testing

### DIFF
--- a/test/helpers/audio-context-setup.js
+++ b/test/helpers/audio-context-setup.js
@@ -1,0 +1,11 @@
+import 'web-audio-test-api';
+
+const WebAudioTestAPI = global.WebAudioTestAPI;
+
+beforeAll(() => {
+    WebAudioTestAPI.setState('AudioContext#resume', 'enabled');
+});
+
+afterAll(() => {
+    WebAudioTestAPI.setState('AudioContext#resume', 'disabled');
+});

--- a/test/unit/util/audio-context.test.js
+++ b/test/unit/util/audio-context.test.js
@@ -1,5 +1,5 @@
-import 'web-audio-test-api';
 import SharedAudioContext from '../../../src/lib/audio/shared-audio-context';
+import '../../helpers/audio-context-setup';
 
 describe('Shared Audio Context', () => {
     const audioContext = new AudioContext();

--- a/test/unit/util/vm-manager-hoc.test.jsx
+++ b/test/unit/util/vm-manager-hoc.test.jsx
@@ -1,4 +1,4 @@
-import 'web-audio-test-api';
+import '../../helpers/audio-context-setup';
 
 import React from 'react';
 import configureStore from 'redux-mock-store';


### PR DESCRIPTION
### Resolves

- Related https://github.com/LLK/scratch-gui/issues/8034

### Proposed Changes

This avoids unhandled rejections during the unit test suite.

### Reason for Changes

These two tests end up triggering an `AudioContext#resume` which the `web-audio-test-api` has disabled by default. Prior to node 15, this just gets logged as an error. But in upgrading for https://github.com/LLK/scratch-gui/issues/8034 it turns into a hard failure.

So we'll need to properly enable the audio context before testing it if we want to use newer node versions.

### Test Coverage

Only tests changed

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
