### PR TITLE
ci: use ⌘ or Ctrl based on whether platform is Mac

### DIFF
--- a/test/integration/sounds.test.js
+++ b/test/integration/sounds.test.js
@@ -169,16 +169,18 @@ describe('Working with sounds', () => {
     });
 
     test('Keyboard shortcuts', async () => {
+        const cmdCtrl = process.platform.includes('darwin') ? Key.COMMAND : Key.CONTROL;
+
         await loadUri(uri);
         await clickText('Sounds');
         const el = await findByXpath('//button[@aria-label="Choose a Sound"]');
-        await el.sendKeys(Key.chord(Key.COMMAND, 'a')); // Select all
+        await el.sendKeys(Key.chord(cmdCtrl, 'a')); // Select all
         await findByText('0.85', scope.soundsTab); // Meow sound duration
         await el.sendKeys(Key.DELETE);
         await findByText('0.00', scope.soundsTab); // Sound is now empty
-        await el.sendKeys(Key.chord(Key.COMMAND, 'z')); // undo
+        await el.sendKeys(Key.chord(cmdCtrl, 'z')); // undo
         await findByText('0.85', scope.soundsTab); // Meow sound is back
-        await el.sendKeys(Key.chord(Key.COMMAND, Key.SHIFT, 'z')); // redo
+        await el.sendKeys(Key.chord(cmdCtrl, Key.SHIFT, 'z')); // redo
         await findByText('0.00', scope.soundsTab); // Sound is empty again
 
         const logs = await getLogs();


### PR DESCRIPTION
### Resolves

This was blocking ENA-108 from being deployed.

### Proposed Changes

- Conditionally use command or control in the "Keyboard shortcuts" integration test based on whether the platform is Mac or not.

### Reason for Changes

One of the integration tests was using key combinations to select-all, undo, and redo. The test was failing in CircleCI with: 

```
ECONNREFUSED connect ECONNREFUSED 127.0.0.1:51720
```

The test started failing after `chromedriver` updated to version 107. 

### Test Coverage

*N/A*

### Browser Coverage

Not particularly relevant since this is an integration test being run with `chromedriver`. Local development was done on a Mac, and it is also being run in CircleCI.
