### PR TITLE
fix: tell renovate to ignore cat-blocks

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -3,5 +3,9 @@
 
   "extends": [
     "github>LLK/scratch-renovate-config:conservative"
+  ],
+
+  "ignoreDeps": [
+    "cat-blocks"
   ]
 }


### PR DESCRIPTION
Prevent Renovate from updating `cat-blocks` since it needs to be fixed at a specific version of `scratch-blocks`.