### PR TITLE
move [skip ci] in deploy script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "npm run clean && webpack --colors --bail",
     "clean": "rimraf ./build && mkdirp build && rimraf ./dist && mkdirp dist",
-    "deploy": "touch build/.nojekyll && gh-pages -t -d build -m \"Build for $(git log --pretty=format:%H -n1) [skip ci]\"",
+    "deploy": "touch build/.nojekyll && gh-pages -t -d build -m \"[skip ci] Build for $(git log --pretty=format:%H -n1)\"",
     "prune": "./prune-gh-pages.sh",
     "i18n:push": "tx-push-src scratch-editor interface translations/en.json",
     "i18n:src": "rimraf ./translations/messages/src && babel src > tmp.js && rimraf tmp.js && build-i18n-src ./translations/messages/src ./translations/ && npm run i18n:push",


### PR DESCRIPTION
### Resolves

we still run a followup build after deploying to gh-pages even though we attempt to instruct it to [skip ci] in the commit message


### Proposed Changes

Moves [skip ci] to the beginning of the commit message.  This worked in paint.

### Reason for Changes

After deploying we commit to the gh-pages branch, which kicks off another build.  We would like to not kick off another build

