### PR TITLE
fix(backpack-api): reject with response.statusCode instead of response.status

### DIFF
--- a/src/lib/backpack-api.js
+++ b/src/lib/backpack-api.js
@@ -26,7 +26,7 @@ const getBackpackContents = ({
         json: true
     }, (error, response) => {
         if (error || response.statusCode !== 200) {
-            return reject(new Error(response.status));
+            return reject(new Error(response.statusCode));
         }
         return resolve(response.body.map(item => includeFullUrls(item, host)));
     });
@@ -49,7 +49,7 @@ const saveBackpackObject = ({
         json: {type, mime, name, body, thumbnail}
     }, (error, response) => {
         if (error || response.statusCode !== 200) {
-            return reject(new Error(response.status));
+            return reject(new Error(response.statusCode));
         }
         return resolve(includeFullUrls(response.body, host));
     });
@@ -67,7 +67,7 @@ const deleteBackpackObject = ({
         headers: {'x-token': token}
     }, (error, response) => {
         if (error || response.statusCode !== 200) {
-            return reject(new Error(response.status));
+            return reject(new Error(response.statusCode));
         }
         return resolve(response.body);
     });
@@ -78,7 +78,7 @@ const deleteBackpackObject = ({
 const fetchAs = (responseType, uri) => new Promise((resolve, reject) => {
     xhr({uri, responseType}, (error, response) => {
         if (error || response.statusCode !== 200) {
-            return reject(new Error(response.status));
+            return reject(new Error(response.statusCode));
         }
         return resolve(response.body);
     });


### PR DESCRIPTION
## Bug

Every backpack xhr callback rejects with \`new Error(response.status)\`, but the surrounding check is \`response.statusCode !== 200\`. As a result, every non-2xx response (and every error path) bubbles up as \`Error: undefined\` to callers, hiding the real HTTP code from logs and UI.

\`\`\`js
if (error || response.statusCode !== 200) {
    return reject(new Error(response.status));   // response.status === undefined
}
\`\`\`

## Root cause

This file uses the \`xhr\` npm package, whose response object exposes the HTTP code as \`statusCode\`, not \`status\`. The status check on the same line uses the correct name; only the error-construction half of each pair was wrong. Same copy-paste typo across all four functions (\`getBackpackContents\`, \`saveBackpackObject\`, \`deleteBackpackObject\`, \`fetchAs\`).

## Fix

Pass \`response.statusCode\` into the \`Error\` so the rejection actually carries the HTTP code. Mechanical 4-line change matching the check immediately above each line.