### PR TITLE
fix(list-monitor): wire touch events to resize handle

### DIFF
--- a/src/components/monitor/list-monitor.jsx
+++ b/src/components/monitor/list-monitor.jsx
@@ -45,6 +45,7 @@ const ListMonitor = ({draggable, label, width, height, value, onResizeMouseDown,
             <div
                 className={classNames(draggable ? styles.resizeHandle : null, 'no-drag')}
                 onMouseDown={draggable ? onResizeMouseDown : null}
+                onTouchStart={draggable ? onResizeMouseDown : null}
             >
                 {'=' /* TODO waiting on asset */}
             </div>
@@ -81,3 +82,4 @@ ListMonitor.defaultProps = {
 };
 
 export default ListMonitor;
+

--- a/src/containers/list-monitor.jsx
+++ b/src/containers/list-monitor.jsx
@@ -141,6 +141,8 @@ class ListMonitor extends React.Component {
             onMouseMove(ev); // Make sure width/height are up-to-date
             window.removeEventListener('mousemove', onMouseMove);
             window.removeEventListener('mouseup', onMouseUp);
+            window.removeEventListener('touchmove', onMouseMove);
+            window.removeEventListener('touchend', onMouseUp);
             this.props.vm.runtime.requestUpdateMonitor(Map({
                 id: this.props.id,
                 height: this.state.height,
@@ -150,6 +152,8 @@ class ListMonitor extends React.Component {
 
         window.addEventListener('mousemove', onMouseMove);
         window.addEventListener('mouseup', onMouseUp);
+        window.addEventListener('touchmove', onMouseMove);
+        window.addEventListener('touchend', onMouseUp);
 
     }
 
@@ -199,3 +203,4 @@ ListMonitor.propTypes = {
 const mapStateToProps = state => ({vm: state.scratchGui.vm});
 
 export default connect(mapStateToProps)(ListMonitor);
+


### PR DESCRIPTION
## Bug

List monitors cannot be resized on touchscreen devices. The resize handle (`=`) registers only `onMouseDown` / `mousemove` / `mouseup`, so dragging on a phone or tablet has no effect.

Fixes #9821.

## Root cause

`handleResizeMouseDown` in `src/containers/list-monitor.jsx` already uses `getEventXY` from `src/lib/touch-utils`, which normalises both `MouseEvent` and `TouchEvent` coordinates. The logic is touch-aware; the events were simply never registered.

`src/components/monitor/list-monitor.jsx` passes `onResizeMouseDown` to `onMouseDown` only — there is no `onTouchStart` binding on the resize `<div>`.

## Fix

Two files, five lines added:

**`src/components/monitor/list-monitor.jsx`** — add `onTouchStart` alongside `onMouseDown` on the resize div so the handler fires on touch devices.

**`src/containers/list-monitor.jsx`** — register `touchmove` / `touchend` alongside `mousemove` / `mouseup` when the drag starts, and remove them symmetrically in the cleanup closure.

No coordinate-extraction changes are needed because `getEventXY` already handles both event types.