### PR TITLE
Preserve list contents when CSV column import is cancelled

### DIFF
--- a/src/containers/monitor.jsx
+++ b/src/containers/monitor.jsx
@@ -177,6 +177,9 @@ class Monitor extends React.Component {
             if (numberOfColumns > 1) {
                 const msg = this.props.intl.formatMessage(messages.columnPrompt, {numberOfColumns});
                 columnNumber = parseInt(prompt(msg), 10); // eslint-disable-line no-alert
+                if (!columnNumber || columnNumber < 1 || columnNumber > numberOfColumns) {
+                    return;
+                }
             }
             const newListValue = rows.map(row => row[columnNumber - 1])
                 .filter(item => typeof item === 'string'); // CSV importer can leave undefineds


### PR DESCRIPTION
## Bug
Importing a multi-column CSV into a list monitor prompts for a column number. Cancelling that prompt deletes all existing list items (#7313).

## Root cause
`parseInt(prompt(msg), 10)` returns `NaN` when the user cancels. Mapping rows with `row[NaN - 1]` yields `undefined` for every row, and the subsequent string filter produces an empty array that replaces the list.

## Why this fix is correct
Return early when the prompt is cancelled or the column number is out of range, so `setVariableValue` is not called and the existing list is left unchanged.

Fixes #7313

Made with [Cursor](https://cursor.com)