### PR TITLE
ci: use DETECT_CHROMEDRIVER_VERSION

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,11 +56,13 @@ jobs:
   build-test-no-cache:
     <<: *defaults
     environment:
+      DETECT_CHROMEDRIVER_VERSION: "true"
       JEST_JUNIT_OUTPUT_DIR: test-results
       NODE_OPTIONS: --max-old-space-size=4000
     steps:
       - *restore_git_cache
       - checkout
+      - browser-tools/install-chrome # must be before node/install-packages
       - node/install-packages
       - run:
           name: Lint
@@ -75,15 +77,13 @@ jobs:
           environment:
             NODE_ENV: production
           command: npm run build
-      - browser-tools/install-chrome
-      - browser-tools/install-chromedriver
       - run:
           name: Integration
           environment:
               JEST_JUNIT_OUTPUT_NAME: integration-results.xml
           command: |
               google-chrome --version
-              chromedriver --version
+              npx --no -- chromedriver --version
               npm run test:integration -- --reporters="default" --reporters="jest-junit"
       - store_artifacts:
           path: coverage
@@ -91,9 +91,12 @@ jobs:
           path: test-results
   setup:
     <<: *defaults
+    environment:
+      DETECT_CHROMEDRIVER_VERSION: "true"
     steps:
       - *restore_git_cache
       - checkout
+      - browser-tools/install-chrome # must be before node/install-packages
       - node/install-packages
       - *save_git_cache
       - *save_npm_cache
@@ -162,14 +165,13 @@ jobs:
       - *restore_npm_cache
       - *restore_build_cache
       - browser-tools/install-chrome
-      - browser-tools/install-chromedriver
       - run:
           name: Integration
           environment:
               JEST_JUNIT_OUTPUT_DIR: test-results/integration
           command: |
             google-chrome --version
-            chromedriver --version
+            npx --no -- chromedriver --version
             export TESTFILES=$(circleci tests glob "test/integration/*.test.js" | circleci tests split --split-by=timings)
             $(npm bin)/jest ${TESTFILES} --reporters="default" --reporters="jest-junit" --runInBand
       - store_test_results:


### PR DESCRIPTION
### Resolves

Resolves #5790 in a more permanent way

### Proposed Changes

Implement these changes in both CI workflows:

* Set the `DETECT_CHROMEDRIVER_VERSION` to `true` when installing Node dependencies
* Ensure that `chrome` is installed before Node dependencies
* Remove `browser-tools/install-chromedriver` since `node-chromedriver` causes it to be ignored

### Reason for Changes

The `DETECT_CHROMEDRIVER_VERSION` environment variable tells `node-chromedriver` to check the version of `chrome` and install a matching version of `chromedriver`. This also means that `chrome` must be installed before `node-chromedriver`, so I've rearranged the steps in `setup` and `build-test-no-cache` to ensure that. Installing a system-wide `chromedriver` with `browser-tools` is not necessary when using `node-chromedriver` since the system-wide copy gets ignored.

The short version is: integration tests will no longer suddenly break between when Chrome releases an update and when we merge the matching update to `node-chromedriver`.

### Test Coverage

See CircleCI build logs on this PR: the current version of Chrome is 107.x, and as of this PR, `scratch-gui` depends on `node-chromedriver` at version 105.x. That's causing integration tests to fail in `develop` right now. With this change, most integration tests are succeeding.

Note that `chromedriver` version 107 currently seems to cause an issue where the very first integration test always fails with `ECONNREFUSED`. That problem is unrelated to this PR's changes. I'm still investigating, but right now it seems like it might be a bug in `selenium-webdriver`, `node-chromedriver`, or maybe even `chromedriver` itself.

### Browser Coverage

N/A