### PR TITLE
fix: input and label association

### DIFF
--- a/src/components/direction-picker/direction-picker.jsx
+++ b/src/components/direction-picker/direction-picker.jsx
@@ -51,6 +51,7 @@ const messages = defineMessages({
 
 const DirectionPicker = props => (
     <Label
+        for={directionLabel.props.defaultMessage}
         secondary
         above={props.labelAbove}
         text={directionLabel}
@@ -92,9 +93,9 @@ const DirectionPicker = props => (
             onOuterAction={props.onClosePopover}
         >
             <BufferedInput
+                id={directionLabel.props.defaultMessage}
                 small
                 disabled={props.disabled}
-                label={directionLabel}
                 tabIndex="0"
                 type="text"
                 value={props.disabled ? '' : props.direction}

--- a/src/components/forms/label.jsx
+++ b/src/components/forms/label.jsx
@@ -4,7 +4,10 @@ import React from 'react';
 import styles from './label.css';
 
 const Label = props => (
-    <label className={props.above ? styles.inputGroupColumn : styles.inputGroup}>
+    <label
+        htmlFor={props.for}
+        className={props.above ? styles.inputGroupColumn : styles.inputGroup}
+    >
         <span className={props.secondary ? styles.inputLabelSecondary : styles.inputLabel}>
             {props.text}
         </span>
@@ -13,6 +16,7 @@ const Label = props => (
 );
 
 Label.propTypes = {
+    for: PropTypes.string,
     above: PropTypes.bool,
     children: PropTypes.node,
     secondary: PropTypes.bool,

--- a/src/components/sound-editor/sound-editor.jsx
+++ b/src/components/sound-editor/sound-editor.jsx
@@ -145,8 +145,12 @@ const SoundEditor = props => (
     >
         <div className={styles.row}>
             <div className={styles.inputGroup}>
-                <Label text={props.intl.formatMessage(messages.sound)}>
+                <Label
+                    for={props.name}
+                    text={props.intl.formatMessage(messages.sound)}
+                >
                     <BufferedInput
+                        id={props.name}
                         tabIndex="1"
                         type="text"
                         value={props.name}

--- a/src/components/sprite-info/sprite-info.jsx
+++ b/src/components/sprite-info/sprite-info.jsx
@@ -219,11 +219,12 @@ class SpriteInfo extends React.Component {
                             secondary
                             above={labelAbove}
                             text={sizeLabel}
+                            for={sizeLabel.props.defaultMessage}
                         >
                             <BufferedInput
+                                id={sizeLabel.props.defaultMessage}
                                 small
                                 disabled={this.props.disabled}
-                                label={sizeLabel}
                                 tabIndex="0"
                                 type="text"
                                 value={this.props.disabled ? '' : Math.round(this.props.size)}

--- a/test/unit/components/__snapshots__/sound-editor.test.jsx.snap
+++ b/test/unit/components/__snapshots__/sound-editor.test.jsx.snap
@@ -13,6 +13,7 @@ exports[`Sound Editor Component matches snapshot 1`] = `
     >
       <label
         className={undefined}
+        htmlFor="sound name"
       >
         <span
           className={undefined}
@@ -21,6 +22,7 @@ exports[`Sound Editor Component matches snapshot 1`] = `
         </span>
         <input
           className=""
+          id="sound name"
           onBlur={[Function]}
           onChange={[Function]}
           onKeyPress={[Function]}


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_ 

- Resolves #9151 

### Proposed Changes

- Delete the unsupported `label` attribute from Size and Direction Sprite property inputs
- Add `for` attribute to label elements
- Add `id` attribute to input elements

### Reason for Changes

This will properly support accessibility needs by utilizing HTML5 specification for associating labels and inputs

### Test Coverage

Tests did not exist for the `sprite-info` or `direction-picker` components but did exist for the `sound-editor` component which had it's test snapshot updated to reflect the change.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
