### PR TITLE
fix: support browsers that don't implement 'prefers-contrast' media query

### DIFF
--- a/src/lib/system-preferences-hoc.jsx
+++ b/src/lib/system-preferences-hoc.jsx
@@ -14,12 +14,18 @@ const systemPreferencesHOC = function (WrappedComponent) {
         componentDidMount () {
             this.preferencesListener = () => this.props.onSetTheme(detectTheme());
 
-            this.highContrastMatchMedia = window.matchMedia(prefersHighContrastQuery);
-            this.highContrastMatchMedia.addEventListener('change', this.preferencesListener);
+            if (window.matchMedia) {
+                this.highContrastMatchMedia = window.matchMedia(prefersHighContrastQuery);
+                if (this.highContrastMatchMedia) {
+                    this.highContrastMatchMedia.addEventListener('change', this.preferencesListener);
+                }
+            }
         }
 
         componentWillUnmount () {
-            this.highContrastMatchMedia.removeEventListener('change', this.preferencesListener);
+            if (this.highContrastMatchMedia) {
+                this.highContrastMatchMedia.removeEventListener('change', this.preferencesListener);
+            }
         }
 
         render () {


### PR DESCRIPTION
### Resolves

Resolves ENA-343: Editor fails in Safari 13.1 and earlier

### Proposed Changes

Check for `matchMedia` and `prefers-contrast` support in `system-preferences-hoc.jsx` before listening for the `change` event.

### Reason for Changes

Safari 13.1 and earlier (and probably other browsers) don't support `window.matchMedia("(prefers-contrast: more)")`, resulting in `TypeError: (...).addEventListener is not a function` (and similar with `removeEventListener`) in the old code. The new code checks for that and does nothing if this feature is not supported.

### Browser Coverage

Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [x] Chrome 
 * [x] Firefox 
 * [x] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
