### PR TITLE
fix: sprite selector not resizing properly

### DIFF
--- a/src/components/sprite-selector/sprite-selector.css
+++ b/src/components/sprite-selector/sprite-selector.css
@@ -3,6 +3,8 @@
 @import "../../css/z-index.css";
 
 .sprite-selector {
+    display: flex;
+    flex-direction: column;
     flex-grow: 1;
     position: relative;
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;


### PR DESCRIPTION
### Resolves

N/A

### Proposed Changes

Makes the sprite selector a column flexbox.

### Reason for Changes

Certain languages trigger the sprite info panel to line wrap, and become taller than the 6rem which is expected. This means that the scroll bar doesn't properly appear when the sprites start to be obfuscated. Making the sprite selector a flexbox fixes this.

English:
[Screen recording 2022-11-18 2.34.01 PM.webm](https://user-images.githubusercontent.com/25440652/202814728-0b9a75ce-5bd4-444c-8585-80670ac77f70.webm)


Italian:
[Screen recording 2022-11-18 2.34.31 PM.webm](https://user-images.githubusercontent.com/25440652/202814741-e2a6c933-b878-45fb-acfd-32fb02c34e44.webm)



This height miscalculation was also causing rendering problems for CSFirst.

### Test Coverage

_Please show how you have added tests to cover your changes_
No automated tests, just manual testing.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [X] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome

Linux
 * [X] Chrome
