### PR TITLE
Allow creating % in custom blocks & prevent "" as custom block name

### DIFF
--- a/src/containers/custom-procedures.jsx
+++ b/src/containers/custom-procedures.jsx
@@ -114,6 +114,9 @@ class CustomProcedures extends React.Component {
     }
     handleOk () {
         const newMutation = this.mutationRoot ? this.mutationRoot.mutationToDom(true) : null;
+        if (newMutation.getAttribute('proccode')[0] == "%") {
+            newMutation.setAttribute('proccode', "\\" + newMutation.getAttribute('proccode'));
+        }
         this.props.onRequestClose(newMutation);
     }
     handleAddLabel () {

--- a/src/containers/custom-procedures.jsx
+++ b/src/containers/custom-procedures.jsx
@@ -117,7 +117,11 @@ class CustomProcedures extends React.Component {
         if (newMutation.getAttribute('proccode')[0] == "%") {
             newMutation.setAttribute('proccode', "\\" + newMutation.getAttribute('proccode'));
         }
-        this.props.onRequestClose(newMutation);
+        if (newMutation.getAttribute('proccode') == "") {
+            this.props.onRequestClose();
+        } else {
+            this.props.onRequestClose(newMutation);
+        }
     }
     handleAddLabel () {
         if (this.mutationRoot) {


### PR DESCRIPTION
### Resolves

- https://github.com/scratchfoundation/scratch-gui/issues/9562
- https://github.com/scratchfoundation/scratch-gui/issues/9571

### Proposed Changes

Fixes it

### Reason for Changes

Bug = bad

### Test Coverage

_Please show how you have added tests to cover your changes_

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [x] Chrome 
 * [ ] Firefox 
 * [x] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
