### PR TITLE
fix: alt+left arrow previous page navigation

### DIFF
--- a/src/lib/vm-listener-hoc.jsx
+++ b/src/lib/vm-listener-hoc.jsx
@@ -95,7 +95,7 @@ const vmListenerHOC = function (WrappedComponent) {
 
             // Prevent space/arrow key from scrolling the page.
             if (e.keyCode === 32 || // 32=space
-                (e.keyCode >= 37 && e.keyCode <= 40)) { // 37, 38, 39, 40 are arrows
+                (e.keyCode >= 37 && e.keyCode <= 40 && !e.altKey)) { // 37, 38, 39, 40 are arrows
                 e.preventDefault();
             }
         }


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves #8395 

### Proposed Changes

- Allow Alt+Left Arrow previous page navigation
- Preserve current blocking of all other space bar and arrow key scroll blocking

### Reason for Changes

- Blocking arrow keys and space bar from scrolling in the page is great
- It's unnecessary to block the Alt+Left Arrow previous page navigation

### Test Coverage

- Backfilled tests that space bar and arrow keys for scrolling are blocked
- Added new test to show that Alt+Left Arrow works

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
