### PR TITLE
test: boost screen height to fix l10n test

### DIFF
--- a/test/helpers/selenium-helper.js
+++ b/test/helpers/selenium-helper.js
@@ -236,8 +236,13 @@ class SeleniumHelper {
         const outerError = new Error(`loadUri failed with arguments:\n\turi: ${uri}`);
         try {
             await this.setTitle(`loadUri ${uri}`);
+            // TODO: The height is set artificially high to fix this test:
+            // 'Loading with locale shows correct translation for string length block parameter'
+            // which fails because the block is offscreen.
+            // We should set this back to 1024x768 once we find a good way to fix that test.
+            // Using `scrollIntoView` didn't seem to do the trick.
             const WINDOW_WIDTH = 1024;
-            const WINDOW_HEIGHT = 768;
+            const WINDOW_HEIGHT = 960;
             await this.driver
                 .get(`file://${uri}`);
             await this.driver


### PR DESCRIPTION
### Proposed Changes

Increase the window height of the browser used by integration tests

### Reason for Changes

The test `'Loading with locale shows correct translation for string length block parameter'` was failing because the block is offscreen. I tried to use `scrollIntoView` but that didn't fix the issue. I started building more code around that and it was getting more complicated than I was comfortable with, so I fell back to this solution. Hopefully we can move to a better testing framework soon. If not, I left a TODO explaining why I did this.

I'm not sure why this wasn't failing before...

### Test Coverage

Tested locally with `USE_HEADLESS=no`
