### PR TITLE
fix: adjust autosave interval

### DIFF
--- a/src/lib/project-saver-hoc.jsx
+++ b/src/lib/project-saver-hoc.jsx
@@ -398,7 +398,7 @@ const ProjectSaverHOC = function (WrappedComponent) {
         vm: PropTypes.instanceOf(VM).isRequired
     };
     ProjectSaverComponent.defaultProps = {
-        autoSaveIntervalSecs: 120,
+        autoSaveIntervalSecs: 600, // 10 minutes = 600 seconds
         onRemixing: () => {},
         onSetProjectThumbnailer: () => {},
         onSetProjectSaver: () => {},


### PR DESCRIPTION
### Resolves

Resolves ENG-74

### Proposed Changes

Adjust autosave interval from 120 to 600 seconds.

### Reason for Changes

This should still support our users well while reducing server load.

### Test Coverage

Tested locally, but testing in staging will be the "real" test.
