### PR TITLE
Also initialize the shared audio context on keydown

### DIFF
--- a/src/lib/audio/shared-audio-context.js
+++ b/src/lib/audio/shared-audio-context.js
@@ -11,13 +11,16 @@ if (!bowser.msie) {
         typeof document.ontouchstart === 'undefined' ?
             'mousedown' :
             'touchstart';
+    const keyEvent = 'keydown';
     const initAudioContext = () => {
         document.removeEventListener(event, initAudioContext);
+        document.removeEventListener(keyEvent, initAudioContext);
         AUDIO_CONTEXT = new (window.AudioContext ||
             window.webkitAudioContext)();
         StartAudioContext(AUDIO_CONTEXT);
     };
     document.addEventListener(event, initAudioContext);
+    document.addEventListener(keyEvent, initAudioContext);
 }
 
 /**


### PR DESCRIPTION
### Resolves

- Resolves #8545

### Proposed Changes

Adds an additional event listener in `src/lib/audio/shared-audio-context.js` which listens for `keydown` events. This fixes a crash that happens if you use only Tab and the arrow keys to go to the Sounds tab without clicking.

### Reason for Changes

Fixes a bug, and because:
> If something can be done using a keyboard, it would behave the same way as when used with a mouse.

### Test Coverage

Did not add any tests.

### Browser Coverage

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [x] Chrome 
 * [x] Firefox 
 * [x] Edge *(Edge Chromium)*
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
