### PR TITLE
Add padding to Save Now to increase clickable area

### DIFF
--- a/src/components/menu-bar/save-status.css
+++ b/src/components/menu-bar/save-status.css
@@ -1,4 +1,6 @@
 .save-now {
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
     cursor: pointer;
+    padding-top: 10px;
+    padding-bottom: 10px;
 }


### PR DESCRIPTION
### Resolves

- Resolves #8571

### Proposed Changes

Adds padding to both the top and bottom of the Save Now element next to the My Stuff button, which is clickable. This increases the clickable area of the Save Now button

### Reason for Changes

The clickable area of Save Now is a little small and hard to click every time. I just wanted it to be slightly more forgiving.

### Test Coverage

I don't use Git or npm, so I could not "test" my changes, but I hope it works. It was very easy.

### Browser Coverage
Check the OS/browser combinations tested (At least 2) 😕

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [x] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome

(Tested by adding the style rules to the Save Now element in the browser's developer tools.)
(We use parental controls and it only works in Edge, so I don't have any other browsers to test these changes in, but I'm pretty confident that it will work across browsers.)