### PR TITLE
docs: Update GitHub link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Scratch GUI is a set of React components that comprise the interface for creating and running Scratch 3.0 projects
 
+To open the current build in your browser on Github Pages:
+
+https://scratchfoundation.github.io/scratch-gui/
+
 ## Installation
 
 This requires you to have Git and Node.js installed.
@@ -9,19 +13,19 @@ This requires you to have Git and Node.js installed.
 In your own node environment/application:
 
 ```bash
-npm install https://github.com/LLK/scratch-gui.git
+npm install https://github.com/scratchfoundation/scratch-gui.git
 ```
 
 If you want to edit/play yourself:
 
 ```bash
-git clone https://github.com/LLK/scratch-gui.git
+git clone https://github.com/scratchfoundation/scratch-gui.git
 cd scratch-gui
 npm install
 ```
 
 **You may want to add `--depth=1` to the `git clone` command because there are some [large files in the git repository
-history](https://github.com/LLK/scratch-gui/issues/5140).**
+history](https://github.com/scratchfoundation/scratch-gui/issues/5140).**
 
 ## Getting started
 
@@ -223,7 +227,7 @@ If you run into npm install errors, try these steps:
 ## Publishing to GitHub Pages
 
 You can publish the GUI to github.io so that others on the Internet can view it.
-[Read the wiki for a step-by-step guide.](https://github.com/LLK/scratch-gui/wiki/Publishing-to-GitHub-Pages)
+[Read the wiki for a step-by-step guide.](https://github.com/scratchfoundation/scratch-gui/wiki/Publishing-to-GitHub-Pages)
 
 ## Understanding the project state machine
 


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_
N/A

### Proposed Changes

Replace the username LLK to scratchfoundation in the links
Add a link to the updated GitHub Pages link

### Reason for Changes

The current links are only redirects to the correct organization (since the gits were moved)

### Test Coverage

N/A - No tests cover README

### Browser Coverage
Check the OS/browser combinations tested (At least 2)
N/A

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
