### PR TITLE
ci: do not run commitlint on develop branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,6 +219,12 @@ workflows:
     jobs:
       - commitlint/lint:
           target-branch: develop
+          filters:
+            branches:
+              ignore:
+                - master
+                - develop
+                - /^hotfix\/.*/
   push-translations:
     triggers:
       - schedule:


### PR DESCRIPTION
### Resolves

- Resolves [ENA-199](https://scratchfoundation.atlassian.net/browse/ENA-199)

### Proposed Changes

- Skip `commitlint` on the following branches:
  - `master`
  - `develop`
  - `hotfix/*`

### Reason for Changes

We do not want to re-write commit history on these "main" branches. Commit messages that do not follow conventional commit should be caught in other branches. However, this way the CI won't fail if they are merged to one of these branches. 

### Test Coverage

- Ran `circleci config validate` to validate the configuration

### Browser Coverage

n/a


[ENA-199]: https://scratchfoundation.atlassian.net/browse/ENA-199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ