### PR TITLE
feat: apply color theme to extension categories and blocks

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -18,7 +18,8 @@ import {BLOCKS_DEFAULT_SCALE, STAGE_DISPLAY_SIZES} from '../lib/layout-constants
 import DropAreaHOC from '../lib/drop-area-hoc.jsx';
 import DragConstants from '../lib/drag-constants';
 import defineDynamicBlock from '../lib/define-dynamic-block';
-import {getColorsForTheme, themes} from '../lib/themes';
+import {DEFAULT_THEME, getColorsForTheme, themes} from '../lib/themes';
+import {injectExtensionBlockColors, injectExtensionCategoryColors} from '../lib/themes/blockHelpers';
 
 import {connect} from 'react-redux';
 import {updateToolbox} from '../reducers/toolbox';
@@ -348,7 +349,10 @@ class Blocks extends React.Component {
             const stageCostumes = stage.getCostumes();
             const targetCostumes = target.getCostumes();
             const targetSounds = target.getSounds();
-            const dynamicBlocksXML = this.props.vm.runtime.getBlocksXML(target);
+            const dynamicBlocksXML = injectExtensionCategoryColors(
+                this.props.vm.runtime.getBlocksXML(target),
+                this.props.theme
+            );
             return makeToolboxXML(false, target.isStage, target.id, dynamicBlocksXML,
                 targetCostumes[targetCostumes.length - 1].name,
                 stageCostumes[stageCostumes.length - 1].name,
@@ -432,7 +436,7 @@ class Blocks extends React.Component {
                     if (blockInfo.info && blockInfo.info.isDynamic) {
                         dynamicBlocksInfo.push(blockInfo);
                     } else if (blockInfo.json) {
-                        staticBlocksJson.push(blockInfo.json);
+                        staticBlocksJson.push(injectExtensionBlockColors(blockInfo.json, this.props.theme));
                     }
                     // otherwise it's a non-block entry such as '---'
                 });
@@ -655,7 +659,7 @@ Blocks.defaultOptions = {
 Blocks.defaultProps = {
     isVisible: true,
     options: Blocks.defaultOptions,
-    theme: 'standard'
+    theme: DEFAULT_THEME
 };
 
 const mapStateToProps = state => ({

--- a/src/containers/gui.jsx
+++ b/src/containers/gui.jsx
@@ -36,6 +36,7 @@ import storage from '../lib/storage';
 import vmListenerHOC from '../lib/vm-listener-hoc.jsx';
 import vmManagerHOC from '../lib/vm-manager-hoc.jsx';
 import cloudManagerHOC from '../lib/cloud-manager-hoc.jsx';
+import systemPreferencesHOC from '../lib/system-preferences-hoc.jsx';
 
 import GUIComponent from '../components/gui/gui.jsx';
 import {setIsScratchDesktop} from '../lib/isScratchDesktop.js';
@@ -183,7 +184,8 @@ const WrappedGui = compose(
     vmListenerHOC,
     vmManagerHOC,
     SBFileUploaderHOC,
-    cloudManagerHOC
+    cloudManagerHOC,
+    systemPreferencesHOC
 )(ConnectedGUI);
 
 WrappedGui.setAppElement = ReactModal.setAppElement;

--- a/src/containers/monitor.jsx
+++ b/src/containers/monitor.jsx
@@ -9,6 +9,7 @@ import {addMonitorRect, getInitialPosition, resizeMonitorRect, removeMonitorRect
 import {getVariable, setVariableValue} from '../lib/variable-utils';
 import importCSV from '../lib/import-csv';
 import downloadBlob from '../lib/download-blob';
+import {DEFAULT_THEME} from '../lib/themes';
 import SliderPrompt from './slider-prompt.jsx';
 
 import {connect} from 'react-redux';
@@ -267,7 +268,7 @@ Monitor.propTypes = {
     y: PropTypes.number
 };
 Monitor.defaultProps = {
-    theme: 'standard'
+    theme: DEFAULT_THEME
 };
 const mapStateToProps = state => ({
     monitorLayout: state.scratchGui.monitorLayout,

--- a/src/lib/system-preferences-hoc.jsx
+++ b/src/lib/system-preferences-hoc.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {connect} from 'react-redux';
+import {DEFAULT_THEME} from './themes';
+import {setTheme} from '../reducers/theme';
+
+const prefersDarkQuery = '(prefers-color-scheme: dark)';
+const prefersHighContrastQuery = '(prefers-contrast: more)';
+
+const getTheme = () => {
+    const highContrast = window.matchMedia(prefersHighContrastQuery).matches;
+
+    if (highContrast) return 'high-contrast';
+
+    const dark = window.matchMedia(prefersDarkQuery).matches;
+
+    if (dark) return 'dark-mode';
+
+    return DEFAULT_THEME;
+};
+
+const systemPreferencesHOC = function (WrappedComponent) {
+    class SystemPreferences extends React.Component {
+        componentDidMount () {
+            this.props.onSetTheme(getTheme());
+            this.preferencesListener = () => this.props.onSetTheme(getTheme());
+            this.highContrastMatchMedia = window.matchMedia(prefersHighContrastQuery);
+            this.highContrastMatchMedia.addEventListener('change', this.preferencesListener);
+            this.darkMatchMedia = window.matchMedia(prefersDarkQuery);
+            this.darkMatchMedia.addEventListener('change', this.preferencesListener);
+        }
+
+        componentWillUnmount () {
+            this.highContrastMatchMedia.removeEventListener('change', this.preferencesListener);
+            this.darkMatchMedia.removeEventListener('change', this.preferencesListener);
+        }
+
+        render () {
+            const {
+                /* eslint-disable no-unused-vars */
+                onSetTheme,
+                /* eslint-enable no-unused-vars */
+                ...props
+            } = this.props;
+            return <WrappedComponent {...props} />;
+        }
+    }
+
+    SystemPreferences.propTypes = {
+        onSetTheme: PropTypes.func
+    };
+
+    const mapDispatchToProps = dispatch => ({
+        onSetTheme: theme => dispatch(setTheme(theme))
+    });
+
+    return connect(
+        null,
+        mapDispatchToProps
+    )(SystemPreferences);
+};
+
+export default systemPreferencesHOC;

--- a/src/lib/themes/__mocks__/dark-mode.js
+++ b/src/lib/themes/__mocks__/dark-mode.js
@@ -2,6 +2,11 @@ const blockColors = {
     motion: {
         primary: '#AAAAAA'
     },
+    pen: {
+        primary: '#FFFFFF',
+        secondary: '#EEEEEE',
+        tertiary: '#DDDDDD'
+    },
     text: '#BBBBBB'
 };
 

--- a/src/lib/themes/__mocks__/default-colors.js
+++ b/src/lib/themes/__mocks__/default-colors.js
@@ -4,6 +4,11 @@ const blockColors = {
         secondary: '#222222',
         tertiary: '#333333'
     },
+    pen: {
+        primary: '#121212',
+        secondary: '#232323',
+        tertiary: '#343434'
+    },
     text: '#444444',
     workspace: '#555555'
 };

--- a/src/lib/themes/blockHelpers.js
+++ b/src/lib/themes/blockHelpers.js
@@ -1,0 +1,61 @@
+import {DEFAULT_THEME, getColorsForTheme} from '.';
+
+// scratch-blocks colours has a pen property that scratch-gui uses for all extensions
+const getExtensionColors = theme => getColorsForTheme(theme).pen;
+
+/**
+ * Applies extension color theme to categories.
+ * No changes are applied if called with the default theme, allowing extensions to provide their own colors.
+ * These colors are not seen if the category provides a blockIconURI.
+ * @param {Array.<object>} dynamicBlockXML - XML for each category of extension blocks, returned from getBlocksXML
+ * in the vm runtime.
+ * @param {string} theme - Theme name
+ * @returns {Array.<object>} Dynamic block XML updated with colors.
+ */
+const injectExtensionCategoryColors = (dynamicBlockXML, theme) => {
+    // Don't do any manipulation for the default theme
+    if (theme === DEFAULT_THEME) return dynamicBlockXML;
+
+    const extensionColors = getExtensionColors(theme);
+    const parser = new DOMParser();
+    const serializer = new XMLSerializer();
+
+    return dynamicBlockXML.map(extension => {
+        const dom = parser.parseFromString(extension.xml, 'text/xml');
+
+        dom.documentElement.setAttribute('colour', extensionColors.primary);
+        // Note: the category's secondaryColour matches up with the blocks' tertiary color, both used for border color.
+        dom.documentElement.setAttribute('secondaryColour', extensionColors.tertiary);
+
+        return {
+            ...extension,
+            xml: serializer.serializeToString(dom)
+        };
+    });
+};
+
+/**
+ * Applies extension color theme to static block json.
+ * No changes are applied if called with the default theme, allowing extensions to provide their own colors.
+ * @param {object} blockInfoJson - Static block json
+ * @param {string} theme - Theme name
+ * @returns {object} Block info json with updated colors. The original blockInfoJson is not modified.
+ */
+const injectExtensionBlockColors = (blockInfoJson, theme) => {
+    // Don't do any manipulation for the default theme
+    if (theme === DEFAULT_THEME) return blockInfoJson;
+
+    const extensionColors = getExtensionColors(theme);
+
+    return {
+        ...blockInfoJson,
+        colour: extensionColors.primary,
+        colourSecondary: extensionColors.secondary,
+        colourTertiary: extensionColors.tertiary
+    };
+};
+
+export {
+    injectExtensionBlockColors,
+    injectExtensionCategoryColors
+};

--- a/src/lib/themes/index.js
+++ b/src/lib/themes/index.js
@@ -4,12 +4,13 @@ import darkMode from './dark-mode';
 import highContrast from './high-contrast';
 import defaultColors from './default-colors';
 
+const DEFAULT_THEME = 'standard';
 const mergeWithDefaults = colors => defaultsDeep({}, colors, defaultColors);
 
 const themeMap = {
     'dark-mode': mergeWithDefaults(darkMode),
     'high-contrast': mergeWithDefaults(highContrast),
-    'standard': defaultColors
+    [DEFAULT_THEME]: defaultColors
 };
 
 const getColorsForTheme = theme => {
@@ -25,6 +26,7 @@ const getColorsForTheme = theme => {
 const themes = Object.keys(themeMap);
 
 export {
+    DEFAULT_THEME,
     defaultColors,
     getColorsForTheme,
     themes

--- a/src/reducers/theme.js
+++ b/src/reducers/theme.js
@@ -1,7 +1,9 @@
+import {DEFAULT_THEME} from '../lib/themes';
+
 const SET_THEME = 'scratch-gui/theme/SET_THEME';
 
 const initialState = {
-    theme: 'standard'
+    theme: DEFAULT_THEME
 };
 
 const reducer = (state = initialState, action) => {

--- a/test/unit/components/monitor-list.test.jsx
+++ b/test/unit/components/monitor-list.test.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import {mountWithIntl} from '../../helpers/intl-helpers.jsx';
-import MonitorList from '../../../src/components/monitor-list/monitor-list.jsx';
 import {OrderedMap} from 'immutable';
 import configureStore from 'redux-mock-store';
 import {Provider} from 'react-redux';
+import {mountWithIntl} from '../../helpers/intl-helpers.jsx';
+import MonitorList from '../../../src/components/monitor-list/monitor-list.jsx';
+import {DEFAULT_THEME} from '../../../src/lib/themes';
 
 describe('MonitorListComponent', () => {
     const store = configureStore()({scratchGui: {
@@ -12,7 +13,7 @@ describe('MonitorListComponent', () => {
             savedMonitorPositions: {}
         },
         theme: {
-            theme: 'standard'
+            theme: DEFAULT_THEME
         },
         toolbox: {
             toolboxXML: ''

--- a/test/unit/util/themes.test.js
+++ b/test/unit/util/themes.test.js
@@ -1,10 +1,20 @@
 import {defaultColors, DEFAULT_THEME, getColorsForTheme} from '../../../src/lib/themes';
-import {injectExtensionBlockColors} from '../../../src/lib/themes/blockHelpers';
+import {injectExtensionBlockColors, injectExtensionCategoryColors} from '../../../src/lib/themes/blockHelpers';
 
 jest.mock('../../../src/lib/themes/default-colors');
 jest.mock('../../../src/lib/themes/dark-mode');
 
 describe('themes', () => {
+    let serializeToString;
+
+    beforeEach(() => {
+        serializeToString = jest.fn(() => 'mocked xml');
+
+        global.XMLSerializer = () => ({
+            serializeToString
+        });
+    });
+
     test('provides the default theme colors', () => {
         expect(defaultColors.motion.primary).toEqual('#111111');
     });
@@ -57,5 +67,21 @@ describe('themes', () => {
             colourSecondary: '#0DA57A',
             colourTertiary: '#0B8E69'
         });
+    });
+
+    test('updates extension category based on theme', () => {
+        const dynamicBlockXML = [
+            {
+                id: 'pen',
+                xml: '<category name="Pen" id="pen" colour="#0FBD8C" secondaryColour="#0DA57A"></category>'
+            }
+        ];
+
+        injectExtensionCategoryColors(dynamicBlockXML, 'dark-mode');
+
+        // XMLSerializer is not available outside the browser.
+        // Verify the mocked XMLSerializer.serializeToString is called with updated colors.
+        expect(serializeToString.mock.calls[0][0].documentElement.getAttribute('colour')).toBe('#FFFFFF');
+        expect(serializeToString.mock.calls[0][0].documentElement.getAttribute('secondaryColour')).toBe('#DDDDDD');
     });
 });

--- a/test/unit/util/themes.test.js
+++ b/test/unit/util/themes.test.js
@@ -1,4 +1,5 @@
-import {defaultColors, getColorsForTheme} from '../../../src/lib/themes';
+import {defaultColors, DEFAULT_THEME, getColorsForTheme} from '../../../src/lib/themes';
+import {injectExtensionBlockColors} from '../../../src/lib/themes/blockHelpers';
 
 jest.mock('../../../src/lib/themes/default-colors');
 jest.mock('../../../src/lib/themes/dark-mode');
@@ -18,5 +19,43 @@ describe('themes', () => {
         const colors = getColorsForTheme('dark-mode');
 
         expect(colors.motion.secondary).toEqual('#222222');
+    });
+
+    test('updates extension blocks based on theme', () => {
+        const blockInfoJson = {
+            type: 'dummy_block',
+            colour: '#0FBD8C',
+            colourSecondary: '#0DA57A',
+            colourTertiary: '#0B8E69'
+        };
+
+        const updated = injectExtensionBlockColors(blockInfoJson, 'dark-mode');
+
+        expect(updated).toEqual({
+            type: 'dummy_block',
+            colour: '#FFFFFF',
+            colourSecondary: '#EEEEEE',
+            colourTertiary: '#DDDDDD'
+        });
+        // The original value was not modified
+        expect(blockInfoJson.colour).toBe('#0FBD8C');
+    });
+
+    test('bypasses updates if using the default theme', () => {
+        const blockInfoJson = {
+            type: 'dummy_block',
+            colour: '#0FBD8C',
+            colourSecondary: '#0DA57A',
+            colourTertiary: '#0B8E69'
+        };
+
+        const updated = injectExtensionBlockColors(blockInfoJson, DEFAULT_THEME);
+
+        expect(updated).toEqual({
+            type: 'dummy_block',
+            colour: '#0FBD8C',
+            colourSecondary: '#0DA57A',
+            colourTertiary: '#0B8E69'
+        });
     });
 });


### PR DESCRIPTION
_Part of the color contrast epic. During development this will live on the `feature/color-contrast` branch._

_If you want to test this locally, there are also some changes in `scratch-blocks` on the `feature/color-contrast` branch. This would involve building `scratch-blocks` and using `npm link scratch-blocks`. This is not strictly necessary, but some of the block colors won't look identical to the screenshots._

_There is not a way to change the color theme in the UI yet. If you want to see this in action, you can change your operating system appearance and accessibility settings, change the `initialState` in `src/reducers/theme.js`, or use Redux developer tools to dispatch the set theme action._

### Resolves

- Resolves [ENA-242](https://scratchfoundation.atlassian.net/browse/ENA-242)

### Proposed Changes

- `blocks.jsx` receives extension categories and blocks from `scratch-vm` and passes them on to `scratch-blocks`. Modify these data structures to apply the color theme.
- Added `system-preferences-hoc.jsx` to apply color theme based on operating system preferences (dark mode, high contrast accessibility setttings). This is just for ease of testing. I don't think we need to be overly critical of this code right now as it will either be removed or significantly refactored when the user can select color themes.

### Reason for Changes

The color theme for extensions needs to be applied somewhere. Since the definition for extensions currently comes from the virtual machine, one option would be to somehow support color theming in the virtual machine. However, I felt it would be nice if the virtual machine did not take on that responsibility.

Since all of the extensions currently have icons, here is a screenshot of high contrast mode with an icon-less extension:

<img width="312" alt="Screenshot 2023-02-17 at 4 24 58 PM" src="https://user-images.githubusercontent.com/4893763/219799343-3aec1f51-4d52-447e-8677-34a22c937d1d.png">

### Test Coverage

- Added unit tests for `injectExtensionBlockColors`
- Manual testing for `injectExtensionCategoryColors`. It uses `XMLSerializer` which is a browser API.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [x] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome


[ENA-242]: https://scratchfoundation.atlassian.net/browse/ENA-242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ