### PR TITLE
fix: don't clear list when CSV import column prompt is cancelled

### DIFF
--- a/src/containers/monitor.jsx
+++ b/src/containers/monitor.jsx
@@ -176,7 +176,9 @@ class Monitor extends React.Component {
             let columnNumber = 1;
             if (numberOfColumns > 1) {
                 const msg = this.props.intl.formatMessage(messages.columnPrompt, {numberOfColumns});
-                columnNumber = parseInt(prompt(msg), 10); // eslint-disable-line no-alert
+                const response = prompt(msg); // eslint-disable-line no-alert
+                if (response === null) return; // Cancelled the prompt; leave the list unchanged.
+                columnNumber = parseInt(response, 10);
             }
             const newListValue = rows.map(row => row[columnNumber - 1])
                 .filter(item => typeof item === 'string'); // CSV importer can leave undefineds

--- a/test/unit/containers/monitor.test.jsx
+++ b/test/unit/containers/monitor.test.jsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import {Provider} from 'react-redux';
+import configureStore from 'redux-mock-store';
+import {mountWithIntl} from '../../helpers/intl-helpers.jsx';
+
+import Monitor from '../../../src/containers/monitor';
+import importCSV from '../../../src/lib/import-csv';
+import {setVariableValue} from '../../../src/lib/variable-utils';
+
+jest.mock('react-ga');
+jest.mock('../../../src/lib/import-csv', () => ({
+    __esModule: true,
+    default: jest.fn()
+}));
+jest.mock('../../../src/lib/variable-utils', () => ({
+    getVariable: jest.fn(),
+    setVariableValue: jest.fn()
+}));
+
+const flushPromises = () => new Promise(resolve => setImmediate(resolve));
+
+describe('Monitor Container', () => {
+    const mockStore = configureStore();
+    let store;
+    let vm;
+
+    beforeEach(() => {
+        vm = {
+            runtime: {
+                getLabelForOpcode: jest.fn(() => ({label: 'my list', category: 'data'})),
+                requestUpdateMonitor: jest.fn()
+            }
+        };
+        store = mockStore({
+            scratchGui: {
+                monitorLayout: {monitors: {}, savedMonitorPositions: {}},
+                theme: {theme: 'default'},
+                toolbox: {toolboxXML: ''},
+                vm: vm
+            }
+        });
+        setVariableValue.mockClear();
+    });
+
+    const mountMonitor = () => mountWithIntl(
+        <Provider store={store}>
+            <Monitor
+                id="my-list"
+                opcode="data_listcontents"
+                mode="list"
+                targetId="target1"
+                params={{}}
+                value={['existing']}
+                draggable={false}
+                vm={vm}
+            />
+        </Provider>
+    );
+
+    test('cancelling the column prompt leaves the list unchanged', async () => {
+        importCSV.mockReturnValue(Promise.resolve([['a1', 'a2'], ['b1', 'b2']]));
+        window.prompt = jest.fn(() => null); // user presses cancel
+
+        const wrapper = mountMonitor();
+        const instance = wrapper.find('Monitor').instance();
+        instance.handleImport();
+        await flushPromises();
+
+        expect(window.prompt).toHaveBeenCalled();
+        expect(setVariableValue).not.toHaveBeenCalled();
+    });
+
+    test('choosing a column imports that column into the list', async () => {
+        importCSV.mockReturnValue(Promise.resolve([['a1', 'a2'], ['b1', 'b2']]));
+        window.prompt = jest.fn(() => '2'); // user picks the second column
+
+        const wrapper = mountMonitor();
+        const instance = wrapper.find('Monitor').instance();
+        instance.handleImport();
+        await flushPromises();
+
+        expect(setVariableValue).toHaveBeenCalledWith(vm, 'target1', 'my-list', ['a2', 'b2']);
+    });
+});


### PR DESCRIPTION
### Resolves

Resolves #7313

### Proposed Changes

When importing a multi-column `.csv`/`.tsv` into a list, `Monitor`'s `handleImport` asks which column to use with `window.prompt`. The return value was passed straight into `parseInt(...)`:

```js
columnNumber = parseInt(prompt(msg), 10);
```

If the user presses **Cancel**, `prompt` returns `null`, so `parseInt(null, 10)` is `NaN`. Every `row[NaN - 1]` is then `undefined`, the `.filter(item => typeof item === 'string')` drops them all, and the list is overwritten with an empty array — silently deleting the list's existing contents.

This change reads the prompt response first and returns early when it is `null`, leaving the list untouched on cancel. Entering a valid column still works exactly as before.

### Reason for Changes

Pressing Cancel should abort the import without changing the project, as described in the issue. The old code treated a cancelled prompt as "import an empty column," which wiped the list (High Severity data loss).

### Test Coverage

Added `test/unit/containers/monitor.test.jsx` with two cases:
- cancelling the column prompt (`prompt` → `null`) does **not** call `setVariableValue`, so the list is unchanged;
- choosing a column (`prompt` → `'2'`) imports that column (`['a2', 'b2']`).

The first test fails on the current `master` and passes with this change; the second guards against regressing normal imports. `npm run test:unit -- test/unit/containers/monitor.test.jsx` passes and `eslint . --ext .js,.jsx` is clean.
