### PR TITLE
fix: center the question submit button's checkmark

### DIFF
--- a/src/components/question/question.css
+++ b/src/components/question/question.css
@@ -34,7 +34,10 @@
     border-radius: 100%;
 
     color: white;
-    background: $looks-secondary;
+    background: url('./icon--enter.svg'), $looks-secondary;
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: cover;
 }
 
 [dir="ltr"] .question-submit-button {
@@ -61,12 +64,4 @@
 
 .question-input > input:focus {
     box-shadow: 0px 0px 0px 3px $looks-transparent;
-}
-
-.question-submit-button-icon {
-    width: calc(2rem - $space);
-    height: calc(2rem - $space);
-    position: relative;
-    right: -7px;
-    left: -7px;
 }

--- a/src/components/question/question.jsx
+++ b/src/components/question/question.jsx
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styles from './question.css';
 import Input from '../forms/input.jsx';
-import enterIcon from './icon--enter.svg';
 
 const QuestionComponent = props => {
     const {
@@ -29,13 +28,7 @@ const QuestionComponent = props => {
                     <button
                         className={styles.questionSubmitButton}
                         onClick={onClick}
-                    >
-                        <img
-                            className={styles.questionSubmitButtonIcon}
-                            draggable={false}
-                            src={enterIcon}
-                        />
-                    </button>
+                    />
                 </div>
             </div>
         </div>


### PR DESCRIPTION
CSS lets us stack backgrounds on top of one another, so let's do that instead of making it an inline image.

### Resolves

- Resolves #9530
- Resolves #5989

### Proposed Changes

Replace the inline checkmark image in the question box's submit button with a CSS background image.

### Reason for Changes

This allows the checkmark to be easily centered within the button, whereas it was previously off-center:

| Before | After |
| - | - |
| ![image](https://github.com/scratchfoundation/scratch-gui/assets/25993062/29e1b30c-096d-44ec-8451-3fe01edf9495) | ![image](https://github.com/scratchfoundation/scratch-gui/assets/25993062/ee6e98ad-9668-4014-adbf-c58e9285b5d3) |

### Test Coverage

Tested manually in Chrome and Firefox

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge

Linux
 * [x] Chrome
 * [x] Firefox
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
