### PR TITLE
CE-185 Fix record modal being closed when dragging selection handles

### DIFF
--- a/src/components/audio-trimmer/selection-handle.jsx
+++ b/src/components/audio-trimmer/selection-handle.jsx
@@ -12,10 +12,16 @@ const SelectionHandle = props => (
         onTouchStart={props.onMouseDown}
     >
         <Box className={classNames(styles.trimHandle, styles.topTrimHandle)}>
-            <img src={handleIcon} />
+            <img
+                src={handleIcon}
+                draggable={false}
+            />
         </Box>
         <Box className={classNames(styles.trimHandle, styles.bottomTrimHandle)}>
-            <img src={handleIcon} />
+            <img
+                src={handleIcon}
+                draggable={false}
+            />
         </Box>
     </Box>
 );

--- a/src/containers/audio-trimmer.jsx
+++ b/src/containers/audio-trimmer.jsx
@@ -42,15 +42,11 @@ class AudioTrimmer extends React.Component {
         this.containerSize = this.containerElement.getBoundingClientRect().width;
         this.trimStartDragRecognizer.start(e);
         this.initialTrim = this.props.trimStart;
-        e.stopPropagation();
-        e.preventDefault();
     }
     handleTrimEndMouseDown (e) {
         this.containerSize = this.containerElement.getBoundingClientRect().width;
         this.trimEndDragRecognizer.start(e);
         this.initialTrim = this.props.trimEnd;
-        e.stopPropagation();
-        e.preventDefault();
     }
     storeRef (el) {
         this.containerElement = el;

--- a/test/unit/components/__snapshots__/sound-editor.test.jsx.snap
+++ b/test/unit/components/__snapshots__/sound-editor.test.jsx.snap
@@ -230,6 +230,7 @@ exports[`Sound Editor Component matches snapshot 1`] = `
               }
             >
               <img
+                draggable={false}
                 src="test-file-stub"
               />
             </div>
@@ -252,6 +253,7 @@ exports[`Sound Editor Component matches snapshot 1`] = `
               }
             >
               <img
+                draggable={false}
                 src="test-file-stub"
               />
             </div>
@@ -295,6 +297,7 @@ exports[`Sound Editor Component matches snapshot 1`] = `
               }
             >
               <img
+                draggable={false}
                 src="test-file-stub"
               />
             </div>
@@ -317,6 +320,7 @@ exports[`Sound Editor Component matches snapshot 1`] = `
               }
             >
               <img
+                draggable={false}
                 src="test-file-stub"
               />
             </div>


### PR DESCRIPTION
### Resolves

- Resolves #5080

### Proposed Changes

Fixes a bug that caused the sound recording modal to close when dragging a selection handle outside the modal.

### Reason for Changes

Apparently the browser treats a mouseup event as a click if `stopPropagation()` and `preventDefault()` were called on the mousedown event. Those calls were added in #5050 to prevent the browser from dragging the image. This PR removes them and sets `draggable=false` on the images instead.

### Test Coverage

Tested manually.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
