### PR TITLE
ci: prevent costumes integration tests from failing

### DIFF
--- a/test/integration/costumes.test.js
+++ b/test/integration/costumes.test.js
@@ -13,6 +13,9 @@ const {
     scope
 } = new SeleniumHelper();
 
+// The costumes library is slow to load. Increase the timeout for these tests.
+jest.setTimeout(60_000);
+
 const uri = path.resolve(__dirname, '../../build/index.html');
 
 let driver;


### PR DESCRIPTION
### Resolves

- Resolves [ENA-263](https://scratchfoundation.atlassian.net/browse/ENA-263)

### Proposed Changes

- Use a longer timeout for the `test/integration/costumes.test.js` tests. Note that the [documentation](https://archive.jestjs.io/docs/en/22.x/jest-object.html#jestsettimeouttimeout) states that `jest.setTimeout` only affects the test file from which it is called.

### Reason for Changes

There are two costume integration tests that frequently fail:

1. Adding a letter costume through the Letters filter in the library, and
2. Costumes animate on mouseover.

After investigation, it appears that the first test is failing because the 30 second test timeout is exceeded while waiting to find the "Letters" filter on the costume library page. The second test is failing because the first test is still executing steps and tries to interact with an element that is no longer attached to the page.

The costume library takes a significant amount of time to load, roughly 20 seconds in CircleCI. This test becomes flaky as sometimes it hits the 30 second test timeout. 

Just increasing the timeout is not an ideal solution. Other options that were considered:

- Use different selectors to select the "Letters" button. I thought that maybe the xpath selector was slow because of the size of the costumes library page. Even selecting by ID was slow. I believe Selenium is waiting for the page to fully load.
- Selenium has options for the [page load strategy](https://www.selenium.dev/documentation/webdriver/drivers/options/#pageloadstrategy). Perhaps using the eager strategy will allow the testing to continue without waiting for all resources to be downloaded. This api is not available in the `selenium-webdriver` version scratch-gui is using. Upgrading this library broke how Jest loads modules. I briefly explored upgrading Jest, but this was turning into a larger task with no guarantee it would work. Worth exploring later if we upgrade the testing framework.

### Test Coverage

_n/a_

### Browser Coverage

_n/a_

Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome


[ENA-263]: https://scratchfoundation.atlassian.net/browse/ENA-263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ