### PR TITLE
feat: use updated names for text colors

### DIFF
--- a/src/lib/themes/dark-mode.js
+++ b/src/lib/themes/dark-mode.js
@@ -54,7 +54,8 @@ const blockColors = {
         secondary: '#4C4C4C',
         tertiary: '#FF6680'
     },
-    text: '#E5E5E5',
+    text: 'rgba(255, 255, 255, .7)',
+    textFieldText: '#E5E5E5',
     workspace: '#121212',
     toolboxSelected: '#4C4C4C',
     toolboxText: '#E5E5E5',

--- a/src/lib/themes/default-colors.js
+++ b/src/lib/themes/default-colors.js
@@ -56,7 +56,7 @@ const blockColors = {
         secondary: '#FF4D6A',
         tertiary: '#FF3355'
     },
-    text: '#575E75',
+    text: '#FFFFFF',
     workspace: '#F9F9F9',
     toolboxHover: '#4C97FF',
     toolboxSelected: '#E9EEF2',
@@ -66,6 +66,7 @@ const blockColors = {
     scrollbar: '#CECDCE',
     scrollbarHover: '#CECDCE',
     textField: '#FFFFFF',
+    textFieldText: '#575E75',
     insertionMarker: '#000000',
     insertionMarkerOpacity: 0.2,
     dragShadowOpacity: 0.6,

--- a/src/lib/themes/high-contrast.js
+++ b/src/lib/themes/high-contrast.js
@@ -73,8 +73,8 @@ const blockColors = {
     // For productionizing: we should look into making this field be the color of the text on the blocks
     // e.g. move and steps in move (10) steps, and rename this property below for controlling the text inside
     // of inputs e.g. 10
-    text: '#000000', // Text inside of inputs e.g. 90 in [point in direction (90)]
-
+    text: '#000000',
+    textFieldText: '#000000', // Text inside of inputs e.g. 90 in [point in direction (90)]
     toolboxText: '#000000', // Toolbox text, color picker text (used to be #575E75)
     // The color that the category menu label (e.g. 'motion', 'looks', etc.) changes to on hover
     toolboxHover: '#3373CC',


### PR DESCRIPTION
_Part of the color contrast epic. During development this will live on the `feature/color-contrast` branch._

### Resolves

- Resolves [ENA-240](https://scratchfoundation.atlassian.net/browse/ENA-240)

### Proposed Changes

Use the new/renamed color property names from LLK/scratch-blocks#2962.

### Reason for Changes

Trivial property changes just used to verify the changes in LLK/scratch-blocks#2962. 

### Test Coverage

Eventually the `package.json` will need to be updated to point to the correct version of `scratch-blocks`. For now anyone that wishes to test this will need to clone/build LLK/scratch-blocks#2962 and use `npm link scratch-blocks` to use it. 

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome


[ENA-240]: https://scratchfoundation.atlassian.net/browse/ENA-240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ