### PR TITLE
resizable stage

### DIFF
--- a/src/components/box/box.jsx
+++ b/src/components/box/box.jsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {Component} from 'react';
 import stylePropType from 'react-style-proptype';
 import styles from './box.css';
 
@@ -100,7 +100,10 @@ Box.propTypes = {
      * A callback function whose first parameter is the underlying dom elements.
      * This call back will be executed immediately after the component is mounted or unmounted
      */
-    componentRef: PropTypes.func,
+    componentRef: PropTypes.oneOfType([
+        PropTypes.func,
+        PropTypes.shape({current: PropTypes.object})
+    ]),
     /** https://developer.mozilla.org/en-US/docs/Web/CSS/flex-direction */
     direction: PropTypes.oneOf([
         'row', 'row-reverse', 'column', 'column-reverse'

--- a/src/components/box/box.jsx
+++ b/src/components/box/box.jsx
@@ -98,7 +98,8 @@ Box.propTypes = {
     className: PropTypes.string,
     /**
      * A callback function whose first parameter is the underlying dom elements.
-     * This call back will be executed immediately after the component is mounted or unmounted
+     * This call back will be executed immediately after the component is mounted or unmounted.
+     * Also accepts component refs created with createRef() and useRef()
      */
     componentRef: PropTypes.oneOfType([
         PropTypes.func,

--- a/src/components/box/resizeableBox.jsx
+++ b/src/components/box/resizeableBox.jsx
@@ -1,0 +1,107 @@
+import PropTypes from 'prop-types';
+import React, {useEffect, useRef, useState, useCallback} from 'react';
+
+import Box from './box.jsx';
+
+const useMouseDrag = (ref, onDrag, onDragEnd) => {
+    useEffect(() => {
+        if (!onDrag) return;
+        let isDragging = false;
+        const onMouseMove = e => {
+            e.preventDefault();
+            if (!isDragging) return;
+            if (onDrag) onDrag(e);
+        };
+        const onMouseUp = e => {
+            isDragging = false;
+            if (onDragEnd) onDragEnd(e);
+        };
+        const onMouseDown = e => {
+            e.preventDefault();
+            isDragging = true;
+        };
+        ref.current.addEventListener('mousedown', onMouseDown);
+        window.addEventListener('mousemove', onMouseMove);
+        window.addEventListener('mouseup', onMouseUp);
+        return () => {
+            ref.current.removeEventListener('mousedown', onMouseDown);
+            window.removeEventListener('mousemove', onMouseMove);
+            window.removeEventListener('mouseup', onMouseUp);
+        };
+    }, [onDrag]);
+};
+
+
+const ResizableBox = props => {
+    const {
+        children,
+        minWidth = 420,
+        maxWidth = 480,
+        defaultWidth = 480,
+        onResize,
+        initialSize,
+        ...rest
+    } = props;
+
+    const boxRef = useRef(null);
+    const handleRef = useRef(null);
+    const [width, setWidth] = useState(defaultWidth);
+
+    // whenever the initial size changes, lets override whatever the current width is
+    useEffect(() => {
+        setWidth(initialSize);
+    }, [initialSize]);
+
+    // This is a workaround to force other elements to resize that
+    // are listening to the window resize event (such as the editor).
+    useEffect(() => {
+        window.dispatchEvent(new Event('resize'));
+    }, [width]);
+
+    const onDrag = useCallback(e => {
+        if (!boxRef.current) return;
+        const rect = boxRef.current.getBoundingClientRect();
+        const newWidth = Math.max(Math.min(rect.width - e.movementX, maxWidth), minWidth);
+        onResize(newWidth);
+        setWidth(newWidth);
+    }, [minWidth, maxWidth]);
+
+
+    useMouseDrag(handleRef, onDrag);
+
+    return (
+        <Box
+            componentRef={boxRef}
+            style={{
+                position: 'relative',
+                width: width,
+                minWidth: minWidth
+            }}
+            {...rest}
+        >
+            <div
+                ref={handleRef}
+                style={{
+                    position: 'absolute',
+                    left: 0,
+                    top: 0,
+                    bottom: 0,
+                    width: '8px',
+                    cursor: 'ew-resize'
+                }}
+            />
+            {children}
+        </Box>
+    );
+};
+
+ResizableBox.propTypes = {
+    children: PropTypes.node,
+    minWidth: PropTypes.number,
+    maxWidth: PropTypes.number,
+    defaultWidth: PropTypes.number,
+    onResize: PropTypes.func,
+    initialSize: PropTypes.number
+};
+
+export default ResizableBox;

--- a/src/components/gui/gui.css
+++ b/src/components/gui/gui.css
@@ -207,9 +207,6 @@
     /* pad entire wrapper to the left and right; allow children to fill width */
     padding-left: $space;
     padding-right: $space;
-
-    /* this will only ever be as wide as the stage */
-    flex-basis: 0;
 }
 
 .target-wrapper {

--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -127,6 +127,8 @@ const GUIComponent = props => {
         theme,
         tipsLibraryVisible,
         vm,
+        onSetStageLarge,
+        onSetStageSmall,
         ...componentProps
     } = omit(props, 'dispatch');
     if (children) {
@@ -137,7 +139,6 @@ const GUIComponent = props => {
     const [stageUserWidth, setStageUserWidth] = useState(480);
 
     // callback to set the stage size mode based on the user's defined width
-    const {onSetStageSmall, onSetStageLarge} = props;
     const onResize = useCallback(size => {
         const stageSize = resolveStageSize(stageSizeMode, false);
         if (size < 480 && stageSize !== STAGE_SIZE_MODES.small) {

--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import omit from 'lodash.omit';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {useState, useEffect, useRef, useCallback} from 'react';
 import {defineMessages, FormattedMessage, injectIntl, intlShape} from 'react-intl';
 import {connect} from 'react-redux';
 import MediaQuery from 'react-responsive';
@@ -17,6 +17,7 @@ import SoundTab from '../../containers/sound-tab.jsx';
 import StageWrapper from '../../containers/stage-wrapper.jsx';
 import Loader from '../loader/loader.jsx';
 import Box from '../box/box.jsx';
+import ResizableBox from '../box/resizeableBox.jsx';
 import MenuBar from '../menu-bar/menu-bar.jsx';
 import CostumeLibrary from '../../containers/costume-library.jsx';
 import BackdropLibrary from '../../containers/backdrop-library.jsx';
@@ -40,6 +41,8 @@ import addExtensionIcon from './icon--extensions.svg';
 import codeIcon from './icon--code.svg';
 import costumesIcon from './icon--costumes.svg';
 import soundsIcon from './icon--sounds.svg';
+
+import {setStageSize} from '../../reducers/stage-size';
 
 const messages = defineMessages({
     addExtension: {
@@ -129,6 +132,28 @@ const GUIComponent = props => {
     if (children) {
         return <Box {...componentProps}>{children}</Box>;
     }
+
+    // This is the width of the stage as set by the user. used as the "large" stage size
+    const [stageUserWidth, setStageUserWidth] = useState(480);
+
+    // callback to set the stage size mode based on the user's defined width
+    const {onSetStageSmall, onSetStageLarge} = props;
+    const onResize = useCallback(size => {
+        const stageSize = resolveStageSize(stageSizeMode, false);
+        if (size < 480 && stageSize !== STAGE_SIZE_MODES.small) {
+            onSetStageSmall();
+        }
+        else if (stageSize !== STAGE_SIZE_MODES.large) {
+            onSetStageLarge();
+        }
+        setStageUserWidth(size);
+    }, [onSetStageSmall, onSetStageLarge, stageSizeMode]);
+
+
+    const getStageSize = () => {
+        const size = stageSizeMode === STAGE_SIZE_MODES.large ? Math.max(stageUserWidth, 480 + 16 + 2) : 240 + 16 + 2;
+        return size;
+    };
 
     const tabClassNames = {
         tabs: styles.tabs,
@@ -348,7 +373,13 @@ const GUIComponent = props => {
                             ) : null}
                         </Box>
 
-                        <Box className={classNames(styles.stageAndTargetWrapper, styles[stageSize])}>
+                        <ResizableBox
+                            className={classNames(styles.stageAndTargetWrapper, styles[stageSize])}
+                            onResize={onResize}
+                            minWidth={240 + 16 + 2}
+                            maxWidth={(480 * 4) + 16 + 2}
+                            initialSize={getStageSize()}
+                        >
                             <StageWrapper
                                 isFullScreen={isFullScreen}
                                 isRendererSupported={isRendererSupported}
@@ -362,7 +393,7 @@ const GUIComponent = props => {
                                     vm={vm}
                                 />
                             </Box>
-                        </Box>
+                        </ResizableBox>
                     </Box>
                 </Box>
                 <DragLayer />
@@ -436,7 +467,9 @@ GUIComponent.propTypes = {
     telemetryModalVisible: PropTypes.bool,
     theme: PropTypes.string,
     tipsLibraryVisible: PropTypes.bool,
-    vm: PropTypes.instanceOf(VM).isRequired
+    vm: PropTypes.instanceOf(VM).isRequired,
+    onSetStageLarge: PropTypes.func.isRequired,
+    onSetStageSmall: PropTypes.func.isRequired,
 };
 GUIComponent.defaultProps = {
     backpackHost: null,
@@ -469,6 +502,12 @@ const mapStateToProps = state => ({
     theme: state.scratchGui.theme.theme
 });
 
+const mapDispatchToProps = dispatch => ({
+    onSetStageLarge: () => dispatch(setStageSize(STAGE_SIZE_MODES.large)),
+    onSetStageSmall: () => dispatch(setStageSize(STAGE_SIZE_MODES.small))
+});
+
 export default injectIntl(connect(
-    mapStateToProps
+    mapStateToProps,
+    mapDispatchToProps
 )(GUIComponent));

--- a/src/components/monitor-list/monitor-list.jsx
+++ b/src/components/monitor-list/monitor-list.jsx
@@ -8,15 +8,32 @@ import {stageSizeToTransform} from '../../lib/screen-utils';
 
 import styles from './monitor-list.css';
 
+// Use static `monitor-overlay` class for bounds of draggables
+// This is just a dummy div which doesn't scale to make the
+// bounds tracking play nicer with react-draggable
+const MonitorOverlay = () => (
+    <div
+        className="monitor-overlay"
+        style={{
+            width: 480,
+            height: 360,
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            visibility: 'hidden'
+        }}
+    />
+);
+
 const MonitorList = props => (
     <Box
-        // Use static `monitor-overlay` class for bounds of draggables
-        className={classNames(styles.monitorList, 'monitor-overlay')}
+        className={styles.monitorList}
         style={{
             width: props.stageSize.width,
             height: props.stageSize.height
         }}
     >
+        <MonitorOverlay />
         <Box
             className={styles.monitorListScaler}
             style={stageSizeToTransform(props.stageSize)}
@@ -41,6 +58,7 @@ const MonitorList = props => (
                         x={monitorData.x}
                         y={monitorData.y}
                         onDragEnd={props.onMonitorChange}
+                        scale={props.stageSize.scale}
                     />
                 ))}
         </Box>
@@ -55,7 +73,8 @@ MonitorList.propTypes = {
         width: PropTypes.number,
         height: PropTypes.number,
         widthDefault: PropTypes.number,
-        heightDefault: PropTypes.number
+        heightDefault: PropTypes.number,
+        scale: PropTypes.number
     }).isRequired
 };
 

--- a/src/components/monitor/monitor.jsx
+++ b/src/components/monitor/monitor.jsx
@@ -52,6 +52,7 @@ const MonitorComponent = props => (
             defaultClassNameDragging={styles.dragging}
             disabled={!props.draggable}
             onStop={props.onDragEnd}
+            scale={props.scale}
         >
             <Box
                 className={styles.monitorContainer}
@@ -149,7 +150,8 @@ MonitorComponent.propTypes = {
     onSetModeToLarge: PropTypes.func,
     onSetModeToSlider: PropTypes.func,
     onSliderPromptOpen: PropTypes.func,
-    theme: PropTypes.string.isRequired
+    theme: PropTypes.string.isRequired,
+    scale: PropTypes.number
 };
 
 MonitorComponent.defaultProps = {

--- a/src/components/sprite-info/sprite-info.css
+++ b/src/components/sprite-info/sprite-info.css
@@ -9,11 +9,16 @@
     border-top-left-radius: $space;
     border-top-right-radius: $space;
     border-bottom: 1px solid $ui-black-transparent;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 }
 
 .row {
     display: flex;
     justify-content: space-between;
+    gap: 0.25rem;
+    width: 100%;
 }
 
 .row-primary {

--- a/src/components/sprite-info/sprite-info.jsx
+++ b/src/components/sprite-info/sprite-info.jsx
@@ -159,14 +159,16 @@ class SpriteInfo extends React.Component {
         if (stageSize === STAGE_DISPLAY_SIZES.small) {
             return (
                 <Box className={styles.spriteInfo}>
-                    <div className={classNames(styles.row, styles.rowPrimary)}>
-                        <div className={styles.group}>
-                            {spriteNameInput}
+                    <div style={{maxWidth: 200, width: '100%'}}>
+                        <div className={classNames(styles.row, styles.rowPrimary)}>
+                            <div className={styles.group}>
+                                {spriteNameInput}
+                            </div>
                         </div>
-                    </div>
-                    <div className={classNames(styles.row, styles.rowSecondary)}>
-                        {xPosition}
-                        {yPosition}
+                        <div className={classNames(styles.row, styles.rowSecondary)}>
+                            {xPosition}
+                            {yPosition}
+                        </div>
                     </div>
                 </Box>
             );
@@ -174,72 +176,79 @@ class SpriteInfo extends React.Component {
 
         return (
             <Box className={styles.spriteInfo}>
-                <div className={classNames(styles.row, styles.rowPrimary)}>
-                    <div className={styles.group}>
-                        <Label
-                            above={labelAbove}
-                            text={sprite}
+                <div style={{maxWidth: 360, width: '100%'}}>
+                    <div className={classNames(styles.row, styles.rowPrimary)}>
+                        <div
+                            className={styles.group}
                         >
-                            {spriteNameInput}
-                        </Label>
+                            <Label
+                                above={labelAbove}
+                                text={sprite}
+                            >
+                                {spriteNameInput}
+                            </Label>
+                        </div>
+                        {xPosition}
+                        {yPosition}
                     </div>
-                    {xPosition}
-                    {yPosition}
-                </div>
-                <div className={classNames(styles.row, styles.rowSecondary)}>
-                    <div className={labelAbove ? styles.column : styles.group}>
-                        {
-                            stageSize === STAGE_DISPLAY_SIZES.large ?
-                                <Label
-                                    secondary
-                                    text={showLabel}
-                                /> :
-                                null
-                        }
-                        <ToggleButtons
-                            buttons={[
-                                {
-                                    handleClick: this.props.onClickVisible,
-                                    icon: showIcon,
-                                    isSelected: this.props.visible && !this.props.disabled,
-                                    title: this.props.intl.formatMessage(messages.showSpriteAction)
-                                },
-                                {
-                                    handleClick: this.props.onClickNotVisible,
-                                    icon: hideIcon,
-                                    isSelected: !this.props.visible && !this.props.disabled,
-                                    title: this.props.intl.formatMessage(messages.hideSpriteAction)
-                                }
-                            ]}
-                            disabled={this.props.disabled}
-                        />
-                    </div>
-                    <div className={classNames(styles.group, styles.largerInput)}>
-                        <Label
-                            secondary
-                            above={labelAbove}
-                            text={sizeLabel}
+                    <div className={classNames(styles.row, styles.rowSecondary)}>
+                        <div
+                            className={labelAbove ? styles.column : styles.group}
+                            // style={{flexGrow: 1}}
                         >
-                            <BufferedInput
-                                small
+                            {
+                                stageSize === STAGE_DISPLAY_SIZES.large ?
+                                    <Label
+                                        secondary
+                                        text={showLabel}
+                                    /> :
+                                    null
+                            }
+                            <ToggleButtons
+                                buttons={[
+                                    {
+                                        handleClick: this.props.onClickVisible,
+                                        icon: showIcon,
+                                        isSelected: this.props.visible && !this.props.disabled,
+                                        title: this.props.intl.formatMessage(messages.showSpriteAction)
+                                    },
+                                    {
+                                        handleClick: this.props.onClickNotVisible,
+                                        icon: hideIcon,
+                                        isSelected: !this.props.visible && !this.props.disabled,
+                                        title: this.props.intl.formatMessage(messages.hideSpriteAction)
+                                    }
+                                ]}
                                 disabled={this.props.disabled}
-                                label={sizeLabel}
-                                tabIndex="0"
-                                type="text"
-                                value={this.props.disabled ? '' : Math.round(this.props.size)}
-                                onSubmit={this.props.onChangeSize}
                             />
-                        </Label>
-                    </div>
-                    <div className={classNames(styles.group, styles.largerInput)}>
-                        <DirectionPicker
-                            direction={Math.round(this.props.direction)}
-                            disabled={this.props.disabled}
-                            labelAbove={labelAbove}
-                            rotationStyle={this.props.rotationStyle}
-                            onChangeDirection={this.props.onChangeDirection}
-                            onChangeRotationStyle={this.props.onChangeRotationStyle}
-                        />
+                        </div>
+                        <div className={classNames(styles.group, styles.largerInput)}>
+                            <Label
+                                secondary
+                                above={labelAbove}
+                                text={sizeLabel}
+                            >
+                                <BufferedInput
+                                    small
+                                    disabled={this.props.disabled}
+                                    label={sizeLabel}
+                                    tabIndex="0"
+                                    type="text"
+                                    value={this.props.disabled ? '' : Math.round(this.props.size)}
+                                    onSubmit={this.props.onChangeSize}
+                                />
+                            </Label>
+                        </div>
+                        <div className={classNames(styles.group, styles.largerInput)}>
+                            <DirectionPicker
+                                direction={Math.round(this.props.direction)}
+                                disabled={this.props.disabled}
+                                labelAbove={labelAbove}
+                                rotationStyle={this.props.rotationStyle}
+                                onChangeDirection={this.props.onChangeDirection}
+                                onChangeRotationStyle={this.props.onChangeRotationStyle}
+                            />
+                        </div>
                     </div>
                 </div>
             </Box>

--- a/src/components/stage-header/stage-header.jsx
+++ b/src/components/stage-header/stage-header.jsx
@@ -8,7 +8,6 @@ import Box from '../box/box.jsx';
 import Button from '../button/button.jsx';
 import ToggleButtons from '../toggle-buttons/toggle-buttons.jsx';
 import Controls from '../../containers/controls.jsx';
-import {getStageDimensions} from '../../lib/screen-utils';
 import {STAGE_SIZE_MODES} from '../../lib/layout-constants';
 
 import fullScreenIcon from './icon--fullscreen.svg';
@@ -64,7 +63,6 @@ const StageHeaderComponent = function (props) {
     let header = null;
 
     if (isFullScreen) {
-        const stageDimensions = getStageDimensions(null, true);
         const stageButton = showBranding ? (
             <div className={styles.embedScratchLogo}>
                 <a
@@ -99,7 +97,7 @@ const StageHeaderComponent = function (props) {
             <Box className={styles.stageHeaderWrapperOverlay}>
                 <Box
                     className={styles.stageMenuWrapper}
-                    style={{width: stageDimensions.width}}
+                    style={{margin: '0 4px'}}
                 >
                     <Controls vm={vm} />
                     {stageButton}

--- a/src/components/stage/stage.css
+++ b/src/components/stage/stage.css
@@ -24,10 +24,18 @@
 
     /* enforce overflow + reset position of absolutely-positioned children */
     position: relative;
+
+    display: block;
+    width: 100%;
+    height: auto;
+    max-height: 100%;
+    aspect-ratio: 4/3;
+    box-sizing: border-box;
 }
 
 .stage.full-screen {
     border: $stage-full-screen-border-width solid rgb(126, 133, 151);
+    left: -3px;
 }
 
 .with-color-picker {
@@ -48,6 +56,29 @@
 
 .stage-wrapper {
     position: relative;
+}
+.stage-wrapper.full-screen {
+    height: calc(100vh - 56px);
+    width: calc(100vw - 2px);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.stage-canvas {
+    display: block;
+    width: 100%;
+    height: auto;
+    aspect-ratio: 4/3;
+}
+
+.stage-max-width {
+    height: 100%;
+    width: auto;
+    max-width: calc(100% - 2px);
+    aspect-ratio: 4/3;
+    display: grid;
+    place-items: center stretch;
 }
 
 /* we want stage overlays to all be positioned in the same spot as the stage, but can't put them inside the border

--- a/src/components/stage/stage.jsx
+++ b/src/components/stage/stage.jsx
@@ -11,8 +11,9 @@ import GreenFlagOverlay from '../../containers/green-flag-overlay.jsx';
 import Question from '../../containers/question.jsx';
 import MicIndicator from '../mic-indicator/mic-indicator.jsx';
 import {STAGE_DISPLAY_SIZES} from '../../lib/layout-constants.js';
-import {getStageDimensions} from '../../lib/screen-utils.js';
 import styles from './stage.css';
+import {useCanvasSize} from '../../lib/screen-utils';
+
 
 const StageComponent = props => {
     const {
@@ -24,7 +25,6 @@ const StageComponent = props => {
         colorInfo,
         micIndicator,
         question,
-        stageSize,
         useEditorDragStyle,
         onDeactivateColorPicker,
         onDoubleClick,
@@ -32,50 +32,48 @@ const StageComponent = props => {
         ...boxProps
     } = props;
 
-    const stageDimensions = getStageDimensions(stageSize, isFullScreen);
+    const stageDimensions = useCanvasSize(canvas);
 
     return (
         <React.Fragment>
             <Box
                 className={classNames(
                     styles.stageWrapper,
+                    {[styles.fullScreen]: isFullScreen},
                     {[styles.withColorPicker]: !isFullScreen && isColorPicking})}
                 onDoubleClick={onDoubleClick}
             >
                 <Box
-                    className={classNames(
-                        styles.stage,
-                        {[styles.fullScreen]: isFullScreen}
-                    )}
-                    style={{
-                        height: stageDimensions.height,
-                        width: stageDimensions.width
-                    }}
+                    className={styles.stageMaxWidth}
                 >
-                    <DOMElementRenderer
-                        domElement={canvas}
-                        style={{
-                            height: stageDimensions.height,
-                            width: stageDimensions.width
-                        }}
-                        {...boxProps}
-                    />
-                    <Box className={styles.monitorWrapper}>
-                        <MonitorList
-                            draggable={useEditorDragStyle}
-                            stageSize={stageDimensions}
+                    <Box
+                        className={classNames(
+                            styles.stage,
+                            {[styles.fullScreen]: isFullScreen}
+                        )}
+                    >
+                        <DOMElementRenderer
+                            domElement={canvas}
+                            className={styles.stageCanvas}
+                            {...boxProps}
                         />
+                        <Box className={styles.monitorWrapper}>
+                            <MonitorList
+                                draggable={useEditorDragStyle}
+                                stageSize={stageDimensions}
+                            />
+                        </Box>
+                        <Box className={styles.frameWrapper}>
+                            <TargetHighlight
+                                className={styles.frame}
+                                stageHeight={stageDimensions.height}
+                                stageWidth={stageDimensions.width}
+                            />
+                        </Box>
+                        {isColorPicking && colorInfo ? (
+                            <Loupe colorInfo={colorInfo} />
+                        ) : null}
                     </Box>
-                    <Box className={styles.frameWrapper}>
-                        <TargetHighlight
-                            className={styles.frame}
-                            stageHeight={stageDimensions.height}
-                            stageWidth={stageDimensions.width}
-                        />
-                    </Box>
-                    {isColorPicking && colorInfo ? (
-                        <Loupe colorInfo={colorInfo} />
-                    ) : null}
                 </Box>
 
                 {/* `stageOverlays` is for items that should *not* have their overflow contained within the stage */}

--- a/src/containers/monitor.jsx
+++ b/src/containers/monitor.jsx
@@ -225,6 +225,7 @@ class Monitor extends React.Component {
                     onSetModeToLarge={isList ? null : this.handleSetModeToLarge}
                     onSetModeToSlider={showSliderOption ? this.handleSetModeToSlider : null}
                     onSliderPromptOpen={this.handleSliderPromptOpen}
+                    scale={this.props.scale}
                 />
             </React.Fragment>
         );
@@ -265,7 +266,8 @@ Monitor.propTypes = {
     vm: PropTypes.instanceOf(VM),
     width: PropTypes.number,
     x: PropTypes.number,
-    y: PropTypes.number
+    y: PropTypes.number,
+    scale: PropTypes.number
 };
 Monitor.defaultProps = {
     theme: DEFAULT_THEME

--- a/src/containers/stage.jsx
+++ b/src/containers/stage.jsx
@@ -146,6 +146,9 @@ class Stage extends React.Component {
     }
     updateRect () {
         this.rect = this.canvas.getBoundingClientRect();
+        this.renderer.resize(this.rect.width, this.rect.height);
+        this.canvas.width = this.rect.width;
+        this.canvas.height = this.rect.height;
     }
     getScratchCoords (x, y) {
         const nativeSize = this.renderer.getNativeSize();

--- a/src/lib/screen-utils.js
+++ b/src/lib/screen-utils.js
@@ -1,4 +1,5 @@
 import layout, {STAGE_DISPLAY_SCALES, STAGE_SIZE_MODES, STAGE_DISPLAY_SIZES} from '../lib/layout-constants';
+import {useEffect, useState} from 'react';
 
 /**
  * @typedef {object} StageDimensions
@@ -36,47 +37,6 @@ const resolveStageSize = (stageSizeMode, isFullSize) => {
 };
 
 /**
- * Retrieve info used to determine the actual stage size based on the current GUI and browser state.
- * @param {STAGE_DISPLAY_SIZES} stageSize - the current fully-resolved stage size.
- * @param {boolean} isFullScreen - true if full-screen mode is enabled.
- * @return {StageDimensions} - an object describing the dimensions of the stage.
- */
-const getStageDimensions = (stageSize, isFullScreen) => {
-    const stageDimensions = {
-        heightDefault: layout.standardStageHeight,
-        widthDefault: layout.standardStageWidth,
-        height: 0,
-        width: 0,
-        scale: 0
-    };
-
-    if (isFullScreen) {
-        stageDimensions.height = window.innerHeight -
-            STAGE_DIMENSION_DEFAULTS.menuHeightAdjustment -
-            STAGE_DIMENSION_DEFAULTS.fullScreenSpacingBorderAdjustment;
-
-        stageDimensions.width = stageDimensions.height + (stageDimensions.height / 3);
-
-        if (stageDimensions.width > window.innerWidth) {
-            stageDimensions.width = window.innerWidth;
-            stageDimensions.height = stageDimensions.width * .75;
-        }
-
-        stageDimensions.scale = stageDimensions.width / stageDimensions.widthDefault;
-    } else {
-        stageDimensions.scale = STAGE_DISPLAY_SCALES[stageSize];
-        stageDimensions.height = stageDimensions.scale * stageDimensions.heightDefault;
-        stageDimensions.width = stageDimensions.scale * stageDimensions.widthDefault;
-    }
-
-    // Round off dimensions to prevent resampling/blurriness
-    stageDimensions.height = Math.round(stageDimensions.height);
-    stageDimensions.width = Math.round(stageDimensions.width);
-
-    return stageDimensions;
-};
-
-/**
  * Take a pair of sizes for the stage (a target height and width and a default height and width),
  * calculate the ratio between them, and return a CSS transform to scale to that ratio.
  * @param {object} sizeInfo An object containing dimensions of the target and default stage sizes.
@@ -97,8 +57,48 @@ const stageSizeToTransform = ({width, height, widthDefault, heightDefault}) => {
     return {transform: `scale(${scaleX},${scaleY})`};
 };
 
-export {
-    getStageDimensions,
-    resolveStageSize,
-    stageSizeToTransform
+/**
+ * React hook that monitors a canvas element's dimensions and returns stage sizing information.
+ * @param {HTMLCanvasElement} canvas - The canvas element to monitor
+ * @returns {object} Stage dimension information
+ * @property {number} heightDefault - The default stage height (standardStageHeight)
+ * @property {number} widthDefault - The default stage width (standardStageWidth) 
+ * @property {number} height - The current height of the canvas in pixels
+ * @property {number} width - The current width of the canvas in pixels
+ * @property {number} scale - Scale factor between current width and default width
+ */
+const useCanvasSize = canvas => {
+    const [stageDimensions, setStageDimensions] = useState({
+        heightDefault: layout.standardStageHeight,
+        widthDefault: layout.standardStageWidth,
+        height: canvas?.clientHeight || layout.standardStageHeight,
+        width: canvas?.clientWidth || layout.standardStageWidth,
+        scale: (canvas?.clientWidth || layout.standardStageWidth) / layout.standardStageWidth
+    });
+
+    useEffect(() => {
+        const resizeObserver = new ResizeObserver(entries => {
+            for (const entry of entries) {
+                setStageDimensions({
+                    heightDefault: layout.standardStageHeight,
+                    widthDefault: layout.standardStageWidth,
+                    height: entry.contentRect.height,
+                    width: entry.contentRect.width,
+                    scale: entry.contentRect.width / layout.standardStageWidth
+                });
+            }
+        });
+
+        if (canvas) {
+            resizeObserver.observe(canvas);
+        }
+
+        return () => {
+            resizeObserver.disconnect();
+        };
+    }, [canvas]);
+
+    return stageDimensions;
 };
+
+export {resolveStageSize, stageSizeToTransform, useCanvasSize};


### PR DESCRIPTION
https://github.com/user-attachments/assets/10e5f8d4-1a68-41b7-b147-0b9a246d8182

### Proposed Changes

This PR implements a drag-resizable stage panel which is also used as the "large" stage toggle. This is a purely additive quality-of-life feature that shouldn't change any behaviors users expect.

### Reason for Changes

With higher DPI displays becoming more common on PCs and Tablets, the stage size options are a less-than-ideal "small" or "tiny." Often this means users rely on full-screen mode to check their work in more detail, but at the cost of losing the context of your code editor making iteration slow and annoying.

The solution is to have a more responsive user-customizable approach to displaying the stage.  Users can set the stage size to whatever makes sense for their working environment.  We can preserve the toggle functionality for users by allowing the "large" setting to be the user-defined draggable size.

This refactors some old code to be more flexible using react hooks to observe the size of the container elements to determine the necessary scale whereas the prior approach had a lot of hard-coded assumptions about the two size modes.

### Resolves

While this PR isn't meant to be a bug-fix, it does address some undocumented issues:
- Fixes dragging monitors in the "small" stage mode
- Fixes the stage size when in full-screen mode to adapt to screen when resized

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [x] Chrome 
 * [x] Firefox 
 * [x] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
