### PR TITLE
Prevent transferring custom blocks

### DIFF
--- a/src/containers/target-pane.jsx
+++ b/src/containers/target-pane.jsx
@@ -156,9 +156,22 @@ class TargetPane extends React.Component {
         this.fileInput = input;
     }
     handleBlockDragEnd (blocks) {
-        if (this.props.hoveredTarget.sprite && this.props.hoveredTarget.sprite !== this.props.editingTarget) {
-            this.shareBlocks(blocks, this.props.hoveredTarget.sprite, this.props.editingTarget);
-            this.props.onReceivedBlocks(true);
+        let canCopy = true;
+
+        for (let i = 0; i < blocks.length; i++) {
+            if (blocks[i].opcode.startsWith("procedures")) {
+                canCopy = false;
+                break;
+            }
+        }
+
+        if (canCopy) {
+            if (this.props.hoveredTarget.sprite && this.props.hoveredTarget.sprite !== this.props.editingTarget) {
+                this.shareBlocks(blocks, this.props.hoveredTarget.sprite, this.props.editingTarget);
+                this.props.onReceivedBlocks(true);
+            }
+        } else {
+            alert('Cannot duplicate custom block to another sprite!')
         }
     }
     shareBlocks (blocks, targetId, optFromTargetId) {


### PR DESCRIPTION
### Resolves

- https://github.com/scratchfoundation/scratch-gui/issues/9577

### Proposed Changes

Fixes the issue

### Reason for Changes

Bug = bad

### Test Coverage

_Please show how you have added tests to cover your changes_

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [x] Chrome 
 * [ ] Firefox 
 * [x] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
