### PR TITLE
Allow using ctrl x for deleting in sounds

### DIFF
--- a/src/containers/sound-editor.jsx
+++ b/src/containers/sound-editor.jsx
@@ -98,7 +98,7 @@ class SoundEditor extends React.Component {
                 this.handlePlay();
             }
         }
-        if (event.key === 'Delete' || event.key === 'Backspace') {
+        if (event.key === 'Delete' || event.key === 'Backspace' || ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'x')) {
             event.preventDefault();
             if (event.shiftKey) {
                 this.handleDeleteInverse();


### PR DESCRIPTION
### Resolves

N/A

### Proposed Changes

Allows the use of Ctrl + x to delete a part of a sound, and Ctrl + shift + x to delete all but that part of the sound

### Reason for Changes

Ctrl + x deletes stuff inside the paint editor, and it should also in the sound editor

### Test Coverage

_Please show how you have added tests to cover your changes_

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [x] Chrome 
 * [ ] Firefox 
 * [x] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
