### PR TITLE
Scratch desktop develop merge

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -168,6 +168,7 @@ jobs:
                 path: ./test-results/*
     deploy-npm:
         needs: [test-integration, test-unit]
+        if: (github.ref == 'refs/heads/master') || (github.ref == 'refs/heads/develop') || (github.ref == 'refs/heads/beta') || startsWith(github.ref, 'refs/heads/hotfix')
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
@@ -187,10 +188,6 @@ jobs:
                 if [[ ${{contains(github.ref, 'hotfix')}}  ]]; then
                 sed -e "s|hotfix/REPLACE|${{ github.ref_name }}|" --in-place release.config.js
                 fi
-            - name: Deduplicate files
-              run: |
-                sudo snap install fclones
-                fclones group --min 128 --no-ignore . | fclones link
             - name: Semantic Release
               env:
                 NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.npmignore
+++ b/.npmignore
@@ -5,11 +5,8 @@
 /node_modules
 npm-*
 
-# TO REVERT: the scratch-desktop branch wants to build scratch-gui from source.
-# To support that we need to un-ignore the /src directory.
-# Once we merge the scratch-desktop branch into develop we should re-ignore /src here.
-# We can also do that by omitting or reverting this commit during the merge.
-# /src
+# Double copies of all the static assets and tutorial gifs
+/src
 
 # Testing
 /.nyc_output


### PR DESCRIPTION
### Reason for Changes
Scratch desktop branch was behind develop and depends on early versions of some packages. This is an obstacle for moving branch to monorepo



[UEPR-34]: https://scratchfoundation.atlassian.net/browse/UEPR-34?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ