### PR TITLE
Guard CloudProvider._sendCloudData against a cleared connection

### DIFF
--- a/src/lib/cloud-provider.js
+++ b/src/lib/cloud-provider.js
@@ -154,7 +154,9 @@ class CloudProvider {
      * @param {string} data The formatted message to send.
      */
     _sendCloudData (data) {
-        this.connection.send(`${data}\n`);
+        if (this.connection) {
+            this.connection.send(`${data}\n`);
+        }
     }
 
     /**


### PR DESCRIPTION
## Bug

`CloudProvider._sendCloudData` throws
`TypeError: Cannot read properties of null (reading 'send')` when a
previously-scheduled cloud-data send fires after the provider has
been cleared (e.g. the user navigates away from a project or
`requestCloseConnection()` is called while messages are still in
flight).

## Root cause

The constructor wraps `_sendCloudData` in a 100 ms lodash throttle:

```javascript
this.sendCloudData = throttle(this._sendCloudData, 100);
```

so a call to `sendCloudData(data)` can be deferred by up to 100 ms.
In that window the owner can run `requestCloseConnection()`, which
calls `clear()`:

```javascript
clear () {
    this.connection = null;
    ...
}
```

When the throttle's trailing call finally fires it hits
`_sendCloudData`:

```javascript
_sendCloudData (data) {
    this.connection.send(`${data}\n`);
}
```

`this.connection` is now `null`, so `.send` explodes. The call sites
that schedule the send (`writeToServer` and the `onOpen` queue flush)
already check `this.connection` before queueing, but they cannot
speak for what the connection is when the throttle trailing-edge
actually executes.

## Why the fix is correct

- Guarding the actual `.send` with `if (this.connection)` makes a
  late-arriving throttled call a no-op instead of a crash; messages
  targeted at an already-closed connection were going to be dropped
  anyway (the server can't receive them).
- Every existing code path that has a valid connection continues to
  send exactly as before.
- No behaviour change under normal operation - the guard only fires
  in the post-`clear()` race window that was previously crashing.

## Change

`src/lib/cloud-provider.js`: wrap `this.connection.send(\`${data}\\n\`)`
in an `if (this.connection)` guard.