### PR TITLE
feat: disconnect from cloud variables immediately after adding video

### DIFF
--- a/src/lib/cloud-manager-hoc.jsx
+++ b/src/lib/cloud-manager-hoc.jsx
@@ -99,6 +99,8 @@ const cloudManagerHOC = function (WrappedComponent) {
             }
         }
         handleExtensionAdded (categoryInfo) {
+            // Note that props.vm.extensionManager.isExtensionLoaded('videoSensing') is still false
+            // at the point of this callback, so it is difficult to reuse the canModifyCloudData logic.
             if (categoryInfo.id === 'videoSensing' && this.isConnected()) {
                 this.disconnectFromCloud();
             }


### PR DESCRIPTION
### Resolves

- Resolves [ENA-173](https://scratchfoundation.atlassian.net/browse/ENA-173)

### Proposed Changes

- listens for `EXTENSION_ADDED` event and disconnects from cloud variable server if it is the `videoSensing` extension
- moves logic to `mapStateToProps` based on previous [PR feedback](https://github.com/LLK/scratch-gui/pull/8634#discussion_r1018116505)

### Reason for Changes

This covers an edge case not handled in ENA-108. We should prevent users from encoding and sending webcam data over cloud variables. To accomplish this, we disconnect from the cloud variable server when the video sensing extension is used. This handles the scenario when a user first adds the video sensing extension to a project. 

Scenario:

1. User A creates a project that can encode/decode image data using cloud variables. Video sensing extension is not included in the project yet.
2. User A shares this project.
3. User B runs the project.
4. User A edits the project, including using the video sensing extension to capture and send their webcam to the cloud variable. User A does not leave the editing view. (_The cloud variable connection will be correctly disabled if they were to leave this page and re-run the project._)
5. Without this change, user B is able to see images from user A’s webcam.

### Test Coverage

Manual testing.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [x] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
