### PR TITLE
Upgrade to node 16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ aliases:
         - v3-npm-
   - &defaults
     docker:
-      - image: cimg/node:12.22.11-browsers
+      - image: cimg/node:16.14-browsers
     working_directory: ~/repo
 
 jobs:


### PR DESCRIPTION
### Resolves

- Requires https://github.com/LLK/scratch-gui/pull/8159
- Resolves https://github.com/LLK/scratch-gui/issues/8034

### Proposed Changes

Updates CI image to node 16

### Reason for Changes

Ease of developer onboarding, see https://github.com/LLK/scratch-gui/issues/8034 for details.

### Test Coverage

N/A

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
