### PR TITLE
Improve contrast for Share Button.

### DIFF
--- a/src/components/menu-bar/share-button.css
+++ b/src/components/menu-bar/share-button.css
@@ -1,10 +1,10 @@
 @import "../../css/colors.css";
 
 .share-button {
-    background: $data-primary;
+    background: #b94846;
 }
 
 .share-button-is-shared {
-    background: $ui-black-transparent;
+    background: #a32622;
     cursor: default;
 }


### PR DESCRIPTION
Relates with: https://github.com/scratchfoundation/scratch-www/pull/9130

### Resolves

Poor contrast with share button

- Resolves #

poor contrast for share button

_Describe what this Pull Request does_

better contrast  for share button

_Explain why these changes should be made_

to fit with WCAG laws

_Please show how you have added tests to cover your changes_

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [V ] Chrome 
 * [ V] Firefox 
 * [ V] Safari
 
Windows
 * [V ] Chrome 
 * [ V] Firefox 
 * [ V] Edge
 
Chromebook
 * [ V] Chrome
 
iPad
* [ V] Safari

Android Tablet
* [ V] Chrome


![Screenshot 2025-01-08 6 19 56 PM](https://github.com/user-attachments/assets/25db5938-c2db-447d-8f94-7eec95a3a1a6)
![Screenshot 2025-01-08 6 19 13 PM](https://github.com/user-attachments/assets/854c937f-941b-48e8-96c0-4d877149411b)
