### PR TITLE
ENA-137 Randomize x/y when creating an empty sprite

### DIFF
--- a/src/containers/target-pane.jsx
+++ b/src/containers/target-pane.jsx
@@ -121,6 +121,7 @@ class TargetPane extends React.Component {
             formatMessage(sharedMessages.pop),
             formatMessage(sharedMessages.costume, {index: 1})
         );
+        randomizeSpritePosition(emptyItem);
         this.props.vm.addSprite(JSON.stringify(emptyItem)).then(() => {
             setTimeout(() => { // Wait for targets update to propagate before tab switching
                 this.props.onActivateTab(COSTUMES_TAB_INDEX);

--- a/src/lib/randomize-sprite-position.js
+++ b/src/lib/randomize-sprite-position.js
@@ -1,7 +1,16 @@
 const randomizeSpritePosition = spriteObject => {
     // https://github.com/LLK/scratch-flash/blob/689f3c79a7e8b2e98f5be80056d877f303a8d8ba/src/Scratch.as#L1385
-    spriteObject.x = Math.floor((200 * Math.random()) - 100);
-    spriteObject.y = Math.floor((100 * Math.random()) - 50);
+    const randomX = Math.floor((200 * Math.random()) - 100);
+    const randomY = Math.floor((100 * Math.random()) - 50);
+    if (Object.prototype.hasOwnProperty.call(spriteObject, 'name')) {
+        // Scratch 3 sprite
+        spriteObject.x = randomX;
+        spriteObject.y = randomY;
+    } else if (Object.prototype.hasOwnProperty.call(spriteObject, 'objName')) {
+        // Scratch 2 sprite (for empty sprites)
+        spriteObject.scratchX = randomX;
+        spriteObject.scratchY = randomY;
+    }
 };
 
 export default randomizeSpritePosition;


### PR DESCRIPTION
### Resolves

- Resolves #5499

### Proposed Changes

Randomizes the x/y position of sprites created using the Paint option.

### Reason for Changes

Other new sprites have a random position.

### Test Coverage

Tested manually.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
