### PR TITLE
Fix false change marker

### DIFF
--- a/src/containers/sound-editor.jsx
+++ b/src/containers/sound-editor.jsx
@@ -98,7 +98,7 @@ class SoundEditor extends React.Component {
                 this.handlePlay();
             }
         }
-        if (event.key === 'Delete' || event.key === 'Backspace') {
+        if ((event.key === 'Delete' || event.key === 'Backspace') && this.state.trimStart != null) {
             event.preventDefault();
             if (event.shiftKey) {
                 this.handleDeleteInverse();

--- a/src/containers/sound-editor.jsx
+++ b/src/containers/sound-editor.jsx
@@ -98,7 +98,7 @@ class SoundEditor extends React.Component {
                 this.handlePlay();
             }
         }
-        if ((event.key === 'Delete' || event.key === 'Backspace') && this.state.trimStart != null) {
+        if ((event.key === 'Delete' || event.key === 'Backspace') && this.state.trimStart !== null) {
             event.preventDefault();
             if (event.shiftKey) {
                 this.handleDeleteInverse();


### PR DESCRIPTION
### Resolves

- https://github.com/scratchfoundation/scratch-gui/issues/9567

- Resolves #

### Proposed Changes

Fixes the issue of how when you have no area selected in the sound editor and press delete/backspace, nothing should happen

### Reason for Changes

Bug = bad

### Test Coverage

_Please show how you have added tests to cover your changes_

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [x] Chrome 
 * [ ] Firefox 
 * [x] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
