### PR TITLE
ENA-138 Make show/hide buttons unselectable on backdrop, by removing tabindex from disabled radio buttons

### DIFF
--- a/src/components/sprite-info/sprite-info.jsx
+++ b/src/components/sprite-info/sprite-info.jsx
@@ -196,7 +196,7 @@ class SpriteInfo extends React.Component {
                                         [styles.isDisabled]: this.props.disabled
                                     }
                                 )}
-                                tabIndex="0"
+                                tabIndex={this.props.disabled ? null : 0}
                                 onClick={this.props.onClickVisible}
                                 onKeyPress={this.props.onPressVisible}
                             >
@@ -215,7 +215,7 @@ class SpriteInfo extends React.Component {
                                         [styles.isDisabled]: this.props.disabled
                                     }
                                 )}
-                                tabIndex="0"
+                                tabIndex={this.props.disabled ? null : 0}
                                 onClick={this.props.onClickNotVisible}
                                 onKeyPress={this.props.onPressNotVisible}
                             >


### PR DESCRIPTION
### Resolves

- Resolves #5856

[@benjiwheeler edit] Might also resolve https://github.com/LLK/scratch-gui/issues/1517

### Proposed Changes

Removes the `tabindex` attribute from show/hide buttons in the sprite info section when the stage is selected. This makes focusing them impossible, removing the black outline that appears when clicking them.

### Reason for Changes

The focus outline implies that it's possible to interact with the buttons.

### Test Coverage

Tested manually.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
