### PR TITLE
Add run w/o screen refresh mouseover indication

### DIFF
--- a/src/components/custom-procedures/custom-procedures.jsx
+++ b/src/components/custom-procedures/custom-procedures.jsx
@@ -100,11 +100,12 @@ const CustomProcedures = props => (
                 </div>
             </div>
             <div className={styles.checkboxRow}>
-                <label>
+                <label style={{ cursor: 'pointer' }}>
                     <input
                         checked={props.warp}
                         type="checkbox"
                         onChange={props.onToggleWarp}
+                        style={{ cursor: 'pointer' }}
                     />
                     <FormattedMessage
                         defaultMessage="Run without screen refresh"

--- a/src/lib/libraries/sprites.json
+++ b/src/lib/libraries/sprites.json
@@ -11715,7 +11715,7 @@
             },
             {
                 "assetId": "0b1e3033140d094563248e61de4039e5",
-                "name": "Water drop",
+                "name": "Chomp",
                 "dataFormat": "wav",
                 "format": "",
                 "rate": 44100,

--- a/src/lib/libraries/sprites.json
+++ b/src/lib/libraries/sprites.json
@@ -11715,7 +11715,7 @@
             },
             {
                 "assetId": "0b1e3033140d094563248e61de4039e5",
-                "name": "Chomp",
+                "name": "Water drop",
                 "dataFormat": "wav",
                 "format": "",
                 "rate": 44100,


### PR DESCRIPTION
### Resolves

- https://github.com/scratchfoundation/scratch-gui/issues/9559

- Resolves #

### Proposed Changes

Adds a pointer mouseover effect on the "run without screen refresh" checkbox in the custom block creator

### Reason for Changes

Helps users understand that it is an option better

### Test Coverage

_Please show how you have added tests to cover your changes_

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [x] Chrome 
 * [ ] Firefox 
 * [x] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
