### PR TITLE
ENA-231 Make setting switches colorblind friendly

### DIFF
--- a/src/components/sprite-info/sprite-info.css
+++ b/src/components/sprite-info/sprite-info.css
@@ -51,7 +51,9 @@
     width: 100%;
     height: 100%;
 }
-
+.icon.is-active {
+    filter: brightness(0) invert(1);
+}
 /* @todo: refactor radio divs to input */
 .radio-wrapper {
     white-space: nowrap; /* make sure visibilty buttons don't wrap */
@@ -63,6 +65,7 @@
 }
 .radio.is-active {
     filter: none;
+    background-color: $motion-primary;
 }
 .radio.is-disabled {
     cursor: default;

--- a/src/components/sprite-info/sprite-info.jsx
+++ b/src/components/sprite-info/sprite-info.jsx
@@ -201,7 +201,10 @@ class SpriteInfo extends React.Component {
                                 onKeyPress={this.props.onPressVisible}
                             >
                                 <img
-                                    className={styles.icon}
+                                    className={classNames(styles.icon, {
+                                        [styles.isActive]: this.props.visible && !this.props.disabled,
+                                        [styles.isDisabled]: this.props.disabled
+                                    })}
                                     src={showIcon}
                                 />
                             </div>
@@ -220,7 +223,10 @@ class SpriteInfo extends React.Component {
                                 onKeyPress={this.props.onPressNotVisible}
                             >
                                 <img
-                                    className={styles.icon}
+                                    className={classNames(styles.icon, {
+                                        [styles.isActive]: !this.props.visible && !this.props.disabled,
+                                        [styles.isDisabled]: this.props.disabled
+                                    })}
                                     src={hideIcon}
                                 />
                             </div>


### PR DESCRIPTION
### Resolves


- Resolves llk/scratch-gui#8577

### Proposed Changes

Change the switch to the style of the solution indicated by the issue
> **Note** This pull request doesn't affect the rotation style icons in the popup for changing a sprite's direction.
>
> ![image](https://user-images.githubusercontent.com/106949016/230852603-f8a24e4a-0e20-4c07-b11d-f9dc6e6911a2.png)


![screenshot001](https://user-images.githubusercontent.com/106949016/230300934-95c2b78a-1d63-483e-bb15-8fa6ac8331f5.png)
![screenshot002](https://user-images.githubusercontent.com/106949016/230300988-073db69d-dd3e-430d-a1d9-975539258df1.png)

### Reason for Changes
Previously, the background was white, making it difficult for colorblind to see.

### Test Coverage

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [x] Chrome 
 * [x] Firefox 
 * [x] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
