### PR TITLE
build: move back to port 8601

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -95,7 +95,7 @@ const distConfig = baseConfig.clone()
 
 // build the examples and debugging tools in `build/`
 const buildConfig = baseConfig.clone()
-    .enableDevServer(process.env.PORT || 8602)
+    .enableDevServer(process.env.PORT || 8601)
     .merge({
         entry: {
             gui: './src/playground/index.jsx',


### PR DESCRIPTION
Thanks @champierre and @takaokouji, and sorry for the trouble!

### Resolves

- Resolves #9598 
- Closes #9611 

### Proposed Changes

Change the webpack dev server port back to 8601.

### Reason for Changes

I accidentally changed the port to 8602 a while ago. That was meant as a temporary change for local development (I was comparing two instances) but I accidentally committed it with other changes.

Why 8601? Because 601 kind of looks like GUI :)

### Test Coverage

This change affects only dev server builds, so I tested it locally
