### PR TITLE
fix: add support for scratch-storage chunk files in webpack configuration

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -76,6 +76,11 @@ const baseConfig = new ScratchWebpackConfigBuilder(
                 context: 'node_modules/scratch-vm/dist/web',
                 from: 'extension-worker.{js,js.map}',
                 noErrorOnMissing: true
+            },
+            {
+                context: 'node_modules/scratch-storage/dist/web',
+                from: 'chunks/*.{js,js.map}',
+                noErrorOnMissing: true
             }
         ]
     }));


### PR DESCRIPTION
### Resolves

Assets in libraries are loaded correctly. 

- Resolves #9817

### Proposed Changes

Copy scratch-storage workers under the build path to be accessed by browser. 

### Reason for Changes

scratch-storage 4 changed to bundle workers using Webpack 5 native (not plugin) syntax. So that, the worker code ignored by webpack of scratch-gui. 


