### PR TITLE
feat: Disable cloud vars when video sensing

### DIFF
--- a/src/lib/cloud-manager-hoc.jsx
+++ b/src/lib/cloud-manager-hoc.jsx
@@ -57,7 +57,7 @@ const cloudManagerHOC = function (WrappedComponent) {
         shouldConnect (props) {
             return !this.isConnected() && this.canUseCloud(props) &&
                 props.isShowingWithId && props.vm.runtime.hasCloudData() &&
-                props.canModifyCloudData;
+                props.canModifyCloudData && !props.vm.extensionManager.isExtensionLoaded('videoSensing');
         }
         shouldDisconnect (props, prevProps) {
             return this.isConnected() &&

--- a/test/unit/util/cloud-manager-hoc.test.jsx
+++ b/test/unit/util/cloud-manager-hoc.test.jsx
@@ -50,6 +50,9 @@ describe('CloudManagerHOC', () => {
         vm.runtime = {
             hasCloudData: jest.fn(() => true)
         };
+        vm.extensionManager = {
+            isExtensionLoaded: jest.fn(() => false)
+        };
         CloudProvider.mockClear();
         mockCloudProviderInstance.requestCloseConnection.mockClear();
     });
@@ -130,6 +133,25 @@ describe('CloudManagerHOC', () => {
             <WrappedComponent
                 cloudHost="nonEmpty"
                 hasCloudPermission={false}
+                store={store}
+                username="user"
+                vm={vm}
+            />
+        );
+
+        expect(vm.setCloudProvider.mock.calls.length).toBe(0);
+        expect(CloudProvider).not.toHaveBeenCalled();
+    });
+
+    test('when videoSensing extension is active, the cloud provider is not set on the vm', () => {
+        const Component = () => <div />;
+        const WrappedComponent = cloudManagerHOC(Component);
+        vm.extensionManager.isExtensionLoaded = jest.fn(extension => extension === 'videoSensing');
+
+        mount(
+            <WrappedComponent
+                hasCloudPermission
+                cloudHost="nonEmpty"
                 store={store}
                 username="user"
                 vm={vm}


### PR DESCRIPTION
This is paired with LLK/scratch-www#7165.

### Resolves

Resolves LLK/scratch-ops#565

### Proposed Changes

Disable cloud variables when camera is active. 

### Reason for Changes

The logic is in `shouldConnect` rather than `canUseCloud` because we don't want to change the editor's experience. This way they still have the option to create cloud variables in the editor.

### Test Coverage

Added test to cloud-manager-hoc to cover this scenario.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [x] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
