### PR TITLE
fix: load flyout correctly when switching languages

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -191,6 +191,9 @@ class Blocks extends React.Component {
         this.detachVM();
         this.workspace.dispose();
         clearTimeout(this.toolboxUpdateTimeout);
+
+        // Clear the flyout blocks so that they can be recreated on mount.
+        this.props.vm.clearFlyoutBlocks();
     }
     requestToolboxUpdate () {
         clearTimeout(this.toolboxUpdateTimeout);

--- a/test/integration/blocks.test.js
+++ b/test/integration/blocks.test.js
@@ -291,4 +291,45 @@ describe('Working with the blocks', () => {
         await clickButton('OK');
         await clickText('list1', scope.blocksTab);
     });
+
+    test('Use variable blocks after switching languages', async () => {
+        const myVariable = 'my\u00A0variable';
+        const changeVariableByScope = "*[@data-id='data_changevariableby']";
+
+        await loadUri(uri);
+
+        await clickText('Code');
+        await clickBlocksCategory('Variables');
+
+        // change "my variable" by 1
+        await clickText('change', changeVariableByScope);
+
+        // check reported value 1
+        await clickText(myVariable, scope.blocksTab);
+        await findByText('1', scope.reportedValue);
+
+        // change language
+        await clickXpath('//*[@aria-label="language selector"]');
+        await clickText('Deutsch');
+
+        await clickText('Skripte');
+        await clickBlocksCategory('Variablen');
+
+        // make sure "my variable" is still 1
+        await clickText(myVariable);
+        await findByText('1', scope.reportedValue);
+
+        // change step from 1 to 10
+        await clickText('1', changeVariableByScope);
+        await driver.actions()
+            .sendKeys('10')
+            .perform();
+
+        // change "my variable" by 10
+        await clickText('ändere', changeVariableByScope);
+
+        // check it is turned up to 11
+        await clickText(myVariable);
+        await findByText('11', scope.reportedValue);
+    });
 });


### PR DESCRIPTION
*Depends on LLK/scratch-vm#3819*

### Resolves

- Resolves [ENA-146](https://scratchfoundation.atlassian.net/browse/ENA-146)
- Resolves #8362 

### Proposed Changes

- The flyout blocks are stored inside the virtual machine at `runtime.flyoutBlocks`. Clear out those blocks when `blocks.js` unmounts.

### Reason for Changes

When the locale changes, the Blocks component unmounts and mounts. This appears to be [intentional](https://github.com/formatjs/formatjs/issues/234). I do not see a simple way to avoid this.

When the Blocks component unmounts, it disposes of the workspace from `scratch-blocks`, but the virtual machine still has references to the blocks from the flyout, including the data blocks.

When the Blocks component mounts, at first the workspace flyout is missing the data blocks, then it is updated with all of the blocks. This update triggers some events to be sent to `vm.runtime.flyoutBlocks`. Most of the blocks trigger a "delete" and a "create" event, but the data blocks only trigger "create" events since this is the first time they are being created from the workspace's perspective. `vm.runtime.flyoutBlocks` ignores the "create" events for the data blocks because they already exist in memory. However, these are "new" data blocks with different block ids for the arguments.

For example, when the user now triggers the change-by data block in the flyout, the virtual machine runs the old one pointing to the old arguments.

Alternative solutions considered:

- Trigger something in the Blocks unmount to cause the workspace to send delete events to the virtual machine for all of the flyout blocks. I was unable to find a method that achieved this.
- Modify the "create" handler in `vm.runtime.flyoutBlocks` to detect these blocks and update instead. This would probably leave around some old blocks that will never be cleaned up.

### Test Coverage

- Added integration test in `blocks.test.js`. Recreate the issue by changing the language and verifying that the change-by block uses the correct argument.
- Manual testing 

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [x] Safari
 
Windows
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome


[ENA-146]: https://scratchfoundation.atlassian.net/browse/ENA-146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ