### PR TITLE
Update to storage v2.0.1 & handle storage.load possibly returning null

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3899,7 +3899,7 @@
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg=="
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
     "ansi-colors": {
       "version": "3.2.4",
@@ -5289,7 +5289,7 @@
     "browser-stdout": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-      "integrity": "sha512-7Rfk377tpSM9TWBEeHs0FlDZGoAIei2V/4MdZJoFMBFAK6BqLpxAIUepGRHGdPFgGsLb02PXovC4qddyHvQqTg=="
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
     },
     "browserify-aes": {
       "version": "1.2.0",
@@ -15521,6 +15521,26 @@
         "scratch-storage": "^1.0.0",
         "scratch-svg-renderer": "0.2.0-prerelease.20210727023023",
         "twgl.js": "4.4.0"
+      },
+      "dependencies": {
+        "base64-js": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+          "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+        },
+        "scratch-storage": {
+          "version": "1.3.6",
+          "resolved": "https://registry.npmjs.org/scratch-storage/-/scratch-storage-1.3.6.tgz",
+          "integrity": "sha512-L/7z7SB7cGANsgjyiE+qZNaPEqFHK1yPbNomizkgN3WHGcKRogLvmheR57kOxHNpQzodUTbG+pVVH6fR2ZY1Sg==",
+          "requires": {
+            "arraybuffer-loader": "^1.0.3",
+            "base64-js": "1.3.0",
+            "fastestsmallesttextencoderdecoder": "^1.0.7",
+            "js-md5": "0.7.3",
+            "minilog": "3.1.0",
+            "worker-loader": "^2.0.0"
+          }
+        }
       }
     },
     "scratch-render-fonts": {
@@ -15542,9 +15562,9 @@
       }
     },
     "scratch-storage": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/scratch-storage/-/scratch-storage-1.3.6.tgz",
-      "integrity": "sha512-L/7z7SB7cGANsgjyiE+qZNaPEqFHK1yPbNomizkgN3WHGcKRogLvmheR57kOxHNpQzodUTbG+pVVH6fR2ZY1Sg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/scratch-storage/-/scratch-storage-2.0.1.tgz",
+      "integrity": "sha512-1Z4sR6jwhpcaFeOY9W5l/u3KKzGKDQcV0WH77OVQ6FFpxXZuKcE/PcXukKnu/PozB/l6QvX2fSADjoXNJ6hbOQ==",
       "requires": {
         "arraybuffer-loader": "^1.0.3",
         "base64-js": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "scratch-paint": "0.2.0-prerelease.20220519104435",
     "scratch-render": "0.1.0-prerelease.20211028200436",
     "scratch-render-fonts": "1.0.0-prerelease.20210401210003",
-    "scratch-storage": "1.3.6",
+    "scratch-storage": "2.0.1",
     "scratch-svg-renderer": "0.2.0-prerelease.20210727023023",
     "scratch-vm": "0.2.0-prerelease.20220519224632",
     "startaudiocontext": "1.2.1",

--- a/src/containers/sound-library.jsx
+++ b/src/containers/sound-library.jsx
@@ -60,7 +60,8 @@ class SoundLibrary extends React.PureComponent {
     }
     onStop () {
         if (this.playingSoundPromise !== null) {
-            this.playingSoundPromise.then(soundPlayer => soundPlayer.removeListener('stop', this.onStop));
+            this.playingSoundPromise.then(soundPlayer =>
+                soundPlayer && soundPlayer.removeListener('stop', this.onStop));
             if (this.handleStop) this.handleStop();
         }
 
@@ -73,7 +74,8 @@ class SoundLibrary extends React.PureComponent {
         // normally.
         if (this.playingSoundPromise !== null) {
             // Forcing sound to stop, so stop listening for sound ending:
-            this.playingSoundPromise.then(soundPlayer => soundPlayer.removeListener('stop', this.onStop));
+            this.playingSoundPromise.then(soundPlayer =>
+                soundPlayer && soundPlayer.removeListener('stop', this.onStop));
             // Queued playback began playing before this method.
             if (this.playingSoundPromise.isPlaying) {
                 // Fetch the player from the promise and stop playback soon.
@@ -86,7 +88,7 @@ class SoundLibrary extends React.PureComponent {
                 // immediately after the sound starts playback. Stopping it
                 // immediately will have the effect of no sound being played.
                 this.playingSoundPromise.then(soundPlayer => {
-                    soundPlayer.stopImmediately();
+                    if (soundPlayer) soundPlayer.stopImmediately();
                 });
             }
             // No further work should be performed on this promise and its
@@ -108,26 +110,28 @@ class SoundLibrary extends React.PureComponent {
         // instruction after the play instruction.
         this.playingSoundPromise = vm.runtime.storage.load(vm.runtime.storage.AssetType.Sound, md5)
             .then(soundAsset => {
-                const sound = {
-                    md5: md5ext,
-                    name: soundItem.name,
-                    format: soundItem.format,
-                    data: soundAsset.data
-                };
-                return this.audioEngine.decodeSoundPlayer(sound);
-            })
-            .then(soundPlayer => {
-                soundPlayer.connect(this.audioEngine);
-                // Play the sound. Playing the sound will always come before a
-                // paired stop if the sound must stop early.
-                soundPlayer.play();
-                soundPlayer.addListener('stop', this.onStop);
-                // Set that the sound is playing. This affects the type of stop
-                // instruction given if the sound must stop early.
-                if (this.playingSoundPromise !== null) {
-                    this.playingSoundPromise.isPlaying = true;
+                if (soundAsset) {
+                    const sound = {
+                        md5: md5ext,
+                        name: soundItem.name,
+                        format: soundItem.format,
+                        data: soundAsset.data
+                    };
+                    return this.audioEngine.decodeSoundPlayer(sound)
+                        .then(soundPlayer => {
+                            soundPlayer.connect(this.audioEngine);
+                            // Play the sound. Playing the sound will always come before a
+                            // paired stop if the sound must stop early.
+                            soundPlayer.play();
+                            soundPlayer.addListener('stop', this.onStop);
+                            // Set that the sound is playing. This affects the type of stop
+                            // instruction given if the sound must stop early.
+                            if (this.playingSoundPromise !== null) {
+                                this.playingSoundPromise.isPlaying = true;
+                            }
+                            return soundPlayer;
+                        });
                 }
-                return soundPlayer;
             });
     }
     handleItemMouseLeave () {


### PR DESCRIPTION
### Proposed Changes

- Update to storage v2.0.1 (LLK/scratch-storage#388 and LLK/scratch-storage#389) which includes changes for handling missing assets (storage now resolves null if the asset is missing and also no longer swallows errors during attempts to fetch the asset).

- Update sound library to handle storage resolving null for missing sounds. Don't attempt to play the sound if this happens.

### Test Coverage

Tested locally in the browser, and tested error and non-error path in the sound library.