### PR TITLE
feat: use scratchFetch

### DIFF
--- a/src/containers/gui.jsx
+++ b/src/containers/gui.jsx
@@ -40,15 +40,31 @@ import cloudManagerHOC from '../lib/cloud-manager-hoc.jsx';
 import GUIComponent from '../components/gui/gui.jsx';
 import {setIsScratchDesktop} from '../lib/isScratchDesktop.js';
 
+const {RequestMetadata, setMetadata, unsetMetadata} = storage.scratchFetch;
+
+const setProjectIdMetadata = projectId => {
+    // If project ID is '0' or zero, it's not a real project ID. In that case, remove the project ID metadata.
+    // Same if it's null undefined.
+    if (projectId && projectId !== '0') {
+        setMetadata(RequestMetadata.ProjectId, projectId);
+    } else {
+        unsetMetadata(RequestMetadata.ProjectId);
+    }
+};
+
 class GUI extends React.Component {
     componentDidMount () {
         setIsScratchDesktop(this.props.isScratchDesktop);
         this.props.onStorageInit(storage);
         this.props.onVmInit(this.props.vm);
+        setProjectIdMetadata(this.props.projectId);
     }
     componentDidUpdate (prevProps) {
-        if (this.props.projectId !== prevProps.projectId && this.props.projectId !== null) {
-            this.props.onUpdateProjectId(this.props.projectId);
+        if (this.props.projectId !== prevProps.projectId) {
+            if (this.props.projectId !== null) {
+                this.props.onUpdateProjectId(this.props.projectId);
+            }
+            setProjectIdMetadata(this.props.projectId);
         }
         if (this.props.isShowingProject && !prevProps.isShowingProject) {
             // this only notifies container when a project changes from not yet loaded to loaded


### PR DESCRIPTION
**DO NOT MERGE THIS YET**

These changes require server-side support and should only be merged after verifying that support is ready.

### Resolves

Implements part of ENA-245

- [x] Depends on https://github.com/LLK/scratch-storage/pull/404. ~This branch will need a `package.json` change once that PR is merged. Until then, CI builds of this branch will fail.~

~Note that some integration tests will fail until our project & asset servers accept the new headers.~

### Proposed Changes

Register the project ID with `scratchFetch`.

### Test Coverage

I tried to implement automated testing for this, but I was unable to find a good way to do it. It seems I would either need to access Redux state from the tests or hook/mock `fetch`. I put enough work into each path to discover that both options will take more work than I anticipated.

I did perform some artisanal hand-testing with locally-sourced servers, and that worked well.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [x] Chrome 
 * [ ] Firefox 
 * [x] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
